### PR TITLE
Fix null errors on conversation holder (#32258) (#32266)

### DIFF
--- a/web_src/js/features/repo-issue.js
+++ b/web_src/js/features/repo-issue.js
@@ -188,14 +188,17 @@ export function initRepoIssueCommentDelete() {
           const path = conversationHolder.getAttribute('data-path');
           const side = conversationHolder.getAttribute('data-side');
           const idx = conversationHolder.getAttribute('data-idx');
-          const lineType = conversationHolder.closest('tr').getAttribute('data-line-type');
+          const lineType = conversationHolder.closest('tr')?.getAttribute('data-line-type');
 
-          if (lineType === 'same') {
-            document.querySelector(`[data-path="${path}"] .add-code-comment[data-idx="${idx}"]`).classList.remove('tw-invisible');
-          } else {
-            document.querySelector(`[data-path="${path}"] .add-code-comment[data-side="${side}"][data-idx="${idx}"]`).classList.remove('tw-invisible');
+          // the conversation holder could appear either on the "Conversation" page, or the "Files Changed" page
+          // on the Conversation page, there is no parent "tr", so no need to do anything for "add-code-comment"
+          if (lineType) {
+            if (lineType === 'same') {
+              document.querySelector(`[data-path="${path}"] .add-code-comment[data-idx="${idx}"]`).classList.remove('tw-invisible');
+            } else {
+              document.querySelector(`[data-path="${path}"] .add-code-comment[data-side="${side}"][data-idx="${idx}"]`).classList.remove('tw-invisible');
+            }
           }
-
           conversationHolder.remove();
         }
 


### PR DESCRIPTION
Backport #32266

fix #32258

Errors in the issue was due to unhandled null check. so i fixed it.

### Detailed description for Issue & Fix
To reproduce that issue, the comment must be deleted on Conversation tab.
#### Before Delete
<img width="1032" alt="image"
src="https://github.com/user-attachments/assets/72df61ba-7db6-44c9-bebc-ca1178dd27f1">

#### After Delete (AS-IS)
<img width="1010" alt="image"
src="https://github.com/user-attachments/assets/36fa537e-4f8e-4535-8d02-e538c50f0dd8">

gitea already have remove logic for `timeline-item-group`, but because of null ref exception the later logic that removes `timeline-item-group` could be not be called correctly.
