### PR TITLE
fix(cache): cache test triggered by non memory cache

### DIFF
--- a/modules/cache/cache.go
+++ b/modules/cache/cache.go
@@ -37,10 +37,15 @@ func Init() error {
 }
 
 const (
-	testCacheKey       = "DefaultCache.TestKey"
-	SlowCacheThreshold = 100 * time.Microsecond
+	testCacheKey = "DefaultCache.TestKey"
+	// SlowCacheThreshold marks cache tests as slow
+	// set to 30ms per discussion: https://github.com/go-gitea/gitea/issues/33190
+	// TODO: Replace with metrics histogram
+	SlowCacheThreshold = 30 * time.Millisecond
 )
 
+// Test performs delete, put and get operations on a predefined key
+// returns
 func Test() (time.Duration, error) {
 	if defaultCache == nil {
 		return 0, fmt.Errorf("default cache not initialized")

--- a/modules/cache/cache_test.go
+++ b/modules/cache/cache_test.go
@@ -43,7 +43,8 @@ func TestTest(t *testing.T) {
 	elapsed, err := Test()
 	assert.NoError(t, err)
 	// mem cache should take from 300ns up to 1ms on modern hardware ...
-	assert.Less(t, elapsed, time.Millisecond)
+	assert.Positive(t, elapsed)
+	assert.Less(t, elapsed, SlowCacheThreshold)
 }
 
 func TestGetCache(t *testing.T) {


### PR DESCRIPTION
Change SlowCacheThreshold to 30 milliseconds so it doesn't trigger on non memory cache

Closes: https://github.com/go-gitea/gitea/issues/33190
Closes: https://github.com/go-gitea/gitea/issues/32657

---

I don't like this solution either but I guess it removal would count as breaking/regression so I'll leave that for the next release.