### PR TITLE
Fix broken image when editing comment with non-image attachments (#32319)

### DIFF
--- a/web_src/js/features/repo-issue-edit.js
+++ b/web_src/js/features/repo-issue-edit.js
@@ -87,10 +87,10 @@ async function onEditContent(event) {
               dz.emit('addedfile', attachment);
               if (isImageFile(attachment.name)) {
                 dz.emit('thumbnail', attachment, imgSrc);
+                dropzone.querySelector(`img[src='${imgSrc}']`).style.maxWidth = '100%';
               }
               dz.emit('complete', attachment);
               fileUuidDict[attachment.uuid] = {submitted: true};
-              dropzone.querySelector(`img[src='${imgSrc}']`).style.maxWidth = '100%';
               const input = document.createElement('input');
               input.id = attachment.uuid;
               input.name = 'files';

--- a/web_src/js/features/repo-issue-edit.js
+++ b/web_src/js/features/repo-issue-edit.js
@@ -4,6 +4,7 @@ import {getComboMarkdownEditor, initComboMarkdownEditor} from './comp/ComboMarkd
 import {createDropzone} from './dropzone.js';
 import {GET, POST} from '../modules/fetch.js';
 import {hideElem, showElem} from '../utils/dom.js';
+import {isImageFile} from '../utils/image.js';
 import {attachRefIssueContextPopup} from './contextpopup.js';
 import {initCommentContent, initMarkupContent} from '../markup/content.js';
 
@@ -84,7 +85,9 @@ async function onEditContent(event) {
             for (const attachment of data) {
               const imgSrc = `${dropzone.getAttribute('data-link-url')}/${attachment.uuid}`;
               dz.emit('addedfile', attachment);
-              dz.emit('thumbnail', attachment, imgSrc);
+              if (isImageFile(attachment.name)) {
+                dz.emit('thumbnail', attachment, imgSrc);
+              }
               dz.emit('complete', attachment);
               fileUuidDict[attachment.uuid] = {submitted: true};
               dropzone.querySelector(`img[src='${imgSrc}']`).style.maxWidth = '100%';

--- a/web_src/js/utils/image.js
+++ b/web_src/js/utils/image.js
@@ -45,3 +45,7 @@ export async function imageInfo(blob) {
 
   return {width, dppx};
 }
+
+export function isImageFile(name) {
+  return /\.(jpe?g|png|gif|webp|svg|heic)$/i.test(name);
+}


### PR DESCRIPTION
Backport #32319 

Fix #32316
