### PR TITLE
Fix the location of Escape button in the Wiki page

### DIFF
--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -44,17 +44,17 @@
 					</div>
 				</div>
 				<div class="eight wide right aligned column">
-					{{if .EscapeStatus.Escaped}}
-						<a class="ui small button unescape-button tw-hidden">{{ctx.Locale.Tr "repo.unescape_control_characters"}}</a>
-						<a class="ui small button escape-button">{{ctx.Locale.Tr "repo.escape_control_characters"}}</a>
-					{{end}}
-					{{if and .CanWriteWiki (not .Repository.IsMirror)}}
-						<div class="ui right">
+					<div class="ui right">
+						{{if not .EscapeStatus.Escaped}}
+							<a class="ui small button unescape-button tw-hidden">{{ctx.Locale.Tr "repo.unescape_control_characters"}}</a>
+							<a class="ui small button escape-button">{{ctx.Locale.Tr "repo.escape_control_characters"}}</a>
+						{{end}}
+						{{if and .CanWriteWiki (not .Repository.IsMirror)}}
 							<a class="ui small button" href="{{.RepoLink}}/wiki/{{.PageURL}}?action=_edit">{{ctx.Locale.Tr "repo.wiki.edit_page_button"}}</a>
 							<a class="ui small primary button" href="{{.RepoLink}}/wiki?action=_new">{{ctx.Locale.Tr "repo.wiki.new_page_button"}}</a>
 							<a class="ui small red button delete-button" href="" data-url="{{.RepoLink}}/wiki/{{.PageURL}}?action=_delete" data-id="{{.PageURL}}">{{ctx.Locale.Tr "repo.wiki.delete_page_button"}}</a>
-						</div>
-					{{end}}
+						{{end}}
+					</div>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Fix #32774

After:
![image](https://github.com/user-attachments/assets/52c189ef-5b17-4e9c-b1e2-1fe3842914bf)

TODO:
fix mobile view