### PR TITLE
Label grouping

### DIFF
--- a/routers/web/repo/issue_page_meta.go
+++ b/routers/web/repo/issue_page_meta.go
@@ -441,4 +441,8 @@ func (d *IssuePageMetaData) retrieveLabelsData(ctx *context.Context) {
 	}
 	labelsData.AllLabels = append(labelsData.AllLabels, labelsData.RepoLabels...)
 	labelsData.AllLabels = append(labelsData.AllLabels, labelsData.OrgLabels...)
+
+	sort.Slice(labelsData.AllLabels, func(i, j int) bool {
+		return labelsData.AllLabels[i].Name < labelsData.AllLabels[j].Name
+	})
 }

--- a/templates/repo/issue/sidebar/label_list.tmpl
+++ b/templates/repo/issue/sidebar/label_list.tmpl
@@ -19,23 +19,15 @@
 				<a class="item clear-selection" href="#">{{ctx.Locale.Tr "repo.issues.new.clear_labels"}}</a>
 				<div class="scrolling menu">
 					{{$previousExclusiveScope := "_no_scope"}}
-					{{range $data.RepoLabels}}
-						{{$exclusiveScope := .ExclusiveScope}}
-						{{if and (ne $previousExclusiveScope "_no_scope") (ne $previousExclusiveScope $exclusiveScope)}}
-							<div class="divider"></div>
+					{{range $data.AllLabels}}
+						{{if or (not .IsArchived) (.IsChecked)}}
+							{{$exclusiveScope := .ExclusiveScope}}
+							{{if and (ne $previousExclusiveScope "_no_scope") (ne $previousExclusiveScope $exclusiveScope)}}
+								<div class="divider"></div>
+							{{end}}
+							{{$previousExclusiveScope = $exclusiveScope}}
+							{{template "repo/issue/sidebar/label_list_item" dict "Label" .}}
 						{{end}}
-						{{$previousExclusiveScope = $exclusiveScope}}
-						{{template "repo/issue/sidebar/label_list_item" dict "Label" .}}
-					{{end}}
-					{{if and $data.RepoLabels $data.OrgLabels}}<div class="divider"></div>{{end}}
-					{{$previousExclusiveScope = "_no_scope"}}
-					{{range $data.OrgLabels}}
-						{{$exclusiveScope := .ExclusiveScope}}
-						{{if and (ne $previousExclusiveScope "_no_scope") (ne $previousExclusiveScope $exclusiveScope)}}
-							<div class="divider"></div>
-						{{end}}
-						{{$previousExclusiveScope = $exclusiveScope}}
-						{{template "repo/issue/sidebar/label_list_item" dict "Label" .}}
 					{{end}}
 				</div>
 			{{end}}


### PR DESCRIPTION
Labels are being passed to front-end dropdown as single list, meaning there was no intention to "group" or divide labels by org defined and repo defined.

In the UX it's looking weird why labels with same prefix are not grouped. This issue fixes that. 

### Screenshots
before
![image](https://github.com/user-attachments/assets/68a37973-c30b-4ed8-945a-2cf670acbeb7)
after
![image](https://github.com/user-attachments/assets/2174b37b-a68f-4244-92d6-2f27c43f75b2)