### PR TITLE
Use user.FullName in Oauth2 id_token response

### DIFF
--- a/routers/web/auth/oauth2_provider.go
+++ b/routers/web/auth/oauth2_provider.go
@@ -98,7 +98,7 @@ func InfoOAuth(ctx *context.Context) {
 
 	response := &userInfoResponse{
 		Sub:               fmt.Sprint(ctx.Doer.ID),
-		Name:              ctx.Doer.FullName,
+		Name:              ctx.Doer.DisplayName(),
 		PreferredUsername: ctx.Doer.Name,
 		Email:             ctx.Doer.Email,
 		Picture:           ctx.Doer.AvatarLink(ctx),

--- a/routers/web/auth/oauth_test.go
+++ b/routers/web/auth/oauth_test.go
@@ -10,7 +10,6 @@ import (
 	"code.gitea.io/gitea/models/db"
 	"code.gitea.io/gitea/models/unittest"
 	user_model "code.gitea.io/gitea/models/user"
-	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/services/oauth2_provider"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -66,25 +65,7 @@ func TestNewAccessTokenResponse_OIDCToken(t *testing.T) {
 
 	// Scopes: openid profile email
 	oidcToken = createAndParseToken(t, grants[0])
-	assert.Equal(t, user.Name, oidcToken.Name)
-	assert.Equal(t, user.Name, oidcToken.PreferredUsername)
-	assert.Equal(t, user.HTMLURL(), oidcToken.Profile)
-	assert.Equal(t, user.AvatarLink(db.DefaultContext), oidcToken.Picture)
-	assert.Equal(t, user.Website, oidcToken.Website)
-	assert.Equal(t, user.UpdatedUnix, oidcToken.UpdatedAt)
-	assert.Equal(t, user.Email, oidcToken.Email)
-	assert.Equal(t, user.IsActive, oidcToken.EmailVerified)
-
-	// set DefaultShowFullName to true
-	oldDefaultShowFullName := setting.UI.DefaultShowFullName
-	setting.UI.DefaultShowFullName = true
-	defer func() {
-		setting.UI.DefaultShowFullName = oldDefaultShowFullName
-	}()
-
-	// Scopes: openid profile email
-	oidcToken = createAndParseToken(t, grants[0])
-	assert.Equal(t, user.FullName, oidcToken.Name)
+	assert.Equal(t, user.DisplayName(), oidcToken.Name)
 	assert.Equal(t, user.Name, oidcToken.PreferredUsername)
 	assert.Equal(t, user.HTMLURL(), oidcToken.Profile)
 	assert.Equal(t, user.AvatarLink(db.DefaultContext), oidcToken.Picture)

--- a/services/oauth2_provider/access_token.go
+++ b/services/oauth2_provider/access_token.go
@@ -148,7 +148,7 @@ func NewAccessTokenResponse(ctx context.Context, grant *auth.OAuth2Grant, server
 			Nonce: grant.Nonce,
 		}
 		if grant.ScopeContains("profile") {
-			idToken.Name = user.GetDisplayName()
+			idToken.Name = user.DisplayName()
 			idToken.PreferredUsername = user.Name
 			idToken.Profile = user.HTMLURL()
 			idToken.Picture = user.AvatarLink(ctx)


### PR DESCRIPTION
This makes `/login/oauth/authorize` behave the same way as the `/login/oauth/userinfo` endpoint.