### PR TITLE
Add missing transaction when set merge

### DIFF
--- a/services/pull/check.go
+++ b/services/pull/check.go
@@ -301,23 +301,23 @@ func manuallyMerged(ctx context.Context, pr *issues_model.PullRequest) bool {
 	pr.Merger = merger
 	pr.MergerID = merger.ID
 
-	ctx, commiter, err := db.TxContext(ctx)
+	ctx, committer, err := db.TxContext(ctx)
 	if err != nil {
 		log.Error("%-v db.TxContext: %v", pr, err)
 		return false
 	}
-	defer commiter.Close()
+	defer committer.Close()
 	if merged, err := pr.SetMerged(ctx); err != nil {
 		log.Error("%-v setMerged : %v", pr, err)
 		return false
 	} else if !merged {
 		return false
 	}
-	if err := commiter.Commit(); err != nil {
-		log.Error("%-v commiter.Commit: %v", pr, err)
+	if err := committer.Commit(); err != nil {
+		log.Error("%-v committer.Commit: %v", pr, err)
 		return false
 	}
-	commiter.Close()
+	committer.Close()
 
 	notify_service.MergePullRequest(ctx, merger, pr)
 

--- a/services/pull/check.go
+++ b/services/pull/check.go
@@ -301,12 +301,23 @@ func manuallyMerged(ctx context.Context, pr *issues_model.PullRequest) bool {
 	pr.Merger = merger
 	pr.MergerID = merger.ID
 
+	ctx, commiter, err := db.TxContext(ctx)
+	if err != nil {
+		log.Error("%-v db.TxContext: %v", pr, err)
+		return false
+	}
+	defer commiter.Close()
 	if merged, err := pr.SetMerged(ctx); err != nil {
 		log.Error("%-v setMerged : %v", pr, err)
 		return false
 	} else if !merged {
 		return false
 	}
+	if err := commiter.Commit(); err != nil {
+		log.Error("%-v commiter.Commit: %v", pr, err)
+		return false
+	}
+	commiter.Close()
 
 	notify_service.MergePullRequest(ctx, merger, pr)
 


### PR DESCRIPTION
backport from #33079 

`SetMerged` should be in a database transaction otherwise it's possible to have dirty data.