### PR TITLE
make `show stats` work when only one file changed (#32244)

### DIFF
--- a/web_src/js/features/repo-diff-filetree.js
+++ b/web_src/js/features/repo-diff-filetree.js
@@ -8,7 +8,9 @@ export function initDiffFileTree() {
 
   const fileTreeView = createApp(DiffFileTree);
   fileTreeView.mount(el);
+}
 
+export function initDiffFileList() {
   const fileListElement = document.getElementById('diff-file-list');
   if (!fileListElement) return;
 

--- a/web_src/js/features/repo-diff.js
+++ b/web_src/js/features/repo-diff.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import {initCompReactionSelector} from './comp/ReactionSelector.js';
 import {initRepoIssueContentHistory} from './repo-issue-content.js';
-import {initDiffFileTree} from './repo-diff-filetree.js';
+import {initDiffFileTree, initDiffFileList} from './repo-diff-filetree.js';
 import {initDiffCommitSelect} from './repo-diff-commitselect.js';
 import {validateTextareaNonEmpty} from './comp/ComboMarkdownEditor.js';
 import {initViewedCheckboxListenerFor, countAndUpdateViewedFiles, initExpandAndCollapseFilesButton} from './pull-view-file.js';
@@ -220,6 +220,7 @@ export function initRepoDiffView() {
   initRepoDiffConversationForm();
   if (!$('#diff-file-list').length) return;
   initDiffFileTree();
+  initDiffFileList();
   initDiffCommitSelect();
   initRepoDiffShowMore();
   initRepoDiffReviewButton();


### PR DESCRIPTION
Backport #32244

fix https://github.com/go-gitea/gitea/issues/32226

in https://github.com/go-gitea/gitea/pull/27775 , it do some changes to only show diff file tree when more than one file changed. But looks it also break the `diff-file-list` logic, which looks not expected change. so try fix it.

/cc @silverwind

example view:

![image](https://github.com/user-attachments/assets/281e9c4f-a269-4d36-94eb-a132058aea87)

