### PR TITLE
Update commit status when changing labels

### DIFF
--- a/models/actions/run.go
+++ b/models/actions/run.go
@@ -154,7 +154,9 @@ func (run *ActionRun) GetPushEventPayload() (*api.PushPayload, error) {
 }
 
 func (run *ActionRun) GetPullRequestEventPayload() (*api.PullRequestPayload, error) {
-	if run.Event == webhook_module.HookEventPullRequest || run.Event == webhook_module.HookEventPullRequestSync {
+	if run.Event == webhook_module.HookEventPullRequest ||
+		run.Event == webhook_module.HookEventPullRequestSync ||
+		run.Event == webhook_module.HookEventPullRequestLabel {
 		var payload api.PullRequestPayload
 		if err := json.Unmarshal([]byte(run.EventPayload), &payload); err != nil {
 			return nil, err

--- a/services/actions/commit_status.go
+++ b/services/actions/commit_status.go
@@ -54,7 +54,9 @@ func createCommitStatus(ctx context.Context, job *actions_model.ActionRunJob) er
 			return fmt.Errorf("head commit is missing in event payload")
 		}
 		sha = payload.HeadCommit.ID
-	case webhook_module.HookEventPullRequest, webhook_module.HookEventPullRequestSync:
+	case webhook_module.HookEventPullRequest,
+		webhook_module.HookEventPullRequestSync,
+		webhook_module.HookEventPullRequestLabel:
 		if run.TriggerEvent == actions_module.GithubEventPullRequestTarget {
 			event = "pull_request_target"
 		} else {


### PR DESCRIPTION
Fix #33051

---

Should we support all the `pull_request` related events?
https://github.com/go-gitea/gitea/blob/3c1c508421159970682c7d002bc8a180c8a1aeb7/modules/actions/workflows.go#L220-L226