### PR TITLE
Add `last_committer_date` and `last_author_date` for file contents API

### DIFF
--- a/modules/structs/repo_file.go
+++ b/modules/structs/repo_file.go
@@ -4,6 +4,8 @@
 
 package structs
 
+import "time"
+
 // FileOptions options for all file APIs
 type FileOptions struct {
 	// message (optional) for the commit of this file. if not supplied, a default message will be used
@@ -121,6 +123,10 @@ type ContentsResponse struct {
 	Path          string `json:"path"`
 	SHA           string `json:"sha"`
 	LastCommitSHA string `json:"last_commit_sha"`
+	// swagger:strfmt date-time
+	LastCommitterDate time.Time `json:"last_committer_date"`
+	// swagger:strfmt date-time
+	LastAuthorDate time.Time `json:"last_author_date"`
 	// `type` will be `file`, `dir`, `symlink`, or `submodule`
 	Type string `json:"type"`
 	Size int64  `json:"size"`

--- a/services/repository/files/content.go
+++ b/services/repository/files/content.go
@@ -188,6 +188,14 @@ func GetContents(ctx context.Context, repo *repo_model.Repository, treePath, ref
 		},
 	}
 
+	// GitHub doesn't have these fields in the response, but we could follow other similar APIs to name them
+	// https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-commits
+	if lastCommit.Committer != nil {
+		contentsResponse.LastCommitterDate = lastCommit.Committer.When
+	}
+	if lastCommit.Author != nil {
+		contentsResponse.LastAuthorDate = lastCommit.Author.When
+	}
 	// Now populate the rest of the ContentsResponse based on entry type
 	if entry.IsRegular() || entry.IsExecutable() {
 		contentsResponse.Type = string(ContentTypeRegular)

--- a/services/repository/files/content_test.go
+++ b/services/repository/files/content_test.go
@@ -5,6 +5,7 @@ package files
 
 import (
 	"testing"
+	"time"
 
 	"code.gitea.io/gitea/models/unittest"
 	"code.gitea.io/gitea/modules/gitrepo"
@@ -30,18 +31,20 @@ func getExpectedReadmeContentsResponse() *api.ContentsResponse {
 	gitURL := "https://try.gitea.io/api/v1/repos/user2/repo1/git/blobs/" + sha
 	downloadURL := "https://try.gitea.io/user2/repo1/raw/branch/master/" + treePath
 	return &api.ContentsResponse{
-		Name:          treePath,
-		Path:          treePath,
-		SHA:           "4b4851ad51df6a7d9f25c979345979eaeb5b349f",
-		LastCommitSHA: "65f1bf27bc3bf70f64657658635e66094edbcb4d",
-		Type:          "file",
-		Size:          30,
-		Encoding:      &encoding,
-		Content:       &content,
-		URL:           &selfURL,
-		HTMLURL:       &htmlURL,
-		GitURL:        &gitURL,
-		DownloadURL:   &downloadURL,
+		Name:              treePath,
+		Path:              treePath,
+		SHA:               "4b4851ad51df6a7d9f25c979345979eaeb5b349f",
+		LastCommitSHA:     "65f1bf27bc3bf70f64657658635e66094edbcb4d",
+		LastCommitterDate: time.Date(2017, time.March, 19, 16, 47, 59, 0, time.FixedZone("", -14400)),
+		LastAuthorDate:    time.Date(2017, time.March, 19, 16, 47, 59, 0, time.FixedZone("", -14400)),
+		Type:              "file",
+		Size:              30,
+		Encoding:          &encoding,
+		Content:           &content,
+		URL:               &selfURL,
+		HTMLURL:           &htmlURL,
+		GitURL:            &gitURL,
+		DownloadURL:       &downloadURL,
 		Links: &api.FileLinksResponse{
 			Self:    &selfURL,
 			GitURL:  &gitURL,

--- a/services/repository/files/file_test.go
+++ b/services/repository/files/file_test.go
@@ -5,6 +5,7 @@ package files
 
 import (
 	"testing"
+	"time"
 
 	"code.gitea.io/gitea/models/unittest"
 	"code.gitea.io/gitea/modules/gitrepo"
@@ -42,18 +43,20 @@ func getExpectedFileResponse() *api.FileResponse {
 	downloadURL := setting.AppURL + "user2/repo1/raw/branch/master/" + treePath
 	return &api.FileResponse{
 		Content: &api.ContentsResponse{
-			Name:          treePath,
-			Path:          treePath,
-			SHA:           sha,
-			LastCommitSHA: "65f1bf27bc3bf70f64657658635e66094edbcb4d",
-			Type:          "file",
-			Size:          30,
-			Encoding:      &encoding,
-			Content:       &content,
-			URL:           &selfURL,
-			HTMLURL:       &htmlURL,
-			GitURL:        &gitURL,
-			DownloadURL:   &downloadURL,
+			Name:              treePath,
+			Path:              treePath,
+			SHA:               sha,
+			LastCommitSHA:     "65f1bf27bc3bf70f64657658635e66094edbcb4d",
+			LastCommitterDate: time.Date(2017, time.March, 19, 16, 47, 59, 0, time.FixedZone("", -14400)),
+			LastAuthorDate:    time.Date(2017, time.March, 19, 16, 47, 59, 0, time.FixedZone("", -14400)),
+			Type:              "file",
+			Size:              30,
+			Encoding:          &encoding,
+			Content:           &content,
+			URL:               &selfURL,
+			HTMLURL:           &htmlURL,
+			GitURL:            &gitURL,
+			DownloadURL:       &downloadURL,
 			Links: &api.FileLinksResponse{
 				Self:    &selfURL,
 				GitURL:  &gitURL,

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -20411,9 +20411,19 @@
           "type": "string",
           "x-go-name": "HTMLURL"
         },
+        "last_author_date": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "LastAuthorDate"
+        },
         "last_commit_sha": {
           "type": "string",
           "x-go-name": "LastCommitSHA"
+        },
+        "last_committer_date": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "LastCommitterDate"
         },
         "name": {
           "type": "string",

--- a/tests/integration/api_repo_get_contents_list_test.go
+++ b/tests/integration/api_repo_get_contents_list_test.go
@@ -6,8 +6,9 @@ package integration
 import (
 	"net/http"
 	"net/url"
-	"path/filepath"
+	"path"
 	"testing"
+	"time"
 
 	auth_model "code.gitea.io/gitea/models/auth"
 	repo_model "code.gitea.io/gitea/models/repo"
@@ -31,16 +32,18 @@ func getExpectedContentsListResponseForContents(ref, refType, lastCommitSHA stri
 	downloadURL := setting.AppURL + "user2/repo1/raw/" + refType + "/" + ref + "/" + treePath
 	return []*api.ContentsResponse{
 		{
-			Name:          filepath.Base(treePath),
-			Path:          treePath,
-			SHA:           sha,
-			LastCommitSHA: lastCommitSHA,
-			Type:          "file",
-			Size:          30,
-			URL:           &selfURL,
-			HTMLURL:       &htmlURL,
-			GitURL:        &gitURL,
-			DownloadURL:   &downloadURL,
+			Name:              path.Base(treePath),
+			Path:              treePath,
+			SHA:               sha,
+			LastCommitSHA:     lastCommitSHA,
+			LastCommitterDate: time.Date(2017, time.March, 19, 16, 47, 59, 0, time.FixedZone("", -14400)),
+			LastAuthorDate:    time.Date(2017, time.March, 19, 16, 47, 59, 0, time.FixedZone("", -14400)),
+			Type:              "file",
+			Size:              30,
+			URL:               &selfURL,
+			HTMLURL:           &htmlURL,
+			GitURL:            &gitURL,
+			DownloadURL:       &downloadURL,
 			Links: &api.FileLinksResponse{
 				Self:    &selfURL,
 				GitURL:  &gitURL,

--- a/tests/integration/api_repo_get_contents_test.go
+++ b/tests/integration/api_repo_get_contents_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 
 	auth_model "code.gitea.io/gitea/models/auth"
 	repo_model "code.gitea.io/gitea/models/repo"
@@ -33,18 +34,20 @@ func getExpectedContentsResponseForContents(ref, refType, lastCommitSHA string) 
 	gitURL := setting.AppURL + "api/v1/repos/user2/repo1/git/blobs/" + sha
 	downloadURL := setting.AppURL + "user2/repo1/raw/" + refType + "/" + ref + "/" + treePath
 	return &api.ContentsResponse{
-		Name:          treePath,
-		Path:          treePath,
-		SHA:           sha,
-		LastCommitSHA: lastCommitSHA,
-		Type:          "file",
-		Size:          30,
-		Encoding:      &encoding,
-		Content:       &content,
-		URL:           &selfURL,
-		HTMLURL:       &htmlURL,
-		GitURL:        &gitURL,
-		DownloadURL:   &downloadURL,
+		Name:              treePath,
+		Path:              treePath,
+		SHA:               sha,
+		LastCommitSHA:     lastCommitSHA,
+		LastCommitterDate: time.Date(2017, time.March, 19, 16, 47, 59, 0, time.FixedZone("", -14400)),
+		LastAuthorDate:    time.Date(2017, time.March, 19, 16, 47, 59, 0, time.FixedZone("", -14400)),
+		Type:              "file",
+		Size:              30,
+		Encoding:          &encoding,
+		Content:           &content,
+		URL:               &selfURL,
+		HTMLURL:           &htmlURL,
+		GitURL:            &gitURL,
+		DownloadURL:       &downloadURL,
 		Links: &api.FileLinksResponse{
 			Self:    &selfURL,
 			GitURL:  &gitURL,


### PR DESCRIPTION
Fix #32886

Add `last_committer_date` and `last_author_date` in the content API which is not implemented by Github API v3 at the moment.