### PR TITLE
Add new [lfs_client].BATCH_SIZE and [server].LFS_MAX_BATCH_SIZE config settings.

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -324,6 +324,10 @@ RUN_USER = ; git
 ;; Maximum number of locks returned per page
 ;LFS_LOCKS_PAGING_NUM = 50
 ;;
+;; When clients make lfs batch requests, reject them if there are more pointers than this number
+;; zero means 'unlimited'
+;LFS_MAX_BATCH_SIZE = 0
+;;
 ;; Allow graceful restarts using SIGHUP to fork
 ;ALLOW_GRACEFUL_RESTARTS = true
 ;;
@@ -2637,6 +2641,10 @@ LEVEL = Info
 ;;
 ;; override the azure blob base path if storage type is azureblob
 ;AZURE_BLOB_BASE_PATH = lfs/
+
+;[lfs_client]
+;; When mirroring an upstream lfs endpoint, limit the number of pointers in each batch request to this number
+;BATCH_SIZE = 20
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/modules/lfs/http_client.go
+++ b/modules/lfs/http_client.go
@@ -16,9 +16,8 @@ import (
 	"code.gitea.io/gitea/modules/json"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/proxy"
+	"code.gitea.io/gitea/modules/setting"
 )
-
-const httpBatchSize = 20
 
 // HTTPClient is used to communicate with the LFS server
 // https://github.com/git-lfs/git-lfs/blob/main/docs/api/batch.md
@@ -30,7 +29,7 @@ type HTTPClient struct {
 
 // BatchSize returns the preferred size of batchs to process
 func (c *HTTPClient) BatchSize() int {
-	return httpBatchSize
+	return setting.LFSClient.BatchSize
 }
 
 func newHTTPClient(endpoint *url.URL, httpTransport *http.Transport) *HTTPClient {

--- a/modules/setting/lfs.go
+++ b/modules/setting/lfs.go
@@ -10,12 +10,10 @@ import (
 	"code.gitea.io/gitea/modules/generate"
 )
 
-const (
-	LFSConfigSectionServer = "server"
-	LFSConfigSectionClient = "lfs_client"
-)
-
-// LFS represents the legacy configuration for Git LFS, to be migrated to LFSServer
+// LFS represents the server-side configuration for Git LFS.
+// Ideally these options should be in a section like "[lfs_server]",
+// but they are in "[server]" section due to historical reasons.
+// Could be refactored in the future while keeping backwards compatibility.
 var LFS = struct {
 	StartServer    bool          `ini:"LFS_START_SERVER"`
 	AllowPureSSH   bool          `ini:"LFS_ALLOW_PURE_SSH"`
@@ -28,16 +26,16 @@ var LFS = struct {
 	Storage *Storage
 }{}
 
-// LFSClient represents configuration for mirroring upstream Git LFS
+// LFSClient represents configuration for Gitea's LFS clients, for example: mirroring upstream Git LFS
 var LFSClient = struct {
 	BatchSize int `ini:"BATCH_SIZE"`
 }{}
 
 func loadLFSFrom(rootCfg ConfigProvider) error {
-	mustMapSetting(rootCfg, LFSConfigSectionClient, &LFSClient)
-	mustMapSetting(rootCfg, LFSConfigSectionServer, &LFS)
+	mustMapSetting(rootCfg, "lfs_client", &LFSClient)
 
-	sec := rootCfg.Section(LFSConfigSectionServer)
+	mustMapSetting(rootCfg, "server", &LFS)
+	sec := rootCfg.Section("server")
 
 	lfsSec, _ := rootCfg.GetSection("lfs")
 

--- a/modules/setting/lfs_test.go
+++ b/modules/setting/lfs_test.go
@@ -99,3 +99,19 @@ STORAGE_TYPE = minio
 	assert.EqualValues(t, "gitea", LFS.Storage.MinioConfig.Bucket)
 	assert.EqualValues(t, "lfs/", LFS.Storage.MinioConfig.BasePath)
 }
+
+func Test_LFSClientServerConfigs(t *testing.T) {
+	iniStr := `
+[server]
+LFS_MAX_BATCH_SIZE = 100
+[lfs_client]
+# will default to 20
+BATCH_SIZE = 0
+`
+	cfg, err := NewConfigProviderFromData(iniStr)
+	assert.NoError(t, err)
+
+	assert.NoError(t, loadLFSFrom(cfg))
+	assert.EqualValues(t, 100, LFS.MaxBatchSize)
+	assert.EqualValues(t, 20, LFSClient.BatchSize)
+}

--- a/services/lfs/server.go
+++ b/services/lfs/server.go
@@ -179,6 +179,11 @@ func BatchHandler(ctx *context.Context) {
 		return
 	}
 
+	if setting.LFS.MaxBatchSize != 0 && len(br.Objects) > setting.LFS.MaxBatchSize {
+		writeStatus(ctx, http.StatusRequestEntityTooLarge)
+		return
+	}
+
 	contentStore := lfs_module.NewContentStore()
 
 	var responseObjects []*lfs_module.ObjectResponse


### PR DESCRIPTION
This contains two backwards-compatible changes:
    * in the lfs http_client, the number of lfs oids requested per batch is loaded from lfs_client#BATCH_SIZE and defaulted to the previous value of 20
    * in the lfs server/service, the max number of lfs oids allowed in a batch api request is loaded from server#LFS_MAX_BATCH_SIZE and defaults to 'nil' which equates to the previous behavior of 'infinite'

This fixes #32306