### PR TITLE
refactor: remove redundant err declarations

### DIFF
--- a/build/generate-emoji.go
+++ b/build/generate-emoji.go
@@ -53,8 +53,6 @@ func (e Emoji) MarshalJSON() ([]byte, error) {
 }
 
 func main() {
-	var err error
-
 	flag.Parse()
 
 	// generate data
@@ -83,8 +81,6 @@ var replacer = strings.NewReplacer(
 var emojiRE = regexp.MustCompile(`\{Emoji:"([^"]*)"`)
 
 func generate() ([]byte, error) {
-	var err error
-
 	// load gemoji data
 	res, err := http.Get(gemojiURL)
 	if err != nil {

--- a/models/git/lfs.go
+++ b/models/git/lfs.go
@@ -136,8 +136,6 @@ var ErrLFSObjectNotExist = db.ErrNotExist{Resource: "LFS Meta object"}
 // NewLFSMetaObject stores a given populated LFSMetaObject structure in the database
 // if it is not already present.
 func NewLFSMetaObject(ctx context.Context, repoID int64, p lfs.Pointer) (*LFSMetaObject, error) {
-	var err error
-
 	ctx, committer, err := db.TxContext(ctx)
 	if err != nil {
 		return nil, err

--- a/models/issues/label_test.go
+++ b/models/issues/label_test.go
@@ -229,8 +229,7 @@ func TestGetLabelsByOrgID(t *testing.T) {
 	testSuccess(3, "reversealphabetically", []int64{4, 3})
 	testSuccess(3, "default", []int64{3, 4})
 
-	var err error
-	_, err = issues_model.GetLabelsByOrgID(db.DefaultContext, 0, "leastissues", db.ListOptions{})
+	_, err := issues_model.GetLabelsByOrgID(db.DefaultContext, 0, "leastissues", db.ListOptions{})
 	assert.True(t, issues_model.IsErrOrgLabelNotExist(err))
 
 	_, err = issues_model.GetLabelsByOrgID(db.DefaultContext, -1, "leastissues", db.ListOptions{})

--- a/modules/charset/charset_test.go
+++ b/modules/charset/charset_test.go
@@ -40,14 +40,12 @@ func TestMaybeRemoveBOM(t *testing.T) {
 
 func TestToUTF8(t *testing.T) {
 	resetDefaultCharsetsOrder()
-	var res string
-	var err error
 
 	// Note: golang compiler seems so behave differently depending on the current
 	// locale, so some conversions might behave differently. For that reason, we don't
 	// depend on particular conversions but in expected behaviors.
 
-	res, err = ToUTF8([]byte{0x41, 0x42, 0x43}, ConvertOpts{})
+	res, err := ToUTF8([]byte{0x41, 0x42, 0x43}, ConvertOpts{})
 	assert.NoError(t, err)
 	assert.Equal(t, "ABC", res)
 

--- a/modules/markup/markdown/goldmark.go
+++ b/modules/markup/markdown/goldmark.go
@@ -213,8 +213,7 @@ func (r *HTMLRenderer) renderIcon(w util.BufWriter, source []byte, node ast.Node
 		return ast.WalkContinue, nil
 	}
 
-	var err error
-	_, err = w.WriteString(fmt.Sprintf(`<i class="icon %s"></i>`, name))
+	_, err := w.WriteString(fmt.Sprintf(`<i class="icon %s"></i>`, name))
 	if err != nil {
 		return ast.WalkStop, err
 	}

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -202,7 +202,6 @@ func Search(ctx *context.APIContext) {
 		}
 	}
 
-	var err error
 	repos, count, err := repo_model.SearchRepository(ctx, opts)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, api.SearchError{

--- a/routers/api/v1/user/repo.go
+++ b/routers/api/v1/user/repo.go
@@ -111,7 +111,6 @@ func ListMyRepos(ctx *context.APIContext) {
 		IncludeDescription: true,
 	}
 
-	var err error
 	repos, count, err := repo_model.SearchRepository(ctx, opts)
 	if err != nil {
 		ctx.Error(http.StatusInternalServerError, "SearchRepository", err)

--- a/routers/web/repo/actions/view.go
+++ b/routers/web/repo/actions/view.go
@@ -276,7 +276,6 @@ func ViewPost(ctx *context_module.Context) {
 			if validCursor {
 				length := step.LogLength - cursor.Cursor
 				offset := task.LogIndexes[index]
-				var err error
 				logRows, err := actions.ReadLogs(ctx, task.LogInStorage, task.LogFilename, offset, length)
 				if err != nil {
 					ctx.Error(http.StatusInternalServerError, err.Error())

--- a/routers/web/repo/activity.go
+++ b/routers/web/repo/activity.go
@@ -94,7 +94,6 @@ func ActivityAuthors(ctx *context.Context) {
 		timeFrom = timeUntil.Add(-time.Hour * 168)
 	}
 
-	var err error
 	authors, err := activities_model.GetActivityStatsTopAuthors(ctx, ctx.Repo.Repository, timeFrom, 10)
 	if err != nil {
 		ctx.ServerError("GetActivityStatsTopAuthors", err)

--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -143,7 +143,6 @@ func findReadmeFileInEntries(ctx *context.Context, entries []*git.TreeEntry, try
 				// this should be impossible; if subTreeEntry exists so should this.
 				continue
 			}
-			var err error
 			childEntries, err := subTree.ListEntries()
 			if err != nil {
 				return "", nil, err

--- a/services/issue/template.go
+++ b/services/issue/template.go
@@ -52,8 +52,6 @@ func GetTemplateConfig(gitRepo *git.Repository, path string, commit *git.Commit)
 		return GetDefaultTemplateConfig(), nil
 	}
 
-	var err error
-
 	treeEntry, err := commit.GetTreeEntryByPath(path)
 	if err != nil {
 		return GetDefaultTemplateConfig(), err


### PR DESCRIPTION
The PR refactors code by removing redundant `var err error` lines.