### PR TITLE
Fix typo in Dutch locale file: change "Vertlaat" to "Verlaat".

### DIFF
--- a/options/locale/locale_nl-NL.ini
+++ b/options/locale/locale_nl-NL.ini
@@ -2030,7 +2030,7 @@ members.invite_desc=Voeg nieuw lid toe aan %s:
 members.invite_now=Nu uitnodigen
 
 teams.join=Lid worden
-teams.leave=Vertlaat
+teams.leave=Verlaat
 teams.can_create_org_repo=Maak repositories
 teams.can_create_org_repo_helper=Leden kunnen nieuwe repositories aanmaken in de organisatie. De maker krijgt beheerder toegang tot de nieuwe repository.
 teams.read_access=Gelezen


### PR DESCRIPTION
A simple PR to solve a typo in the Dutch locale file (`locale_nl-NL.ini`)
