### PR TITLE
show warning on navigation if currently editing comment or title

### DIFF
--- a/templates/repo/issue/view_content.tmpl
+++ b/templates/repo/issue/view_content.tmpl
@@ -139,7 +139,7 @@
 </div>
 
 <template id="issue-comment-editor-template">
-	<div class="ui form comment">
+	<form class="ui form comment">
 		<div class="field">
 			{{template "shared/combomarkdowneditor" (dict
 				"CustomInit" true
@@ -162,7 +162,7 @@
 				<button class="ui primary button">{{ctx.Locale.Tr "repo.issues.save"}}</button>
 			</div>
 		</div>
-	</div>
+	</form>
 </template>
 
 {{template "repo/issue/view_content/reference_issue_dialog" .}}

--- a/templates/repo/issue/view_content.tmpl
+++ b/templates/repo/issue/view_content.tmpl
@@ -158,8 +158,8 @@
 
 		<div class="field">
 			<div class="text right edit">
-				<button class="ui cancel button">{{ctx.Locale.Tr "repo.issues.cancel"}}</button>
-				<button class="ui primary button">{{ctx.Locale.Tr "repo.issues.save"}}</button>
+				<button type="button" class="ui cancel button">{{ctx.Locale.Tr "repo.issues.cancel"}}</button>
+				<button type="submit" class="ui primary button">{{ctx.Locale.Tr "repo.issues.save"}}</button>
 			</div>
 		</div>
 	</form>

--- a/templates/repo/issue/view_title.tmpl
+++ b/templates/repo/issue/view_title.tmpl
@@ -31,8 +31,8 @@
 			<input name="title" value="{{.Issue.Title}}" data-old-title="{{.Issue.Title}}" maxlength="255" autocomplete="off" />
 		</div>
 		<div class="issue-title-buttons">
-			<button class="ui small basic cancel button">{{ctx.Locale.Tr "repo.issues.cancel"}}</button>
-			<button class="ui small primary button" data-update-url="{{$.RepoLink}}/issues/{{.Issue.Index}}/title">
+			<button type="button" class="ui small basic cancel button">{{ctx.Locale.Tr "repo.issues.cancel"}}</button>
+			<button type="submit" class="ui small primary button" data-update-url="{{$.RepoLink}}/issues/{{.Issue.Index}}/title">
 				{{ctx.Locale.Tr "repo.issues.save"}}
 			</button>
 		</div>

--- a/templates/repo/issue/view_title.tmpl
+++ b/templates/repo/issue/view_title.tmpl
@@ -26,9 +26,9 @@
 		</div>
 	</div>
 	{{if $canEditIssueTitle}}
-	<div class="ui form issue-title tw-hidden" id="issue-title-editor">
+	<form class="ui form issue-title tw-hidden" id="issue-title-editor">
 		<div class="ui input tw-flex-1">
-			<input value="{{.Issue.Title}}" data-old-title="{{.Issue.Title}}" maxlength="255" autocomplete="off">
+			<input name="title" value="{{.Issue.Title}}" data-old-title="{{.Issue.Title}}" maxlength="255" autocomplete="off" />
 		</div>
 		<div class="issue-title-buttons">
 			<button class="ui small basic cancel button">{{ctx.Locale.Tr "repo.issues.cancel"}}</button>
@@ -36,7 +36,7 @@
 				{{ctx.Locale.Tr "repo.issues.save"}}
 			</button>
 		</div>
-	</div>
+	</form>
 	{{end}}
 	<div class="issue-title-meta">
 		{{if .HasMerged}}

--- a/templates/repo/issue/view_title.tmpl
+++ b/templates/repo/issue/view_title.tmpl
@@ -28,7 +28,7 @@
 	{{if $canEditIssueTitle}}
 	<form class="ui form issue-title tw-hidden" id="issue-title-editor">
 		<div class="ui input tw-flex-1">
-			<input name="title" value="{{.Issue.Title}}" data-old-title="{{.Issue.Title}}" maxlength="255" autocomplete="off" />
+			<input name="title" value="{{.Issue.Title}}" data-old-title="{{.Issue.Title}}" maxlength="255" autocomplete="off">
 		</div>
 		<div class="issue-title-buttons">
 			<button type="button" class="ui small basic cancel button">{{ctx.Locale.Tr "repo.issues.cancel"}}</button>

--- a/web_src/js/features/repo-issue-edit.ts
+++ b/web_src/js/features/repo-issue-edit.ts
@@ -100,8 +100,10 @@ async function tryOnEditContent(e) {
     comboMarkdownEditor.container.addEventListener(ComboMarkdownEditor.EventUploadStateChanged, syncUiState);
     cancelButton.addEventListener('click', cancelAndReset);
     form.addEventListener('submit', saveAndRefresh);
+  } else {
+    form = editContentZone.querySelector('form');
+    form.classList.remove('ignore-dirty'); // the form is shown again, respect the "dirty" state
   }
-  form.classList.remove('ignore-dirty');
 
   // FIXME: ideally here should reload content and attachment list from backend for existing editor, to avoid losing data
   if (!comboMarkdownEditor.value()) {

--- a/web_src/js/features/repo-issue-edit.ts
+++ b/web_src/js/features/repo-issue-edit.ts
@@ -7,6 +7,7 @@ import {attachRefIssueContextPopup} from './contextpopup.ts';
 import {initCommentContent, initMarkupContent} from '../markup/content.ts';
 import {triggerUploadStateChanged} from './comp/EditorUpload.ts';
 import {convertHtmlToMarkdown} from '../markup/html2markdown.ts';
+import {applyAreYouSure} from '../vendor/jquery.are-you-sure.ts';
 
 async function tryOnEditContent(e) {
   const clickTarget = e.target.closest('.edit-content');
@@ -86,6 +87,7 @@ async function tryOnEditContent(e) {
   comboMarkdownEditor = getComboMarkdownEditor(editContentZone.querySelector('.combo-markdown-editor'));
   if (!comboMarkdownEditor) {
     editContentZone.innerHTML = document.querySelector('#issue-comment-editor-template').innerHTML;
+    applyAreYouSure(editContentZone.firstElementChild);
     const saveButton = querySingleVisibleElem<HTMLButtonElement>(editContentZone, '.ui.primary.button');
     const cancelButton = querySingleVisibleElem<HTMLButtonElement>(editContentZone, '.ui.cancel.button');
     comboMarkdownEditor = await initComboMarkdownEditor(editContentZone.querySelector('.combo-markdown-editor'));

--- a/web_src/js/features/repo-issue-edit.ts
+++ b/web_src/js/features/repo-issue-edit.ts
@@ -32,7 +32,6 @@ async function tryOnEditContent(e) {
 
   const saveAndRefresh = async (e) => {
     e.preventDefault();
-    form.classList.remove('ignore-dirty');
     renderContent.classList.add('is-loading');
     showElem(renderContent);
     hideElem(editContentZone);
@@ -52,6 +51,7 @@ async function tryOnEditContent(e) {
         showErrorToast(data.errorMessage);
         return;
       }
+      form.classList.remove('ignore-dirty'); // the form is no longer dirty
       reinitializeAreYouSure(form);
       editContentZone.setAttribute('data-content-version', data.contentVersion);
       if (!data.content) {
@@ -101,6 +101,7 @@ async function tryOnEditContent(e) {
     cancelButton.addEventListener('click', cancelAndReset);
     form.addEventListener('submit', saveAndRefresh);
   }
+  form.classList.remove('ignore-dirty');
 
   // FIXME: ideally here should reload content and attachment list from backend for existing editor, to avoid losing data
   if (!comboMarkdownEditor.value()) {

--- a/web_src/js/features/repo-issue-edit.ts
+++ b/web_src/js/features/repo-issue-edit.ts
@@ -20,11 +20,9 @@ async function tryOnEditContent(e) {
   const rawContent = segment.querySelector('.raw-content');
 
   let comboMarkdownEditor : ComboMarkdownEditor;
-  let form: HTMLFormElement;
 
   const cancelAndReset = (e) => {
     e.preventDefault();
-    form.classList.add('ignore-dirty');
     showElem(renderContent);
     hideElem(editContentZone);
     comboMarkdownEditor.dropzoneReloadFiles();
@@ -51,8 +49,7 @@ async function tryOnEditContent(e) {
         showErrorToast(data.errorMessage);
         return;
       }
-      form.classList.remove('ignore-dirty'); // the form is no longer dirty
-      reinitializeAreYouSure(form);
+      reinitializeAreYouSure(editContentZone.querySelector('form')); // the form is no longer dirty
       editContentZone.setAttribute('data-content-version', data.contentVersion);
       if (!data.content) {
         renderContent.innerHTML = document.querySelector('#no-content').innerHTML;
@@ -91,7 +88,7 @@ async function tryOnEditContent(e) {
   comboMarkdownEditor = getComboMarkdownEditor(editContentZone.querySelector('.combo-markdown-editor'));
   if (!comboMarkdownEditor) {
     editContentZone.innerHTML = document.querySelector('#issue-comment-editor-template').innerHTML;
-    form = editContentZone.querySelector('form');
+    const form = editContentZone.querySelector('form');
     applyAreYouSure(form);
     const saveButton = querySingleVisibleElem<HTMLButtonElement>(editContentZone, '.ui.primary.button');
     const cancelButton = querySingleVisibleElem<HTMLButtonElement>(editContentZone, '.ui.cancel.button');
@@ -100,9 +97,6 @@ async function tryOnEditContent(e) {
     comboMarkdownEditor.container.addEventListener(ComboMarkdownEditor.EventUploadStateChanged, syncUiState);
     cancelButton.addEventListener('click', cancelAndReset);
     form.addEventListener('submit', saveAndRefresh);
-  } else {
-    form = editContentZone.querySelector('form');
-    form.classList.remove('ignore-dirty'); // the form is shown again, respect the "dirty" state
   }
 
   // FIXME: ideally here should reload content and attachment list from backend for existing editor, to avoid losing data

--- a/web_src/js/features/repo-issue.ts
+++ b/web_src/js/features/repo-issue.ts
@@ -16,7 +16,6 @@ import {GET, POST} from '../modules/fetch.ts';
 import {showErrorToast} from '../modules/toast.ts';
 import {initRepoIssueSidebar} from './repo-issue-sidebar.ts';
 import {fomanticQuery} from '../modules/fomantic/base.ts';
-import {applyAreYouSure} from '../vendor/jquery.are-you-sure.ts';
 
 const {appSubUrl} = window.config;
 
@@ -533,14 +532,13 @@ export function initRepoIssueWipToggle() {
 
 export function initRepoIssueTitleEdit() {
   const issueTitleDisplay = document.querySelector('#issue-title-display');
-  const issueTitleEditor = document.querySelector('#issue-title-editor');
+  const issueTitleEditor = document.querySelector<HTMLFormElement>('#issue-title-editor');
   if (!issueTitleEditor) return;
-
-  applyAreYouSure(issueTitleEditor);
 
   const issueTitleInput = issueTitleEditor.querySelector('input');
   const oldTitle = issueTitleInput.getAttribute('data-old-title');
   issueTitleDisplay.querySelector('#issue-title-edit-show').addEventListener('click', () => {
+    issueTitleEditor.classList.remove('ignore-dirty');
     hideElem(issueTitleDisplay);
     hideElem('#pull-desc-display');
     showElem(issueTitleEditor);
@@ -551,6 +549,7 @@ export function initRepoIssueTitleEdit() {
     issueTitleInput.focus();
   });
   issueTitleEditor.querySelector('.ui.cancel.button').addEventListener('click', () => {
+    issueTitleEditor.classList.add('ignore-dirty');
     hideElem(issueTitleEditor);
     hideElem('#pull-desc-editor');
     showElem(issueTitleDisplay);
@@ -561,7 +560,8 @@ export function initRepoIssueTitleEdit() {
   const prTargetUpdateUrl = pullDescEditor?.getAttribute('data-target-update-url');
 
   const editSaveButton = issueTitleEditor.querySelector('.ui.primary.button');
-  editSaveButton.addEventListener('click', async () => {
+  issueTitleEditor.addEventListener('submit', async (e) => {
+    e.preventDefault();
     const newTitle = issueTitleInput.value.trim();
     try {
       if (newTitle && newTitle !== oldTitle) {
@@ -580,6 +580,7 @@ export function initRepoIssueTitleEdit() {
           }
         }
       }
+      issueTitleEditor.classList.remove('dirty');
       window.location.reload();
     } catch (error) {
       console.error(error);

--- a/web_src/js/features/repo-issue.ts
+++ b/web_src/js/features/repo-issue.ts
@@ -16,6 +16,7 @@ import {GET, POST} from '../modules/fetch.ts';
 import {showErrorToast} from '../modules/toast.ts';
 import {initRepoIssueSidebar} from './repo-issue-sidebar.ts';
 import {fomanticQuery} from '../modules/fomantic/base.ts';
+import {applyAreYouSure} from '../vendor/jquery.are-you-sure.ts';
 
 const {appSubUrl} = window.config;
 
@@ -534,6 +535,8 @@ export function initRepoIssueTitleEdit() {
   const issueTitleDisplay = document.querySelector('#issue-title-display');
   const issueTitleEditor = document.querySelector('#issue-title-editor');
   if (!issueTitleEditor) return;
+
+  applyAreYouSure(issueTitleEditor);
 
   const issueTitleInput = issueTitleEditor.querySelector('input');
   const oldTitle = issueTitleInput.getAttribute('data-old-title');

--- a/web_src/js/features/repo-issue.ts
+++ b/web_src/js/features/repo-issue.ts
@@ -538,7 +538,6 @@ export function initRepoIssueTitleEdit() {
   const issueTitleInput = issueTitleEditor.querySelector('input');
   const oldTitle = issueTitleInput.getAttribute('data-old-title');
   issueTitleDisplay.querySelector('#issue-title-edit-show').addEventListener('click', () => {
-    issueTitleEditor.classList.remove('ignore-dirty');
     hideElem(issueTitleDisplay);
     hideElem('#pull-desc-display');
     showElem(issueTitleEditor);
@@ -549,7 +548,6 @@ export function initRepoIssueTitleEdit() {
     issueTitleInput.focus();
   });
   issueTitleEditor.querySelector('.ui.cancel.button').addEventListener('click', () => {
-    issueTitleEditor.classList.add('ignore-dirty');
     hideElem(issueTitleEditor);
     hideElem('#pull-desc-editor');
     showElem(issueTitleDisplay);

--- a/web_src/js/vendor/jquery.are-you-sure.ts
+++ b/web_src/js/vendor/jquery.are-you-sure.ts
@@ -2,7 +2,7 @@
 // Fork of the upstream module. The only changes are:
 // * use export to make it work with ES6 modules.
 // * the addition of `const` to make it strict mode compatible.
-// * check "ignore-dirty" class, ignore forms with this class.
+// * ignore forms with "ignore-dirty" class, ignore hidden forms (closest('.tw-hidden'))
 
 /*!
  * jQuery Plugin: Are-You-Sure (Dirty Form Detection)

--- a/web_src/js/vendor/jquery.are-you-sure.ts
+++ b/web_src/js/vendor/jquery.are-you-sure.ts
@@ -2,6 +2,7 @@
 // Fork of the upstream module. The only changes are:
 // * use export to make it work with ES6 modules.
 // * the addition of `const` to make it strict mode compatible.
+// * check "ignore-dirty" class, ignore forms with this class.
 
 /*!
  * jQuery Plugin: Are-You-Sure (Dirty Form Detection)
@@ -161,7 +162,7 @@ export function initAreYouSure($) {
     if (!settings.silent && !window.aysUnloadSet) {
       window.aysUnloadSet = true;
       $(window).bind('beforeunload', function() {
-        const $dirtyForms = $("form").filter('.' + settings.dirtyClass);
+        const $dirtyForms = $("form:not(.ignore-dirty)").filter('.' + settings.dirtyClass);
         if ($dirtyForms.length == 0) {
           return;
         }
@@ -198,4 +199,8 @@ export function initAreYouSure($) {
 
 export function applyAreYouSure(selectorOrEl: string|Element|$, opts = {}) {
   $(selectorOrEl).areYouSure(opts);
+}
+
+export function reinitializeAreYouSure(selectorOrEl: string|Element|$) {
+  $(selectorOrEl).trigger('reinitialize.areYouSure');
 }

--- a/web_src/js/vendor/jquery.are-you-sure.ts
+++ b/web_src/js/vendor/jquery.are-you-sure.ts
@@ -162,10 +162,10 @@ export function initAreYouSure($) {
     if (!settings.silent && !window.aysUnloadSet) {
       window.aysUnloadSet = true;
       $(window).bind('beforeunload', function() {
-        const $dirtyForms = $("form:not(.ignore-dirty)").filter('.' + settings.dirtyClass);
-        if ($dirtyForms.length == 0) {
-          return;
-        }
+        const $forms = $("form:not(.ignore-dirty)").filter('.' + settings.dirtyClass);
+        const dirtyFormCount = Array.from($forms).reduce((res, form) => form.closest('.tw-hidden') ? res : res + 1, 0);
+        if (dirtyFormCount === 0) return;
+
         // Prevent multiple prompts - seen on Chrome and IE
         if (navigator.userAgent.toLowerCase().match(/msie|chrome/)) {
           if (window.aysHasPrompted) {


### PR DESCRIPTION
This PR fixes the issue https://github.com/go-gitea/gitea/issues/32223

With this little event handler, I'm forcing the browser to show the popup, as it does with normal forms.

![image](https://github.com/user-attachments/assets/e34fab90-dc61-4add-a79e-17fb97347494)