### PR TITLE
Fix review code comment avatar alignment

### DIFF
--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -365,7 +365,8 @@
 					{{if .Review}}{{$reviewType = .Review.Type}}{{end}}
 					{{if not .OriginalAuthor}}
 					{{/* Some timeline avatars need a offset to correctly align with their speech bubble.
-						The condition depends on whether the comment has contents/attachments or reviews */}}
+						The condition depends on whether the comment has contents/attachments,
+						review's comment is also controlled/rendered by issue comment's Content field */}}
 					<a class="timeline-avatar{{if or .Content .Attachments}} timeline-avatar-offset{{end}}"{{if gt .Poster.ID 0}} href="{{.Poster.HomeLink}}"{{end}}>
 						{{ctx.AvatarUtils.Avatar .Poster 40}}
 					</a>

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -366,7 +366,7 @@
 					{{if not .OriginalAuthor}}
 					{{/* Some timeline avatars need a offset to correctly align with their speech bubble.
 						The condition depends on whether the comment has contents/attachments or reviews */}}
-					<a class="timeline-avatar{{if or .Content .Attachments (and .Review .Review.CodeComments)}} timeline-avatar-offset{{end}}"{{if gt .Poster.ID 0}} href="{{.Poster.HomeLink}}"{{end}}>
+					<a class="timeline-avatar{{if or .Content .Attachments (and .Review .Review.Content)}} timeline-avatar-offset{{end}}"{{if gt .Poster.ID 0}} href="{{.Poster.HomeLink}}"{{end}}>
 						{{ctx.AvatarUtils.Avatar .Poster 40}}
 					</a>
 					{{end}}

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -366,7 +366,7 @@
 					{{if not .OriginalAuthor}}
 					{{/* Some timeline avatars need a offset to correctly align with their speech bubble.
 						The condition depends on whether the comment has contents/attachments or reviews */}}
-					<a class="timeline-avatar{{if or .Content .Attachments (and .Review .Review.Content)}} timeline-avatar-offset{{end}}"{{if gt .Poster.ID 0}} href="{{.Poster.HomeLink}}"{{end}}>
+					<a class="timeline-avatar{{if or .Content .Attachments}} timeline-avatar-offset{{end}}"{{if gt .Poster.ID 0}} href="{{.Poster.HomeLink}}"{{end}}>
 						{{ctx.AvatarUtils.Avatar .Poster 40}}
 					</a>
 					{{end}}


### PR DESCRIPTION
Fixes #33017

Avatar should only have offset if the `Comment` has `Content` or `Attachment` to align with the speech bubble:

![image](https://github.com/user-attachments/assets/168e367f-be35-4383-be4c-3b52cebd262b)

Otherwise, it should align with the timeline event badge.

Issue occurs when a comment is posted with `Review.CodeComments` but no `Content`.
Can be fixed by simply checking `Content` exists

**Before:**
![broken_alignment](https://github.com/user-attachments/assets/965b2d54-f3fc-4ec5-905e-c02d3472a821)

**After:**
![fixed_alignment](https://github.com/user-attachments/assets/9dd5bd96-4171-46ac-bd5e-bcd79bcc7c92)
