### PR TITLE
Fix editor markdown not incrementing in a numbered list

### DIFF
--- a/web_src/js/features/comp/EditorMarkdown.test.ts
+++ b/web_src/js/features/comp/EditorMarkdown.test.ts
@@ -32,10 +32,10 @@ test('EditorMarkdown', () => {
   testInput({value: '1. \n2. ', pos: 3}, {value: '\n2. ', pos: 0});
 
   testInput('- x', '- x\n- ');
-  testInput('1. foo', '1. foo\n1. ');
-  testInput({value: '1. a\n2. b\n3. c', pos: 4}, {value: '1. a\n1. \n2. b\n3. c', pos: 8});
+  testInput('1. foo', '1. foo\n2. ');
+  testInput({value: '1. a\n2. b\n3. c', pos: 4}, {value: '1. a\n2. \n2. b\n3. c', pos: 8});
   testInput('- [ ]', '- [ ]\n- ');
   testInput('- [ ] foo', '- [ ] foo\n- [ ] ');
   testInput('* [x] foo', '* [x] foo\n* [ ] ');
-  testInput('1. [x] foo', '1. [x] foo\n1. [ ] ');
+  testInput('1. [x] foo', '1. [x] foo\n2. [ ] ');
 });

--- a/web_src/js/features/comp/EditorMarkdown.test.ts
+++ b/web_src/js/features/comp/EditorMarkdown.test.ts
@@ -126,6 +126,29 @@ test('markdownHandleIndention', () => {
 3. |
 `);
 
+  testInput(`
+1. a
+2. a
+3. a
+4. a
+5. a
+6. a
+7. a
+8. a
+9. b|c
+`, `
+1. a
+2. a
+3. a
+4. a
+5. a
+6. a
+7. a
+8. a
+9. b
+10. |c
+`);
+
   // this is a special case, it's difficult to re-format the parent level at the moment, so leave it to the future
   testInput(`
 1. a

--- a/web_src/js/features/comp/EditorMarkdown.test.ts
+++ b/web_src/js/features/comp/EditorMarkdown.test.ts
@@ -1,4 +1,4 @@
-import {initTextareaMarkdown, markdownHandleListNumbers, textareaSplitLines} from './EditorMarkdown.ts';
+import {initTextareaMarkdown, markdownHandleIndention, textareaSplitLines} from './EditorMarkdown.ts';
 
 test('textareaSplitLines', () => {
   let ret = textareaSplitLines('a\nbc\nd', 0);
@@ -23,11 +23,11 @@ test('textareaSplitLines', () => {
   expect(ret).toEqual({lines: ['a', 'bc', 'd'], lengthBeforePosLine: 5, posLineIndex: 2, inlinePos: 1});
 });
 
-test('markdownHandleListNumbers', () => {
+test('markdownHandleIndention', () => {
   const testInput = (input: string, expected?: string) => {
     const inputPos = input.indexOf('|');
     input = input.replace('|', '');
-    const ret = markdownHandleListNumbers({value: input, selStart: inputPos, selEnd: inputPos});
+    const ret = markdownHandleIndention({value: input, selStart: inputPos, selEnd: inputPos});
     if (expected === null) {
       expect(ret).toEqual({handled: false});
     } else {
@@ -39,6 +39,13 @@ test('markdownHandleListNumbers', () => {
       });
     }
   };
+
+  testInput(`
+  a|b
+`, `
+  a
+  |b
+`);
 
   testInput(`
 1. a
@@ -54,11 +61,11 @@ test('markdownHandleListNumbers', () => {
 
   testInput(`
 1. a
-1. b|
+1. b|c
 `, `
 1. a
 2. b
-3. |
+3. |c
 `);
 
   testInput(`

--- a/web_src/js/features/comp/EditorMarkdown.test.ts
+++ b/web_src/js/features/comp/EditorMarkdown.test.ts
@@ -1,4 +1,67 @@
-import {initTextareaMarkdown, markdownHandleListNumbers} from './EditorMarkdown.ts';
+import {initTextareaMarkdown, markdownHandleListNumbers, textareaSplitLines} from './EditorMarkdown.ts';
+
+test('textareaSplitLines', () => {
+  let ret = textareaSplitLines('a\nbc\nd', 0);
+  expect(ret).toEqual({lines: ['a', 'bc', 'd'], lengthBeforePosLine: 0, posLineIndex: 0, inlinePos: 0});
+
+  ret = textareaSplitLines('a\nbc\nd', 1);
+  expect(ret).toEqual({lines: ['a', 'bc', 'd'], lengthBeforePosLine: 0, posLineIndex: 0, inlinePos: 1});
+
+  ret = textareaSplitLines('a\nbc\nd', 2);
+  expect(ret).toEqual({lines: ['a', 'bc', 'd'], lengthBeforePosLine: 2, posLineIndex: 1, inlinePos: 0});
+
+  ret = textareaSplitLines('a\nbc\nd', 3);
+  expect(ret).toEqual({lines: ['a', 'bc', 'd'], lengthBeforePosLine: 2, posLineIndex: 1, inlinePos: 1});
+
+  ret = textareaSplitLines('a\nbc\nd', 4);
+  expect(ret).toEqual({lines: ['a', 'bc', 'd'], lengthBeforePosLine: 2, posLineIndex: 1, inlinePos: 2});
+
+  ret = textareaSplitLines('a\nbc\nd', 5);
+  expect(ret).toEqual({lines: ['a', 'bc', 'd'], lengthBeforePosLine: 5, posLineIndex: 2, inlinePos: 0});
+
+  ret = textareaSplitLines('a\nbc\nd', 6);
+  expect(ret).toEqual({lines: ['a', 'bc', 'd'], lengthBeforePosLine: 5, posLineIndex: 2, inlinePos: 1});
+});
+
+test('markdownHandleListNumbers', () => {
+  const testInput = (input: string, expected: string) => {
+    const inputPos = input.indexOf('|');
+    input = input.replace('|', '');
+    const ret = markdownHandleListNumbers({value: input, selStart: inputPos, selEnd: inputPos});
+
+    const expectedPos = expected.indexOf('|');
+    expected = expected.replace('|', '');
+    expect(ret).toEqual({handled: true, valueSelection: {value: expected, selStart: expectedPos, selEnd: expectedPos}});
+  };
+
+  testInput(`
+1. a
+2. |
+`, `
+1. a
+|
+`);
+
+  testInput(`
+1. a
+1. b|
+`, `
+1. a
+2. b
+3. |
+`);
+
+  testInput(`
+1. a
+2. b|
+3. c
+`, `
+1. a
+2. b
+3. |
+4. c
+`);
+});
 
 test('EditorMarkdown', () => {
   const textarea = document.createElement('textarea');
@@ -38,7 +101,4 @@ test('EditorMarkdown', () => {
   testInput('- [ ] foo', '- [ ] foo\n- [ ] ');
   testInput('* [x] foo', '* [x] foo\n* [ ] ');
   testInput('1. [x] foo', '1. [x] foo\n2. [ ] ');
-
-  // TODO: test separately
-  markdownHandleListNumbers({value: '1.', selStart: 1, selEnd: 2});
 });

--- a/web_src/js/features/comp/EditorMarkdown.test.ts
+++ b/web_src/js/features/comp/EditorMarkdown.test.ts
@@ -24,14 +24,20 @@ test('textareaSplitLines', () => {
 });
 
 test('markdownHandleListNumbers', () => {
-  const testInput = (input: string, expected: string) => {
+  const testInput = (input: string, expected?: string) => {
     const inputPos = input.indexOf('|');
     input = input.replace('|', '');
     const ret = markdownHandleListNumbers({value: input, selStart: inputPos, selEnd: inputPos});
-
-    const expectedPos = expected.indexOf('|');
-    expected = expected.replace('|', '');
-    expect(ret).toEqual({handled: true, valueSelection: {value: expected, selStart: expectedPos, selEnd: expectedPos}});
+    if (expected === null) {
+      expect(ret).toEqual({handled: false});
+    } else {
+      const expectedPos = expected.indexOf('|');
+      expected = expected.replace('|', '');
+      expect(ret).toEqual({
+        handled: true,
+        valueSelection: {value: expected, selStart: expectedPos, selEnd: expectedPos},
+      });
+    }
   };
 
   testInput(`
@@ -43,12 +49,46 @@ test('markdownHandleListNumbers', () => {
 `);
 
   testInput(`
+|1. a
+`, null); // let browser handle it
+
+  testInput(`
 1. a
 1. b|
 `, `
 1. a
 2. b
 3. |
+`);
+
+  testInput(`
+2. a
+2. b|
+
+1. x
+1. y
+`, `
+1. a
+2. b
+3. |
+
+1. x
+1. y
+`);
+
+  testInput(`
+2. a
+2. b
+
+1. x|
+1. y
+`, `
+2. a
+2. b
+
+1. x
+2. |
+3. y
 `);
 
   testInput(`
@@ -60,6 +100,35 @@ test('markdownHandleListNumbers', () => {
 2. b
 3. |
 4. c
+`);
+
+  testInput(`
+1. a
+  1. b
+  2. b
+  3. b
+  4. b
+1. c|
+`, `
+1. a
+  1. b
+  2. b
+  3. b
+  4. b
+2. c
+3. |
+`);
+
+  // this is a special case, it's difficult to re-format the parent level at the moment, so leave it to the future
+  testInput(`
+1. a
+  2. b|
+3. c
+`, `
+1. a
+  1. b
+  2. |
+3. c
 `);
 });
 

--- a/web_src/js/features/comp/EditorMarkdown.test.ts
+++ b/web_src/js/features/comp/EditorMarkdown.test.ts
@@ -1,4 +1,4 @@
-import {initTextareaMarkdown} from './EditorMarkdown.ts';
+import {initTextareaMarkdown, markdownHandleListNumbers} from './EditorMarkdown.ts';
 
 test('EditorMarkdown', () => {
   const textarea = document.createElement('textarea');
@@ -33,9 +33,12 @@ test('EditorMarkdown', () => {
 
   testInput('- x', '- x\n- ');
   testInput('1. foo', '1. foo\n2. ');
-  testInput({value: '1. a\n2. b\n3. c', pos: 4}, {value: '1. a\n2. \n2. b\n3. c', pos: 8});
+  testInput({value: '1. a\n2. b\n3. c', pos: 4}, {value: '1. a\n2. \n3. b\n4. c', pos: 8});
   testInput('- [ ]', '- [ ]\n- ');
   testInput('- [ ] foo', '- [ ] foo\n- [ ] ');
   testInput('* [x] foo', '* [x] foo\n* [ ] ');
   testInput('1. [x] foo', '1. [x] foo\n2. [ ] ');
+
+  // TODO: test separately
+  markdownHandleListNumbers({value: '1.', selStart: 1, selEnd: 2});
 });

--- a/web_src/js/features/comp/EditorMarkdown.ts
+++ b/web_src/js/features/comp/EditorMarkdown.ts
@@ -14,7 +14,13 @@ export function textareaInsertText(textarea, value) {
   triggerEditorContentChanged(textarea);
 }
 
-function handleIndentSelection(textarea, e) {
+type TextareaValueSelection = {
+  value: string;
+  selStart: number;
+  selEnd: number;
+}
+
+function handleIndentSelection(textarea: HTMLTextAreaElement, e) {
   const selStart = textarea.selectionStart;
   const selEnd = textarea.selectionEnd;
   if (selEnd === selStart) return; // do not process when no selection
@@ -56,18 +62,21 @@ function handleIndentSelection(textarea, e) {
   triggerEditorContentChanged(textarea);
 }
 
-function handleNewline(textarea: HTMLTextAreaElement, e: Event) {
-  const selStart = textarea.selectionStart;
-  const selEnd = textarea.selectionEnd;
-  if (selEnd !== selStart) return; // do not process when there is a selection
+type MarkdownHandleListNumbersResult = {
+  handled: boolean;
+  valueSelection?: TextareaValueSelection;
+}
 
-  const value = textarea.value;
+export function markdownHandleListNumbers(tvs: TextareaValueSelection): MarkdownHandleListNumbersResult {
+  const ret: MarkdownHandleListNumbersResult = {handled: false};
+  if (tvs.selEnd !== tvs.selStart) return ret; // do not process when there is a selection
 
+  const value = tvs.value;
   // find the current line
   // * if selStart is 0, lastIndexOf(..., -1) is the same as lastIndexOf(..., 0)
   // * if lastIndexOf reruns -1, lineStart is 0 and it is still correct.
-  const lineStart = value.lastIndexOf('\n', selStart - 1) + 1;
-  let lineEnd = value.indexOf('\n', selStart);
+  const lineStart = value.lastIndexOf('\n', tvs.selStart - 1) + 1;
+  let lineEnd = value.indexOf('\n', tvs.selStart);
   lineEnd = lineEnd < 0 ? value.length : lineEnd;
   let line = value.slice(lineStart, lineEnd);
   if (!line) return; // if the line is empty, do nothing, let the browser handle it
@@ -82,17 +91,20 @@ function handleNewline(textarea: HTMLTextAreaElement, e: Event) {
   let prefix = '';
   if (prefixMatch) {
     prefix = prefixMatch[0];
-    if (lineStart + prefix.length > selStart) prefix = ''; // do not add new line if cursor is at prefix
+    if (lineStart + prefix.length > tvs.selStart) prefix = ''; // do not add new line if cursor is at prefix
   }
 
   line = line.slice(prefix.length);
-  if (!indention && !prefix) return; // if no indention and no prefix, do nothing, let the browser handle it
+  if (!indention && !prefix) return ret; // if no indention and no prefix, do nothing, let the browser handle it
 
-  e.preventDefault();
+  ret.handled = true;
   if (!line) {
     // clear current line if we only have i.e. '1. ' and the user presses enter again to finish creating a list
-    textarea.value = value.slice(0, lineStart) + value.slice(lineEnd);
-    textarea.setSelectionRange(selStart - prefix.length, selStart - prefix.length);
+    ret.valueSelection = {
+      value: value.slice(0, lineStart) + value.slice(lineEnd),
+      selStart: tvs.selStart - prefix.length,
+      selEnd: tvs.selStart - prefix.length,
+    };
   } else {
     // start a new line with the same indention and prefix
     let newPrefix = prefix;
@@ -104,9 +116,21 @@ function handleNewline(textarea: HTMLTextAreaElement, e: Event) {
     }
     newPrefix = newPrefix.replace('[x]', '[ ]');
     const newLine = `\n${indention}${newPrefix}`;
-    textarea.value = value.slice(0, selStart) + newLine + value.slice(selEnd);
-    textarea.setSelectionRange(selStart + newLine.length, selStart + newLine.length);
+    ret.valueSelection = {
+      value: value.slice(0, tvs.selStart) + newLine + value.slice(tvs.selEnd),
+      selStart: tvs.selStart + newLine.length,
+      selEnd: tvs.selStart + newLine.length,
+    };
   }
+  return ret;
+}
+
+function handleNewline(textarea: HTMLTextAreaElement, e: Event) {
+  const ret = markdownHandleListNumbers({value: textarea.value, selStart: textarea.selectionStart, selEnd: textarea.selectionEnd});
+  if (!ret.handled) return;
+  e.preventDefault();
+  textarea.value = ret.valueSelection.value;
+  textarea.setSelectionRange(ret.valueSelection.selStart, ret.valueSelection.selEnd);
   triggerEditorContentChanged(textarea);
 }
 

--- a/web_src/js/features/comp/EditorMarkdown.ts
+++ b/web_src/js/features/comp/EditorMarkdown.ts
@@ -99,16 +99,22 @@ function markdownReformatListNumbers(linesBuf: TextLinesBuffer, indention: strin
   firstLineIdx++;
   let num = 1;
   for (let i = firstLineIdx; i < linesBuf.lines.length; i++) {
-    const line = linesBuf.lines[i];
-    const sameLevel = reSameLevel.test(line);
-    if (!sameLevel && !reDeeperIndention.test(line)) break;
+    const oldLine = linesBuf.lines[i];
+    const sameLevel = reSameLevel.test(oldLine);
+    if (!sameLevel && !reDeeperIndention.test(oldLine)) break;
     if (sameLevel) {
-      linesBuf.lines[i] = `${indention}${num}.${line.replace(reSameLevel, '')}`;
+      const newLine = `${indention}${num}.${oldLine.replace(reSameLevel, '')}`;
+      linesBuf.lines[i] = newLine;
       num++;
+      if (linesBuf.posLineIndex === i) {
+        // need to correct the cursor inline position if the line length changes
+        linesBuf.inlinePos += newLine.length - oldLine.length;
+        linesBuf.inlinePos = Math.max(0, linesBuf.inlinePos);
+        linesBuf.inlinePos = Math.min(newLine.length, linesBuf.inlinePos);
+      }
     }
   }
   recalculateLengthBeforeLine(linesBuf);
-  linesBuf.posLineIndex = linesBuf.lines[linesBuf.posLineIndex].length;
 }
 
 function recalculateLengthBeforeLine(linesBuf: TextLinesBuffer) {

--- a/web_src/js/features/comp/EditorMarkdown.ts
+++ b/web_src/js/features/comp/EditorMarkdown.ts
@@ -96,8 +96,12 @@ function handleNewline(textarea: HTMLTextAreaElement, e: Event) {
   } else {
     // start a new line with the same indention and prefix
     let newPrefix = prefix;
-    // a simple approach, otherwise it needs to parse the lines after the current line
-    if (/^\d+\./.test(prefix)) newPrefix = `1. ${newPrefix.slice(newPrefix.indexOf('.') + 2)}`;
+    const digitMatch = /^\d+/.exec(prefix);
+    if (digitMatch) {
+      const number = parseInt(digitMatch[0]);
+      const incremented = number + 1;
+      newPrefix = `${incremented}. ${newPrefix.slice(newPrefix.indexOf('.') + 2)}`;
+    }
     newPrefix = newPrefix.replace('[x]', '[ ]');
     const newLine = `\n${indention}${newPrefix}`;
     textarea.value = value.slice(0, selStart) + newLine + value.slice(selEnd);


### PR DESCRIPTION
Amended the logic for newPrefix in the MarkdownEditor to resolve incorrect number ordering.

Fixes #33184

Attached screenshot of fixed input similar to issue 
<img width="175" alt="Screenshot 2025-01-09 at 23 59 24" src="https://github.com/user-attachments/assets/dfa23cf1-f3db-4b5e-99d2-a71bbcb289a8" />


