### PR TITLE
Fix broken forms

### DIFF
--- a/routers/web/repo/repo.go
+++ b/routers/web/repo/repo.go
@@ -228,8 +228,12 @@ func CreatePost(ctx *context.Context) {
 	ctx.Data["Licenses"] = repo_module.Licenses
 	ctx.Data["Readmes"] = repo_module.Readmes
 
+	// the logic is still buggy, the complete fix is in 1.24
+	ctx.Data["IsForcedPrivate"] = setting.Repository.ForcePrivate
 	ctx.Data["CanCreateRepo"] = ctx.Doer.CanCreateRepo()
 	ctx.Data["MaxCreationLimit"] = ctx.Doer.MaxCreationLimit()
+	ctx.Data["SupportedObjectFormats"] = git.DefaultFeatures().SupportedObjectFormats
+	ctx.Data["DefaultObjectFormat"] = git.Sha1ObjectFormat
 
 	ctxUser := checkContextUser(ctx, form.UID)
 	if ctx.Written() {

--- a/web_src/css/form.css
+++ b/web_src/css/form.css
@@ -483,7 +483,7 @@ textarea:focus,
     margin-bottom: 1em;
     width: 100%;
   }
-  .new.org .ui.form .field input {
+  .new.org .ui.form .field input:not([type="checkbox"], [type="radio"]) {
     width: 100% !important;
   }
 }


### PR DESCRIPTION
The complete fix is in  Clean up dirty form CSS styles #33081 

Before:

<details>

![image](https://github.com/user-attachments/assets/248b03c0-72ec-49cd-b179-d6eeb3abf72e)

</details>

After:

<details>

![image](https://github.com/user-attachments/assets/3bc078ae-1020-43c0-8fc5-7cd0f9c9c642)

</details>
