### PR TITLE
update git book link to v2

### DIFF
--- a/modules/git/git.go
+++ b/modules/git/git.go
@@ -111,12 +111,12 @@ func SetExecutablePath(path string) error {
 
 func ensureGitVersion() error {
 	if !DefaultFeatures().CheckVersionAtLeast(RequiredVersion) {
-		moreHint := "get git: https://git-scm.com/download/"
+		moreHint := "get git: https://git-scm.com/downloads"
 		if runtime.GOOS == "linux" {
 			// there are a lot of CentOS/RHEL users using old git, so we add a special hint for them
 			if _, err := os.Stat("/etc/redhat-release"); err == nil {
 				// ius.io is the recommended official(git-scm.com) method to install git
-				moreHint = "get git: https://git-scm.com/download/linux and https://ius.io"
+				moreHint = "get git: https://git-scm.com/downloads/linux and https://ius.io"
 			}
 		}
 		return fmt.Errorf("installed git version %q is not supported, Gitea requires git version >= %q, %s", DefaultFeatures().gitVersion.Original(), RequiredVersion, moreHint)

--- a/templates/repo/empty.tmpl
+++ b/templates/repo/empty.tmpl
@@ -24,7 +24,7 @@
 					</h4>
 					<div class="ui attached guide table segment empty-repo-guide">
 						<div class="item">
-							<h3>{{ctx.Locale.Tr "repo.clone_this_repo"}} <small>{{ctx.Locale.Tr "repo.clone_helper" "http://git-scm.com/book/en/Git-Basics-Getting-a-Git-Repository"}}</small></h3>
+							<h3>{{ctx.Locale.Tr "repo.clone_this_repo"}} <small>{{ctx.Locale.Tr "repo.clone_helper" "http://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository"}}</small></h3>
 
 							<div class="repo-button-row">
 								{{if and .CanWriteCode (not .Repository.IsArchived)}}


### PR DESCRIPTION
fix the dead link `https://git-scm.com/book/en/Git-Basics-Getting-a-Git-Repository` for empty repositories to help how to clone the repository
to `https://git-scm.com/book/en/v2/Git-Basics-Getting-a-Git-Repository` which is v2 of the git book 

also update download git links 
