### PR TITLE
Refactor LFS SSH and internal routers

### DIFF
--- a/cmd/serv.go
+++ b/cmd/serv.go
@@ -111,12 +111,10 @@ func fail(ctx context.Context, userMessage, logMsgFmt string, args ...any) error
 		if !setting.IsProd {
 			_, _ = fmt.Fprintln(os.Stderr, "Gitea:", logMsg)
 		}
-		if userMessage != "" {
-			if unicode.IsPunct(rune(userMessage[len(userMessage)-1])) {
-				logMsg = userMessage + " " + logMsg
-			} else {
-				logMsg = userMessage + ". " + logMsg
-			}
+		if unicode.IsPunct(rune(userMessage[len(userMessage)-1])) {
+			logMsg = userMessage + " " + logMsg
+		} else {
+			logMsg = userMessage + ". " + logMsg
 		}
 		_ = private.SSHLog(ctx, true, logMsg)
 	}
@@ -288,10 +286,10 @@ func runServ(c *cli.Context) error {
 	if allowedCommands.Contains(verb) {
 		if allowedCommandsLfs.Contains(verb) {
 			if !setting.LFS.StartServer {
-				return fail(ctx, "Unknown git command", "LFS authentication request over SSH denied, LFS support is disabled")
+				return fail(ctx, "LFS Server is not enabled", "")
 			}
 			if verb == verbLfsTransfer && !setting.LFS.AllowPureSSH {
-				return fail(ctx, "Unknown git command", "LFS SSH transfer connection denied, pure SSH protocol is disabled")
+				return fail(ctx, "LFS SSH transfer is not enabled", "")
 			}
 			if len(words) > 2 {
 				lfsVerb = words[2]

--- a/models/fixtures/lfs_meta_object.yml
+++ b/models/fixtures/lfs_meta_object.yml
@@ -1,4 +1,11 @@
 # These are the LFS objects in user2/lfs.git
+# user2/lfs is an INVALID repository
+#
+#  commit e9c32647bab825977942598c0efa415de300304b (HEAD -> master)
+#  Author: Rowan Bohde <rowan.bohde@gmail.com>
+#  Date:   Thu Aug 1 14:38:23 2024 -0500
+#
+#      add invalid lfs file
 -
 
   id: 1
@@ -11,7 +18,7 @@
 
   id: 2
   oid: 2eccdb43825d2a49d99d542daa20075cff1d97d9d2349a8977efe9c03661737c
-  size: 107
+  size: 107 # real size is 2048
   repository_id: 54
   created_unix: 1671607299
 
@@ -30,3 +37,12 @@
   size: 25
   repository_id: 54
   created_unix: 1671607299
+
+# this file is missing
+# -
+#
+#   id: 5
+#   oid: 9d178b5f15046343fd32f451df93acc2bdd9e6373be478b968e4cad6b6647351
+#   size: 25
+#   repository_id: 54
+#   created_unix: 1671607299

--- a/models/migrations/v1_21/v276.go
+++ b/models/migrations/v1_21/v276.go
@@ -12,6 +12,7 @@ import (
 	"code.gitea.io/gitea/modules/git"
 	giturl "code.gitea.io/gitea/modules/git/url"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/util"
 
 	"xorm.io/xorm"
 )
@@ -163,7 +164,9 @@ func migratePushMirrors(x *xorm.Engine) error {
 
 func getRemoteAddress(ownerName, repoName, remoteName string) (string, error) {
 	repoPath := filepath.Join(setting.RepoRootPath, strings.ToLower(ownerName), strings.ToLower(repoName)+".git")
-
+	if exist, _ := util.IsExist(repoPath); !exist {
+		return "", nil
+	}
 	remoteURL, err := git.GetRemoteAddress(context.Background(), repoPath, remoteName)
 	if err != nil {
 		return "", fmt.Errorf("get remote %s's address of %s/%s failed: %v", remoteName, ownerName, repoName, err)

--- a/modules/git/batch_reader.go
+++ b/modules/git/batch_reader.go
@@ -146,9 +146,8 @@ func catFileBatch(ctx context.Context, repoPath string) (WriteCloserError, *bufi
 }
 
 // ReadBatchLine reads the header line from cat-file --batch
-// We expect:
-// <sha> SP <type> SP <size> LF
-// sha is a hex encoded here
+// We expect: <oid> SP <type> SP <size> LF
+// then leaving the rest of the stream "<contents> LF" to be read
 func ReadBatchLine(rd *bufio.Reader) (sha []byte, typ string, size int64, err error) {
 	typ, err = rd.ReadString('\n')
 	if err != nil {

--- a/modules/lfstransfer/backend/lock.go
+++ b/modules/lfstransfer/backend/lock.go
@@ -21,17 +21,17 @@ import (
 var _ transfer.LockBackend = &giteaLockBackend{}
 
 type giteaLockBackend struct {
-	ctx    context.Context
-	g      *GiteaBackend
-	server *url.URL
-	token  string
-	itoken string
-	logger transfer.Logger
+	ctx          context.Context
+	g            *GiteaBackend
+	server       *url.URL
+	authToken    string
+	internalAuth string
+	logger       transfer.Logger
 }
 
 func newGiteaLockBackend(g *GiteaBackend) transfer.LockBackend {
 	server := g.server.JoinPath("locks")
-	return &giteaLockBackend{ctx: g.ctx, g: g, server: server, token: g.token, itoken: g.itoken, logger: g.logger}
+	return &giteaLockBackend{ctx: g.ctx, g: g, server: server, authToken: g.authToken, internalAuth: g.internalAuth, logger: g.logger}
 }
 
 // Create implements transfer.LockBackend
@@ -45,10 +45,10 @@ func (g *giteaLockBackend) Create(path, refname string) (transfer.Lock, error) {
 	}
 	url := g.server.String()
 	headers := map[string]string{
-		headerAuthorisation: g.itoken,
-		headerAuthX:         g.token,
-		headerAccept:        mimeGitLFS,
-		headerContentType:   mimeGitLFS,
+		headerAuthorization:     g.authToken,
+		headerGiteaInternalAuth: g.internalAuth,
+		headerAccept:            mimeGitLFS,
+		headerContentType:       mimeGitLFS,
 	}
 	req := newInternalRequest(g.ctx, url, http.MethodPost, headers, bodyBytes)
 	resp, err := req.Response()
@@ -97,10 +97,10 @@ func (g *giteaLockBackend) Unlock(lock transfer.Lock) error {
 	}
 	url := g.server.JoinPath(lock.ID(), "unlock").String()
 	headers := map[string]string{
-		headerAuthorisation: g.itoken,
-		headerAuthX:         g.token,
-		headerAccept:        mimeGitLFS,
-		headerContentType:   mimeGitLFS,
+		headerAuthorization:     g.authToken,
+		headerGiteaInternalAuth: g.internalAuth,
+		headerAccept:            mimeGitLFS,
+		headerContentType:       mimeGitLFS,
 	}
 	req := newInternalRequest(g.ctx, url, http.MethodPost, headers, bodyBytes)
 	resp, err := req.Response()
@@ -180,10 +180,10 @@ func (g *giteaLockBackend) queryLocks(v url.Values) ([]transfer.Lock, string, er
 	urlq.RawQuery = v.Encode()
 	url := urlq.String()
 	headers := map[string]string{
-		headerAuthorisation: g.itoken,
-		headerAuthX:         g.token,
-		headerAccept:        mimeGitLFS,
-		headerContentType:   mimeGitLFS,
+		headerAuthorization:     g.authToken,
+		headerGiteaInternalAuth: g.internalAuth,
+		headerAccept:            mimeGitLFS,
+		headerContentType:       mimeGitLFS,
 	}
 	req := newInternalRequest(g.ctx, url, http.MethodGet, headers, nil)
 	resp, err := req.Response()

--- a/modules/lfstransfer/backend/util.go
+++ b/modules/lfstransfer/backend/util.go
@@ -20,11 +20,11 @@ import (
 
 // HTTP headers
 const (
-	headerAccept        = "Accept"
-	headerAuthorisation = "Authorization"
-	headerAuthX         = "X-Auth"
-	headerContentType   = "Content-Type"
-	headerContentLength = "Content-Length"
+	headerAccept            = "Accept"
+	headerAuthorization     = "Authorization"
+	headerGiteaInternalAuth = "X-Gitea-Internal-Auth"
+	headerContentType       = "Content-Type"
+	headerContentLength     = "Content-Length"
 )
 
 // MIME types

--- a/modules/private/internal.go
+++ b/modules/private/internal.go
@@ -43,7 +43,7 @@ Ensure you are running in the correct environment or set the correct configurati
 	req := httplib.NewRequest(url, method).
 		SetContext(ctx).
 		Header("X-Real-IP", getClientIP()).
-		Header("Authorization", fmt.Sprintf("Bearer %s", setting.InternalToken)).
+		Header("X-Gitea-Internal-Auth", fmt.Sprintf("Bearer %s", setting.InternalToken)).
 		SetTLSClientConfig(&tls.Config{
 			InsecureSkipVerify: true,
 			ServerName:         setting.Domain,

--- a/modules/web/route.go
+++ b/modules/web/route.go
@@ -6,6 +6,7 @@ package web
 import (
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 
 	"code.gitea.io/gitea/modules/setting"
@@ -82,15 +83,23 @@ func (r *Router) getPattern(pattern string) string {
 	return strings.TrimSuffix(newPattern, "/")
 }
 
+func isNilOrFuncNil(v any) bool {
+	if v == nil {
+		return true
+	}
+	r := reflect.ValueOf(v)
+	return r.Kind() == reflect.Func && r.IsNil()
+}
+
 func (r *Router) wrapMiddlewareAndHandler(h []any) ([]func(http.Handler) http.Handler, http.HandlerFunc) {
 	handlerProviders := make([]func(http.Handler) http.Handler, 0, len(r.curMiddlewares)+len(h)+1)
 	for _, m := range r.curMiddlewares {
-		if m != nil {
+		if !isNilOrFuncNil(m) {
 			handlerProviders = append(handlerProviders, toHandlerProvider(m))
 		}
 	}
 	for _, m := range h {
-		if h != nil {
+		if !isNilOrFuncNil(m) {
 			handlerProviders = append(handlerProviders, toHandlerProvider(m))
 		}
 	}

--- a/routers/common/lfs.go
+++ b/routers/common/lfs.go
@@ -1,0 +1,29 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package common
+
+import (
+	"net/http"
+
+	"code.gitea.io/gitea/modules/web"
+	"code.gitea.io/gitea/services/lfs"
+)
+
+func AddOwnerRepoGitLFSRoutes(m *web.Router, middlewares ...any) {
+	// shared by web and internal routers
+	m.Group("/{username}/{reponame}/info/lfs", func() {
+		m.Post("/objects/batch", lfs.CheckAcceptMediaType, lfs.BatchHandler)
+		m.Put("/objects/{oid}/{size}", lfs.UploadHandler)
+		m.Get("/objects/{oid}/{filename}", lfs.DownloadHandler)
+		m.Get("/objects/{oid}", lfs.DownloadHandler)
+		m.Post("/verify", lfs.CheckAcceptMediaType, lfs.VerifyHandler)
+		m.Group("/locks", func() {
+			m.Get("/", lfs.GetListLockHandler)
+			m.Post("/", lfs.PostLockHandler)
+			m.Post("/verify", lfs.VerifyLockHandler)
+			m.Post("/{lid}/unlock", lfs.UnLockHandler)
+		}, lfs.CheckAcceptMediaType)
+		m.Any("/*", http.NotFound)
+	}, middlewares...)
+}

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -44,7 +44,6 @@ import (
 	auth_service "code.gitea.io/gitea/services/auth"
 	"code.gitea.io/gitea/services/context"
 	"code.gitea.io/gitea/services/forms"
-	"code.gitea.io/gitea/services/lfs"
 
 	_ "code.gitea.io/gitea/modules/session" // to registers all internal adapters
 
@@ -1598,23 +1597,8 @@ func registerRoutes(m *web.Router) {
 		m.Post("/action/{action}", reqSignIn, repo.Action)
 	}, ignSignIn, context.RepoAssignment, context.RepoRef())
 
+	common.AddOwnerRepoGitLFSRoutes(m, ignSignInAndCsrf, lfsServerEnabled)
 	m.Group("/{username}/{reponame}", func() {
-		m.Group("/info/lfs", func() {
-			m.Post("/objects/batch", lfs.CheckAcceptMediaType, lfs.BatchHandler)
-			m.Put("/objects/{oid}/{size}", lfs.UploadHandler)
-			m.Get("/objects/{oid}/{filename}", lfs.DownloadHandler)
-			m.Get("/objects/{oid}", lfs.DownloadHandler)
-			m.Post("/verify", lfs.CheckAcceptMediaType, lfs.VerifyHandler)
-			m.Group("/locks", func() {
-				m.Get("/", lfs.GetListLockHandler)
-				m.Post("/", lfs.PostLockHandler)
-				m.Post("/verify", lfs.VerifyLockHandler)
-				m.Post("/{lid}/unlock", lfs.UnLockHandler)
-			}, lfs.CheckAcceptMediaType)
-			m.Any("/*", func(ctx *context.Context) {
-				ctx.NotFound("", nil)
-			})
-		}, ignSignInAndCsrf, lfsServerEnabled)
 		gitHTTPRouters(m)
 	})
 	// end "/{username}/{reponame}.git": git support

--- a/tests/integration/api_repo_file_get_test.go
+++ b/tests/integration/api_repo_file_get_test.go
@@ -39,7 +39,7 @@ func TestAPIGetRawFileOrLFS(t *testing.T) {
 
 			t.Run("Partial Clone", doPartialGitClone(dstPath2, u))
 
-			lfs, _ := lfsCommitAndPushTest(t, dstPath)
+			lfs := lfsCommitAndPushTest(t, dstPath, littleSize)[0]
 
 			reqLFS := NewRequest(t, "GET", "/api/v1/repos/user2/repo1/media/"+lfs)
 			respLFS := MakeRequestNilResponseRecorder(t, reqLFS, http.StatusOK)

--- a/tests/integration/git_lfs_ssh_test.go
+++ b/tests/integration/git_lfs_ssh_test.go
@@ -1,0 +1,61 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package integration
+
+import (
+	"net/url"
+	"sync"
+	"testing"
+
+	auth_model "code.gitea.io/gitea/models/auth"
+	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/web"
+	"code.gitea.io/gitea/routers/private"
+	"code.gitea.io/gitea/services/context"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitLFSSSH(t *testing.T) {
+	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+		dstPath := t.TempDir()
+		apiTestContext := NewAPITestContext(t, "user2", "repo1", auth_model.AccessTokenScopeWriteRepository, auth_model.AccessTokenScopeWriteUser)
+
+		var mu sync.Mutex
+		var routerCalls []string
+		web.RouteMock(private.RouterMockPointInternalLFS, func(ctx *context.PrivateContext) {
+			mu.Lock()
+			routerCalls = append(routerCalls, ctx.Req.Method+" "+ctx.Req.URL.Path)
+			mu.Unlock()
+		})
+
+		withKeyFile(t, "my-testing-key", func(keyFile string) {
+			t.Run("CreateUserKey", doAPICreateUserKey(apiTestContext, "test-key", keyFile))
+			cloneURL := createSSHUrl(apiTestContext.GitPath(), u)
+			t.Run("Clone", doGitClone(dstPath, cloneURL))
+
+			cfg, err := setting.CfgProvider.PrepareSaving()
+			require.NoError(t, err)
+			cfg.Section("server").Key("LFS_ALLOW_PURE_SSH").SetValue("true")
+			setting.LFS.AllowPureSSH = true
+			require.NoError(t, cfg.Save())
+
+			// do LFS SSH transfer?
+			lfsCommitAndPushTest(t, dstPath, 10)
+		})
+
+		// FIXME: Here we only see the following calls, but actually there should be calls to "PUT"?
+		// 0 = {string} "GET /api/internal/repo/user2/repo1.git/info/lfs/locks"
+		// 1 = {string} "POST /api/internal/repo/user2/repo1.git/info/lfs/objects/batch"
+		// 2 = {string} "GET /api/internal/repo/user2/repo1.git/info/lfs/locks"
+		// 3 = {string} "POST /api/internal/repo/user2/repo1.git/info/lfs/locks"
+		// 4 = {string} "GET /api/internal/repo/user2/repo1.git/info/lfs/locks"
+		// 5 = {string} "GET /api/internal/repo/user2/repo1.git/info/lfs/locks"
+		// 6 = {string} "GET /api/internal/repo/user2/repo1.git/info/lfs/locks"
+		// 7 = {string} "POST /api/internal/repo/user2/repo1.git/info/lfs/locks/24/unlock"
+		assert.NotEmpty(t, routerCalls)
+		// assert.Contains(t, routerCalls, "PUT /api/internal/repo/user2/repo1.git/info/lfs/objects/....")
+	})
+}

--- a/tests/integration/git_misc_test.go
+++ b/tests/integration/git_misc_test.go
@@ -1,0 +1,138 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/url"
+	"sync"
+	"testing"
+
+	auth_model "code.gitea.io/gitea/models/auth"
+	"code.gitea.io/gitea/models/db"
+	issues_model "code.gitea.io/gitea/models/issues"
+	repo_model "code.gitea.io/gitea/models/repo"
+	"code.gitea.io/gitea/models/unittest"
+	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/git"
+	"code.gitea.io/gitea/modules/gitrepo"
+	files_service "code.gitea.io/gitea/services/repository/files"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDataAsyncDoubleRead_Issue29101(t *testing.T) {
+	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+		user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+		repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+
+		testContent := bytes.Repeat([]byte{'a'}, 10000)
+		resp, err := files_service.ChangeRepoFiles(db.DefaultContext, repo, user, &files_service.ChangeRepoFilesOptions{
+			Files: []*files_service.ChangeRepoFile{
+				{
+					Operation:     "create",
+					TreePath:      "test.txt",
+					ContentReader: bytes.NewReader(testContent),
+				},
+			},
+			OldBranch: repo.DefaultBranch,
+			NewBranch: repo.DefaultBranch,
+		})
+		assert.NoError(t, err)
+
+		sha := resp.Commit.SHA
+
+		gitRepo, err := gitrepo.OpenRepository(db.DefaultContext, repo)
+		assert.NoError(t, err)
+
+		commit, err := gitRepo.GetCommit(sha)
+		assert.NoError(t, err)
+
+		entry, err := commit.GetTreeEntryByPath("test.txt")
+		assert.NoError(t, err)
+
+		b := entry.Blob()
+		r1, err := b.DataAsync()
+		assert.NoError(t, err)
+		defer r1.Close()
+		r2, err := b.DataAsync()
+		assert.NoError(t, err)
+		defer r2.Close()
+
+		var data1, data2 []byte
+		wg := sync.WaitGroup{}
+		wg.Add(2)
+		go func() {
+			data1, _ = io.ReadAll(r1)
+			assert.NoError(t, err)
+			wg.Done()
+		}()
+		go func() {
+			data2, _ = io.ReadAll(r2)
+			assert.NoError(t, err)
+			wg.Done()
+		}()
+		wg.Wait()
+		assert.Equal(t, testContent, data1)
+		assert.Equal(t, testContent, data2)
+	})
+}
+
+func TestAgitPullPush(t *testing.T) {
+	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+		baseAPITestContext := NewAPITestContext(t, "user2", "repo1", auth_model.AccessTokenScopeWriteRepository, auth_model.AccessTokenScopeWriteUser)
+
+		u.Path = baseAPITestContext.GitPath()
+		u.User = url.UserPassword("user2", userPassword)
+
+		dstPath := t.TempDir()
+		doGitClone(dstPath, u)(t)
+
+		gitRepo, err := git.OpenRepository(context.Background(), dstPath)
+		assert.NoError(t, err)
+		defer gitRepo.Close()
+
+		doGitCreateBranch(dstPath, "test-agit-push")
+
+		// commit 1
+		_, err = generateCommitWithNewData(littleSize, dstPath, "user2@example.com", "User Two", "branch-data-file-")
+		assert.NoError(t, err)
+
+		// push to create an agit pull request
+		err = git.NewCommand(git.DefaultContext, "push", "origin",
+			"-o", "title=test-title", "-o", "description=test-description",
+			"HEAD:refs/for/master/test-agit-push",
+		).Run(&git.RunOpts{Dir: dstPath})
+		assert.NoError(t, err)
+
+		// check pull request exist
+		pr := unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{BaseRepoID: 1, Flow: issues_model.PullRequestFlowAGit, HeadBranch: "user2/test-agit-push"})
+		assert.NoError(t, pr.LoadIssue(db.DefaultContext))
+		assert.Equal(t, "test-title", pr.Issue.Title)
+		assert.Equal(t, "test-description", pr.Issue.Content)
+
+		// commit 2
+		_, err = generateCommitWithNewData(littleSize, dstPath, "user2@example.com", "User Two", "branch-data-file-2-")
+		assert.NoError(t, err)
+
+		// push 2
+		err = git.NewCommand(git.DefaultContext, "push", "origin", "HEAD:refs/for/master/test-agit-push").Run(&git.RunOpts{Dir: dstPath})
+		assert.NoError(t, err)
+
+		// reset to first commit
+		err = git.NewCommand(git.DefaultContext, "reset", "--hard", "HEAD~1").Run(&git.RunOpts{Dir: dstPath})
+		assert.NoError(t, err)
+
+		// test force push without confirm
+		_, stderr, err := git.NewCommand(git.DefaultContext, "push", "origin", "HEAD:refs/for/master/test-agit-push").RunStdString(&git.RunOpts{Dir: dstPath})
+		assert.Error(t, err)
+		assert.Contains(t, stderr, "[remote rejected] HEAD -> refs/for/master/test-agit-push (request `force-push` push option)")
+
+		// test force push with confirm
+		err = git.NewCommand(git.DefaultContext, "push", "origin", "HEAD:refs/for/master/test-agit-push", "-o", "force-push").Run(&git.RunOpts{Dir: dstPath})
+		assert.NoError(t, err)
+	})
+}

--- a/tests/test_utils.go
+++ b/tests/test_utils.go
@@ -9,7 +9,6 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"testing"
 
@@ -53,7 +52,7 @@ func InitTest(requireGitea bool) {
 		if setting.IsWindows {
 			giteaBinary += ".exe"
 		}
-		setting.AppPath = path.Join(giteaRoot, giteaBinary)
+		setting.AppPath = filepath.Join(giteaRoot, giteaBinary)
 		if _, err := os.Stat(setting.AppPath); err != nil {
 			exitf("Could not find gitea binary at %s", setting.AppPath)
 		}
@@ -70,7 +69,7 @@ func InitTest(requireGitea bool) {
 			exitf(`sqlite3 requires: import _ "github.com/mattn/go-sqlite3" or -tags sqlite,sqlite_unlock_notify`)
 		}
 	}
-	if !path.IsAbs(giteaConf) {
+	if !filepath.IsAbs(giteaConf) {
 		setting.CustomConf = filepath.Join(giteaRoot, giteaConf)
 	} else {
 		setting.CustomConf = giteaConf
@@ -193,8 +192,12 @@ func PrepareAttachmentsStorage(t testing.TB) {
 }
 
 func PrepareGitRepoDirectory(t testing.TB) {
+	if !assert.NotEmpty(t, setting.RepoRootPath) {
+		return
+	}
+
 	assert.NoError(t, util.RemoveAll(setting.RepoRootPath))
-	assert.NoError(t, unittest.CopyDir(path.Join(filepath.Dir(setting.AppPath), "tests/gitea-repositories-meta"), setting.RepoRootPath))
+	assert.NoError(t, unittest.CopyDir(filepath.Join(filepath.Dir(setting.AppPath), "tests/gitea-repositories-meta"), setting.RepoRootPath))
 
 	ownerDirs, err := os.ReadDir(setting.RepoRootPath)
 	if err != nil {


### PR DESCRIPTION
My Gitea instance keeps reporting a lot of errors like "LFS SSH transfer connection denied, pure SSH protocol is disabled"

When I started debugging the problem, I found more problems to fix. This PR addresses most of them:

1. unnecessary server side error logs (change `fail()` to not log them)
1. the broken user2/lfs.git (added comments)
1. `migratePushMirrors` could fail when a repository doesn't exist (ignore them)
1. "Authorization" (internal&lfs) header conflicts, remove the tricky "swapAuth" and use "X-Gitea-Internal-Auth"
1. internal token comparing is not constant time (use ConstantTimeCompare, it wasn't a serous problem because in a real world it's nearly impossible to timing-attack the token, but good to fix and backport)
1. duplicate routers (introduce AddOwnerRepoGitLFSRoutes)
1. "internal (private)" routes shouldn't use web context, they should use private context
1. incorrect "path" usages (use "filepath")
1. incorrect mocked route point handling (need to check func nil correctly)

By the way, split some tests from "git general tests" to "git misc tests" (to keep "git_general_test.go" simple)

Then I tried to write a test for "LFS SSH Transfer" but I guess I haven't gotten the correct result. So the code is kept there (`tests/integration/git_lfs_ssh_test.go`) and a FIXME explains the details. Indeed it's worth to take a deep look (in another PR)