### PR TITLE
Fix a compilation error in the Gitpod environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,6 @@
             poetry
 
             # backend
-            go_1_22
             gofumpt
             sqlite
           ];


### PR DESCRIPTION
When opening the latest code in **Gitpod** and running `make lint-backend`, the following error occurs: 
```bash
gitpod /workspace/gitea (main) $ make lint-backend
go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3 run
# internal/profilerecord
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# internal/goarch
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# unicode/utf8
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# internal/coverage/rtcov
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# internal/byteorder
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# cmp
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# internal/itoa
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# internal/race
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# internal/goos
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# internal/unsafeheader
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# unicode
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# internal/godebugs
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# internal/asan
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# math/bits
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# internal/goexperiment
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# internal/msan
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# internal/runtime/atomic
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# sync/atomic
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# internal/runtime/syscall
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# crypto/internal/alias
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# encoding
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# log/internal
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# vendor/golang.org/x/crypto/cryptobyte/asn1
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# github.com/golangci/golangci-lint/pkg/exitcodes
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# internal/cpu
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# unicode/utf16
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# container/list
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# crypto/subtle
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# internal/goversion
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# golang.org/x/exp/maps
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# github.com/ccojocar/zxcvbn-go/match
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# golang.org/x/exp/constraints
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# golang.org/x/tools/internal/packagesinternal
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# github.com/quasilyte/go-ruleguard/dsl/types
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# vendor/golang.org/x/crypto/internal/alias
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# internal/nettrace
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# github.com/google/go-cmp/cmp/internal/flags
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# github.com/gobwas/glob/util/runes
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# internal/platform
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# crypto/internal/boring/sig
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# github.com/quasilyte/gogrep/internal/stdinfo
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# github.com/daixiang0/gci/pkg/utils
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# github.com/quasilyte/stdinfo
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# github.com/Antonboom/testifylint/internal/testify
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# hash/maphash
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# github.com/nunnatsa/ginkgolinter/version
compile: version "go1.23.1" does not match go tool version "go1.22.9"
# google.golang.org/protobuf/internal/flags
compile: version "go1.23.1" does not match go tool version "go1.22.9"
make: *** [Makefile:413: lint-go] Error 1
```