### PR TITLE
Remove translation to issue add time because the format is fixed should not be translated

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1680,7 +1680,6 @@ issues.timetracker_timer_stop = Stop timer
 issues.timetracker_timer_discard = Discard timer
 issues.timetracker_timer_manually_add = Add Time
 
-issues.time_estimate_placeholder = 1h 2m
 issues.time_estimate_set = Set estimated time
 issues.time_estimate_display = Estimate: %s
 issues.change_time_estimate_at = changed time estimate to <b>%s</b> %s

--- a/templates/repo/issue/sidebar/stopwatch_timetracker.tmpl
+++ b/templates/repo/issue/sidebar/stopwatch_timetracker.tmpl
@@ -44,7 +44,7 @@
 				<form method="post" class="ui form form-fetch-action" action="{{.Issue.Link}}/time_estimate">
 					<div class="content">
 						{{$.CsrfTokenHtml}}
-						<input name="time_estimate" placeholder="{{ctx.Locale.Tr "repo.issues.time_estimate_placeholder"}}" value="{{TimeEstimateString .Issue.TimeEstimate}}">
+						<input name="time_estimate" placeholder="1h 2m" value="{{TimeEstimateString .Issue.TimeEstimate}}">
 						<div class="actions">
 							<button class="ui cancel button">{{ctx.Locale.Tr "cancel"}}</button>
 							<button class="ui primary button">{{ctx.Locale.Tr "repo.issues.save"}}</button>


### PR DESCRIPTION
The input content should always be `1h 2m 3s` and will be the same on different UI languages. So the translation is wrong.