### PR TITLE
Remove extended glob pattern from branch protection UI

### DIFF
--- a/web_src/js/features/repo-settings.ts
+++ b/web_src/js/features/repo-settings.ts
@@ -107,7 +107,7 @@ function initRepoSettingsBranches() {
       let matched = false;
       const statusCheck = el.getAttribute('data-status-check');
       for (const pattern of validPatterns) {
-        if (minimatch(statusCheck, pattern)) {
+        if (minimatch(statusCheck, pattern, {noext: true})) { // https://github.com/go-gitea/gitea/issues/33121 disable extended glob syntax
           matched = true;
           break;
         }


### PR DESCRIPTION
Underlying go library has no support for it

Fixes: https://github.com/go-gitea/gitea/issues/33121

---

I never touched frontend tests so pointers how to write them are welcome.

This can be either fix or workaround, depending if this is something gitea should support in the future or not. The golang side is unlikely to get updates though.