### PR TITLE
Fix AccessibleTeamReposEnv.RepoIDs can not get the correct result

### DIFF
--- a/models/organization/org.go
+++ b/models/organization/org.go
@@ -715,7 +715,7 @@ func (env *accessibleReposEnv) cond() builder.Cond {
 	if env.team != nil {
 		cond = cond.And(builder.Eq{"team_repo.team_id": env.team.ID})
 	} else {
-		if env.user == nil || !env.user.IsRestricted {
+		if env.user == nil || env.user.IsRestricted {
 			cond = cond.Or(builder.Eq{
 				"`repository`.owner_id":   env.org.ID,
 				"`repository`.is_private": false,


### PR DESCRIPTION
Possibly fix #32677

There are two function we can remove a member from an organization.
`RemoveOrgUser` and `RemoveTeamMember`

`RemoveTeamMember` seems correct, as by my test it can correctly update the watch list.
But for `RemoveOrgUser`, it can not correctly remove the watch list for private repos in the organization, as there's a miss in the condition.

About the fix:
If user is null or user is restricted, then we need to add the condition to filter the private repos.
But the logic now is if user is not restricted, only public repos will be count.

This line comes from: 
https://github.com/go-gitea/gitea/pull/6274/files#diff-780b130df406563b7f1b2dd8add33e4160a91f9a130ef99f7282389e20ea9efbR777