### PR TITLE
fix empty repo updated time

### DIFF
--- a/models/repo/update.go
+++ b/models/repo/update.go
@@ -46,6 +46,12 @@ func UpdateRepositoryCols(ctx context.Context, repo *Repository, cols ...string)
 	return err
 }
 
+// UpdateRepositoryColsNoAutoTime updates repository's columns and but applies time change automatically
+func UpdateRepositoryColsNoAutoTime(ctx context.Context, repo *Repository, cols ...string) error {
+	_, err := db.GetEngine(ctx).ID(repo.ID).Cols(cols...).NoAutoTime().Update(repo)
+	return err
+}
+
 // ErrReachLimitOfRepo represents a "ReachLimitOfRepo" kind of error.
 type ErrReachLimitOfRepo struct {
 	Limit int

--- a/routers/web/repo/view_home.go
+++ b/routers/web/repo/view_home.go
@@ -224,12 +224,11 @@ func prepareRecentlyPushedNewBranches(ctx *context.Context) {
 }
 
 func updateContextRepoEmptyAndStatus(ctx *context.Context, empty bool, status repo_model.RepositoryStatus) {
-	repo := ctx.Repo.Repository
-	repo.IsEmpty = empty
-	if repo.Status == repo_model.RepositoryReady || repo.Status == repo_model.RepositoryBroken {
-		repo.Status = status // only handle ready and broken status, leave other status as-is
+	ctx.Repo.Repository.IsEmpty = empty
+	if ctx.Repo.Repository.Status == repo_model.RepositoryReady || ctx.Repo.Repository.Status == repo_model.RepositoryBroken {
+		ctx.Repo.Repository.Status = status // only handle ready and broken status, leave other status as-is
 	}
-	if _, err := db.GetEngine(ctx).ID(repo.ID).Cols("is_empty", "status").NoAutoTime().Update(repo); err != nil {
+	if err := repo_model.UpdateRepositoryColsNoAutoTime(ctx, ctx.Repo.Repository, "is_empty", "status"); err != nil {
 		ctx.ServerError("updateContextRepoEmptyAndStatus: UpdateRepositoryCols", err)
 		return
 	}

--- a/routers/web/repo/view_home.go
+++ b/routers/web/repo/view_home.go
@@ -224,6 +224,9 @@ func prepareRecentlyPushedNewBranches(ctx *context.Context) {
 }
 
 func updateContextRepoEmptyAndStatus(ctx *context.Context, empty bool, status repo_model.RepositoryStatus) {
+	if ctx.Repo.Repository.IsEmpty == empty && ctx.Repo.Repository.Status == status {
+		return
+	}
 	ctx.Repo.Repository.IsEmpty = empty
 	if ctx.Repo.Repository.Status == repo_model.RepositoryReady || ctx.Repo.Repository.Status == repo_model.RepositoryBroken {
 		ctx.Repo.Repository.Status = status // only handle ready and broken status, leave other status as-is


### PR DESCRIPTION
fixes #33119 

routers/web/repo/view_home.go
![image](https://github.com/user-attachments/assets/b0d6c5f5-7abc-478a-8d41-4b44dbd460aa)

Calling `updateContextRepoEmptyAndStatus` will always ask the DB to update the updated Unix attributes.
When revisiting the repo's home page, the timestamp will be updated unexpectedly, so I added the needsUpdate variable to check whether, in the end, the commitment to db update is necessary if columns have not changed at all.