### PR TITLE
Fix commit status will not be updated if the schedule job is canceled manually

### DIFF
--- a/services/actions/commit_status.go
+++ b/services/actions/commit_status.go
@@ -70,7 +70,7 @@ func createCommitStatus(ctx context.Context, job *actions_model.ActionRunJob) er
 			return fmt.Errorf("head of pull request is missing in event payload")
 		}
 		sha = payload.PullRequest.Head.Sha
-	case webhook_module.HookEventRelease:
+	case webhook_module.HookEventRelease, webhook_module.HookEventSchedule:
 		event = string(run.Event)
 		sha = run.CommitSHA
 	default:


### PR DESCRIPTION
Fix #32228
Actually, this can only be partly fixed, as there's another problem #31699