### PR TITLE
Filter reviews of one pull request in memory instead of database to reduce slow response because of lacking database index

### DIFF
--- a/models/issues/pull.go
+++ b/models/issues/pull.go
@@ -301,7 +301,7 @@ func (pr *PullRequest) LoadRequestedReviewers(ctx context.Context) error {
 		return nil
 	}
 
-	reviews, err := GetReviewsByIssueID(ctx, pr.Issue.ID)
+	reviews, _, err := GetReviewsByIssueID(ctx, pr.Issue.ID)
 	if err != nil {
 		return err
 	}
@@ -320,7 +320,7 @@ func (pr *PullRequest) LoadRequestedReviewers(ctx context.Context) error {
 
 // LoadRequestedReviewersTeams loads the requested reviewers teams.
 func (pr *PullRequest) LoadRequestedReviewersTeams(ctx context.Context) error {
-	reviews, err := GetReviewsByIssueID(ctx, pr.Issue.ID)
+	reviews, _, err := GetReviewsByIssueID(ctx, pr.Issue.ID)
 	if err != nil {
 		return err
 	}

--- a/models/issues/review_list.go
+++ b/models/issues/review_list.go
@@ -167,7 +167,7 @@ func GetReviewsByIssueID(ctx context.Context, issueID int64) (ReviewList, Review
 	}
 
 	// filter them in memory to get the latest review of each reviewer
-	// Since the reviewes should not be too many for one issue, less than 100 commonly, it's acceptable to do this in memory
+	// Since the reviews should not be too many for one issue, less than 100 commonly, it's acceptable to do this in memory
 	// And since there are too less indexes in review table, it will be very slow to filter in the database
 	reviewersMap := make(map[int64][]*Review) // key is reviewer id
 	originalReviewersMap := make(map[int64][]*Review)

--- a/models/issues/review_list.go
+++ b/models/issues/review_list.go
@@ -206,5 +206,5 @@ func GetReviewsByIssueID(ctx context.Context, issueID int64) (ReviewList, Review
 		return teamReviewRequests[i].UpdatedUnix < teamReviewRequests[j].UpdatedUnix
 	})
 
-	return append(teamReviewRequests, teamReviewRequests...), originalReviewers, nil
+	return append(mergedReviews, teamReviewRequests...), originalReviewers, nil
 }

