### PR TITLE
Add webpack EnvironmentPlugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -213,7 +213,7 @@ export default {
       __VUE_PROD_DEVTOOLS__: false, // do not enable devtools support in production
       __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false, // https://github.com/vuejs/vue-cli/pull/7443
     }),
-    // all environment variables used in bundled js via process.env must be defined here
+    // all environment variables used in bundled js via process.env must be declared here
     new EnvironmentPlugin({
       TEST: 'false',
     }),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ import tailwindcssNesting from 'tailwindcss/nesting/index.js';
 import postcssNesting from 'postcss-nesting';
 
 const {EsbuildPlugin} = EsBuildLoader;
-const {SourceMapDevToolPlugin, DefinePlugin} = webpack;
+const {SourceMapDevToolPlugin, DefinePlugin, EnvironmentPlugin} = webpack;
 const formatLicenseText = (licenseText) => wrapAnsi(licenseText || '', 80).trim();
 
 const glob = (pattern) => fastGlob.sync(pattern, {
@@ -212,6 +212,10 @@ export default {
       __VUE_OPTIONS_API__: true, // at the moment, many Vue components still use the Vue Options API
       __VUE_PROD_DEVTOOLS__: false, // do not enable devtools support in production
       __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false, // https://github.com/vuejs/vue-cli/pull/7443
+    }),
+    // all environment variables used in bundled js via process.env must be defined here
+    new EnvironmentPlugin({
+      TEST: 'false',
     }),
     new VueLoaderPlugin(),
     new MiniCssExtractPlugin({


### PR DESCRIPTION
Fixes: https://github.com/go-gitea/gitea/issues/32660

Environment vars in Webpack need to be declared in the config, otherwise they will not be elimininated during compilation.