### PR TITLE
Fix JS regression from 32656

### DIFF
--- a/web_src/js/utils/testhelper.ts
+++ b/web_src/js/utils/testhelper.ts
@@ -2,5 +2,5 @@
 // even if backend is in testing mode, frontend could be complied in production mode
 // so this function only checks if the frontend is in unit testing mode (usually from *.test.ts files)
 export function isInFrontendUnitTest() {
-  return process.env.TEST === 'true';
+  return process && process.env.TEST === 'true';
 }


### PR DESCRIPTION
#32656 seem to cause a JavaScript error when visiting https://gitea.com/gitea/helm-chart/pulls/239. `process` is undefined. Only occurs when logged in.

This should fix it.

![image](https://github.com/user-attachments/assets/04de80ee-67a4-4673-8a8b-647c6917710b)
![image](https://github.com/user-attachments/assets/ac707558-3d29-4222-9216-0285c7ccaf81)
