### PR TITLE
Refactor issue filter (labels, poster, assignee)

### DIFF
--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -42,7 +42,7 @@ func NewFuncMap() template.FuncMap {
 		"HTMLFormat":   htmlutil.HTMLFormat,
 		"HTMLEscape":   htmlEscape,
 		"QueryEscape":  queryEscape,
-		"QueryBuild":   queryBuild,
+		"QueryBuild":   QueryBuild,
 		"JSEscape":     jsEscapeSafe,
 		"SanitizeHTML": SanitizeHTML,
 		"URLJoin":      util.URLJoin,
@@ -294,24 +294,27 @@ func timeEstimateString(timeSec any) string {
 	return util.TimeEstimateString(v)
 }
 
-func queryBuild(a ...any) template.URL {
+// QueryBuild builds a query string from a list of key-value pairs.
+// It omits the nil and empty strings, but it doesn't omit other zero values,
+// because the zero value of number types may have a meaning.
+func QueryBuild(a ...any) template.URL {
 	var s string
 	if len(a)%2 == 1 {
 		if v, ok := a[0].(string); ok {
 			if v == "" || (v[0] != '?' && v[0] != '&') {
-				panic("queryBuild: invalid argument")
+				panic("QueryBuild: invalid argument")
 			}
 			s = v
 		} else if v, ok := a[0].(template.URL); ok {
 			s = string(v)
 		} else {
-			panic("queryBuild: invalid argument")
+			panic("QueryBuild: invalid argument")
 		}
 	}
 	for i := len(a) % 2; i < len(a); i += 2 {
 		k, ok := a[i].(string)
 		if !ok {
-			panic("queryBuild: invalid argument")
+			panic("QueryBuild: invalid argument")
 		}
 		var v string
 		if va, ok := a[i+1].(string); ok {

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1109,7 +1109,7 @@ delete_preexisting_success = Deleted unadopted files in %s
 blame_prior = View blame prior to this change
 blame.ignore_revs = Ignoring revisions in <a href="%s">.git-blame-ignore-revs</a>. Click <a href="%s">here to bypass</a> and see the normal blame view.
 blame.ignore_revs.failed = Failed to ignore revisions in <a href="%s">.git-blame-ignore-revs</a>.
-author_search_tooltip = Shows a maximum of 30 users
+user_search_tooltip = Shows a maximum of 30 users
 
 tree_path_not_found_commit = Path %[1]s doesn't exist in commit %[2]s
 tree_path_not_found_branch = Path %[1]s doesn't exist in branch %[2]s
@@ -1529,7 +1529,8 @@ issues.filter_assignee = Assignee
 issues.filter_assginee_no_select = All assignees
 issues.filter_assginee_no_assignee = No assignee
 issues.filter_poster = Author
-issues.filter_poster_no_select = All authors
+issues.filter_user_placeholder = Search users
+issues.filter_user_no_select = All users
 issues.filter_type = Type
 issues.filter_type.all_issues = All issues
 issues.filter_type.assigned_to_you = Assigned to you

--- a/routers/web/org/projects.go
+++ b/routers/web/org/projects.go
@@ -339,12 +339,7 @@ func ViewProject(ctx *context.Context) {
 	// 0 means issues with no label
 	// blank means labels will not be filtered for issues
 	selectLabels := ctx.FormString("labels")
-	if selectLabels == "" {
-		ctx.Data["AllLabels"] = true
-	} else if selectLabels == "0" {
-		ctx.Data["NoLabel"] = true
-	}
-	if len(selectLabels) > 0 {
+	if selectLabels != "" {
 		labelIDs, err = base.StringsToInt64s(strings.Split(selectLabels, ","))
 		if err != nil {
 			ctx.Flash.Error(ctx.Tr("invalid_data", selectLabels), true)

--- a/routers/web/repo/issue_list.go
+++ b/routers/web/repo/issue_list.go
@@ -798,6 +798,7 @@ func issues(ctx *context.Context, milestoneID, projectID int64, isPullOption opt
 	ctx.Data["MilestoneID"] = milestoneID
 	ctx.Data["ProjectID"] = projectID
 	ctx.Data["AssigneeID"] = assigneeID
+	ctx.Data["PosterUserID"] = posterUserID
 	ctx.Data["PosterUsername"] = posterUsername
 	ctx.Data["Keyword"] = keyword
 	ctx.Data["IsShowClosed"] = isShowClosed

--- a/routers/web/repo/issue_list.go
+++ b/routers/web/repo/issue_list.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 
@@ -531,12 +530,7 @@ func issues(ctx *context.Context, milestoneID, projectID int64, isPullOption opt
 	// 0 means issues with no label
 	// blank means labels will not be filtered for issues
 	selectLabels := ctx.FormString("labels")
-	if selectLabels == "" {
-		ctx.Data["AllLabels"] = true
-	} else if selectLabels == "0" {
-		ctx.Data["NoLabel"] = true
-	}
-	if len(selectLabels) > 0 {
+	if selectLabels != "" {
 		labelIDs, err = base.StringsToInt64s(strings.Split(selectLabels, ","))
 		if err != nil {
 			ctx.Flash.Error(ctx.Tr("invalid_data", selectLabels), true)
@@ -615,8 +609,6 @@ func issues(ctx *context.Context, milestoneID, projectID int64, isPullOption opt
 		}
 		ctx.Data["TotalTrackedTime"] = totalTrackedTime
 	}
-
-	archived := ctx.FormBool("archived")
 
 	page := ctx.FormInt("page")
 	if page <= 1 {
@@ -792,21 +784,13 @@ func issues(ctx *context.Context, milestoneID, projectID int64, isPullOption opt
 		return
 	}
 
+	showArchivedLabels := ctx.FormBool("archived_labels")
+	ctx.Data["ShowArchivedLabels"] = showArchivedLabels
 	ctx.Data["PinnedIssues"] = pinned
 	ctx.Data["IsRepoAdmin"] = ctx.IsSigned && (ctx.Repo.IsAdmin() || ctx.Doer.IsAdmin)
 	ctx.Data["IssueStats"] = issueStats
 	ctx.Data["OpenCount"] = issueStats.OpenCount
 	ctx.Data["ClosedCount"] = issueStats.ClosedCount
-	linkStr := "%s?q=%s&type=%s&sort=%s&state=%s&labels=%s&milestone=%d&project=%d&assignee=%d&poster=%v&archived=%t"
-	ctx.Data["AllStatesLink"] = fmt.Sprintf(linkStr, ctx.Link,
-		url.QueryEscape(keyword), url.QueryEscape(viewType), url.QueryEscape(sortType), "all", url.QueryEscape(selectLabels),
-		milestoneID, projectID, assigneeID, url.QueryEscape(posterUsername), archived)
-	ctx.Data["OpenLink"] = fmt.Sprintf(linkStr, ctx.Link,
-		url.QueryEscape(keyword), url.QueryEscape(viewType), url.QueryEscape(sortType), "open", url.QueryEscape(selectLabels),
-		milestoneID, projectID, assigneeID, url.QueryEscape(posterUsername), archived)
-	ctx.Data["ClosedLink"] = fmt.Sprintf(linkStr, ctx.Link,
-		url.QueryEscape(keyword), url.QueryEscape(viewType), url.QueryEscape(sortType), "closed", url.QueryEscape(selectLabels),
-		milestoneID, projectID, assigneeID, url.QueryEscape(posterUsername), archived)
 	ctx.Data["SelLabelIDs"] = labelIDs
 	ctx.Data["SelectLabels"] = selectLabels
 	ctx.Data["ViewType"] = viewType
@@ -825,7 +809,6 @@ func issues(ctx *context.Context, milestoneID, projectID int64, isPullOption opt
 	default:
 		ctx.Data["State"] = "open"
 	}
-	ctx.Data["ShowArchivedLabels"] = archived
 
 	pager.AddParamString("q", keyword)
 	pager.AddParamString("type", viewType)
@@ -836,8 +819,9 @@ func issues(ctx *context.Context, milestoneID, projectID int64, isPullOption opt
 	pager.AddParamString("project", fmt.Sprint(projectID))
 	pager.AddParamString("assignee", fmt.Sprint(assigneeID))
 	pager.AddParamString("poster", posterUsername)
-	pager.AddParamString("archived", fmt.Sprint(archived))
-
+	if showArchivedLabels {
+		pager.AddParamString("archived_labels", "true")
+	}
 	ctx.Data["Page"] = pager
 }
 

--- a/routers/web/repo/milestone.go
+++ b/routers/web/repo/milestone.go
@@ -66,12 +66,6 @@ func Milestones(ctx *context.Context) {
 	}
 	ctx.Data["OpenCount"] = stats.OpenCount
 	ctx.Data["ClosedCount"] = stats.ClosedCount
-	linkStr := "%s/milestones?state=%s&q=%s&sort=%s"
-	ctx.Data["OpenLink"] = fmt.Sprintf(linkStr, ctx.Repo.RepoLink, "open",
-		url.QueryEscape(keyword), url.QueryEscape(sortType))
-	ctx.Data["ClosedLink"] = fmt.Sprintf(linkStr, ctx.Repo.RepoLink, "closed",
-		url.QueryEscape(keyword), url.QueryEscape(sortType))
-
 	if ctx.Repo.Repository.IsTimetrackerEnabled(ctx) {
 		if err := issues_model.MilestoneList(miles).LoadTotalTrackedTimes(ctx); err != nil {
 			ctx.ServerError("LoadTotalTrackedTimes", err)

--- a/routers/web/repo/projects.go
+++ b/routers/web/repo/projects.go
@@ -312,12 +312,7 @@ func ViewProject(ctx *context.Context) {
 	// 0 means issues with no label
 	// blank means labels will not be filtered for issues
 	selectLabels := ctx.FormString("labels")
-	if selectLabels == "" {
-		ctx.Data["AllLabels"] = true
-	} else if selectLabels == "0" {
-		ctx.Data["NoLabel"] = true
-	}
-	if len(selectLabels) > 0 {
+	if selectLabels != "" {
 		labelIDs, err = base.StringsToInt64s(strings.Split(selectLabels, ","))
 		if err != nil {
 			ctx.Flash.Error(ctx.Tr("invalid_data", selectLabels), true)

--- a/templates/projects/view.tmpl
+++ b/templates/projects/view.tmpl
@@ -5,79 +5,19 @@
 		<h2 class="tw-mb-0 tw-flex-1 tw-break-anywhere">{{.Project.Title}}</h2>
 			<div class="project-toolbar-right">
 				<div class="ui secondary filter menu labels">
-					<!-- Label -->
-					<div class="ui {{if not .Labels}}disabled{{end}} dropdown jump item label-filter">
-						<span class="text">
-							{{ctx.Locale.Tr "repo.issues.filter_label"}}
-						</span>
-						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-						<div class="menu">
-							<div class="ui icon search input">
-								<i class="icon">{{svg "octicon-search" 16}}</i>
-								<input type="text" placeholder="{{ctx.Locale.Tr "repo.issues.filter_label"}}">
-							</div>
-							<div class="ui checkbox compact archived-label-filter">
-								<input name="archived" type="checkbox"
-									id="archived-filter-checkbox"
-									{{if .ShowArchivedLabels}}checked{{end}}
-								>
-								<label for="archived-filter-checkbox">
-									{{ctx.Locale.Tr "repo.issues.label_archived_filter"}}
-									<i class="tw-ml-1" data-tooltip-content={{ctx.Locale.Tr "repo.issues.label_archive_tooltip"}}>
-										{{svg "octicon-info"}}
-									</i>
-								</label>
-							</div>
-							<span class="info">{{ctx.Locale.Tr "repo.issues.filter_label_exclude"}}</span>
-							<div class="divider"></div>
-							<a class="{{if .AllLabels}}active selected {{end}}item" href="?assignee={{$.AssigneeID}}{{if $.ShowArchivedLabels}}&archived=true{{end}}">{{ctx.Locale.Tr "repo.issues.filter_label_no_select"}}</a>
-							<a class="{{if .NoLabel}}active selected {{end}}item" href="?assignee={{$.AssigneeID}}{{if $.ShowArchivedLabels}}&archived=true{{end}}">{{ctx.Locale.Tr "repo.issues.filter_label_select_no_label"}}</a>
-							{{$previousExclusiveScope := "_no_scope"}}
-							{{range .Labels}}
-								{{$exclusiveScope := .ExclusiveScope}}
-								{{if and (ne $previousExclusiveScope $exclusiveScope)}}
-									<div class="divider" data-scope="{{.ExclusiveScope}}"></div>
-								{{end}}
-								{{$previousExclusiveScope = $exclusiveScope}}
-								<a class="item label-filter-item tw-flex tw-items-center" data-label-id="{{.ID}}" data-scope="{{.ExclusiveScope}}" {{if .IsArchived}}data-is-archived{{end}}
-									href="?labels={{.QueryString}}&assignee={{$.AssigneeID}}{{if $.ShowArchivedLabels}}&archived=true{{end}}">
-									{{if .IsExcluded}}
-										{{svg "octicon-circle-slash"}}
-									{{else if .IsSelected}}
-										{{if $exclusiveScope}}
-											{{svg "octicon-dot-fill"}}
-										{{else}}
-											{{svg "octicon-check"}}
-										{{end}}
-									{{end}}
-									{{ctx.RenderUtils.RenderLabel .}}
-									<p class="tw-ml-auto">{{template "repo/issue/labels/label_archived" .}}</p>
-								</a>
-							{{end}}
-						</div>
-					</div>
+					{{$queryLink := QueryBuild "?" "labels" .SelectLabels "assignee" $.AssigneeID "archived_labels" (Iif $.ShowArchivedLabels "true")}}
 
-					<!-- Assignee -->
-					<div class="ui {{if not .Assignees}}disabled{{end}} dropdown jump item">
-						<span class="text">
-							{{ctx.Locale.Tr "repo.issues.filter_assignee"}}
-						</span>
-						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-						<div class="menu">
-							<div class="ui icon search input">
-								<i class="icon">{{svg "octicon-search" 16}}</i>
-								<input type="text" placeholder="{{ctx.Locale.Tr "repo.issues.filter_assignee"}}">
-							</div>
-							<a class="{{if not .AssigneeID}}active selected {{end}}item" href="?labels={{.SelectLabels}}{{if $.ShowArchivedLabels}}&archived=true{{end}}">{{ctx.Locale.Tr "repo.issues.filter_assginee_no_select"}}</a>
-							<a class="{{if eq .AssigneeID -1}}active selected {{end}}item" href="?labels={{.SelectLabels}}&assignee=-1{{if $.ShowArchivedLabels}}&archived=true{{end}}">{{ctx.Locale.Tr "repo.issues.filter_assginee_no_assignee"}}</a>
-							<div class="divider"></div>
-							{{range .Assignees}}
-								<a class="{{if eq $.AssigneeID .ID}}active selected{{end}} item tw-flex" href="?labels={{$.SelectLabels}}&assignee={{.ID}}{{if $.ShowArchivedLabels}}&archived=true{{end}}">
-									{{ctx.AvatarUtils.Avatar . 20}}{{template "repo/search_name" .}}
-								</a>
-							{{end}}
-						</div>
-					</div>
+					{{template "repo/issue/filter_item_label" dict "Labels" .Labels "QueryLink" $queryLink "SupportArchivedLabel" true}}
+
+					{{template "repo/issue/filter_item_user_assign" dict
+						"QueryParamKey" "assignee"
+						"QueryLink" $queryLink
+						"UserSearchList" $.Assignees
+						"SelectedUserId" $.AssigneeID
+						"TextFilterTitle" (ctx.Locale.Tr "repo.issues.filter_assignee")
+						"TextZeroValue" (ctx.Locale.Tr "repo.issues.filter_assginee_no_select")
+						"TextNegativeOne" (ctx.Locale.Tr "repo.issues.filter_assginee_no_assignee")
+					}}
 				</div>
 			</div>
 		{{if $canWriteProject}}

--- a/templates/repo/issue/filter_item_label.tmpl
+++ b/templates/repo/issue/filter_item_label.tmpl
@@ -2,7 +2,7 @@
 * "labels" from query string (needed by JS)
 * QueryLink
 * Labels
-* SupportArchivedLabel, if true, then it needs "archived_labes" from query string
+* SupportArchivedLabel, if true, then it needs "archived_labels" from query string
 */}}
 {{$queryLink := .QueryLink}}
 <div class="item ui dropdown jump {{if not .Labels}}disabled{{end}} label-filter">

--- a/templates/repo/issue/filter_item_label.tmpl
+++ b/templates/repo/issue/filter_item_label.tmpl
@@ -1,11 +1,11 @@
 {{/*
-* "labels" from query string
+* "labels" from query string (needed by JS)
 * QueryLink
 * Labels
 * SupportArchivedLabel, if true, then it needs "archived_labes" from query string
 */}}
 {{$queryLink := .QueryLink}}
-<div class="item ui {{if not .Labels}}disabled{{end}} dropdown jump label-filter">
+<div class="item ui dropdown jump {{if not .Labels}}disabled{{end}} label-filter">
 	<span class="text">{{ctx.Locale.Tr "repo.issues.filter_label"}}</span>
 	{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 	<div class="menu flex-items-menu">

--- a/templates/repo/issue/filter_item_label.tmpl
+++ b/templates/repo/issue/filter_item_label.tmpl
@@ -1,0 +1,45 @@
+{{/*
+* "labels" from query string
+* QueryLink
+* Labels
+* SupportArchivedLabel, if true, then it needs "archived_labes" from query string
+*/}}
+{{$queryLink := .QueryLink}}
+<div class="item ui {{if not .Labels}}disabled{{end}} dropdown jump label-filter">
+	<span class="text">{{ctx.Locale.Tr "repo.issues.filter_label"}}</span>
+	{{svg "octicon-triangle-down" 14 "dropdown icon"}}
+	<div class="menu flex-items-menu">
+		<div class="ui icon search input">
+			<i class="icon">{{svg "octicon-search" 16}}</i>
+			<input type="text" placeholder="{{ctx.Locale.Tr "repo.issues.filter_label"}}">
+		</div>
+		{{if .SupportArchivedLabel}}{{/* this checkbox has a hard dependency with the "labels" and "archived_label" query parameter */}}
+		<label class="label-filter-archived-toggle flex-text-block">
+			<input type="checkbox"> {{ctx.Locale.Tr "repo.issues.label_archived_filter"}}
+			<span data-tooltip-content={{ctx.Locale.Tr "repo.issues.label_archive_tooltip"}}>{{svg "octicon-info"}}</span>
+		</label>
+		{{end}}
+		<span class="info">{{ctx.Locale.Tr "repo.issues.filter_label_exclude"}}</span>
+		<div class="divider"></div>
+		<a class="item label-filter-query-default" href="{{QueryBuild $queryLink "labels" NIL}}">{{ctx.Locale.Tr "repo.issues.filter_label_no_select"}}</a>
+		<a class="item label-filter-query-not-set" href="{{QueryBuild $queryLink "labels" 0}}">{{ctx.Locale.Tr "repo.issues.filter_label_select_no_label"}}</a>
+		{{$previousExclusiveScope := "_no_scope"}}
+		{{range .Labels}}
+			{{$exclusiveScope := .ExclusiveScope}}
+			{{if and (ne $previousExclusiveScope $exclusiveScope)}}
+				<div class="divider" data-scope="{{.ExclusiveScope}}"></div>
+			{{end}}
+			{{$previousExclusiveScope = $exclusiveScope}}
+			<a class="item label-filter-query-item" data-label-id="{{.ID}}" data-scope="{{.ExclusiveScope}}" {{if .IsArchived}}data-is-archived{{end}}
+				href="{{QueryBuild $queryLink "labels" .QueryString}}">
+				{{if .IsExcluded}}
+					{{svg "octicon-circle-slash"}}
+				{{else if .IsSelected}}
+					{{Iif $exclusiveScope (svg "octicon-dot-fill") (svg "octicon-check")}}
+				{{end}}
+				{{ctx.RenderUtils.RenderLabel .}}
+				<p class="tw-ml-auto">{{template "repo/issue/labels/label_archived" .}}</p>
+			</a>
+		{{end}}
+	</div>
+</div>

--- a/templates/repo/issue/filter_item_user_assign.tmpl
+++ b/templates/repo/issue/filter_item_user_assign.tmpl
@@ -8,7 +8,7 @@
 * TextNegativeOne: the text for "issues with no assignee"
 */}}
 {{$queryLink := .QueryLink}}
-<div class="item ui {{if not .UserSearchList}}disabled{{end}} dropdown jump">
+<div class="item ui dropdown jump {{if not .UserSearchList}}disabled{{end}}">
 	{{$.TextFilterTitle}} {{svg "octicon-triangle-down" 14 "dropdown icon"}}
 	<div class="menu">
 		<div class="ui icon search input">
@@ -23,7 +23,7 @@
 		{{end}}
 		<div class="divider"></div>
 		{{range .UserSearchList}}
-			<a class="item {{if eq $.SelectedUserId .ID}}selected{{end}} item" href="{{QueryBuild $queryLink $.QueryParamKey .ID}}">
+			<a class="item {{if eq $.SelectedUserId .ID}}selected{{end}}" href="{{QueryBuild $queryLink $.QueryParamKey .ID}}">
 				{{ctx.AvatarUtils.Avatar . 20}}{{template "repo/search_name" .}}
 			</a>
 		{{end}}

--- a/templates/repo/issue/filter_item_user_assign.tmpl
+++ b/templates/repo/issue/filter_item_user_assign.tmpl
@@ -1,0 +1,31 @@
+{{/* This is a user list for filter, the data is provided by a local variable assignment
+* QueryParamKey: eg: "poster", "assignee"
+* QueryLink
+* UserSearchList
+* SelectedUserId: 0 or empty means default, -1 means "no user is set"
+* TextFilterTitle
+* TextZeroValue: the text for "all issues"
+* TextNegativeOne: the text for "issues with no assignee"
+*/}}
+{{$queryLink := .QueryLink}}
+<div class="item ui {{if not .UserSearchList}}disabled{{end}} dropdown jump">
+	{{$.TextFilterTitle}} {{svg "octicon-triangle-down" 14 "dropdown icon"}}
+	<div class="menu">
+		<div class="ui icon search input">
+			<i class="icon">{{svg "octicon-search" 16}}</i>
+			<input type="text" placeholder="{{ctx.Locale.Tr "repo.issues.filter_user_placeholder"}}">
+		</div>
+		{{if $.TextZeroValue}}
+			<a class="item {{if not .SelectedUserId}}selected{{end}}" href="{{QueryBuild $queryLink $.QueryParamKey NIL}}">{{$.TextZeroValue}}</a>
+		{{end}}
+		{{if $.TextNegativeOne}}
+			<a class="item {{if eq .SelectedUserId -1}}selected{{end}}" href="{{QueryBuild $queryLink $.QueryParamKey -1}}">{{$.TextNegativeOne}}</a>
+		{{end}}
+		<div class="divider"></div>
+		{{range .UserSearchList}}
+			<a class="item {{if eq $.SelectedUserId .ID}}selected{{end}} item" href="{{QueryBuild $queryLink $.QueryParamKey .ID}}">
+				{{ctx.AvatarUtils.Avatar . 20}}{{template "repo/search_name" .}}
+			</a>
+		{{end}}
+	</div>
+</div>

--- a/templates/repo/issue/filter_item_user_fetch.tmpl
+++ b/templates/repo/issue/filter_item_user_fetch.tmpl
@@ -1,0 +1,23 @@
+{{/* This is a user list for filter, the data is provided by a remote "fetch" request
+* QueryParamKey: eg: "poster", "assignee"
+* QueryLink
+* UserSearchUrl
+* SelectedUserId
+* TextFilterTitle
+*/}}
+{{$queryLink := .QueryLink}}
+<div class="item ui dropdown custom user-remote-search" data-tooltip-content="{{ctx.Locale.Tr "repo.user_search_tooltip"}}"
+		data-search-url="{{$.UserSearchUrl}}"
+		data-selected-user-id="{{$.SelectedUserId}}"
+		data-action-jump-url="{{QueryBuild $queryLink $.QueryParamKey NIL}}&{{$.QueryParamKey}}={username}"
+>
+	{{$.TextFilterTitle}} {{svg "octicon-triangle-down" 14 "dropdown icon"}}
+	<div class="menu">
+		<div class="ui icon search input">
+			<i class="icon">{{svg "octicon-search" 16}}</i>
+			<input type="text" placeholder="{{ctx.Locale.Tr "repo.issues.filter_user_placeholder"}}">
+		</div>
+		<a class="item" data-value="">{{ctx.Locale.Tr "repo.issues.filter_user_no_select"}}</a>
+		<a class="item item-from-input tw-hidden"></a>
+	</div>
+</div>

--- a/templates/repo/issue/filter_list.tmpl
+++ b/templates/repo/issue/filter_list.tmpl
@@ -84,7 +84,7 @@
 	"QueryParamKey" "poster"
 	"QueryLink" $queryLink
 	"UserSearchUrl" (Iif .Milestone (print $.RepoLink "/issues/posters") (print $.Link "/posters"))
-	"SelectedUserId" $.PosterID
+	"SelectedUserId" $.PosterUserID
 	"TextFilterTitle" (ctx.Locale.Tr "repo.issues.filter_poster")
 }}
 

--- a/templates/repo/issue/filter_list.tmpl
+++ b/templates/repo/issue/filter_list.tmpl
@@ -1,55 +1,6 @@
-{{$queryLink := QueryBuild "?" "q" $.Keyword "type" $.ViewType "sort" $.SortType "state" $.State "labels" $.SelectLabels "milestone" $.MilestoneID "project" $.ProjectID "assignee" $.AssigneeID "poster" $.PosterUsername "archived" (Iif $.ShowArchivedLabels NIL)}}
-<!-- Label -->
-<div class="ui {{if not .Labels}}disabled{{end}} dropdown jump item label-filter">
-	<span class="text">
-		{{ctx.Locale.Tr "repo.issues.filter_label"}}
-	</span>
-	{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-	<div class="menu">
-		<div class="ui icon search input">
-			<i class="icon">{{svg "octicon-search" 16}}</i>
-			<input type="text" placeholder="{{ctx.Locale.Tr "repo.issues.filter_label"}}">
-		</div>
-		<div class="ui checkbox compact archived-label-filter">
-			<input name="archived" type="checkbox"
-				id="archived-filter-checkbox"
-				{{if .ShowArchivedLabels}}checked{{end}}
-			>
-			<label for="archived-filter-checkbox">
-				{{ctx.Locale.Tr "repo.issues.label_archived_filter"}}
-				<i class="tw-ml-1" data-tooltip-content={{ctx.Locale.Tr "repo.issues.label_archive_tooltip"}}>
-					{{svg "octicon-info"}}
-				</i>
-			</label>
-		</div>
-		<span class="info">{{ctx.Locale.Tr "repo.issues.filter_label_exclude"}}</span>
-		<div class="divider"></div>
-		<a class="{{if .AllLabels}}active selected {{end}}item" href="{{QueryBuild $queryLink "labels" NIL}}">{{ctx.Locale.Tr "repo.issues.filter_label_no_select"}}</a>
-		<a class="{{if .NoLabel}}active selected {{end}}item" href="{{QueryBuild $queryLink "labels" 0}}">{{ctx.Locale.Tr "repo.issues.filter_label_select_no_label"}}</a>
-		{{$previousExclusiveScope := "_no_scope"}}
-		{{range .Labels}}
-			{{$exclusiveScope := .ExclusiveScope}}
-			{{if and (ne $previousExclusiveScope $exclusiveScope)}}
-				<div class="divider" data-scope="{{.ExclusiveScope}}"></div>
-			{{end}}
-			{{$previousExclusiveScope = $exclusiveScope}}
-			<a class="item label-filter-item tw-flex tw-items-center" data-label-id="{{.ID}}" data-scope="{{.ExclusiveScope}}" {{if .IsArchived}}data-is-archived{{end}}
-				href="{{QueryBuild $queryLink "labels" .QueryString}}">
-				{{if .IsExcluded}}
-					{{svg "octicon-circle-slash"}}
-				{{else if .IsSelected}}
-					{{if $exclusiveScope}}
-						{{svg "octicon-dot-fill"}}
-					{{else}}
-						{{svg "octicon-check"}}
-					{{end}}
-				{{end}}
-				{{ctx.RenderUtils.RenderLabel .}}
-				<p class="tw-ml-auto">{{template "repo/issue/labels/label_archived" .}}</p>
-			</a>
-		{{end}}
-	</div>
-</div>
+{{$queryLink := QueryBuild "?" "q" $.Keyword "type" $.ViewType "sort" $.SortType "state" $.State "labels" $.SelectLabels "milestone" $.MilestoneID "project" $.ProjectID "assignee" $.AssigneeID "poster" $.PosterUsername "archived_label" (Iif $.ShowArchivedLabels "true")}}
+
+{{template "repo/issue/filter_item_label" dict "Labels" .Labels "QueryLink" $queryLink "SupportArchivedLabel" true}}
 
 {{if not .Milestone}}
 <!-- Milestone -->
@@ -128,46 +79,24 @@
 	</div>
 </div>
 
-<!-- Author -->
-<div class="ui dropdown jump item user-remote-search" data-tooltip-content="{{ctx.Locale.Tr "repo.author_search_tooltip"}}"
-	data-search-url="{{if .Milestone}}{{$.RepoLink}}/issues/posters{{else}}{{$.Link}}/posters{{end}}"
-	data-selected-user-id="{{$.PosterID}}"
-	data-action-jump-url="{{QueryBuild $queryLink "poster" NIL}}&poster={username}"
->
-	<span class="text">
-		{{ctx.Locale.Tr "repo.issues.filter_poster"}}
-	</span>
-	{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-	<div class="menu">
-		<div class="ui icon search input">
-			<i class="icon">{{svg "octicon-search" 16}}</i>
-			<input type="text" placeholder="{{ctx.Locale.Tr "repo.issues.filter_poster"}}">
-		</div>
-		<a class="item" data-value="0">{{ctx.Locale.Tr "repo.issues.filter_poster_no_select"}}</a>
-	</div>
-</div>
+{{/* TODO: the UserSearchUrl is old logic but not right, milestone could also have "pull request" posters */}}
+{{template "repo/issue/filter_item_user_fetch" dict
+	"QueryParamKey" "poster"
+	"QueryLink" $queryLink
+	"UserSearchUrl" (Iif .Milestone (print $.RepoLink "/issues/posters") (print $.Link "/posters"))
+	"SelectedUserId" $.PosterID
+	"TextFilterTitle" (ctx.Locale.Tr "repo.issues.filter_poster")
+}}
 
-<!-- Assignee -->
-<div class="ui {{if not .Assignees}}disabled{{end}} dropdown jump item">
-	<span class="text">
-		{{ctx.Locale.Tr "repo.issues.filter_assignee"}}
-	</span>
-	{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-	<div class="menu">
-		<div class="ui icon search input">
-			<i class="icon">{{svg "octicon-search" 16}}</i>
-			<input type="text" placeholder="{{ctx.Locale.Tr "repo.issues.filter_assignee"}}">
-		</div>
-		<a class="{{if not .AssigneeID}}active selected {{end}}item" href="{{QueryBuild $queryLink "assignee" NIL}}">{{ctx.Locale.Tr "repo.issues.filter_assginee_no_select"}}</a>
-		<a class="{{if eq .AssigneeID -1}}active selected {{end}}item" href="{{QueryBuild $queryLink "assignee" -1}}">{{ctx.Locale.Tr "repo.issues.filter_assginee_no_assignee"}}</a>
-		<div class="divider"></div>
-		{{range .Assignees}}
-			<a class="{{if eq $.AssigneeID .ID}}active selected{{end}} item tw-flex" href="{{QueryBuild $queryLink "assignee" .ID}}">
-				{{ctx.AvatarUtils.Avatar . 20}}{{template "repo/search_name" .}}
-			</a>
-		{{end}}
-	</div>
-</div>
+{{template "repo/issue/filter_item_user_assign" dict
+	"QueryParamKey" "assignee"
+	"QueryLink" $queryLink
+	"UserSearchList" $.Assignees
+	"SelectedUserId" $.AssigneeID
+	"TextFilterTitle" (ctx.Locale.Tr "repo.issues.filter_assignee")
+	"TextZeroValue" (ctx.Locale.Tr "repo.issues.filter_assginee_no_select")
+	"TextNegativeOne" (ctx.Locale.Tr "repo.issues.filter_assginee_no_assignee")
+}}
 
 {{if .IsSigned}}
 	<!-- Type -->

--- a/templates/repo/issue/filter_list.tmpl
+++ b/templates/repo/issue/filter_list.tmpl
@@ -1,4 +1,4 @@
-{{$queryLink := QueryBuild "?" "q" $.Keyword "type" $.ViewType "sort" $.SortType "state" $.State "labels" $.SelectLabels "milestone" $.MilestoneID "project" $.ProjectID "assignee" $.AssigneeID "poster" $.PosterUsername "archived_label" (Iif $.ShowArchivedLabels "true")}}
+{{$queryLink := QueryBuild "?" "q" $.Keyword "type" $.ViewType "sort" $.SortType "state" $.State "labels" $.SelectLabels "milestone" $.MilestoneID "project" $.ProjectID "assignee" $.AssigneeID "poster" $.PosterUsername "archived_labels" (Iif $.ShowArchivedLabels "true")}}
 
 {{template "repo/issue/filter_item_label" dict "Labels" .Labels "QueryLink" $queryLink "SupportArchivedLabel" true}}
 

--- a/templates/repo/issue/openclose.tmpl
+++ b/templates/repo/issue/openclose.tmpl
@@ -3,7 +3,7 @@
 {{if .PageIsMilestones}}
 	{{$allStatesLink = QueryBuild "?" "q" $.Keyword "sort" $.SortType "state" "all"}}
 {{else}}
-	{{$allStatesLink = QueryBuild "?" "q" $.Keyword "type" $.ViewType "sort" $.SortType "state" "all" "labels" $.SelectLabels "milestone" $.MilestoneID "project" $.ProjectID "assignee" $.AssigneeID "poster" $.PosterUsername "archived_label" (Iif $.ShowArchivedLabels "true")}}
+	{{$allStatesLink = QueryBuild "?" "q" $.Keyword "type" $.ViewType "sort" $.SortType "state" "all" "labels" $.SelectLabels "milestone" $.MilestoneID "project" $.ProjectID "assignee" $.AssigneeID "poster" $.PosterUsername "archived_labels" (Iif $.ShowArchivedLabels "true")}}
 {{end}}
 {{$openLink = QueryBuild $allStatesLink "state" "open"}}
 {{$closedLink = QueryBuild $allStatesLink "state" "closed"}}

--- a/templates/repo/issue/openclose.tmpl
+++ b/templates/repo/issue/openclose.tmpl
@@ -1,16 +1,23 @@
+{{/* this tmpl is quite dirty, it should not mix unrelated things together .... need to split it in the future*/}}
+{{$allStatesLink := ""}}{{$openLink := ""}}{{$closedLink := ""}}
+{{if .PageIsMilestones}}
+	{{$allStatesLink = QueryBuild "?" "q" $.Keyword "sort" $.SortType "state" "all"}}
+{{else}}
+	{{$allStatesLink = QueryBuild "?" "q" $.Keyword "type" $.ViewType "sort" $.SortType "state" "all" "labels" $.SelectLabels "milestone" $.MilestoneID "project" $.ProjectID "assignee" $.AssigneeID "poster" $.PosterUsername "archived_label" (Iif $.ShowArchivedLabels "true")}}
+{{end}}
+{{$openLink = QueryBuild $allStatesLink "state" "open"}}
+{{$closedLink = QueryBuild $allStatesLink "state" "closed"}}
 <div class="small-menu-items ui compact tiny menu">
-	<a class="{{if eq .State "open"}}active {{end}}item" href="{{if eq .State "open"}}{{.AllStatesLink}}{{else}}{{.OpenLink}}{{end}}">
+	<a class="{{if eq .State "open"}}active {{end}}item flex-text-inline" href="{{if eq .State "open"}}{{$allStatesLink}}{{else}}{{$openLink}}{{end}}">
 		{{if .PageIsMilestones}}
-			{{svg "octicon-milestone" 16 "tw-mr-2"}}
-		{{else if .PageIsPullList}}
-			{{svg "octicon-git-pull-request" 16 "tw-mr-2"}}
+			{{svg "octicon-milestone"}}
 		{{else}}
-			{{svg "octicon-issue-opened" 16 "tw-mr-2"}}
+			{{Iif .PageIsPullList (svg "octicon-git-pull-request") (svg "octicon-issue-opened")}}
 		{{end}}
-		{{ctx.Locale.PrettyNumber .OpenCount}}&nbsp;{{ctx.Locale.Tr "repo.issues.open_title"}}
+		{{ctx.Locale.PrettyNumber .OpenCount}} {{ctx.Locale.Tr "repo.issues.open_title"}}
 	</a>
-	<a class="{{if eq .State "closed"}}active {{end}}item" href="{{if eq .State "closed"}}{{.AllStatesLink}}{{else}}{{.ClosedLink}}{{end}}">
-		{{svg "octicon-check" 16 "tw-mr-2"}}
-		{{ctx.Locale.PrettyNumber .ClosedCount}}&nbsp;{{ctx.Locale.Tr "repo.issues.closed_title"}}
+	<a class="{{if eq .State "closed"}}active {{end}}item flex-text-inline" href="{{if eq .State "closed"}}{{$allStatesLink}}{{else}}{{$closedLink}}{{end}}">
+		{{svg "octicon-check"}}
+		{{ctx.Locale.PrettyNumber .ClosedCount}} {{ctx.Locale.Tr "repo.issues.closed_title"}}
 	</a>
 </div>

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -1390,8 +1390,9 @@ table th[data-sortt-desc] .svg {
   min-width: 0;
 }
 
-/* to override Fomantic's default display: block for ".menu .item", and use a slightly larger gap for menu item content */
-.ui.dropdown .menu.flex-items-menu > .item {
+/* to override Fomantic's default display: block for ".menu .item", and use a slightly larger gap for menu item content
+the "!important" is necessary to override Fomantic UI menu item styles, meanwhile we should keep the "hidden" items still hidden */
+.ui.dropdown .menu.flex-items-menu > .item:not(.hidden, .filtered, .tw-hidden) {
   display: flex !important;
   align-items: center;
   gap: .5rem;

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -74,24 +74,6 @@
   }
 }
 
-.repository .filter.menu.labels .label-filter .menu .info {
-  display: inline-block;
-  padding: 0.5rem 0;
-  font-size: 12px;
-  width: 100%;
-  white-space: nowrap;
-  margin-left: 10px;
-  margin-right: 8px;
-  text-align: left;
-}
-
-.repository .filter.menu.labels .label-filter .menu .info code {
-  border: 1px solid var(--color-secondary);
-  border-radius: var(--border-radius);
-  padding: 1px 2px;
-  font-size: 11px;
-}
-
 /* make all issue filter dropdown menus popup leftward, to avoid go out the viewport (right side) */
 .repository .filter.menu .ui.dropdown .menu {
   max-height: 500px;
@@ -106,6 +88,24 @@
   min-width: max-content;
   right: unset;
   left: 0;
+}
+
+.repository .filter.menu .ui.dropdown.label-filter .menu .info {
+  display: inline-block;
+  padding: 0.5rem 0;
+  font-size: 12px;
+  width: 100%;
+  white-space: nowrap;
+  margin-left: 10px;
+  margin-right: 8px;
+  text-align: left;
+}
+
+.repository .filter.menu .ui.dropdown.label-filter .menu .info code {
+  border: 1px solid var(--color-secondary);
+  border-radius: var(--border-radius);
+  padding: 1px 2px;
+  font-size: 11px;
 }
 
 /* For the secondary pointing menu, respect its own border-bottom */

--- a/web_src/css/repo/issue-list.css
+++ b/web_src/css/repo/issue-list.css
@@ -68,10 +68,8 @@
   background-color: var(--color-secondary-dark-4);
 }
 
-.archived-label-filter {
-  margin-left: 10px;
+.label-filter-archived-toggle {
+  margin: 8px 10px;
   font-size: 12px;
-  display: flex !important;
-  margin-bottom: 8px;
   min-width: fit-content;
 }

--- a/web_src/js/features/repo-issue.ts
+++ b/web_src/js/features/repo-issue.ts
@@ -1,7 +1,14 @@
 import $ from 'jquery';
 import {htmlEscape} from 'escape-goat';
 import {createTippy, showTemporaryTooltip} from '../modules/tippy.ts';
-import {addDelegatedEventListener, createElementFromHTML, hideElem, showElem, toggleElem} from '../utils/dom.ts';
+import {
+  addDelegatedEventListener,
+  createElementFromHTML,
+  hideElem,
+  queryElems,
+  showElem,
+  toggleElem,
+} from '../utils/dom.ts';
 import {setFileFolding} from './file-fold.ts';
 import {ComboMarkdownEditor, getComboMarkdownEditor, initComboMarkdownEditor} from './comp/ComboMarkdownEditor.ts';
 import {parseIssuePageInfo, toAbsoluteUrl} from '../utils.ts';
@@ -11,19 +18,6 @@ import {initRepoIssueSidebar} from './repo-issue-sidebar.ts';
 import {fomanticQuery} from '../modules/fomantic/base.ts';
 
 const {appSubUrl} = window.config;
-
-/**
- * @param {HTMLElement} item
- */
-function excludeLabel(item) {
-  const href = item.getAttribute('href');
-  const id = item.getAttribute('data-label-id');
-
-  const regStr = `labels=((?:-?[0-9]+%2c)*)(${id})((?:%2c-?[0-9]+)*)&`;
-  const newStr = 'labels=$1-$2$3&';
-
-  window.location.assign(href.replace(new RegExp(regStr), newStr));
-}
 
 export function initRepoIssueSidebarList() {
   const issuePageInfo = parseIssuePageInfo();
@@ -58,24 +52,74 @@ export function initRepoIssueSidebarList() {
   });
 }
 
-export function initRepoIssueLabelFilter() {
-  // the "label-filter" is used in 2 templates: projects/view, issue/filter_list (issue list page including the milestone page)
-  $('.ui.dropdown.label-filter a.label-filter-item').each(function () {
-    $(this).on('click', function (e) {
-      if (e.altKey) {
-        e.preventDefault();
-        excludeLabel(this);
-      }
+function initRepoIssueLabelFilter(elDropdown: Element) {
+  const url = new URL(window.location.href);
+  const showArchivedLabels = url.searchParams.get('archived_labels') === 'true';
+  const queryLabels = url.searchParams.get('labels') || '';
+  const selectedLabelIds = new Set<string>();
+  for (const id of queryLabels ? queryLabels.split(',') : []) {
+    selectedLabelIds.add(`${Math.abs(parseInt(id))}`); // "labels" contains negative ids, which are excluded
+  }
+
+  const excludeLabel = (e: MouseEvent|KeyboardEvent, item: Element) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const labelId = item.getAttribute('data-label-id');
+    let labelIds: string[] = queryLabels ? queryLabels.split(',') : [];
+    labelIds = labelIds.filter((id) => Math.abs(parseInt(id)) !== Math.abs(parseInt(labelId)));
+    labelIds.push(`-${labelId}`);
+    url.searchParams.set('labels', labelIds.join(','));
+    window.location.assign(url);
+  };
+
+  // alt(or option) + click to exclude label
+  queryElems(elDropdown, '.label-filter-query-item', (el) => {
+    el.addEventListener('click', (e: MouseEvent) => {
+      if (e.altKey) excludeLabel(e, el);
     });
   });
-  $('.ui.dropdown.label-filter').on('keydown', (e) => {
+  // alt(or option) + enter to exclude selected label
+  elDropdown.addEventListener('keydown', (e: KeyboardEvent) => {
     if (e.altKey && e.key === 'Enter') {
-      const selectedItem = document.querySelector('.ui.dropdown.label-filter .menu .item.selected');
-      if (selectedItem) {
-        excludeLabel(selectedItem);
-      }
+      const selectedItem = elDropdown.querySelector('.label-filter-query-item.selected');
+      if (selectedItem) excludeLabel(e, selectedItem);
     }
   });
+  // no "labels" query parameter means "all issues"
+  elDropdown.querySelector('.label-filter-query-default').classList.toggle('selected', queryLabels === '');
+  // "labels=0" query parameter means "issues without label"
+  elDropdown.querySelector('.label-filter-query-not-set').classList.toggle('selected', queryLabels === '0');
+
+  // prepare to process "archived" labels
+  const elShowArchivedLabel = elDropdown.querySelector('.label-filter-archived-toggle');
+  if (!elShowArchivedLabel) return;
+  const elShowArchivedInput = elShowArchivedLabel.querySelector<HTMLInputElement>('input');
+  elShowArchivedInput.checked = showArchivedLabels;
+  const archivedLabels = elDropdown.querySelectorAll('.item[data-is-archived]');
+  // if no archived labels, hide the toggle and return
+  if (!archivedLabels.length) {
+    hideElem(elShowArchivedLabel);
+    return;
+  }
+
+  // show the archived labels if the toggle is checked or the label is selected
+  for (const label of archivedLabels) {
+    toggleElem(label, showArchivedLabels || selectedLabelIds.has(label.getAttribute('data-label-id')));
+  }
+  // update the url when the toggle is changed and reload
+  elShowArchivedInput.addEventListener('input', () => {
+    if (elShowArchivedInput.checked) {
+      url.searchParams.set('archived_labels', 'true');
+    } else {
+      url.searchParams.delete('archived_labels');
+    }
+    window.location.assign(url);
+  });
+}
+
+export function initRepoIssueFilterItemLabel() {
+  // the "label-filter" is used in 2 templates: projects/view, issue/filter_list (issue list page including the milestone page)
+  queryElems(document, '.ui.dropdown.label-filter', initRepoIssueLabelFilter);
 }
 
 export function initRepoIssueCommentDelete() {

--- a/web_src/js/index.ts
+++ b/web_src/js/index.ts
@@ -29,7 +29,7 @@ import {
   initRepoIssueWipTitle,
   initRepoPullRequestMergeInstruction,
   initRepoPullRequestAllowMaintainerEdit,
-  initRepoPullRequestReview, initRepoIssueSidebarList, initRepoIssueLabelFilter,
+  initRepoPullRequestReview, initRepoIssueSidebarList, initRepoIssueFilterItemLabel,
 } from './features/repo-issue.ts';
 import {initRepoEllipsisButton, initCommitStatuses} from './features/repo-commit.ts';
 import {initRepoTopicBar} from './features/repo-home.ts';
@@ -181,7 +181,7 @@ onDomReady(() => {
     initRepoGraphGit,
     initRepoIssueContentHistory,
     initRepoIssueList,
-    initRepoIssueLabelFilter,
+    initRepoIssueFilterItemLabel,
     initRepoIssueSidebarList,
     initRepoIssueReferenceRepositorySearch,
     initRepoIssueWipTitle,


### PR DESCRIPTION
Rewrite a lot of legacy strange code, remove duplicate code, remove jquery, and make these filters reusable.

Let's forget the old code, new code affects: 

* issue list open/close switch
* issue list filter (label, author, assignee)
* milestone list open/close switch
* milestone issue list filter (label, author, assignee)
* project view (label, assignee)

Next plan: add the user filter and label filter to other pages, eg: user/org home issue list