### PR TITLE
Repo homepage tweaks

### DIFF
--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -1,4 +1,4 @@
-<table id="repo-files-table" class="ui single line fixed table tw-mt-0" {{if .HasFilesWithoutLatestCommit}}hx-indicator="tr.notready td.message span" hx-trigger="load" hx-swap="morph" hx-post="{{.LastCommitLoaderURL}}"{{end}}>
+<table id="repo-files-table" class="ui single line table tw-mt-0" {{if .HasFilesWithoutLatestCommit}}hx-indicator="tr.notready td.message span" hx-trigger="load" hx-swap="morph" hx-post="{{.LastCommitLoaderURL}}"{{end}}>
 	<thead>
 		<tr class="commit-list">
 			<th class="tw-overflow-hidden" colspan="2">

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -1800,7 +1800,7 @@ td .commit-summary {
 
 .repository .repository-summary .sub-menu .item {
   flex: 1;
-  height: 30px;
+  height: 33.6px; /* match search bar height */
   line-height: var(--line-height-default);
   display: flex;
   align-items: center;

--- a/web_src/css/repo/home.css
+++ b/web_src/css/repo/home.css
@@ -24,7 +24,7 @@
   border-top: 1px solid var(--color-secondary); /* same to .flex-list > .flex-item + .flex-item */
 }
 
-@media (max-width: 767.98px) {
+@media (max-width: 872px) { /* value is exactly where the file table starts to overflow */
   .repo-grid-filelist-sidebar {
     grid-template-columns: 100%;
     grid-template-rows: auto auto auto;


### PR DESCRIPTION
1. Fix commit message limited too small by `fixed` table layout. The non-fixed layout causes overflow issue between 872px and 768px width, fix that by switching to the mobile layout at 872px.

<img width="999" alt="image" src="https://github.com/user-attachments/assets/899c33c3-316e-4fa6-bcd4-a4efd9180482">

2. Match `.repository-summary` to search bar in height:
<img width="180" alt="image" src="https://github.com/user-attachments/assets/b0ea9655-c454-41af-9983-7f3287256b4d">
