### PR TITLE
Fix the missing menu in organization project view page (#32313)

### DIFF
--- a/templates/org/projects/view.tmpl
+++ b/templates/org/projects/view.tmpl
@@ -1,9 +1,13 @@
 {{template "base/head" .}}
-<div role="main" aria-label="{{.Title}}" class="page-content repository projects view-project">
-	{{template "shared/user/org_profile_avatar" .}}
-	<div class="ui container tw-mb-4">
-		{{template "user/overview/header" .}}
-	</div>
+<div role="main" aria-label="{{.Title}}" class="page-content organization repository projects view-project">
+	{{if .ContextUser.IsOrganization}}
+		{{template "org/header" .}}
+	{{else}}
+		{{template "shared/user/org_profile_avatar" .}}
+		<div class="ui container tw-mb-4">
+			{{template "user/overview/header" .}}
+		</div>
+	{{end}}
 	<div class="ui container fluid padded">
 		{{template "projects/view" .}}
 	</div>


### PR DESCRIPTION
Backport #32313 

#29248 didn't modify the view page.
The class name is not good enough, so this is a quick fix.

Before:
org:

![image](https://github.com/user-attachments/assets/3e26502d-66b4-4043-ab03-003ba7391487) user:

![image](https://github.com/user-attachments/assets/9b22b90c-d63c-4228-acad-4d9fb20590ac)

After:
org:

![image](https://github.com/user-attachments/assets/21bf98a7-8a5b-4dc6-950a-88f529e36450) user: (no change)

![image](https://github.com/user-attachments/assets/fea0dcae-3625-44e8-bb9e-4c3733da8764)
