### PR TITLE
Add 'Copy path' button to file view

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -104,6 +104,7 @@ copy_url = Copy URL
 copy_hash = Copy hash
 copy_content = Copy content
 copy_branch = Copy branch name
+copy_path = Copy path
 copy_success = Copied!
 copy_error = Copy failed
 copy_type_unsupported = This file type cannot be copied

--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -130,7 +130,7 @@
 								</div>
 								<span class="file tw-flex tw-items-center tw-font-mono tw-flex-1"><a class="muted file-link" title="{{if $file.IsRenamed}}{{$file.OldName}} → {{end}}{{$file.Name}}" href="#diff-{{$file.NameHash}}">{{if $file.IsRenamed}}{{$file.OldName}} → {{end}}{{$file.Name}}</a>
 									{{if .IsLFSFile}} ({{ctx.Locale.Tr "repo.stored_lfs"}}){{end}}
-									<button class="btn interact-fg tw-p-2" data-clipboard-text="{{$file.Name}}">{{svg "octicon-copy" 14}}</button>
+									<button class="btn interact-fg tw-p-2" data-clipboard-text="{{$file.Name}}" data-tooltip-content="{{ctx.Locale.Tr "copy_path"}}">{{svg "octicon-copy" 14}}</button>
 									{{if $file.IsGenerated}}
 										<span class="ui label">{{ctx.Locale.Tr "repo.diff.generated"}}</span>
 									{{end}}

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -106,6 +106,7 @@
 							<span class="breadcrumb-divider">/</span>
 							{{- if eq $i $l -}}
 								<span class="active section" title="{{$v}}">{{$v}}</span>
+								<button class="btn interact-fg tw-mx-1" data-clipboard-text="{{$.TreePath}}" data-tooltip-content="{{ctx.Locale.Tr "copy_path"}}">{{svg "octicon-copy" 14}}</button>
 							{{- else -}}
 								{{$p := index $.Paths $i}}<span class="section"><a href="{{$.BranchLink}}/{{PathEscapeSegments $p}}" title="{{$v}}">{{$v}}</a></span>
 							{{- end -}}


### PR DESCRIPTION
Also adds a tooltip which is replicated to the same button in the diff box.

Fixes: https://github.com/go-gitea/gitea/issues/32583

<img width="566" alt="Screenshot 2024-11-21 at 01 47 08" src="https://github.com/user-attachments/assets/12a48205-6ab1-409f-b498-864b7bde7477">
<img width="460" alt="Screenshot 2024-11-21 at 01 47 22" src="https://github.com/user-attachments/assets/bce8cd7c-331c-42cc-b55f-1b2aa69d15e7">

