### PR TITLE
Support HTTP POST requests to `/userinfo`, aligning to OpenID Core specification

### DIFF
--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -561,7 +561,7 @@ func registerRoutes(m *web.Router) {
 			m.Post("/authorize", web.Bind(forms.AuthorizationForm{}), auth.AuthorizeOAuth)
 		}, optSignInIgnoreCsrf, reqSignIn)
 
-		m.Methods("GET, OPTIONS", "/userinfo", optionsCorsHandler(), optSignInIgnoreCsrf, auth.InfoOAuth)
+		m.Methods("GET, POST, OPTIONS", "/userinfo", optionsCorsHandler(), optSignInIgnoreCsrf, auth.InfoOAuth)
 		m.Methods("POST, OPTIONS", "/access_token", optionsCorsHandler(), web.Bind(forms.AccessTokenForm{}), optSignInIgnoreCsrf, auth.AccessTokenOAuth)
 		m.Methods("GET, OPTIONS", "/keys", optionsCorsHandler(), optSignInIgnoreCsrf, auth.OIDCKeys)
 		m.Methods("POST, OPTIONS", "/introspect", optionsCorsHandler(), web.Bind(forms.IntrospectTokenForm{}), optSignInIgnoreCsrf, auth.IntrospectOAuth)


### PR DESCRIPTION
This PR adds support for the HTTP POST requests to /userinfo endpoint. While the OpenID Core specification recommends using HTTP GET, at least MinIO uses HTTP POST in their OIDC login flow.

[OpenID Core](https://openid.net/specs/openid-connect-core-1_0.html):
 - [5.3. Userinfo Endpoint](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo):
   > The UserInfo Endpoint MUST support the use of the HTTP GET and HTTP POST methods
 - [5.3.1. Userinfo Request](https://openid.net/specs/openid-connect-core-1_0.html#UserInfoRequest):
   >  It is RECOMMENDED that the request use the HTTP GET method and the Access Token be sent using the Authorization header field.
   
I tested this manually with a local MinIO instance, and it successfully allows their `[x] Claim User Info` setting to be checked. Without this change, it fails with a `Method not allowed` error from the IdP.