### PR TITLE
Fix ACME panic

### DIFF
--- a/cmd/web_acme.go
+++ b/cmd/web_acme.go
@@ -54,6 +54,8 @@ func runACME(listenAddr string, m http.Handler) error {
 		altTLSALPNPort = p
 	}
 
+	// FIXME: this path is not right, it uses "AppWorkPath" incorrectly, and writes the data into "AppWorkPath/https"
+	// Ideally it should migrate to AppDataPath write to "AppDataPath/https"
 	certmagic.Default.Storage = &certmagic.FileStorage{Path: setting.AcmeLiveDirectory}
 	magic := certmagic.NewDefault()
 	// Try to use private CA root if provided, otherwise defaults to system's trust

--- a/cmd/web_acme.go
+++ b/cmd/web_acme.go
@@ -54,8 +54,8 @@ func runACME(listenAddr string, m http.Handler) error {
 		altTLSALPNPort = p
 	}
 
-	magic := &certmagic.Default
-	magic.Storage = &certmagic.FileStorage{Path: setting.AcmeLiveDirectory}
+	certmagic.Default.Storage = &certmagic.FileStorage{Path: setting.AcmeLiveDirectory}
+	magic := certmagic.NewDefault()
 	// Try to use private CA root if provided, otherwise defaults to system's trust
 	var certPool *x509.CertPool
 	if setting.AcmeCARoot != "" {


### PR DESCRIPTION
Fix #33177, Manually tested:

````
1.7364311850484018e+09	info	maintenance	started background certificate maintenance	{"cache": "0x1400ca64180"}
1.736431185054049e+09	info	obtain	acquiring lock	{"identifier": "example.com"}
1.736431185058073e+09	info	obtain	lock acquired	{"identifier": "example.com"}
1.736431185058133e+09	info	obtain	obtaining certificate	{"identifier": "example.com"}
````