### PR TITLE
Adjustments to remove dangling repository locks

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1039,6 +1039,9 @@ LEVEL = Info
 ;; Allow fork repositories without maximum number limit
 ;ALLOW_FORK_WITHOUT_MAXIMUM_LIMIT = true
 
+;; The elapsed time for dangling repository lock to be removed
+;DANGLING_LOCK_THRESHOLD = 1h
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;[repository.editor]

--- a/modules/git/repo_cleanup.go
+++ b/modules/git/repo_cleanup.go
@@ -1,0 +1,60 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package git
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/setting"
+)
+
+func ForciblyUnlockRepository(ctx context.Context, repoPath string) error {
+	return cleanLocksIfNeeded(repoPath, time.Now())
+}
+
+func ForciblyUnlockRepositoryIfNeeded(ctx context.Context, repoPath string) error {
+	lockThreshold := time.Now().Add(-1 * setting.Repository.DanglingLockThreshold)
+	return cleanLocksIfNeeded(repoPath, lockThreshold)
+}
+
+func cleanLocksIfNeeded(repoPath string, threshold time.Time) error {
+	if repoPath == "" {
+		return nil
+	}
+	log.Trace("Checking if repository %s is locked [lock threshold is %s]", repoPath, threshold)
+	return filepath.Walk(repoPath, func(filePath string, fileInfo os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if err := cleanLockIfNeeded(filePath, fileInfo, threshold); err != nil {
+			log.Error("Failed to remove lock file %s: %v", filePath, err)
+			return err
+		}
+		return nil
+	})
+}
+
+func cleanLockIfNeeded(filePath string, fileInfo os.FileInfo, threshold time.Time) error {
+	if isLock(fileInfo) {
+		if fileInfo.ModTime().Before(threshold) {
+			if err := os.Remove(filePath); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+			log.Info("Lock file %s has been removed since its older than %s [timestamp: %s]", filePath, threshold, fileInfo.ModTime())
+			return nil
+		}
+		log.Warn("Cannot exclude lock file %s because it is younger than the threshold %s [timestamp: %s]", filePath, threshold, fileInfo.ModTime())
+		return nil
+	}
+	return nil
+}
+
+func isLock(lockFile os.FileInfo) bool {
+	return !lockFile.IsDir() && strings.HasSuffix(lockFile.Name(), ".lock")
+}

--- a/modules/git/repo_cleanup_test.go
+++ b/modules/git/repo_cleanup_test.go
@@ -1,0 +1,101 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+
+	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/test"
+	"github.com/stretchr/testify/assert"
+)
+
+// This test mimics a repository having dangling locks. If the locks are older than the threshold, they should be
+// removed. Otherwise, they'll remain and the command will fail.
+
+func TestMaintainExistentLock(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		// Need to use touch to change the last access time of the lock files
+		t.Skip("Skipping test on non-linux OS")
+	}
+
+	shouldRemainLocked := func(lockFiles []string, err error) {
+		assert.Error(t, err)
+		for _, lockFile := range lockFiles {
+			assert.FileExists(t, lockFile)
+		}
+	}
+
+	shouldBeUnlocked := func(lockFiles []string, err error) {
+		assert.NoError(t, err)
+		for _, lockFile := range lockFiles {
+			assert.NoFileExists(t, lockFile)
+		}
+	}
+
+	t.Run("2 days lock file (1 hour threshold)", func(t *testing.T) {
+		doTestLockCleanup(t, "2 days", time.Hour, shouldBeUnlocked)
+	})
+
+	t.Run("1 hour lock file (1 hour threshold)", func(t *testing.T) {
+		doTestLockCleanup(t, "1 hour", time.Hour, shouldBeUnlocked)
+	})
+
+	t.Run("1 minutes lock file (1 hour threshold)", func(t *testing.T) {
+		doTestLockCleanup(t, "1 minutes", time.Hour, shouldRemainLocked)
+	})
+
+	t.Run("1 hour lock file (2 hour threshold)", func(t *testing.T) {
+		doTestLockCleanup(t, "1 hour", 2*time.Hour, shouldRemainLocked)
+	})
+}
+
+func doTestLockCleanup(t *testing.T, lockAge string, threshold time.Duration, expectedResult func(lockFiles []string, err error)) {
+	defer test.MockVariableValue(&setting.Repository, setting.Repository)()
+
+	setting.Repository.DanglingLockThreshold = threshold
+
+	if tmpDir, err := os.MkdirTemp("", "cleanup-after-crash"); err != nil {
+		t.Fatal(err)
+	} else {
+		defer os.RemoveAll(tmpDir)
+
+		if err := os.CopyFS(tmpDir, os.DirFS("../../tests/gitea-repositories-meta/org3/repo3.git")); err != nil {
+			t.Fatal(err)
+		}
+
+		lockFiles := lockFilesFor(tmpDir)
+
+		os.MkdirAll(tmpDir+"/objects/info/commit-graphs", os.ModeSticky|os.ModePerm)
+
+		for _, lockFile := range lockFiles {
+			createLockFiles(t, lockFile, lockAge)
+		}
+
+		cmd := NewCommand(context.Background(), "fetch")
+		_, _, cmdErr := cmd.RunStdString(&RunOpts{Dir: tmpDir})
+
+		expectedResult(lockFiles, cmdErr)
+	}
+}
+
+func lockFilesFor(path string) []string {
+	return []string{
+		path + "/config.lock",
+		path + "/HEAD.lock",
+		path + "/objects/info/commit-graphs/commit-graph-chain.lock",
+	}
+}
+
+func createLockFiles(t *testing.T, file, lockAge string) {
+	cmd := exec.Command("touch", "-m", "-a", "-d", "-"+lockAge, file)
+	if err := cmd.Run(); err != nil {
+		t.Error(err)
+	}
+}

