### PR TITLE
feat: badge support tag

### DIFF
--- a/models/actions/run.go
+++ b/models/actions/run.go
@@ -374,10 +374,10 @@ func GetLatestRun(ctx context.Context, repoID int64) (*ActionRun, error) {
 	return run, nil
 }
 
-func GetWorkflowLatestRun(ctx context.Context, repoID int64, workflowFile, branch, event string) (*ActionRun, error) {
+func GetWorkflowLatestRun(ctx context.Context, repoID int64, workflowFile, ref, event string) (*ActionRun, error) {
 	var run ActionRun
-	q := db.GetEngine(ctx).Where("repo_id=?", repoID).
-		And("ref = ?", branch).
+	q := db.GetEngine(ctx).Where("repo_id = ?", repoID).
+		And("ref = ?", ref).
 		And("workflow_id = ?", workflowFile)
 	if event != "" {
 		q.And("event = ?", event)
@@ -386,7 +386,7 @@ func GetWorkflowLatestRun(ctx context.Context, repoID int64, workflowFile, branc
 	if err != nil {
 		return nil, err
 	} else if !has {
-		return nil, util.NewNotExistErrorf("run with repo_id %d, ref %s, workflow_id %s", repoID, branch, workflowFile)
+		return nil, util.NewNotExistErrorf("run with repo_id %d, ref %s, workflow_id %s", repoID, ref, workflowFile)
 	}
 	return &run, nil
 }

--- a/routers/web/repo/actions/badge.go
+++ b/routers/web/repo/actions/badge.go
@@ -31,6 +31,8 @@ func GetWorkflowBadge(ctx *context.Context) {
 		}
 		if len(tags) != 0 {
 			tag = tags[0].Name
+		} else {
+			tag = "" // return empty result on no tag
 		}
 		ref = fmt.Sprintf("refs/tags/%s", tag)
 	case tag != "":


### PR DESCRIPTION
Add a `tag` parameter to the badge.svg endpoint. When `branch` is empty, it will use `tag` to search for the workflow run. This is useful for badges for release.

e.g. https://example.com/org/repo/actions/workflows/release.yaml/badge.svg?tag=h4&event=release