### PR TITLE
Refactor tests

### DIFF
--- a/models/activities/user_heatmap_test.go
+++ b/models/activities/user_heatmap_test.go
@@ -64,11 +64,9 @@ func TestGetUserHeatmapDataByUser(t *testing.T) {
 	for _, tc := range testCases {
 		user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: tc.userID})
 
-		doer := &user_model.User{ID: tc.doerID}
-		_, err := unittest.LoadBeanIfExists(doer)
-		assert.NoError(t, err)
-		if tc.doerID == 0 {
-			doer = nil
+		var doer *user_model.User
+		if tc.doerID != 0 {
+			doer = unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: tc.doerID})
 		}
 
 		// get the action for comparison

--- a/models/auth/webauthn_test.go
+++ b/models/auth/webauthn_test.go
@@ -44,7 +44,7 @@ func TestWebAuthnCredential_UpdateSignCount(t *testing.T) {
 	cred := unittest.AssertExistsAndLoadBean(t, &auth_model.WebAuthnCredential{ID: 1})
 	cred.SignCount = 1
 	assert.NoError(t, cred.UpdateSignCount(db.DefaultContext))
-	unittest.AssertExistsIf(t, true, &auth_model.WebAuthnCredential{ID: 1, SignCount: 1})
+	unittest.AssertExistsAndLoadBean(t, &auth_model.WebAuthnCredential{ID: 1, SignCount: 1})
 }
 
 func TestWebAuthnCredential_UpdateLargeCounter(t *testing.T) {
@@ -52,7 +52,7 @@ func TestWebAuthnCredential_UpdateLargeCounter(t *testing.T) {
 	cred := unittest.AssertExistsAndLoadBean(t, &auth_model.WebAuthnCredential{ID: 1})
 	cred.SignCount = 0xffffffff
 	assert.NoError(t, cred.UpdateSignCount(db.DefaultContext))
-	unittest.AssertExistsIf(t, true, &auth_model.WebAuthnCredential{ID: 1, SignCount: 0xffffffff})
+	unittest.AssertExistsAndLoadBean(t, &auth_model.WebAuthnCredential{ID: 1, SignCount: 0xffffffff})
 }
 
 func TestCreateCredential(t *testing.T) {
@@ -63,5 +63,5 @@ func TestCreateCredential(t *testing.T) {
 	assert.Equal(t, "WebAuthn Created Credential", res.Name)
 	assert.Equal(t, []byte("Test"), res.CredentialID)
 
-	unittest.AssertExistsIf(t, true, &auth_model.WebAuthnCredential{Name: "WebAuthn Created Credential", UserID: 1})
+	unittest.AssertExistsAndLoadBean(t, &auth_model.WebAuthnCredential{Name: "WebAuthn Created Credential", UserID: 1})
 }

--- a/models/issues/issue_user_test.go
+++ b/models/issues/issue_user_test.go
@@ -12,6 +12,7 @@ import (
 	"code.gitea.io/gitea/models/unittest"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_NewIssueUsers(t *testing.T) {
@@ -27,9 +28,8 @@ func Test_NewIssueUsers(t *testing.T) {
 	}
 
 	// artificially insert new issue
-	unittest.AssertSuccessfulInsert(t, newIssue)
-
-	assert.NoError(t, issues_model.NewIssueUsers(db.DefaultContext, repo, newIssue))
+	require.NoError(t, db.Insert(db.DefaultContext, newIssue))
+	require.NoError(t, issues_model.NewIssueUsers(db.DefaultContext, repo, newIssue))
 
 	// issue_user table should now have entries for new issue
 	unittest.AssertExistsAndLoadBean(t, &issues_model.IssueUser{IssueID: newIssue.ID, UID: newIssue.PosterID})

--- a/models/issues/label_test.go
+++ b/models/issues/label_test.go
@@ -387,7 +387,7 @@ func TestDeleteIssueLabel(t *testing.T) {
 
 		expectedNumIssues := label.NumIssues
 		expectedNumClosedIssues := label.NumClosedIssues
-		if unittest.BeanExists(t, &issues_model.IssueLabel{IssueID: issueID, LabelID: labelID}) {
+		if unittest.GetBean(t, &issues_model.IssueLabel{IssueID: issueID, LabelID: labelID}) != nil {
 			expectedNumIssues--
 			if issue.IsClosed {
 				expectedNumClosedIssues--

--- a/models/organization/org_user_test.go
+++ b/models/organization/org_user_test.go
@@ -131,7 +131,7 @@ func TestAddOrgUser(t *testing.T) {
 	testSuccess := func(orgID, userID int64, isPublic bool) {
 		org := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: orgID})
 		expectedNumMembers := org.NumMembers
-		if !unittest.BeanExists(t, &organization.OrgUser{OrgID: orgID, UID: userID}) {
+		if unittest.GetBean(t, &organization.OrgUser{OrgID: orgID, UID: userID}) == nil {
 			expectedNumMembers++
 		}
 		assert.NoError(t, organization.AddOrgUser(db.DefaultContext, orgID, userID))

--- a/models/unittest/fixtures.go
+++ b/models/unittest/fixtures.go
@@ -1,12 +1,10 @@
 // Copyright 2021 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-//nolint:forbidigo
 package unittest
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"code.gitea.io/gitea/models/db"
@@ -37,7 +35,7 @@ func InitFixtures(opts FixturesOptions, engine ...*xorm.Engine) (err error) {
 	} else {
 		fixtureOptionFiles = testfixtures.Files(opts.Files...)
 	}
-	dialect := "unknown"
+	var dialect string
 	switch e.Dialect().URI().DBType {
 	case schemas.POSTGRES:
 		dialect = "postgres"
@@ -48,8 +46,7 @@ func InitFixtures(opts FixturesOptions, engine ...*xorm.Engine) (err error) {
 	case schemas.SQLITE:
 		dialect = "sqlite3"
 	default:
-		fmt.Println("Unsupported RDBMS for integration tests")
-		os.Exit(1)
+		return fmt.Errorf("unsupported RDBMS for integration tests: %q", e.Dialect().URI().DBType)
 	}
 	loaderOptions := []func(loader *testfixtures.Loader) error{
 		testfixtures.Database(e.DB().DB),
@@ -69,9 +66,7 @@ func InitFixtures(opts FixturesOptions, engine ...*xorm.Engine) (err error) {
 
 	// register the dummy hash algorithm function used in the test fixtures
 	_ = hash.Register("dummy", hash.NewDummyHasher)
-
 	setting.PasswordHashAlgo, _ = hash.SetDefaultPasswordHashAlgorithm("dummy")
-
 	return err
 }
 
@@ -87,7 +82,7 @@ func LoadFixtures(engine ...*xorm.Engine) error {
 		time.Sleep(200 * time.Millisecond)
 	}
 	if err != nil {
-		fmt.Printf("LoadFixtures failed after retries: %v\n", err)
+		return fmt.Errorf("LoadFixtures failed after retries: %w", err)
 	}
 	// Now if we're running postgres we need to tell it to update the sequences
 	if e.Dialect().URI().DBType == schemas.POSTGRES {
@@ -108,21 +103,18 @@ func LoadFixtures(engine ...*xorm.Engine) error {
 	     AND T.relname = PGT.tablename
 	 ORDER BY S.relname;`)
 		if err != nil {
-			fmt.Printf("Failed to generate sequence update: %v\n", err)
-			return err
+			return fmt.Errorf("failed to generate sequence update: %w", err)
 		}
 		for _, r := range results {
 			for _, value := range r {
 				_, err = e.Exec(value)
 				if err != nil {
-					fmt.Printf("Failed to update sequence: %s Error: %v\n", value, err)
-					return err
+					return fmt.Errorf("failed to update sequence: %s, error: %w", value, err)
 				}
 			}
 		}
 	}
 	_ = hash.Register("dummy", hash.NewDummyHasher)
 	setting.PasswordHashAlgo, _ = hash.SetDefaultPasswordHashAlgorithm("dummy")
-
-	return err
+	return nil
 }

--- a/models/unittest/reflection.go
+++ b/models/unittest/reflection.go
@@ -4,7 +4,7 @@
 package unittest
 
 import (
-	"log"
+	"fmt"
 	"reflect"
 )
 
@@ -14,7 +14,7 @@ func fieldByName(v reflect.Value, field string) reflect.Value {
 	}
 	f := v.FieldByName(field)
 	if !f.IsValid() {
-		log.Panicf("can not read %s for %v", field, v)
+		panic(fmt.Errorf("can not read %s for %v", field, v))
 	}
 	return f
 }

--- a/models/unittest/testdb.go
+++ b/models/unittest/testdb.go
@@ -34,11 +34,6 @@ var (
 	fixturesDir string
 )
 
-// FixturesDir returns the fixture directory
-func FixturesDir() string {
-	return fixturesDir
-}
-
 func fatalTestError(fmtStr string, args ...any) {
 	_, _ = fmt.Fprintf(os.Stderr, fmtStr, args...)
 	os.Exit(1)

--- a/routers/web/repo/issue_label_test.go
+++ b/routers/web/repo/issue_label_test.go
@@ -162,10 +162,11 @@ func TestUpdateIssueLabel_Toggle(t *testing.T) {
 		UpdateIssueLabel(ctx)
 		assert.EqualValues(t, http.StatusOK, ctx.Resp.Status())
 		for _, issueID := range testCase.IssueIDs {
-			unittest.AssertExistsIf(t, testCase.ExpectedAdd, &issues_model.IssueLabel{
-				IssueID: issueID,
-				LabelID: testCase.LabelID,
-			})
+			if testCase.ExpectedAdd {
+				unittest.AssertExistsAndLoadBean(t, &issues_model.IssueLabel{IssueID: issueID, LabelID: testCase.LabelID})
+			} else {
+				unittest.AssertNotExistsBean(t, &issues_model.IssueLabel{IssueID: issueID, LabelID: testCase.LabelID})
+			}
 		}
 		unittest.CheckConsistencyFor(t, &issues_model.Label{})
 	}

--- a/services/org/user_test.go
+++ b/services/org/user_test.go
@@ -47,7 +47,7 @@ func TestRemoveOrgUser(t *testing.T) {
 
 	testSuccess := func(org *organization.Organization, user *user_model.User) {
 		expectedNumMembers := org.NumMembers
-		if unittest.BeanExists(t, &organization.OrgUser{OrgID: org.ID, UID: user.ID}) {
+		if unittest.GetBean(t, &organization.OrgUser{OrgID: org.ID, UID: user.ID}) != nil {
 			expectedNumMembers--
 		}
 		assert.NoError(t, RemoveOrgUser(db.DefaultContext, org, user))

--- a/tests/integration/auth_ldap_test.go
+++ b/tests/integration/auth_ldap_test.go
@@ -332,7 +332,7 @@ func TestLDAPUserSyncWithGroupFilter(t *testing.T) {
 
 	// Assert members of LDAP group "cn=git" are added
 	for _, gitLDAPUser := range te.gitLDAPUsers {
-		unittest.BeanExists(t, &user_model.User{
+		unittest.AssertExistsAndLoadBean(t, &user_model.User{
 			Name: gitLDAPUser.UserName,
 		})
 	}

--- a/tests/integration/pull_review_test.go
+++ b/tests/integration/pull_review_test.go
@@ -92,7 +92,7 @@ func TestPullView_CodeOwner(t *testing.T) {
 			testPullCreate(t, session, "user2", "test_codeowner", false, repo.DefaultBranch, "codeowner-basebranch", "Test Pull Request")
 
 			pr := unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{BaseRepoID: repo.ID, HeadRepoID: repo.ID, HeadBranch: "codeowner-basebranch"})
-			unittest.AssertExistsIf(t, true, &issues_model.Review{IssueID: pr.IssueID, Type: issues_model.ReviewTypeRequest, ReviewerID: 5})
+			unittest.AssertExistsAndLoadBean(t, &issues_model.Review{IssueID: pr.IssueID, Type: issues_model.ReviewTypeRequest, ReviewerID: 5})
 			assert.NoError(t, pr.LoadIssue(db.DefaultContext))
 
 			err := issue_service.ChangeTitle(db.DefaultContext, pr.Issue, user2, "[WIP] Test Pull Request")
@@ -139,7 +139,7 @@ func TestPullView_CodeOwner(t *testing.T) {
 			testPullCreate(t, session, "user2", "test_codeowner", false, repo.DefaultBranch, "codeowner-basebranch2", "Test Pull Request2")
 
 			pr := unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{BaseRepoID: repo.ID, HeadBranch: "codeowner-basebranch2"})
-			unittest.AssertExistsIf(t, true, &issues_model.Review{IssueID: pr.IssueID, Type: issues_model.ReviewTypeRequest, ReviewerID: 8})
+			unittest.AssertExistsAndLoadBean(t, &issues_model.Review{IssueID: pr.IssueID, Type: issues_model.ReviewTypeRequest, ReviewerID: 8})
 		})
 
 		t.Run("Forked Repo Pull Request", func(t *testing.T) {
@@ -169,13 +169,13 @@ func TestPullView_CodeOwner(t *testing.T) {
 			testPullCreateDirectly(t, session, "user5", "test_codeowner", forkedRepo.DefaultBranch, "", "", "codeowner-basebranch-forked", "Test Pull Request on Forked Repository")
 
 			pr := unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{BaseRepoID: forkedRepo.ID, HeadBranch: "codeowner-basebranch-forked"})
-			unittest.AssertExistsIf(t, false, &issues_model.Review{IssueID: pr.IssueID, Type: issues_model.ReviewTypeRequest, ReviewerID: 8})
+			unittest.AssertNotExistsBean(t, &issues_model.Review{IssueID: pr.IssueID, Type: issues_model.ReviewTypeRequest, ReviewerID: 8})
 
 			// create a pull request to base repository, code reviewers should be mentioned
 			testPullCreateDirectly(t, session, repo.OwnerName, repo.Name, repo.DefaultBranch, forkedRepo.OwnerName, forkedRepo.Name, "codeowner-basebranch-forked", "Test Pull Request3")
 
 			pr = unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{BaseRepoID: repo.ID, HeadRepoID: forkedRepo.ID, HeadBranch: "codeowner-basebranch-forked"})
-			unittest.AssertExistsIf(t, true, &issues_model.Review{IssueID: pr.IssueID, Type: issues_model.ReviewTypeRequest, ReviewerID: 8})
+			unittest.AssertExistsAndLoadBean(t, &issues_model.Review{IssueID: pr.IssueID, Type: issues_model.ReviewTypeRequest, ReviewerID: 8})
 		})
 	})
 }

--- a/tests/integration/signin_test.go
+++ b/tests/integration/signin_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"code.gitea.io/gitea/models/db"
 	"code.gitea.io/gitea/models/unittest"
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/setting"
@@ -17,6 +18,7 @@ import (
 	"code.gitea.io/gitea/tests"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func testLoginFailed(t *testing.T, username, password, message string) {
@@ -42,7 +44,7 @@ func TestSignin(t *testing.T) {
 	user.Name = "testuser"
 	user.LowerName = strings.ToLower(user.Name)
 	user.ID = 0
-	unittest.AssertSuccessfulInsert(t, user)
+	require.NoError(t, db.Insert(db.DefaultContext, user))
 
 	samples := []struct {
 		username string


### PR DESCRIPTION
1. fix incorrect tests, for example: BeanExists doesn't do assert and shouldn't be used
2. remove unnecessary test functions
3. introduce DumpQueryResult to help to see the database rows during test (at least I need it)

```
====== DumpQueryResult: SELECT * FROM action_runner_token ======
- # row[0]
  id: 1
  token: xeiWBL5kuTYxGPynHCqQdoeYmJAeG3IzGXCYTrDX
  owner_id: 0
...
```