### PR TITLE
Fix users with code unit access permission only can not access contributors page

### DIFF
--- a/routers/web/repo/activity.go
+++ b/routers/web/repo/activity.go
@@ -22,6 +22,11 @@ func Activity(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("repo.activity")
 	ctx.Data["PageIsActivity"] = true
 
+	if !ctx.Repo.CanReadAny(unit.TypePullRequests, unit.TypeIssues, unit.TypeReleases) {
+		ctx.Redirect(ctx.Repo.RepoLink + "/activity/contributors")
+		return
+	}
+
 	ctx.Data["PageIsPulse"] = true
 
 	ctx.Data["Period"] = ctx.PathParam("period")

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1456,7 +1456,7 @@ func registerRoutes(m *web.Router) {
 			m.Get("/data", repo.RecentCommitsData)
 		}, reqRepoCodeReader)
 	},
-		ignSignIn, context.RepoAssignment, context.RequireRepoReaderOr(unit.TypePullRequests, unit.TypeIssues, unit.TypeReleases),
+		ignSignIn, context.RepoAssignment, context.RequireRepoReaderOr(unit.TypePullRequests, unit.TypeIssues, unit.TypeReleases, unit.TypeCode),
 		context.RepoRef(), repo.MustBeNotEmpty,
 	)
 	// end "/{username}/{reponame}/activity"

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1446,7 +1446,7 @@ func registerRoutes(m *web.Router) {
 		m.Group("/contributors", func() {
 			m.Get("", repo.Contributors)
 			m.Get("/data", repo.ContributorsData)
-		}, reqRepoCodeReader)
+		})
 		m.Group("/code-frequency", func() {
 			m.Get("", repo.CodeFrequency)
 			m.Get("/data", repo.CodeFrequencyData)

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1446,15 +1446,15 @@ func registerRoutes(m *web.Router) {
 		m.Group("/contributors", func() {
 			m.Get("", repo.Contributors)
 			m.Get("/data", repo.ContributorsData)
-		})
+		}, reqRepoCodeReader)
 		m.Group("/code-frequency", func() {
 			m.Get("", repo.CodeFrequency)
 			m.Get("/data", repo.CodeFrequencyData)
-		})
+		}, reqRepoCodeReader)
 		m.Group("/recent-commits", func() {
 			m.Get("", repo.RecentCommits)
 			m.Get("/data", repo.RecentCommitsData)
-		})
+		}, reqRepoCodeReader)
 	},
 		ignSignIn, context.RepoAssignment, context.RequireRepoReaderOr(unit.TypePullRequests, unit.TypeIssues, unit.TypeReleases),
 		context.RepoRef(), repo.MustBeNotEmpty,

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -208,7 +208,7 @@
 						</a>
 					{{end}}
 
-					{{if and (.Permission.CanReadAny ctx.Consts.RepoUnitTypePullRequests ctx.Consts.RepoUnitTypeIssues ctx.Consts.RepoUnitTypeReleases) (not .IsEmptyRepo)}}
+					{{if and (.Permission.CanReadAny ctx.Consts.RepoUnitTypePullRequests ctx.Consts.RepoUnitTypeIssues ctx.Consts.RepoUnitTypeReleases ctx.Consts.RepoUnitTypeCode) (not .IsEmptyRepo)}}
 						<a class="{{if .PageIsActivity}}active {{end}}item" href="{{.RepoLink}}/activity">
 							{{svg "octicon-pulse"}} {{ctx.Locale.Tr "repo.activity"}}
 						</a>

--- a/templates/repo/navbar.tmpl
+++ b/templates/repo/navbar.tmpl
@@ -1,7 +1,9 @@
 <div class="ui fluid vertical menu">
+	{{if (or (.Permission.CanRead ctx.Consts.RepoUnitTypeIssues) (.Permission.CanRead ctx.Consts.RepoUnitTypePullRequests))}}
 	<a class="{{if .PageIsPulse}}active {{end}}item" href="{{.RepoLink}}/activity">
 		{{ctx.Locale.Tr "repo.activity.navbar.pulse"}}
 	</a>
+	{{end}}
 	{{if .Permission.CanRead ctx.Consts.RepoUnitTypeCode}}
 	<a class="{{if .PageIsContributors}}active {{end}}item" href="{{.RepoLink}}/activity/contributors">
 		{{ctx.Locale.Tr "repo.activity.navbar.contributors"}}

--- a/templates/repo/navbar.tmpl
+++ b/templates/repo/navbar.tmpl
@@ -2,6 +2,7 @@
 	<a class="{{if .PageIsPulse}}active {{end}}item" href="{{.RepoLink}}/activity">
 		{{ctx.Locale.Tr "repo.activity.navbar.pulse"}}
 	</a>
+	{{if .Permission.CanRead ctx.Consts.RepoUnitTypeCode}}
 	<a class="{{if .PageIsContributors}}active {{end}}item" href="{{.RepoLink}}/activity/contributors">
 		{{ctx.Locale.Tr "repo.activity.navbar.contributors"}}
 	</a>
@@ -11,4 +12,5 @@
 	<a class="{{if .PageIsRecentCommits}}active{{end}} item" href="{{.RepoLink}}/activity/recent-commits">
 		{{ctx.Locale.Tr "repo.activity.navbar.recent_commits"}}
 	</a>
+	{{end}}
 </div>


### PR DESCRIPTION
As we added contributor page in activity, the permission check isn't update correctly.
We should show activity unit when user only have code read permission, for the contributor page, but it is impossible now.

Case 1: code unit no access, pr unit has access 
Before: (Empty page)
![image](https://github.com/user-attachments/assets/562045d4-6dd9-4e05-97bd-cad99688f1c4)

After:
![image](https://github.com/user-attachments/assets/ae82ffda-f59e-4cf3-8c0e-2c4a3ec20d35)

Case 2: code unit has access, pr unit has no access
Before: You can not see `Activity` tab
After: (redirect to contributors page)
![image](https://github.com/user-attachments/assets/bed3d83e-236f-42e8-b92c-1b474cc448b1)

