### PR TITLE
Improve Actions status aggregations

### DIFF
--- a/models/actions/run_job.go
+++ b/models/actions/run_job.go
@@ -155,13 +155,12 @@ func UpdateRunJob(ctx context.Context, job *ActionRunJob, cond builder.Cond, col
 func AggregateJobStatus(jobs []*ActionRunJob) Status {
 	allSuccessOrSkipped := len(jobs) != 0
 	allSkipped := len(jobs) != 0
-	var hasFailure, hasCancelled, hasSkipped, hasWaiting, hasRunning, hasBlocked bool
+	var hasFailure, hasCancelled, hasWaiting, hasRunning, hasBlocked bool
 	for _, job := range jobs {
 		allSuccessOrSkipped = allSuccessOrSkipped && (job.Status == StatusSuccess || job.Status == StatusSkipped)
 		allSkipped = allSkipped && job.Status == StatusSkipped
 		hasFailure = hasFailure || job.Status == StatusFailure
 		hasCancelled = hasCancelled || job.Status == StatusCancelled
-		hasSkipped = hasSkipped || job.Status == StatusSkipped
 		hasWaiting = hasWaiting || job.Status == StatusWaiting
 		hasRunning = hasRunning || job.Status == StatusRunning
 		hasBlocked = hasBlocked || job.Status == StatusBlocked
@@ -181,8 +180,6 @@ func AggregateJobStatus(jobs []*ActionRunJob) Status {
 		return StatusWaiting
 	case hasBlocked:
 		return StatusBlocked
-	case hasSkipped:
-		return StatusSkipped
 	default:
 		return StatusUnknown // it shouldn't happen
 	}

--- a/models/actions/run_job_status_test.go
+++ b/models/actions/run_job_status_test.go
@@ -30,8 +30,15 @@ func TestAggregateJobStatus(t *testing.T) {
 		statuses []Status
 		expected Status
 	}{
-		// empty, maybe it shouldn't happen in real world
+		// unknown cases, maybe it shouldn't happen in real world
 		{[]Status{}, StatusUnknown},
+		{[]Status{StatusUnknown, StatusSuccess}, StatusUnknown},
+		{[]Status{StatusUnknown, StatusSkipped}, StatusUnknown},
+		{[]Status{StatusUnknown, StatusFailure}, StatusFailure},
+		{[]Status{StatusUnknown, StatusCancelled}, StatusCancelled},
+		{[]Status{StatusUnknown, StatusWaiting}, StatusWaiting},
+		{[]Status{StatusUnknown, StatusRunning}, StatusRunning},
+		{[]Status{StatusUnknown, StatusBlocked}, StatusBlocked},
 
 		// success with other status
 		{[]Status{StatusSuccess}, StatusSuccess},

--- a/models/actions/run_job_status_test.go
+++ b/models/actions/run_job_status_test.go
@@ -30,6 +30,9 @@ func TestAggregateJobStatus(t *testing.T) {
 		statuses []Status
 		expected Status
 	}{
+		// empty, maybe it shouldn't happen in real world
+		{[]Status{}, StatusUnknown},
+
 		// success with other status
 		{[]Status{StatusSuccess}, StatusSuccess},
 		{[]Status{StatusSuccess, StatusSkipped}, StatusSuccess}, // skipped doesn't affect success


### PR DESCRIPTION
Make the result the same as GitHub:

* all skipped, then result is skipped
* any cancelled, then result cancelled