### PR TITLE
Style unification for the issue_management area

### DIFF
--- a/templates/repo/issue/sidebar/issue_management.tmpl
+++ b/templates/repo/issue/sidebar/issue_management.tmpl
@@ -6,10 +6,10 @@
 			{{$.CsrfTokenHtml}}
 			<button class="fluid ui button {{if not $.NewPinAllowed}}disabled{{end}}">
 				{{if not .Issue.IsPinned}}
-					{{svg "octicon-pin" 16 "tw-mr-2"}}
+					{{svg "octicon-pin"}}
 					{{ctx.Locale.Tr "pin"}}
 				{{else}}
-					{{svg "octicon-pin-slash" 16 "tw-mr-2"}}
+					{{svg "octicon-pin-slash"}}
 					{{ctx.Locale.Tr "unpin"}}
 				{{end}}
 			</button>

--- a/templates/repo/issue/sidebar/milestone_list.tmpl
+++ b/templates/repo/issue/sidebar/milestone_list.tmpl
@@ -39,7 +39,7 @@
 						{{end}}
 					{{end}}
 				</div>
-				{{end}}
+			{{end}}
 		</div>
 	</div>
 


### PR DESCRIPTION
Style unification for the issue_management area (consistent across the layout

before:
![1732237277916](https://github.com/user-attachments/assets/52a20b2d-d6a4-4118-9cdf-9b377115b7f7)
![1732237288802](https://github.com/user-attachments/assets/05592fe8-cab2-412b-99bc-f0a201c08413)
![1732237299849](https://github.com/user-attachments/assets/8be4a891-c514-4983-bad4-fcc5a7a9d838)

after:
![1732237471086](https://github.com/user-attachments/assets/0bd19ef6-79c1-490a-8ffa-6a42208befd9)
