### PR TITLE
Prevent creating empy PR (w/o commits) through API

### DIFF
--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -1240,6 +1240,13 @@ func parseCompareInfo(ctx *context.APIContext, form api.CreatePullRequestOption)
 		return nil, nil, nil, "", ""
 	}
 
+	if !(len(compareInfo.Commits) > 0) {
+		headGitRepo.Close()
+		ctx.Error(http.StatusUnprocessableEntity, "EmptyPullRequest",
+			fmt.Sprintf("no commits between %v:%v and %v:%v", baseRepo.Owner.Name, baseBranch, headUser.Name, headBranch))
+		return nil, nil, nil, "", ""
+	}
+
 	return headRepo, headGitRepo, compareInfo, baseBranch, headBranch
 }
 


### PR DESCRIPTION
Check number of commits between head and base during PR creation, if not greater than zero return error.