### PR TITLE
Support HTTP POST requests to `/userinfo`, aligning to OpenID Core specification (#32578)

### DIFF
--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -551,7 +551,7 @@ func registerRoutes(m *web.Route) {
 		m.Post("/authorize", web.Bind(forms.AuthorizationForm{}), auth.AuthorizeOAuth)
 	}, ignSignInAndCsrf, reqSignIn)
 
-	m.Methods("GET, OPTIONS", "/login/oauth/userinfo", optionsCorsHandler(), ignSignInAndCsrf, auth.InfoOAuth)
+	m.Methods("GET, POST, OPTIONS", "/login/oauth/userinfo", optionsCorsHandler(), ignSignInAndCsrf, auth.InfoOAuth)
 	m.Methods("POST, OPTIONS", "/login/oauth/access_token", optionsCorsHandler(), web.Bind(forms.AccessTokenForm{}), ignSignInAndCsrf, auth.AccessTokenOAuth)
 	m.Methods("GET, OPTIONS", "/login/oauth/keys", optionsCorsHandler(), ignSignInAndCsrf, auth.OIDCKeys)
 	m.Methods("POST, OPTIONS", "/login/oauth/introspect", optionsCorsHandler(), web.Bind(forms.IntrospectTokenForm{}), ignSignInAndCsrf, auth.IntrospectOAuth)


### PR DESCRIPTION
Backport #32578 

This PR adds support for the HTTP POST requests to `/userinfo` endpoint. While the OpenID Core specification says both are supported and recommends using HTTP GET.

ref: https://openid.net/specs/openid-connect-core-1_0.html#UserInfo