### PR TITLE
Fix oauth2 login methods

### DIFF
--- a/templates/user/auth/signin_inner.tmpl
+++ b/templates/user/auth/signin_inner.tmpl
@@ -48,10 +48,11 @@
 			</div>
 		</form>
 		{{end}}{{/*if .EnablePasswordSignInForm*/}}
-		{{if and .OAuth2Providers .EnableOpenIDSignIn .EnablePasswordSignInForm}}
+		{{$showOAuth2Methods := or .OAuth2Providers .EnableOpenIDSignIn}}
+		{{if and $showOAuth2Methods .EnablePasswordSignInForm}}
 			<div class="divider divider-text">{{ctx.Locale.Tr "sign_in_or"}}</div>
 		{{end}}
-		{{if and .OAuth2Providers .EnableOpenIDSignIn}}
+		{{if $showOAuth2Methods}}
 			{{template "user/auth/oauth_container" .}}
 		{{end}}
 	</div>

--- a/templates/user/auth/signup_inner.tmpl
+++ b/templates/user/auth/signup_inner.tmpl
@@ -47,8 +47,8 @@
 					</button>
 				</div>
 			{{end}}
-
-			{{if and .OAuth2Providers .EnableOpenIDSignIn}}
+			{{$showOAuth2Methods := or .OAuth2Providers .EnableOpenIDSignIn}}
+			{{if $showOAuth2Methods}}
 				<div class="divider divider-text">{{ctx.Locale.Tr "sign_in_or"}}</div>
 				{{template "user/auth/oauth_container" .}}
 			{{end}}


### PR DESCRIPTION
Regression of #32687

It should use "or" but not "and", otherwise the oauth2 methods won't show when no ENABLE_OPENID_SIGNIN