--- a/models/issues/review_list.go
+++ b/models/issues/review_list.go
@@ -168,6 +168,7 @@ func GetReviewsByIssueID(ctx context.Context, issueID int64) (ReviewList, Review
 
 	// filter them in memory to get the latest review of each reviewer
 	// Since the reviewes should not be too many for one issue, less than 100 commonly, it's acceptable to do this in memory
+	// And since there are too less indexes in review table, it will be very slow to filter in the database
 	reviewersMap := make(map[int64][]*Review) // key is reviewer id
 	originalReviewersMap := make(map[int64][]*Review)
 	reviewTeamsMap := make(map[int64][]*Review)

--- a/models/issues/review_list.go
+++ b/models/issues/review_list.go
@@ -159,7 +159,7 @@ func CountReviews(ctx context.Context, opts FindReviewOptions) (int64, error) {
 // The first returned parameter is the latest review of each individual reviewer or team
 // The second returned parameter is the latest review of each original author which is migrated from other systems
 // The reviews are sorted by updated time
-func GetReviewsByIssueID(ctx context.Context, issueID int64) (ReviewList, ReviewList, error) {
+func GetReviewsByIssueID(ctx context.Context, issueID int64) (latestReviews ReviewList, migratedOriginalReviews ReviewList, err error) { //nolint
 	reviews := make([]*Review, 0, 10)
 
 	// Get all reviews for the issue id

--- a/models/issues/review_list.go
+++ b/models/issues/review_list.go
@@ -173,8 +173,9 @@ func GetReviewsByIssueID(ctx context.Context, issueID int64) (latestReviews Revi
 	reviewersMap := make(map[int64][]*Review)         // key is reviewer id
 	originalReviewersMap := make(map[int64][]*Review) // key is original author id
 	reviewTeamsMap := make(map[int64][]*Review)       // key is reviewer team id
+	countedReivewTypes := []ReviewType{ReviewTypeApprove, ReviewTypeReject, ReviewTypeRequest}
 	for _, review := range reviews {
-		if review.ReviewerTeamID == 0 && slices.Contains([]ReviewType{ReviewTypeApprove, ReviewTypeReject, ReviewTypeRequest}, review.Type) && !review.Dismissed {
+		if review.ReviewerTeamID == 0 && slices.Contains(countedReivewTypes, review.Type) && !review.Dismissed {
 			if review.OriginalAuthorID != 0 {
 				originalReviewersMap[review.OriginalAuthorID] = append(originalReviewersMap[review.OriginalAuthorID], review)
 			} else {

--- a/models/issues/review_list.go
+++ b/models/issues/review_list.go
@@ -159,7 +159,7 @@ func CountReviews(ctx context.Context, opts FindReviewOptions) (int64, error) {
 // The first returned parameter is the latest review of each individual reviewer or team
 // The second returned parameter is the latest review of each original author which is migrated from other systems
 // The reviews are sorted by updated time
-func GetReviewsByIssueID(ctx context.Context, issueID int64) (latestReviews ReviewList, migratedOriginalReviews ReviewList, err error) { //nolint
+func GetReviewsByIssueID(ctx context.Context, issueID int64) (latestReviews, migratedOriginalReviews ReviewList, err error) {
 	reviews := make([]*Review, 0, 10)
 
 	// Get all reviews for the issue id

--- a/models/issues/review_test.go
+++ b/models/issues/review_test.go
@@ -162,8 +162,9 @@ func TestGetReviewersByIssueID(t *testing.T) {
 		},
 	)
 
-	allReviews, _, err := issues_model.GetReviewsByIssueID(db.DefaultContext, issue.ID)
+	allReviews, migratedReviews, err := issues_model.GetReviewsByIssueID(db.DefaultContext, issue.ID)
 	assert.NoError(t, err)
+	assert.Empty(t, migratedReviews)
 	for _, review := range allReviews {
 		assert.NoError(t, review.LoadReviewer(db.DefaultContext))
 	}

--- a/models/issues/review_test.go
+++ b/models/issues/review_test.go
@@ -162,7 +162,7 @@ func TestGetReviewersByIssueID(t *testing.T) {
 		},
 	)
 
-	allReviews, err := issues_model.GetReviewsByIssueID(db.DefaultContext, issue.ID)
+	allReviews, _, err := issues_model.GetReviewsByIssueID(db.DefaultContext, issue.ID)
 	assert.NoError(t, err)
 	for _, review := range allReviews {
 		assert.NoError(t, review.LoadReviewer(db.DefaultContext))

--- a/routers/web/repo/issue_page_meta.go
+++ b/routers/web/repo/issue_page_meta.go
@@ -193,6 +193,7 @@ func (d *IssuePageMetaData) retrieveReviewersData(ctx *context.Context) {
 	var posterID int64
 	var isClosed bool
 	var reviews issues_model.ReviewList
+	var err error
 
 	if d.Issue == nil {
 		if ctx.Doer != nil {
@@ -206,14 +207,7 @@ func (d *IssuePageMetaData) retrieveReviewersData(ctx *context.Context) {
 
 		isClosed = d.Issue.IsClosed || d.Issue.PullRequest.HasMerged
 
-		originalAuthorReviews, err := issues_model.GetReviewersFromOriginalAuthorsByIssueID(ctx, d.Issue.ID)
-		if err != nil {
-			ctx.ServerError("GetReviewersFromOriginalAuthorsByIssueID", err)
-			return
-		}
-		data.OriginalReviews = originalAuthorReviews
-
-		reviews, err = issues_model.GetReviewsByIssueID(ctx, d.Issue.ID)
+		reviews, data.OriginalReviews, err = issues_model.GetReviewsByIssueID(ctx, d.Issue.ID)
 		if err != nil {
 			ctx.ServerError("GetReviewersByIssueID", err)
 			return


### PR DESCRIPTION
This PR fixes a performance problem when reviewing a pull request in a big instance which have many records in the `review` table. Traditionally, we should add more indexes in that table. But since dismissed reviews of 1 pull request will not be too many as expected in a common repository. Filtering reviews in the memory should be more quick .