### PR TITLE
fix: show tag name on branch/tag selector if repo shown from tag ref

### DIFF
--- a/templates/repo/commits.tmpl
+++ b/templates/repo/commits.tmpl
@@ -9,8 +9,8 @@
 				{{$branchDropdownCurrentRefType := "branch"}}
 				{{$branchDropdownCurrentRefShortName := .BranchName}}
 				{{if .IsViewTag}}
-					{{$branchDropdownCurrentRefType := "tag"}}
-					{{$branchDropdownCurrentRefShortName := .TagName}}
+					{{$branchDropdownCurrentRefType = "tag"}}
+					{{$branchDropdownCurrentRefShortName = .TagName}}
 				{{end}}
 				{{template "repo/branch_dropdown" dict
 					"Repository" .Repository

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -50,8 +50,8 @@
 				{{$branchDropdownCurrentRefType := "branch"}}
 				{{$branchDropdownCurrentRefShortName := .BranchName}}
 				{{if .IsViewTag}}
-					{{$branchDropdownCurrentRefType := "tag"}}
-					{{$branchDropdownCurrentRefShortName := .TagName}}
+					{{$branchDropdownCurrentRefType = "tag"}}
+					{{$branchDropdownCurrentRefShortName = .TagName}}
 				{{end}}
 				{{template "repo/branch_dropdown" dict
 					"Repository" .Repository


### PR DESCRIPTION
This is what i tried to say in https://github.com/go-gitea/gitea/pull/32681#discussion_r1865046789 but sadly in wrong place