### PR TITLE
make `show stats` work when only one file changed

### DIFF
--- a/web_src/js/features/repo-diff-filetree.ts
+++ b/web_src/js/features/repo-diff-filetree.ts
@@ -8,7 +8,9 @@ export function initDiffFileTree() {
 
   const fileTreeView = createApp(DiffFileTree);
   fileTreeView.mount(el);
+}
 
+export function initDiffFileList() {
   const fileListElement = document.querySelector('#diff-file-list');
   if (!fileListElement) return;
 

--- a/web_src/js/features/repo-diff.ts
+++ b/web_src/js/features/repo-diff.ts
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import {initCompReactionSelector} from './comp/ReactionSelector.ts';
 import {initRepoIssueContentHistory} from './repo-issue-content.ts';
-import {initDiffFileTree} from './repo-diff-filetree.ts';
+import {initDiffFileTree, initDiffFileList} from './repo-diff-filetree.ts';
 import {initDiffCommitSelect} from './repo-diff-commitselect.ts';
 import {validateTextareaNonEmpty} from './comp/ComboMarkdownEditor.ts';
 import {initViewedCheckboxListenerFor, countAndUpdateViewedFiles, initExpandAndCollapseFilesButton} from './pull-view-file.ts';
@@ -216,6 +216,7 @@ export function initRepoDiffView() {
   initRepoDiffConversationForm();
   if (!$('#diff-file-list').length) return;
   initDiffFileTree();
+  initDiffFileList();
   initDiffCommitSelect();
   initRepoDiffShowMore();
   initRepoDiffReviewButton();


### PR DESCRIPTION
fix https://github.com/go-gitea/gitea/issues/32226

in https://github.com/go-gitea/gitea/pull/27775 , it do some changes to only show diff file tree when more than one file changed. But looks it also break the `diff-file-list` logic, which looks not expected change. so try fix it.

/cc @silverwind 

example view:
![image](https://github.com/user-attachments/assets/281e9c4f-a269-4d36-94eb-a132058aea87)
