### PR TITLE
Add contrib/ini-to-shell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ RUN if [ -n "${GITEA_VERSION}" ]; then git checkout "${GITEA_VERSION}"; fi \
 # Begin env-to-ini build
 RUN go build contrib/environment-to-ini/environment-to-ini.go
 
+# Begin ini-to-shell build
+RUN go build contrib/ini-to-shell/ini-to-shell.go
+
 # Copy local files
 COPY docker/root /tmp/local
 
@@ -38,7 +41,8 @@ RUN chmod 755 /tmp/local/usr/bin/entrypoint \
               /tmp/local/etc/s6/openssh/* \
               /tmp/local/etc/s6/.s6-svscan/* \
               /go/src/code.gitea.io/gitea/gitea \
-              /go/src/code.gitea.io/gitea/environment-to-ini
+              /go/src/code.gitea.io/gitea/environment-to-ini \
+              /go/src/code.gitea.io/gitea/ini-to-shell
 RUN chmod 644 /go/src/code.gitea.io/gitea/contrib/autocompletion/bash_autocomplete
 
 FROM docker.io/library/alpine:3.20
@@ -83,4 +87,5 @@ CMD ["/bin/s6-svscan", "/etc/s6"]
 COPY --from=build-env /tmp/local /
 COPY --from=build-env /go/src/code.gitea.io/gitea/gitea /app/gitea/gitea
 COPY --from=build-env /go/src/code.gitea.io/gitea/environment-to-ini /usr/local/bin/environment-to-ini
+COPY --from=build-env /go/src/code.gitea.io/gitea/ini-to-shell /usr/local/bin/ini-to-shell
 COPY --from=build-env /go/src/code.gitea.io/gitea/contrib/autocompletion/bash_autocomplete /etc/profile.d/gitea_bash_autocomplete.sh

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -28,6 +28,9 @@ RUN if [ -n "${GITEA_VERSION}" ]; then git checkout "${GITEA_VERSION}"; fi \
 # Begin env-to-ini build
 RUN go build contrib/environment-to-ini/environment-to-ini.go
 
+# Begin ini-to-shell build
+RUN go build contrib/ini-to-shell/ini-to-shell.go
+
 # Copy local files
 COPY docker/rootless /tmp/local
 
@@ -36,7 +39,8 @@ RUN chmod 755 /tmp/local/usr/local/bin/docker-entrypoint.sh \
               /tmp/local/usr/local/bin/docker-setup.sh \
               /tmp/local/usr/local/bin/gitea \
               /go/src/code.gitea.io/gitea/gitea \
-              /go/src/code.gitea.io/gitea/environment-to-ini
+              /go/src/code.gitea.io/gitea/environment-to-ini \
+              /go/src/code.gitea.io/gitea/ini-to-shell
 RUN chmod 644 /go/src/code.gitea.io/gitea/contrib/autocompletion/bash_autocomplete
 
 FROM docker.io/library/alpine:3.20
@@ -71,6 +75,7 @@ RUN chown git:git /var/lib/gitea /etc/gitea
 COPY --from=build-env /tmp/local /
 COPY --from=build-env --chown=root:root /go/src/code.gitea.io/gitea/gitea /app/gitea/gitea
 COPY --from=build-env --chown=root:root /go/src/code.gitea.io/gitea/environment-to-ini /usr/local/bin/environment-to-ini
+COPY --from=build-env --chown=root:root /go/src/code.gitea.io/gitea/ini-to-shell /usr/local/bin/ini-to-shell
 COPY --from=build-env /go/src/code.gitea.io/gitea/contrib/autocompletion/bash_autocomplete /etc/profile.d/gitea_bash_autocomplete.sh
 
 # git:git

--- a/contrib/ini-to-shell/README
+++ b/contrib/ini-to-shell/README
@@ -1,0 +1,19 @@
+Ini to Shell
+==================
+
+This is the counterpart to environment-to-ini. It allows extracting
+settings from an existing ini file for further processing in e.g. a shell.
+
+The original incentive comes from the Helm Chart repository, where
+the ini file must be recreated on changes while preserving some of them.
+
+Since it is not possible to define an environment variable for the
+parent process, this script simply echoes the value.
+
+To build locally, run:
+
+	go build contrib/ini-to-shell/ini-to-shell.go
+
+To extract a value from an ini file, run:
+
+	reflogExpire=$(go run contrib/ini-to-shell/ini-to-shell.go -c app.ini -s 'git.config' -k 'gc.reflogExpire')

--- a/contrib/ini-to-shell/ini-to-shell.go
+++ b/contrib/ini-to-shell/ini-to-shell.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	golog "log"
 	"os"
 
 	"code.gitea.io/gitea/modules/log"
@@ -92,7 +93,9 @@ func runIniToShell(c *cli.Context) error {
 		log.Fatal("Section '%s' does not have key '%s'", sName, kName)
 	}
 
-	os.Stdout.Write([]byte(section.Key(kName).Value()))
+	golog.SetOutput(os.Stdout)
+	golog.SetFlags(golog.Flags() &^ (golog.Ldate | golog.Ltime))
+	golog.Println(section.Key(kName).Value())
 
 	return nil
 }

--- a/contrib/ini-to-shell/ini-to-shell.go
+++ b/contrib/ini-to-shell/ini-to-shell.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"code.gitea.io/gitea/modules/log"
@@ -93,7 +92,7 @@ func runIniToShell(c *cli.Context) error {
 		log.Fatal("Section '%s' does not have key '%s'", sName, kName)
 	}
 
-	fmt.Printf("%s", section.Key(kName).Value())
+	os.Stdout.Write([]byte(section.Key(kName).Value()))
 
 	return nil
 }

--- a/contrib/ini-to-shell/ini-to-shell.go
+++ b/contrib/ini-to-shell/ini-to-shell.go
@@ -1,0 +1,99 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/setting"
+
+	"github.com/urfave/cli/v2"
+)
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "ini-to-shell"
+	app.Usage = "Extract settings from an existing configuration ini"
+	app.Description = `This is the counterpart to environment-to-ini.
+	It allows extracting settings from an existing ini file for further
+	processing in e.g. a shell.
+
+	Since it is not possible to define an environment variable for the
+	parent process, this script simply echoes the value.
+
+		"""
+		./ini-to-shell -c /path/to/app.ini -s '<section name>' -k '<key name>'
+		"""
+
+	Section and key name are case sensitive and MUST match with the ini content.`
+	app.Flags = []cli.Flag{
+		&cli.StringFlag{
+			Name:    "custom-path",
+			Aliases: []string{"C"},
+			Value:   setting.CustomPath,
+			Usage:   "Custom path file path",
+		},
+		&cli.StringFlag{
+			Name:    "config",
+			Aliases: []string{"c"},
+			Value:   setting.CustomConf,
+			Usage:   "Custom configuration file path",
+		},
+		&cli.StringFlag{
+			Name:    "work-path",
+			Aliases: []string{"w"},
+			Value:   setting.AppWorkPath,
+			Usage:   "Set the gitea working path",
+		},
+		&cli.StringFlag{
+			Name:    "section",
+			Aliases: []string{"s"},
+			Value:   "",
+			Usage:   "Section name to search the given key (leave empty for default/root section)",
+		},
+		&cli.StringFlag{
+			Name:     "key",
+			Aliases:  []string{"k"},
+			Required: true,
+			Value:    "",
+			Usage:    "Key name to extract the value from",
+		},
+	}
+	app.Action = runIniToShell
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Fatal("Failed to run app with %s: %v", os.Args, err)
+	}
+}
+
+func runIniToShell(c *cli.Context) error {
+	setting.InitWorkPathAndCfgProvider(os.Getenv, setting.ArgWorkPathAndCustomConf{
+		WorkPath:   c.String("work-path"),
+		CustomPath: c.String("custom-path"),
+		CustomConf: c.String("config"),
+	})
+
+	cfg, err := setting.NewConfigProviderFromFile(setting.CustomConf)
+	if err != nil {
+		log.Fatal("Failed to load custom conf '%s': %v", setting.CustomConf, err)
+	}
+
+	sName := c.String("section")
+	kName := c.String("key")
+
+	section, err := cfg.GetSection(sName)
+	if err != nil {
+		log.Fatal("Failed to load section '%s': %v", sName, err)
+	}
+
+	if !section.HasKey(kName) {
+		log.Fatal("Section '%s' does not have key '%s'", sName, kName)
+	}
+
+	fmt.Printf("%s", section.Key(kName).Value())
+
+	return nil
+}


### PR DESCRIPTION
### Description of the change

This adds a new binary for extracting settings from an existing `app.ini`.

### Benefits

Instead of `grep`-ing the file via shell scripts, this binary uses the Gitea internals for reading the `app.ini`.

### Possible drawbacks

None

### Applicable issues

Helps addressing https://gitea.com/gitea/helm-chart/issues/356.

---

Signed-off-by: justusbunsi <61625851+justusbunsi@users.noreply.github.com>