### PR TITLE
Fix Arch package metadata introduced incorrect field

### DIFF
--- a/modules/packages/arch/metadata.go
+++ b/modules/packages/arch/metadata.go
@@ -69,10 +69,12 @@ type FileMetadata struct {
 	Packager      string   `json:"packager,omitempty"`
 	Groups        []string `json:"groups,omitempty"`
 	Provides      []string `json:"provides,omitempty"`
+	Replaces      []string `json:"replaces,omitempty"`
 	Depends       []string `json:"depends,omitempty"`
 	OptDepends    []string `json:"opt_depends,omitempty"`
 	MakeDepends   []string `json:"make_depends,omitempty"`
 	CheckDepends  []string `json:"check_depends,omitempty"`
+	Conflicts     []string `json:"conflicts,omitempty"`
 	XData         []string `json:"xdata,omitempty"`
 	Backup        []string `json:"backup,omitempty"`
 	Files         []string `json:"files,omitempty"`
@@ -201,12 +203,16 @@ func ParsePackageInfo(r io.Reader) (*Package, error) {
 			p.FileMetadata.Provides = append(p.FileMetadata.Provides, value)
 		case "depend":
 			p.FileMetadata.Depends = append(p.FileMetadata.Depends, value)
+		case "replaces":
+			p.FileMetadata.Replaces = append(p.FileMetadata.Replaces, value)
 		case "optdepend":
 			p.FileMetadata.OptDepends = append(p.FileMetadata.OptDepends, value)
 		case "makedepend":
 			p.FileMetadata.MakeDepends = append(p.FileMetadata.MakeDepends, value)
 		case "checkdepend":
 			p.FileMetadata.CheckDepends = append(p.FileMetadata.CheckDepends, value)
+		case "conflict":
+			p.FileMetadata.Conflicts = append(p.FileMetadata.Conflicts, value)
 		case "backup":
 			p.FileMetadata.Backup = append(p.FileMetadata.Backup, value)
 		case "group":

--- a/modules/packages/arch/metadata_test.go
+++ b/modules/packages/arch/metadata_test.go
@@ -42,8 +42,10 @@ depend = gitea
 provides = common
 provides = gitea
 optdepend = hex
+replaces = gogs
 checkdepend = common
 makedepend = cmake
+conflict = ninja
 backup = usr/bin/paket1`)
 }
 
@@ -149,8 +151,10 @@ func TestParsePackageInfo(t *testing.T) {
 		assert.ElementsMatch(t, []string{"group"}, p.FileMetadata.Groups)
 		assert.ElementsMatch(t, []string{"common", "gitea"}, p.FileMetadata.Provides)
 		assert.ElementsMatch(t, []string{"common", "gitea"}, p.FileMetadata.Depends)
+		assert.ElementsMatch(t, []string{"gogs"}, p.FileMetadata.Replaces)
 		assert.ElementsMatch(t, []string{"hex"}, p.FileMetadata.OptDepends)
 		assert.ElementsMatch(t, []string{"common"}, p.FileMetadata.CheckDepends)
+		assert.ElementsMatch(t, []string{"ninja"}, p.FileMetadata.Conflicts)
 		assert.ElementsMatch(t, []string{"cmake"}, p.FileMetadata.MakeDepends)
 		assert.ElementsMatch(t, []string{"usr/bin/paket1"}, p.FileMetadata.Backup)
 	})

--- a/services/packages/arch/repository.go
+++ b/services/packages/arch/repository.go
@@ -371,11 +371,12 @@ func writeDescription(tw *tar.Writer, opts *entryOptions) error {
 		{"BUILDDATE", fmt.Sprintf("%d", opts.FileMetadata.BuildDate)},
 		{"PACKAGER", opts.FileMetadata.Packager},
 		{"PROVIDES", strings.Join(opts.FileMetadata.Provides, "\n")},
+		{"REPLACES", strings.Join(opts.FileMetadata.Replaces, "\n")},
+		{"CONFLICTS", strings.Join(opts.FileMetadata.Conflicts, "\n")},
 		{"DEPENDS", strings.Join(opts.FileMetadata.Depends, "\n")},
 		{"OPTDEPENDS", strings.Join(opts.FileMetadata.OptDepends, "\n")},
 		{"MAKEDEPENDS", strings.Join(opts.FileMetadata.MakeDepends, "\n")},
 		{"CHECKDEPENDS", strings.Join(opts.FileMetadata.CheckDepends, "\n")},
-		{"XDATA", strings.Join(opts.FileMetadata.XData, "\n")},
 	})
 }
 


### PR DESCRIPTION
Incorrect content was introduced while generating the index, which has now been removed, and the missing fields have been added.

![](https://github.com/user-attachments/assets/4fbb8884-337e-43b1-939f-a5ba687f7ffd)
