### PR TITLE
Fix incorrect "Target branch does not exist" in PR title

### DIFF
--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -166,7 +166,7 @@ func setMergeTarget(ctx *context.Context, pull *issues_model.PullRequest) {
 	ctx.Data["BaseTarget"] = pull.BaseBranch
 	headBranchLink := ""
 	if pull.Flow == issues_model.PullRequestFlowGithub {
-		b, err := git_model.GetBranch(ctx, ctx.Repo.Repository.ID, pull.HeadBranch)
+		b, err := git_model.GetBranch(ctx, pull.HeadRepoID, pull.HeadBranch)
 		switch {
 		case err == nil:
 			if !b.IsDeleted {


### PR DESCRIPTION
This issue may be caused by #32000

"Target branch does not exist" is always displayed when the head branch is form a forked repo

![image](https://github.com/user-attachments/assets/5b64d787-3742-4b36-bfe7-348ecb453ff8)
