### PR TITLE
Remove unnecessary border in repo home page sidebar

### DIFF
--- a/web_src/css/repo/home.css
+++ b/web_src/css/repo/home.css
@@ -20,7 +20,7 @@
   grid-row: 2;
   padding-left: 1em;
 }
-.repo-home-sidebar-bottom > :first-child {
+.repo-home-sidebar-bottom .flex-list > :first-child {
   border-top: 1px solid var(--color-secondary); /* same to .flex-list > .flex-item + .flex-item */
 }
 
@@ -43,7 +43,7 @@
     grid-row: 3;
     padding-left: 0;
   }
-  .repo-home-sidebar-bottom > :first-child {
+  .repo-home-sidebar-bottom .flex-list > :first-child {
     border-top: 0;
   }
 }


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/e761c4f1-1578-49cb-a12c-1eaec904a6e2)

After:
![image](https://github.com/user-attachments/assets/abacdff8-7c2f-45f2-968a-4feb19cc00bf)
