### PR TITLE
Make Gitea always use its internal config, ignore `/etc/gitconfig`

### DIFF
--- a/models/unittest/testdb.go
+++ b/models/unittest/testdb.go
@@ -59,13 +59,7 @@ func InitSettings() {
 	_ = hash.Register("dummy", hash.NewDummyHasher)
 
 	setting.PasswordHashAlgo, _ = hash.SetDefaultPasswordHashAlgorithm("dummy")
-	setting.InitGiteaEnvVars()
-
-	// Avoid loading the git's system config.
-	// On macOS, system config sets the osxkeychain credential helper, which will cause tests to freeze with a dialog.
-	// But we do not set it in production at the moment, because it might be a "breaking" change,
-	// more details are in "modules/git.commonBaseEnvs".
-	_ = os.Setenv("GIT_CONFIG_NOSYSTEM", "true")
+	setting.InitGiteaEnvVarsForTesting()
 }
 
 // TestOptions represents test options

--- a/modules/git/command.go
+++ b/modules/git/command.go
@@ -236,10 +236,16 @@ type RunOpts struct {
 }
 
 func commonBaseEnvs() []string {
-	// at the moment, do not set "GIT_CONFIG_NOSYSTEM", users may have put some configs like "receive.certNonceSeed" in it
 	envs := []string{
-		"HOME=" + HomeDir(),        // make Gitea use internal git config only, to prevent conflicts with user's git config
-		"GIT_NO_REPLACE_OBJECTS=1", // ignore replace references (https://git-scm.com/docs/git-replace)
+		// Make Gitea use internal git config only, to prevent conflicts with user's git config
+		// It's better to use GIT_CONFIG_GLOBAL, but it requires git >= 2.32, so we still use HOME at the moment.
+		"HOME=" + HomeDir(),
+		// Avoid using system git config, it would cause problems (eg: use macOS osxkeychain to show a modal dialog, auto installing lfs hooks)
+		// This might be a breaking change in 1.24, because some users said that they have put some configs like "receive.certNonceSeed" in "/etc/gitconfig"
+		// For these users, they need to migrate the necessary configs to Gitea's git config file manually.
+		"GIT_CONFIG_NOSYSTEM=1",
+		// Ignore replace references (https://git-scm.com/docs/git-replace)
+		"GIT_NO_REPLACE_OBJECTS=1",
 	}
 
 	// some environment variables should be passed to git command

--- a/modules/git/repo_archive.go
+++ b/modules/git/repo_archive.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 )
@@ -63,15 +62,11 @@ func (repo *Repository) CreateArchive(ctx context.Context, format ArchiveType, t
 	cmd.AddOptionFormat("--format=%s", format.String())
 	cmd.AddDynamicArguments(commitID)
 
-	// Avoid LFS hooks getting installed because of /etc/gitconfig, which can break pull requests.
-	env := append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
-
 	var stderr strings.Builder
 	err := cmd.Run(&RunOpts{
 		Dir:    repo.Path,
 		Stdout: target,
 		Stderr: &stderr,
-		Env:    env,
 	})
 	if err != nil {
 		return ConcatenateError(err, stderr.String())

--- a/modules/setting/config_env.go
+++ b/modules/setting/config_env.go
@@ -177,7 +177,10 @@ func InitGiteaEnvVars() {
 	// But git would try "XDG_CONFIG_HOME/git/config" first if "HOME/.gitconfig" does not exist,
 	// then our git.InitFull would still write to "XDG_CONFIG_HOME/git/config" if XDG_CONFIG_HOME is set.
 	_ = os.Unsetenv("XDG_CONFIG_HOME")
+}
 
+func InitGiteaEnvVarsForTesting() {
+	InitGiteaEnvVars()
 	_ = os.Unsetenv("GIT_AUTHOR_NAME")
 	_ = os.Unsetenv("GIT_AUTHOR_EMAIL")
 	_ = os.Unsetenv("GIT_AUTHOR_DATE")


### PR DESCRIPTION
In history, Gitea could use the system config `/etc/gitconfig` because some users said that "they might put certNonceSeed in it"

Actually, we shouldn't not use it, because it also causes conflicts (there are already some fixes like #28848)

To make the system clear, I think it's worth to introduce the breaking change: add `GIT_CONFIG_NOSYSTEM=1` to all git commands.


## :warning: BREAKING :warning:

 For most users, nothing need to do.

If you have made changes to `/etc/gitconfig` to affect Gitea's behavior, you need to move these config options to Gitea's internal git config file, it is usually in Gitea's `{AppDataPath}/home/.gitconfig`.