### PR TITLE
Replace DateTime with proper functions

### DIFF
--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -54,7 +54,7 @@ func NewFuncMap() template.FuncMap {
 		"StringUtils": NewStringUtils,
 		"SliceUtils":  NewSliceUtils,
 		"JsonUtils":   NewJsonUtils,
-		"DateUtils":   NewDateUtils, // TODO: to be replaced by DateUtils
+		"DateUtils":   NewDateUtils,
 
 		// -----------------------------------------------------------------
 		// svg / avatar / icon / color
@@ -71,7 +71,7 @@ func NewFuncMap() template.FuncMap {
 		"CountFmt":      base.FormatNumberSI,
 		"TimeSince":     timeutil.TimeSince,
 		"TimeSinceUnix": timeutil.TimeSinceUnix,
-		"DateTime":      timeutil.DateTime,
+		"DateTime":      dateTimeLegacy, // for backward compatibility only, do not use it anymore
 		"Sec2Time":      util.SecToTime,
 		"LoadTimes": func(startTime time.Time) string {
 			return fmt.Sprint(time.Since(startTime).Nanoseconds()/1e6) + "ms"

--- a/modules/templates/util_date.go
+++ b/modules/templates/util_date.go
@@ -6,7 +6,9 @@ package templates
 import (
 	"context"
 	"html/template"
+	"time"
 
+	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/timeutil"
 )
 
@@ -31,4 +33,28 @@ func (du *DateUtils) AbsoluteLong(time any) template.HTML {
 // FullTime renders in "Jan 01, 2006 20:33:44" format
 func (du *DateUtils) FullTime(time any) template.HTML {
 	return timeutil.DateTime("full", time)
+}
+
+// ParseLegacy parses the datetime in legacy format, eg: "2016-01-02" in server's timezone.
+// It shouldn't be used in new code. New code should use Time or TimeStamp as much as possible.
+func (du *DateUtils) ParseLegacy(datetime string) time.Time {
+	return parseLegacy(datetime)
+}
+
+func parseLegacy(datetime string) time.Time {
+	t, err := time.Parse(time.RFC3339, datetime)
+	if err != nil {
+		t, _ = time.ParseInLocation(time.DateOnly, datetime, setting.DefaultUILocation)
+	}
+	return t
+}
+
+func dateTimeLegacy(format string, datetime any, _ ...string) template.HTML {
+	if !setting.IsProd || setting.IsInTesting {
+		panic("dateTimeLegacy is for backward compatibility only, do not use it in new code")
+	}
+	if s, ok := datetime.(string); ok {
+		datetime = parseLegacy(s)
+	}
+	return timeutil.DateTime(format, datetime)
 }

--- a/modules/timeutil/datetime.go
+++ b/modules/timeutil/datetime.go
@@ -12,9 +12,7 @@ import (
 )
 
 // DateTime renders an absolute time HTML element by datetime.
-func DateTime(format string, datetime any, extraAttrs ...string) template.HTML {
-	// TODO: remove the extraAttrs argument, it's not used in any call to DateTime
-
+func DateTime(format string, datetime any) template.HTML {
 	if p, ok := datetime.(*time.Time); ok {
 		datetime = *p
 	}
@@ -34,9 +32,6 @@ func DateTime(format string, datetime any, extraAttrs ...string) template.HTML {
 	switch v := datetime.(type) {
 	case nil:
 		return "-"
-	case string:
-		datetimeEscaped = html.EscapeString(v)
-		textEscaped = datetimeEscaped
 	case time.Time:
 		if v.IsZero() || v.Unix() == 0 {
 			return "-"
@@ -51,10 +46,7 @@ func DateTime(format string, datetime any, extraAttrs ...string) template.HTML {
 		panic(fmt.Sprintf("Unsupported time type %T", datetime))
 	}
 
-	attrs := make([]string, 0, 10+len(extraAttrs))
-	attrs = append(attrs, extraAttrs...)
-	attrs = append(attrs, `weekday=""`, `year="numeric"`)
-
+	attrs := []string{`weekday=""`, `year="numeric"`}
 	switch format {
 	case "short", "long": // date only
 		attrs = append(attrs, `month="`+format+`"`, `day="numeric"`)

--- a/templates/repo/issue/milestone_issues.tmpl
+++ b/templates/repo/issue/milestone_issues.tmpl
@@ -38,7 +38,7 @@
 						{{if .Milestone.DeadlineString}}
 							<span{{if .IsOverdue}} class="text red"{{end}}>
 								{{svg "octicon-calendar"}}
-								{{DateTime "short" .Milestone.DeadlineString}}
+								{{ctx.DateUtils.AbsoluteShort (.Milestone.DeadlineString|ctx.DateUtils.ParseLegacy)}}
 							</span>
 						{{else}}
 							{{svg "octicon-calendar"}}

--- a/templates/repo/issue/milestones.tmpl
+++ b/templates/repo/issue/milestones.tmpl
@@ -59,7 +59,7 @@
 									{{if .DeadlineString}}
 										<span class="flex-text-inline {{if .IsOverdue}}text red{{end}}">
 											{{svg "octicon-calendar" 14}}
-											{{DateTime "short" .DeadlineString}}
+											{{ctx.DateUtils.AbsoluteShort (.DeadlineString|ctx.DateUtils.ParseLegacy)}}
 										</span>
 									{{else}}
 										{{svg "octicon-calendar" 14}}

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -296,7 +296,8 @@
 				{{template "shared/user/avatarlink" dict "user" .Poster}}
 				<span class="text grey muted-links">
 					{{template "shared/user/authorlink" .Poster}}
-					{{ctx.Locale.Tr "repo.issues.due_date_added" (DateTime "long" .Content) $createdStr}}
+					{{$dueDate := ctx.DateUtils.AbsoluteLong (.Content|ctx.DateUtils.ParseLegacy)}}
+					{{ctx.Locale.Tr "repo.issues.due_date_added" $dueDate $createdStr}}
 				</span>
 			</div>
 		{{else if eq .Type 17}}
@@ -307,8 +308,8 @@
 					{{template "shared/user/authorlink" .Poster}}
 					{{$parsedDeadline := StringUtils.Split .Content "|"}}
 					{{if eq (len $parsedDeadline) 2}}
-						{{$from := DateTime "long" (index $parsedDeadline 1)}}
-						{{$to := DateTime "long" (index $parsedDeadline 0)}}
+						{{$to := ctx.DateUtils.AbsoluteLong ((index $parsedDeadline 0)|ctx.DateUtils.ParseLegacy)}}
+						{{$from := ctx.DateUtils.AbsoluteLong ((index $parsedDeadline 1)|ctx.DateUtils.ParseLegacy)}}
 						{{ctx.Locale.Tr "repo.issues.due_date_modified" $to $from $createdStr}}
 					{{end}}
 				</span>
@@ -319,7 +320,8 @@
 				{{template "shared/user/avatarlink" dict "user" .Poster}}
 				<span class="text grey muted-links">
 					{{template "shared/user/authorlink" .Poster}}
-					{{ctx.Locale.Tr "repo.issues.due_date_remove" (DateTime "long" .Content) $createdStr}}
+					{{$dueDate := ctx.DateUtils.AbsoluteLong (.Content|ctx.DateUtils.ParseLegacy)}}
+					{{ctx.Locale.Tr "repo.issues.due_date_remove" $dueDate $createdStr}}
 				</span>
 			</div>
 		{{else if eq .Type 19}}

--- a/templates/user/dashboard/milestones.tmpl
+++ b/templates/user/dashboard/milestones.tmpl
@@ -116,7 +116,7 @@
 											{{if .DeadlineString}}
 												<span{{if .IsOverdue}} class="text red"{{end}}>
 													{{svg "octicon-calendar" 14}}
-													{{DateTime "short" .DeadlineString}}
+													{{ctx.DateUtils.AbsoluteShort (.DeadlineString|ctx.DateUtils.ParseLegacy)}}
 												</span>
 											{{else}}
 												{{svg "octicon-calendar" 14}}


### PR DESCRIPTION
Follow #32383

This PR cleans up the "Deadline" usages in templates, make them call `ParseLegacy` first to get a `Time` struct then display by `DateUtils`.

Now it should be pretty clear how "deadline string" works, it makes it possible to do further refactoring and correcting.

![image](https://github.com/user-attachments/assets/6f60f783-2530-495c-a3a6-b5b69986f58e)

![image](https://github.com/user-attachments/assets/6f845432-e827-4351-ab95-c5f1f9483d09)
