### PR TITLE
Fix JS error when dropping a file to a editor without dropzone

### DIFF
--- a/web_src/js/features/comp/EditorUpload.ts
+++ b/web_src/js/features/comp/EditorUpload.ts
@@ -178,6 +178,7 @@ export function initTextareaEvents(textarea, dropzoneEl) {
   });
   textarea.addEventListener('drop', (e) => {
     if (!e.dataTransfer.files.length) return;
+    if (!dropzoneEl) return;
     handleUploadFiles(new TextareaEditor(textarea), dropzoneEl, e.dataTransfer.files, e);
   });
   dropzoneEl?.dropzone.on(DropzoneCustomEventRemovedFile, ({fileUuid}) => {


### PR DESCRIPTION
`dropzoneEl` may not exist