### PR TITLE
use dedicated runners for release artifacts

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   nightly-binary:
-    runs-on: nscloud
+    runs-on: namespace-profile-gitea-release-binary
     steps:
       - uses: actions/checkout@v4
       # fetch all commits instead of only the last as some branches are long lived and could have many between versions
@@ -58,7 +58,7 @@ jobs:
         run: |
           aws s3 sync dist/release s3://${{ secrets.AWS_S3_BUCKET }}/gitea/${{ steps.clean_name.outputs.branch }} --no-progress
   nightly-docker-rootful:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-gitea-release-docker
     steps:
       - uses: actions/checkout@v4
       # fetch all commits instead of only the last as some branches are long lived and could have many between versions
@@ -95,7 +95,7 @@ jobs:
           push: true
           tags: gitea/gitea:${{ steps.clean_name.outputs.branch }}
   nightly-docker-rootless:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-gitea-release-docker
     steps:
       - uses: actions/checkout@v4
       # fetch all commits instead of only the last as some branches are long lived and could have many between versions

--- a/.github/workflows/release-tag-rc.yml
+++ b/.github/workflows/release-tag-rc.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   binary:
-    runs-on: nscloud
+    runs-on: namespace-profile-gitea-release-binary
     steps:
       - uses: actions/checkout@v4
       # fetch all commits instead of only the last as some branches are long lived and could have many between versions
@@ -68,7 +68,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
   docker-rootful:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-gitea-release-docker
     steps:
       - uses: actions/checkout@v4
       # fetch all commits instead of only the last as some branches are long lived and could have many between versions
@@ -99,7 +99,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
   docker-rootless:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-gitea-release-docker
     steps:
       - uses: actions/checkout@v4
       # fetch all commits instead of only the last as some branches are long lived and could have many between versions

--- a/.github/workflows/release-tag-version.yml
+++ b/.github/workflows/release-tag-version.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   binary:
-    runs-on: nscloud
+    runs-on: namespace-profile-gitea-release-binary
     steps:
       - uses: actions/checkout@v4
       # fetch all commits instead of only the last as some branches are long lived and could have many between versions
@@ -70,7 +70,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
   docker-rootful:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-gitea-release-docker
     steps:
       - uses: actions/checkout@v4
       # fetch all commits instead of only the last as some branches are long lived and could have many between versions
@@ -105,7 +105,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
   docker-rootless:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-gitea-release-docker
     steps:
       - uses: actions/checkout@v4
       # fetch all commits instead of only the last as some branches are long lived and could have many between versions


### PR DESCRIPTION
GH runners are having trouble, so switch the remaining release jobs to use dedicated runners.