--- a/modules/setting/repository.go
+++ b/modules/setting/repository.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"code.gitea.io/gitea/modules/log"
 )
@@ -53,7 +54,7 @@ var (
 		AllowDeleteOfUnadoptedRepositories      bool
 		DisableDownloadSourceArchives           bool
 		AllowForkWithoutMaximumLimit            bool
-
+		DanglingLockThreshold                   time.Duration
 		// Repository editor settings
 		Editor struct {
 			LineWrapExtensions []string
@@ -283,6 +284,8 @@ func loadRepositoryFrom(rootCfg ConfigProvider) {
 	Repository.GoGetCloneURLProtocol = sec.Key("GO_GET_CLONE_URL_PROTOCOL").MustString("https")
 	Repository.MaxCreationLimit = sec.Key("MAX_CREATION_LIMIT").MustInt(-1)
 	Repository.DefaultBranch = sec.Key("DEFAULT_BRANCH").MustString(Repository.DefaultBranch)
+	Repository.DanglingLockThreshold = sec.Key("DANGLING_LOCK_THRESHOLD").MustDuration(time.Hour)
+
 	RepoRootPath = sec.Key("ROOT").MustString(path.Join(AppDataPath, "gitea-repositories"))
 	if !filepath.IsAbs(RepoRootPath) {
 		RepoRootPath = filepath.Join(AppWorkPath, RepoRootPath)


### PR DESCRIPTION
This PR allows Gitea to detect if a repo has any dangling locks (older than a threshold) and remove them if needed. It also detects if a git process has crashed (in that case, it will also remove any locks that remain).

By default, the threshold for a lock to be eligible for removal is `1 hour`. This can be changed via the `DANGLING_LOCK_THRESHOLD` configuration parameter (the PR for the docs is still in the works).

There are still some points that might need clarification.

1. I still do not know if we need the crontask (as discussed [here](https://github.com/go-gitea/gitea/issues/22578#issuecomment-2465493444), the original idea was to have a cronjob that remove the locks that could not be removed by detecting if the git processed had crashed), since we can check for dangling locks before issuing the actual git command (If you think this is subpar, I can remove it);
2. The code will look for **every** file within the repo whose extension is ´.lock' and remove it if it is older than the threshold. As [pointed out](https://github.com/go-gitea/gitea/pull/32485#discussion_r1840655744), there might be locks at the `refs` level so we must search for them by walking the repo's directory structure;
3. I could not come up with a way of reliably detecting whether a process has crashed when running on Windows. In this case, I assume that the process hasn't and the lock removal process is skipped altogether.  The repo will remain locked until its locks are older than the given threshold.

Resolves #22578

P.S. It seems that the unit tests are breaking due to some timing issue (evidence attached)

![image](https://github.com/user-attachments/assets/d39e5fbe-081f-4f35-9e17-09bfc75b06c4)

P.S, Below is the description of the PR when it was a draft 

>**This is a work-in-progress PR**
>
>Hey @lunny, I've written this PR as a Proof of Concept on removing dangling locks that might be left when a git process crashes. 
>
>Right now, it appears functional. There are, however, some points that I'd like your feedback on before I proceed.
>
>When running on Linux, it is possible to detect if a process has been killed (its exit code should be >128). I'm not sure how to do that on other platforms (e.g., windows or macOS). This is critical because if we release the locks every time a git process fails, we might release those of live processes and end up with broken repositories.
>
>Another option is to execute the command and, if there is an error, check for dangling locks older than an specific threshold before retrying. In the PoC I've hard-coded the threshold to 1 hour, but I think the final version should allow the user to configure a threshold that makes more sense. This approach would allows us to skip the need of having a batch job that look for dangling locks.
>
>If you guys are ok with how this is being handled, I can deploy it in my workplace and see how she behaves and then provide you guys feedback.
>
>How does that sound to you guys?
>
>P.S. In the PR, both approaches are combined.
