### PR TITLE
Upgrade htmx to 2.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "esbuild-loader": "4.2.2",
         "escape-goat": "4.0.0",
         "fast-glob": "3.3.2",
-        "htmx.org": "2.0.3",
+        "htmx.org": "2.0.4",
         "idiomorph": "0.3.0",
         "jquery": "3.7.1",
         "katex": "0.16.11",
@@ -10557,9 +10557,9 @@
       }
     },
     "node_modules/htmx.org": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.3.tgz",
-      "integrity": "sha512-AeoJUAjkCVVajbfKX+3sVQBTCt8Ct4lif1T+z/tptTXo8+8yyq3QIMQQe/IT+R8ssfrO1I0DeX4CAronzCL6oA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
+      "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
       "license": "0BSD"
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "esbuild-loader": "4.2.2",
     "escape-goat": "4.0.0",
     "fast-glob": "3.3.2",
-    "htmx.org": "2.0.3",
+    "htmx.org": "2.0.4",
     "idiomorph": "0.3.0",
     "jquery": "3.7.1",
     "katex": "0.16.11",


### PR DESCRIPTION
Release notes: https://github.com/bigskysoftware/htmx/releases/tag/v2.0.4

Tested `Star`, `Watch`, and the admin dashboard page. All functionality remains unchanged.
