### PR TITLE
Fix basic auth with webauthn

### DIFF
--- a/services/auth/basic.go
+++ b/services/auth/basic.go
@@ -141,16 +141,16 @@ func (b *Basic) Verify(req *http.Request, w http.ResponseWriter, store DataStore
 		return nil, err
 	}
 
-	// Check if the user has webAuthn registration
-	hasWebAuthn, err := auth_model.HasWebAuthnRegistrationsByUID(req.Context(), u.ID)
-	if err != nil {
-		return nil, err
-	}
-	if hasWebAuthn {
-		return nil, errors.New("Basic authorization is not allowed while webAuthn enrolled")
-	}
-
 	if skipper, ok := source.Cfg.(LocalTwoFASkipper); !ok || !skipper.IsSkipLocalTwoFA() {
+		// Check if the user has webAuthn registration
+		hasWebAuthn, err := auth_model.HasWebAuthnRegistrationsByUID(req.Context(), u.ID)
+		if err != nil {
+			return nil, err
+		}
+		if hasWebAuthn {
+			return nil, errors.New("Basic authorization is not allowed while webAuthn enrolled")
+		}
+
 		if err := validateTOTP(req, u); err != nil {
 			return nil, err
 		}

--- a/tests/integration/api_twofa_test.go
+++ b/tests/integration/api_twofa_test.go
@@ -53,3 +53,39 @@ func TestAPITwoFactor(t *testing.T) {
 	req.Header.Set("X-Gitea-OTP", passcode)
 	MakeRequest(t, req, http.StatusOK)
 }
+
+func TestBasicAuthWithWebAuthn(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	// user1 has no webauthn enrolled, he can request API with basic auth
+	user1 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 1})
+	unittest.AssertNotExistsBean(t, &auth_model.WebAuthnCredential{UserID: user1.ID})
+	req := NewRequest(t, "GET", "/api/v1/user")
+	req.SetBasicAuth(user1.Name, "password")
+	MakeRequest(t, req, http.StatusOK)
+
+	// user1 has webauthn enrolled, he can request git protocol with basic auth
+	req = NewRequest(t, "GET", "/user2/repo1/info/refs")
+	req.SetBasicAuth(user1.Name, "password")
+	MakeRequest(t, req, http.StatusOK)
+
+	// user32 has webauthn enrolled, he can't request API with basic auth
+	user32 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 32})
+	unittest.AssertExistsAndLoadBean(t, &auth_model.WebAuthnCredential{UserID: user32.ID})
+
+	req = NewRequest(t, "GET", "/api/v1/user")
+	req.SetBasicAuth(user32.Name, "notpassword")
+	resp := MakeRequest(t, req, http.StatusUnauthorized)
+
+	type userResponse struct {
+		Message string `json:"message"`
+	}
+	var userParsed userResponse
+	DecodeJSON(t, resp, &userParsed)
+	assert.EqualValues(t, "Basic authorization is not allowed while webAuthn enrolled", userParsed.Message)
+
+	// user32 has webauthn enrolled, he can't request git protocol with basic auth
+	req = NewRequest(t, "GET", "/user2/repo1/info/refs")
+	req.SetBasicAuth(user32.Name, "notpassword")
+	MakeRequest(t, req, http.StatusUnauthorized)
+}


### PR DESCRIPTION
WebAuthn should behave the same way as TOTP. When enabled, basic auth with username/password should need to WebAuthn auth, otherwise returned 401.