### PR TITLE
Fix internal server error when updating labels without write permission

### DIFF
--- a/routers/api/v1/repo/issue_label.go
+++ b/routers/api/v1/repo/issue_label.go
@@ -351,7 +351,7 @@ func prepareForReplaceOrAdd(ctx *context.APIContext, form api.IssueLabelsOption)
 	}
 
 	if !ctx.Repo.CanWriteIssuesOrPulls(issue.IsPull) {
-		ctx.Error(http.StatusForbidden, "CanWriteIssuesOrPulls", "you should have write access to issue")
+		ctx.Error(http.StatusForbidden, "CanWriteIssuesOrPulls", "write permission is required")
 		return nil, nil, fmt.Errorf("permission denied")
 	}
 

--- a/routers/api/v1/repo/issue_label.go
+++ b/routers/api/v1/repo/issue_label.go
@@ -319,6 +319,11 @@ func prepareForReplaceOrAdd(ctx *context.APIContext, form api.IssueLabelsOption)
 		return nil, nil, err
 	}
 
+	if !ctx.Repo.CanWriteIssuesOrPulls(issue.IsPull) {
+		ctx.Error(http.StatusForbidden, "CanWriteIssuesOrPulls", "write permission is required")
+		return nil, nil, fmt.Errorf("permission denied")
+	}
+
 	var (
 		labelIDs   []int64
 		labelNames []string
@@ -348,11 +353,6 @@ func prepareForReplaceOrAdd(ctx *context.APIContext, form api.IssueLabelsOption)
 	if err != nil {
 		ctx.Error(http.StatusInternalServerError, "GetLabelsByIDs", err)
 		return nil, nil, err
-	}
-
-	if !ctx.Repo.CanWriteIssuesOrPulls(issue.IsPull) {
-		ctx.Error(http.StatusForbidden, "CanWriteIssuesOrPulls", "write permission is required")
-		return nil, nil, fmt.Errorf("permission denied")
 	}
 
 	return issue, labels, err

--- a/routers/api/v1/repo/issue_label.go
+++ b/routers/api/v1/repo/issue_label.go
@@ -351,8 +351,8 @@ func prepareForReplaceOrAdd(ctx *context.APIContext, form api.IssueLabelsOption)
 	}
 
 	if !ctx.Repo.CanWriteIssuesOrPulls(issue.IsPull) {
-		ctx.Status(http.StatusForbidden)
-		return nil, nil, nil
+		ctx.Error(http.StatusForbidden, "CanWriteIssuesOrPulls", "you should have write access to issue")
+		return nil, nil, fmt.Errorf("permission denied")
 	}
 
 	return issue, labels, err


### PR DESCRIPTION
Fix #32775

if permission denined, `prepareForReplaceOrAdd` will return nothing, and this case is not handled.