### PR TITLE
Update go tool dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,17 +26,17 @@ COMMA := ,
 XGO_VERSION := go-1.23.x
 
 AIR_PACKAGE ?= github.com/air-verse/air@v1
-EDITORCONFIG_CHECKER_PACKAGE ?= github.com/editorconfig-checker/editorconfig-checker/cmd/editorconfig-checker@2.7.0
+EDITORCONFIG_CHECKER_PACKAGE ?= github.com/editorconfig-checker/editorconfig-checker/v3/cmd/editorconfig-checker@v3.0.3
 GOFUMPT_PACKAGE ?= mvdan.cc/gofumpt@v0.7.0
 GOLANGCI_LINT_PACKAGE ?= github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2
-GXZ_PACKAGE ?= github.com/ulikunitz/xz/cmd/gxz@v0.5.11
-MISSPELL_PACKAGE ?= github.com/golangci/misspell/cmd/misspell@v0.5.1
+GXZ_PACKAGE ?= github.com/ulikunitz/xz/cmd/gxz@v0.5.12
+MISSPELL_PACKAGE ?= github.com/golangci/misspell/cmd/misspell@v0.6.0
 SWAGGER_PACKAGE ?= github.com/go-swagger/go-swagger/cmd/swagger@v0.31.0
 XGO_PACKAGE ?= src.techknowlogick.com/xgo@latest
 GO_LICENSES_PACKAGE ?= github.com/google/go-licenses@v1
 GOVULNCHECK_PACKAGE ?= golang.org/x/vuln/cmd/govulncheck@v1
 ACTIONLINT_PACKAGE ?= github.com/rhysd/actionlint/cmd/actionlint@v1
-GOPLS_PACKAGE ?= golang.org/x/tools/gopls@v0.15.3
+GOPLS_PACKAGE ?= golang.org/x/tools/gopls@v0.17.0
 
 DOCKER_IMAGE ?= gitea/gitea
 DOCKER_TAG ?= latest

--- a/modules/markup/common/linkify.go
+++ b/modules/markup/common/linkify.go
@@ -24,7 +24,7 @@ type GlobalVarsType struct {
 	LinkRegex   *regexp.Regexp // fast matching a URL link, no any extra validation.
 }
 
-var GlobalVars = sync.OnceValue[*GlobalVarsType](func() *GlobalVarsType {
+var GlobalVars = sync.OnceValue(func() *GlobalVarsType {
 	v := &GlobalVarsType{}
 	v.wwwURLRegxp = regexp.MustCompile(`^www\.[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}((?:/|[#?])[-a-zA-Z0-9@:%_\+.~#!?&//=\(\);,'">\^{}\[\]` + "`" + `]*)?`)
 	v.LinkRegex, _ = xurls.StrictMatchingScheme("https?://")

--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -42,7 +42,7 @@ type globalVarsType struct {
 	nulCleaner *strings.Replacer
 }
 
-var globalVars = sync.OnceValue[*globalVarsType](func() *globalVarsType {
+var globalVars = sync.OnceValue(func() *globalVarsType {
 	v := &globalVarsType{}
 	// NOTE: All below regex matching do not perform any extra validation.
 	// Thus a link is produced even if the linked entity does not exist.

--- a/modules/markup/internal/renderinternal.go
+++ b/modules/markup/internal/renderinternal.go
@@ -17,7 +17,7 @@ import (
 	"golang.org/x/net/html"
 )
 
-var reAttrClass = sync.OnceValue[*regexp.Regexp](func() *regexp.Regexp {
+var reAttrClass = sync.OnceValue(func() *regexp.Regexp {
 	// TODO: it isn't a problem at the moment because our HTML contents are always well constructed
 	return regexp.MustCompile(`(<[^>]+)\s+class="([^"]+)"([^>]*>)`)
 })

--- a/modules/markup/markdown/goldmark.go
+++ b/modules/markup/markdown/goldmark.go
@@ -112,7 +112,7 @@ func (g *ASTTransformer) Transform(node *ast.Document, reader text.Reader, pc pa
 }
 
 // it is copied from old code, which is quite doubtful whether it is correct
-var reValidIconName = sync.OnceValue[*regexp.Regexp](func() *regexp.Regexp {
+var reValidIconName = sync.OnceValue(func() *regexp.Regexp {
 	return regexp.MustCompile(`^[-\w]+$`) // old: regexp.MustCompile("^[a-z ]+$")
 })
 

--- a/modules/util/time_str.go
+++ b/modules/util/time_str.go
@@ -25,7 +25,7 @@ type timeStrGlobalVarsType struct {
 // In the future, it could be some configurable options to help users
 // to convert the working time to different units.
 
-var timeStrGlobalVars = sync.OnceValue[*timeStrGlobalVarsType](func() *timeStrGlobalVarsType {
+var timeStrGlobalVars = sync.OnceValue(func() *timeStrGlobalVarsType {
 	v := &timeStrGlobalVarsType{}
 	v.re = regexp.MustCompile(`(?i)(\d+)\s*([hms])`)
 	v.units = []struct {

--- a/modules/util/util_test.go
+++ b/modules/util/util_test.go
@@ -242,10 +242,10 @@ func TestReserveLineBreakForTextarea(t *testing.T) {
 }
 
 func TestOptionalArg(t *testing.T) {
-	foo := func(other any, optArg ...int) int {
+	foo := func(_ any, optArg ...int) int {
 		return OptionalArg(optArg)
 	}
-	bar := func(other any, optArg ...int) int {
+	bar := func(_ any, optArg ...int) int {
 		return OptionalArg(optArg, 42)
 	}
 	assert.Equal(t, 0, foo(nil))

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -701,9 +701,6 @@ func viewPullFiles(ctx *context.Context, specifiedStartCommit, specifiedEndCommi
 
 	if ctx.Written() {
 		return
-	} else if prInfo == nil {
-		ctx.NotFound("ViewPullFiles", nil)
-		return
 	}
 
 	headCommitID, err := gitRepo.GetRefCommitID(pull.GetGitRefName())


### PR DESCRIPTION
Update all go tool dependencies to latest version. WIP because I think there are new gopls errors, would like to confirm them on CI first. Here is from a local run:

```
modules/markup/markdown/goldmark.go:115:37-53: unnecessary type arguments
modules/markup/html.go:45:32-49: unnecessary type arguments
modules/markup/internal/renderinternal.go:20:33-49: unnecessary type arguments
modules/markup/common/linkify.go:27:32-49: unnecessary type arguments
modules/util/time_str.go:28:39-63: unnecessary type arguments
routers/web/repo/pull.go:704:19: impossible condition: non-nil == nil
modules/util/util_test.go:248:14-23: unused parameter: other
```

~~Backport because the `gxz` update might have security benefits.~~