### PR TITLE
Refactor find forks and fix possible bugs that weak permissions check

### DIFF
--- a/models/repo/fork.go
+++ b/models/repo/fork.go
@@ -54,21 +54,6 @@ func GetUserFork(ctx context.Context, repoID, userID int64) (*Repository, error)
 	return &forkedRepo, nil
 }
 
-// GetForks returns all the forks of the repository
-func GetForks(ctx context.Context, repo *Repository, listOptions db.ListOptions) ([]*Repository, error) {
-	sess := db.GetEngine(ctx)
-
-	var forks []*Repository
-	if listOptions.Page == 0 {
-		forks = make([]*Repository, 0, repo.NumForks)
-	} else {
-		forks = make([]*Repository, 0, listOptions.PageSize)
-		sess = db.SetSessionPagination(sess, &listOptions)
-	}
-
-	return forks, sess.Find(&forks, &Repository{ForkID: repo.ID})
-}
-
 // IncrementRepoForkNum increment repository fork number
 func IncrementRepoForkNum(ctx context.Context, repoID int64) error {
 	_, err := db.GetEngine(ctx).Exec("UPDATE `repository` SET num_forks=num_forks+1 WHERE id=?", repoID)

--- a/models/repo/repo_list.go
+++ b/models/repo/repo_list.go
@@ -98,8 +98,7 @@ func (repos RepositoryList) IDs() []int64 {
 	return repoIDs
 }
 
-// LoadAttributes loads the attributes for the given RepositoryList
-func (repos RepositoryList) LoadAttributes(ctx context.Context) error {
+func (repos RepositoryList) LoadOwners(ctx context.Context) error {
 	if len(repos) == 0 {
 		return nil
 	}
@@ -107,10 +106,6 @@ func (repos RepositoryList) LoadAttributes(ctx context.Context) error {
 	userIDs := container.FilterSlice(repos, func(repo *Repository) (int64, bool) {
 		return repo.OwnerID, true
 	})
-	repoIDs := make([]int64, len(repos))
-	for i := range repos {
-		repoIDs[i] = repos[i].ID
-	}
 
 	// Load owners.
 	users := make(map[int64]*user_model.User, len(userIDs))
@@ -123,12 +118,19 @@ func (repos RepositoryList) LoadAttributes(ctx context.Context) error {
 	for i := range repos {
 		repos[i].Owner = users[repos[i].OwnerID]
 	}
+	return nil
+}
+
+func (repos RepositoryList) LoadLanguageStats(ctx context.Context) error {
+	if len(repos) == 0 {
+		return nil
+	}
 
 	// Load primary language.
 	stats := make(LanguageStatList, 0, len(repos))
 	if err := db.GetEngine(ctx).
 		Where("`is_primary` = ? AND `language` != ?", true, "other").
-		In("`repo_id`", repoIDs).
+		In("`repo_id`", repos.IDs()).
 		Find(&stats); err != nil {
 		return fmt.Errorf("find primary languages: %w", err)
 	}
@@ -141,8 +143,16 @@ func (repos RepositoryList) LoadAttributes(ctx context.Context) error {
 			}
 		}
 	}
-
 	return nil
+}
+
+// LoadAttributes loads the attributes for the given RepositoryList
+func (repos RepositoryList) LoadAttributes(ctx context.Context) error {
+	if err := repos.LoadOwners(ctx); err != nil {
+		return err
+	}
+
+	return repos.LoadLanguageStats(ctx)
 }
 
 // SearchRepoOptions holds the search options

--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -1151,25 +1151,24 @@ func Forks(ctx *context.Context) {
 	if page <= 0 {
 		page = 1
 	}
+	pageSize := setting.ItemsPerPage
 
-	pager := context.NewPagination(ctx.Repo.Repository.NumForks, setting.ItemsPerPage, page, 5)
-	ctx.Data["Page"] = pager
-
-	forks, err := repo_model.GetForks(ctx, ctx.Repo.Repository, db.ListOptions{
-		Page:     pager.Paginater.Current(),
-		PageSize: setting.ItemsPerPage,
+	forks, total, err := repo_service.FindForks(ctx, ctx.Repo.Repository, ctx.Doer, db.ListOptions{
+		Page:     page,
+		PageSize: pageSize,
 	})
 	if err != nil {
-		ctx.ServerError("GetForks", err)
+		ctx.ServerError("FindForks", err)
 		return
 	}
 
-	for _, fork := range forks {
-		if err = fork.LoadOwner(ctx); err != nil {
-			ctx.ServerError("LoadOwner", err)
-			return
-		}
+	if err := repo_model.RepositoryList(forks).LoadOwners(ctx); err != nil {
+		ctx.ServerError("LoadAttributes", err)
+		return
 	}
+
+	pager := context.NewPagination(int(total), pageSize, page, 5)
+	ctx.Data["Page"] = pager
 
 	ctx.Data["Forks"] = forks
 

--- a/services/mirror/mirror_pull.go
+++ b/services/mirror/mirror_pull.go
@@ -307,7 +307,7 @@ func runSync(ctx context.Context, m *repo_model.Mirror) ([]*mirrorSyncResult, bo
 	output := stderrBuilder.String()
 
 	if err := git.WriteCommitGraph(ctx, repoPath); err != nil {
-		log.Error("SyncMirrors: WriteCommitGraph [repo: %-v]: %v", m.Repo, err)
+		log.Error("SyncMirrors [repo: %-v]: %v", m.Repo, err)
 	}
 
 	gitRepo, err := gitrepo.OpenRepository(ctx, m.Repo)

--- a/services/mirror/mirror_pull.go
+++ b/services/mirror/mirror_pull.go
@@ -307,7 +307,7 @@ func runSync(ctx context.Context, m *repo_model.Mirror) ([]*mirrorSyncResult, bo
 	output := stderrBuilder.String()
 
 	if err := git.WriteCommitGraph(ctx, repoPath); err != nil {
-		log.Error("SyncMirrors [repo: %-v]: %v", m.Repo, err)
+		log.Error("SyncMirrors: WriteCommitGraph [repo: %-v]: %v", m.Repo, err)
 	}
 
 	gitRepo, err := gitrepo.OpenRepository(ctx, m.Repo)

--- a/services/repository/fork.go
+++ b/services/repository/fork.go
@@ -21,6 +21,7 @@ import (
 	"code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/util"
 	notify_service "code.gitea.io/gitea/services/notify"
+
 	"xorm.io/builder"
 )
 

--- a/services/repository/fork.go
+++ b/services/repository/fork.go
@@ -12,6 +12,7 @@ import (
 	"code.gitea.io/gitea/models/db"
 	git_model "code.gitea.io/gitea/models/git"
 	repo_model "code.gitea.io/gitea/models/repo"
+	"code.gitea.io/gitea/models/unit"
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/gitrepo"
@@ -20,6 +21,7 @@ import (
 	"code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/util"
 	notify_service "code.gitea.io/gitea/services/notify"
+	"xorm.io/builder"
 )
 
 // ErrForkAlreadyExist represents a "ForkAlreadyExist" kind of error.
@@ -246,4 +248,25 @@ func ConvertForkToNormalRepository(ctx context.Context, repo *repo_model.Reposit
 	})
 
 	return err
+}
+
+type findForksOptions struct {
+	db.ListOptions
+	RepoID int64
+	Doer   *user_model.User
+}
+
+func (opts findForksOptions) ToConds() builder.Cond {
+	return builder.Eq{"fork_id": opts.RepoID}.And(
+		repo_model.AccessibleRepositoryCondition(opts.Doer, unit.TypeInvalid),
+	)
+}
+
+// FindForks returns all the forks of the repository
+func FindForks(ctx context.Context, repo *repo_model.Repository, doer *user_model.User, listOptions db.ListOptions) ([]*repo_model.Repository, int64, error) {
+	return db.FindAndCount[repo_model.Repository](ctx, findForksOptions{
+		ListOptions: listOptions,
+		RepoID:      repo.ID,
+		Doer:        doer,
+	})
 }

--- a/templates/repo/forks.tmpl
+++ b/templates/repo/forks.tmpl
@@ -5,12 +5,14 @@
 		<h2 class="ui dividing header">
 			{{ctx.Locale.Tr "repo.forks"}}
 		</h2>
+		<div class="flex-list">
 		{{range .Forks}}
-			<div class="tw-flex tw-items-center tw-py-2">
-				<span class="tw-mr-1">{{ctx.AvatarUtils.Avatar .Owner}}</span>
-				<a href="{{.Owner.HomeLink}}">{{.Owner.Name}}</a> / <a href="{{.Link}}">{{.Name}}</a>
+			<div class="flex-item tw-border-0 repo-fork-item">
+				<span>{{ctx.AvatarUtils.Avatar .Owner}}</span>
+				<span><a href="{{.Owner.HomeLink}}">{{.Owner.Name}}</a> / <a href="{{.Link}}">{{.Name}}</a></span>
 			</div>
 		{{end}}
+		</div>
 	</div>
 
 	{{template "base/paginate" .}}

--- a/tests/integration/api_fork_test.go
+++ b/tests/integration/api_fork_test.go
@@ -7,12 +7,108 @@ import (
 	"net/http"
 	"testing"
 
+	"code.gitea.io/gitea/models"
+	auth_model "code.gitea.io/gitea/models/auth"
+	"code.gitea.io/gitea/models/db"
+	org_model "code.gitea.io/gitea/models/organization"
+	"code.gitea.io/gitea/models/unittest"
+	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/structs"
 	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/tests"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateForkNoLogin(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
 	req := NewRequestWithJSON(t, "POST", "/api/v1/repos/user2/repo1/forks", &api.CreateForkOption{})
 	MakeRequest(t, req, http.StatusUnauthorized)
+}
+
+func TestAPIForkListLimitedAndPrivateRepos(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	user1Sess := loginUser(t, "user1")
+	user1 := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user1"})
+	limitedOrg := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 22})
+	assert.EqualValues(t, structs.VisibleTypeLimited, limitedOrg.Visibility)
+
+	ownerTeam1, err := org_model.OrgFromUser(limitedOrg).GetOwnerTeam(db.DefaultContext)
+	assert.NoError(t, err)
+	assert.NoError(t, models.AddTeamMember(db.DefaultContext, ownerTeam1, user1))
+	defer func() {
+		models.RemoveTeamMember(db.DefaultContext, ownerTeam1, user1)
+	}()
+
+	user1Token := getTokenForLoggedInUser(t, user1Sess,
+		auth_model.AccessTokenScopeWriteRepository,
+		auth_model.AccessTokenScopeWriteOrganization)
+
+	req := NewRequestWithJSON(t, "POST", "/api/v1/repos/user2/repo1/forks", &api.CreateForkOption{
+		Organization: &limitedOrg.Name,
+	}).AddTokenAuth(user1Token)
+	MakeRequest(t, req, http.StatusAccepted)
+
+	user4Sess := loginUser(t, "user4")
+	user4 := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user4"})
+
+	privateOrg := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 23})
+	assert.EqualValues(t, structs.VisibleTypePrivate, privateOrg.Visibility)
+
+	ownerTeam2, err := org_model.OrgFromUser(privateOrg).GetOwnerTeam(db.DefaultContext)
+	assert.NoError(t, err)
+	assert.NoError(t, models.AddTeamMember(db.DefaultContext, ownerTeam2, user4))
+	defer func() {
+		models.RemoveTeamMember(db.DefaultContext, ownerTeam2, user4)
+	}()
+
+	user4Token := getTokenForLoggedInUser(t, user4Sess,
+		auth_model.AccessTokenScopeWriteRepository,
+		auth_model.AccessTokenScopeWriteOrganization)
+
+	req = NewRequestWithJSON(t, "POST", "/api/v1/repos/user2/repo1/forks", &api.CreateForkOption{
+		Organization: &privateOrg.Name,
+	}).AddTokenAuth(user4Token)
+	MakeRequest(t, req, http.StatusAccepted)
+
+	t.Run("Anomynous", func(t *testing.T) {
+		defer tests.PrintCurrentTest(t)()
+
+		req := NewRequest(t, "GET", "/api/v1/repos/user2/repo1/forks")
+		resp := MakeRequest(t, req, http.StatusOK)
+
+		var forks []*api.Repository
+		DecodeJSON(t, resp, &forks)
+
+		assert.Empty(t, forks)
+		assert.EqualValues(t, "0", resp.Header().Get("X-Total-Count"))
+	})
+
+	t.Run("Logged in", func(t *testing.T) {
+		defer tests.PrintCurrentTest(t)()
+
+		req := NewRequest(t, "GET", "/api/v1/repos/user2/repo1/forks").AddTokenAuth(user1Token)
+		resp := MakeRequest(t, req, http.StatusOK)
+
+		var forks []*api.Repository
+		DecodeJSON(t, resp, &forks)
+
+		assert.Len(t, forks, 1)
+		assert.EqualValues(t, "1", resp.Header().Get("X-Total-Count"))
+
+		assert.NoError(t, models.AddTeamMember(db.DefaultContext, ownerTeam2, user1))
+		defer func() {
+			models.RemoveTeamMember(db.DefaultContext, ownerTeam2, user1)
+		}()
+
+		req = NewRequest(t, "GET", "/api/v1/repos/user2/repo1/forks").AddTokenAuth(user1Token)
+		resp = MakeRequest(t, req, http.StatusOK)
+
+		forks = []*api.Repository{}
+		DecodeJSON(t, resp, &forks)
+
+		assert.Len(t, forks, 2)
+		assert.EqualValues(t, "2", resp.Header().Get("X-Total-Count"))
+	})
 }

--- a/tests/integration/api_fork_test.go
+++ b/tests/integration/api_fork_test.go
@@ -13,7 +13,6 @@ import (
 	org_model "code.gitea.io/gitea/models/organization"
 	"code.gitea.io/gitea/models/unittest"
 	user_model "code.gitea.io/gitea/models/user"
-	"code.gitea.io/gitea/modules/structs"
 	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/tests"
 
@@ -32,7 +31,7 @@ func TestAPIForkListLimitedAndPrivateRepos(t *testing.T) {
 	user1Sess := loginUser(t, "user1")
 	user1 := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user1"})
 	limitedOrg := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 22})
-	assert.EqualValues(t, structs.VisibleTypeLimited, limitedOrg.Visibility)
+	assert.EqualValues(t, api.VisibleTypeLimited, limitedOrg.Visibility)
 
 	ownerTeam1, err := org_model.OrgFromUser(limitedOrg).GetOwnerTeam(db.DefaultContext)
 	assert.NoError(t, err)
@@ -54,7 +53,7 @@ func TestAPIForkListLimitedAndPrivateRepos(t *testing.T) {
 	user4 := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user4"})
 
 	privateOrg := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 23})
-	assert.EqualValues(t, structs.VisibleTypePrivate, privateOrg.Visibility)
+	assert.EqualValues(t, api.VisibleTypePrivate, privateOrg.Visibility)
 
 	ownerTeam2, err := org_model.OrgFromUser(privateOrg).GetOwnerTeam(db.DefaultContext)
 	assert.NoError(t, err)
@@ -72,7 +71,7 @@ func TestAPIForkListLimitedAndPrivateRepos(t *testing.T) {
 	}).AddTokenAuth(user4Token)
 	MakeRequest(t, req, http.StatusAccepted)
 
-	t.Run("Anomynous", func(t *testing.T) {
+	t.Run("Anonymous", func(t *testing.T) {
 		defer tests.PrintCurrentTest(t)()
 
 		req := NewRequest(t, "GET", "/api/v1/repos/user2/repo1/forks")

--- a/tests/integration/repo_fork_test.go
+++ b/tests/integration/repo_fork_test.go
@@ -81,7 +81,7 @@ func TestRepoForkToOrg(t *testing.T) {
 
 func TestForkListLimitedAndPrivateRepos(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
-	forkItemSelector := ".tw-flex.tw-items-center.tw-py-2"
+	forkItemSelector := ".repo-fork-item"
 
 	user1Sess := loginUser(t, "user1")
 	user1 := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user1"})

--- a/tests/integration/repo_fork_test.go
+++ b/tests/integration/repo_fork_test.go
@@ -7,10 +7,15 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
+	"code.gitea.io/gitea/models"
+	"code.gitea.io/gitea/models/db"
+	org_model "code.gitea.io/gitea/models/organization"
 	"code.gitea.io/gitea/models/unittest"
 	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/tests"
 
 	"github.com/stretchr/testify/assert"
@@ -73,4 +78,65 @@ func TestRepoForkToOrg(t *testing.T) {
 	htmlDoc := NewHTMLParser(t, resp.Body)
 	_, exists := htmlDoc.doc.Find(`a.ui.button[href*="/fork"]`).Attr("href")
 	assert.False(t, exists, "Forking should not be allowed anymore")
+}
+
+func TestForkListLimitedAndPrivateRepos(t *testing.T) {
+	forkItemSelector := ".tw-flex.tw-items-center.tw-py-2"
+
+	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+		user1Sess := loginUser(t, "user1")
+		user1 := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user1"})
+		limitedOrg := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 22})
+		assert.EqualValues(t, structs.VisibleTypeLimited, limitedOrg.Visibility)
+
+		ownerTeam1, err := org_model.OrgFromUser(limitedOrg).GetOwnerTeam(db.DefaultContext)
+		assert.NoError(t, err)
+		assert.NoError(t, models.AddTeamMember(db.DefaultContext, ownerTeam1, user1))
+		defer func() {
+			models.RemoveTeamMember(db.DefaultContext, ownerTeam1, user1)
+		}()
+
+		testRepoFork(t, user1Sess, "user2", "repo1", limitedOrg.Name, "repo1", "")
+
+		user4Sess := loginUser(t, "user4")
+		user4 := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user4"})
+
+		privateOrg := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 23})
+		assert.EqualValues(t, structs.VisibleTypePrivate, privateOrg.Visibility)
+
+		ownerTeam2, err := org_model.OrgFromUser(privateOrg).GetOwnerTeam(db.DefaultContext)
+		assert.NoError(t, err)
+		assert.NoError(t, models.AddTeamMember(db.DefaultContext, ownerTeam2, user4))
+		defer func() {
+			models.RemoveTeamMember(db.DefaultContext, ownerTeam2, user4)
+		}()
+
+		testRepoFork(t, user4Sess, "user2", "repo1", privateOrg.Name, "repo1", "")
+
+		t.Run("Anomynous", func(t *testing.T) {
+			defer tests.PrintCurrentTest(t)()
+
+			req := NewRequest(t, "GET", "/user2/repo1/forks")
+			resp := MakeRequest(t, req, http.StatusOK)
+			htmlDoc := NewHTMLParser(t, resp.Body)
+			assert.EqualValues(t, 0, htmlDoc.Find(forkItemSelector).Length())
+		})
+
+		t.Run("Logged in", func(t *testing.T) {
+			defer tests.PrintCurrentTest(t)()
+
+			req := NewRequest(t, "GET", "/user2/repo1/forks")
+			resp := user1Sess.MakeRequest(t, req, http.StatusOK)
+			htmlDoc := NewHTMLParser(t, resp.Body)
+			assert.EqualValues(t, 1, htmlDoc.Find(forkItemSelector).Length())
+
+			assert.NoError(t, models.AddTeamMember(db.DefaultContext, ownerTeam2, user1))
+			defer func() {
+				models.RemoveTeamMember(db.DefaultContext, ownerTeam2, user1)
+			}()
+			resp = user1Sess.MakeRequest(t, req, http.StatusOK)
+			htmlDoc = NewHTMLParser(t, resp.Body)
+			assert.EqualValues(t, 2, htmlDoc.Find(forkItemSelector).Length())
+		})
+	})
 }

--- a/tests/integration/repo_fork_test.go
+++ b/tests/integration/repo_fork_test.go
@@ -113,7 +113,7 @@ func TestForkListLimitedAndPrivateRepos(t *testing.T) {
 
 		testRepoFork(t, user4Sess, "user2", "repo1", privateOrg.Name, "repo1", "")
 
-		t.Run("Anomynous", func(t *testing.T) {
+		t.Run("Anonymous", func(t *testing.T) {
 			defer tests.PrintCurrentTest(t)()
 
 			req := NewRequest(t, "GET", "/user2/repo1/forks")


### PR DESCRIPTION
- Move models/GetForks to services/FindForks
- Add doer as a parameter of FindForks to check permissions
- Slight performance optimization for get forks API with batch loading of repository units
- Add tests for forking repository to organizations