### PR TITLE
Bump relative-time-element to v4.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@citation-js/plugin-csl": "0.7.11",
         "@citation-js/plugin-software-formats": "0.6.1",
         "@github/markdown-toolbar-element": "2.2.3",
-        "@github/relative-time-element": "4.4.2",
+        "@github/relative-time-element": "4.4.4",
         "@github/text-expander-element": "2.6.1",
         "@mcaptcha/vanilla-glue": "0.1.0-alpha-3",
         "@primer/octicons": "19.9.0",
@@ -1020,9 +1020,9 @@
       "integrity": "sha512-AlquKGee+IWiAMYVB0xyHFZRMnu4n3X4HTvJHu79GiVJ1ojTukCWyxMlF5NMsecoLcBKsuBhx3QPv2vkE/zQ0A=="
     },
     "node_modules/@github/relative-time-element": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@github/relative-time-element/-/relative-time-element-4.4.2.tgz",
-      "integrity": "sha512-wTXunu3hmuGljA5CHaaoUIKV0oI35wno0FKJl2yqKplTRnsCA5bPNj4bDeVIubkuskql6jwionWLlGM1Y6QLaw==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@github/relative-time-element/-/relative-time-element-4.4.4.tgz",
+      "integrity": "sha512-Oi8uOL8O+ZWLD7dHRWCkm2cudcTYtB3VyOYf9BtzCgDGm+OKomyOREtItNMtWl1dxvec62BTKErq36uy+RYxQg==",
       "license": "MIT"
     },
     "node_modules/@github/text-expander-element": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@citation-js/plugin-csl": "0.7.11",
     "@citation-js/plugin-software-formats": "0.6.1",
     "@github/markdown-toolbar-element": "2.2.3",
-    "@github/relative-time-element": "4.4.2",
+    "@github/relative-time-element": "4.4.4",
     "@github/text-expander-element": "2.6.1",
     "@mcaptcha/vanilla-glue": "0.1.0-alpha-3",
     "@primer/octicons": "19.9.0",


### PR DESCRIPTION
Backport https://github.com/go-gitea/gitea/pull/32730 to v1.22