### PR TITLE
Fix incorrect ref "blob"

### DIFF
--- a/routers/web/repo/render.go
+++ b/routers/web/repo/render.go
@@ -21,7 +21,13 @@ import (
 
 // RenderFile renders a file by repos path
 func RenderFile(ctx *context.Context) {
-	blob, err := ctx.Repo.Commit.GetBlobByPath(ctx.Repo.TreePath)
+	var blob *git.Blob
+	var err error
+	if ctx.Repo.TreePath != "" {
+		blob, err = ctx.Repo.Commit.GetBlobByPath(ctx.Repo.TreePath)
+	} else {
+		blob, err = ctx.Repo.GitRepo.GetBlob(ctx.PathParam("sha"))
+	}
 	if err != nil {
 		if git.IsErrNotExist(err) {
 			ctx.NotFound("GetBlobByPath", err)

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1524,7 +1524,7 @@ func registerRoutes(m *web.Router) {
 			m.Get("/branch/*", context.RepoRefByType(context.RepoRefBranch), repo.SingleDownloadOrLFS)
 			m.Get("/tag/*", context.RepoRefByType(context.RepoRefTag), repo.SingleDownloadOrLFS)
 			m.Get("/commit/*", context.RepoRefByType(context.RepoRefCommit), repo.SingleDownloadOrLFS)
-			m.Get("/blob/{sha}", context.RepoRefByType(context.RepoRefBlob), repo.DownloadByIDOrLFS)
+			m.Get("/blob/{sha}", repo.DownloadByIDOrLFS)
 			// "/*" route is deprecated, and kept for backward compatibility
 			m.Get("/*", context.RepoRefByType(context.RepoRefUnknown), repo.SingleDownloadOrLFS)
 		}, repo.MustBeNotEmpty)
@@ -1533,7 +1533,7 @@ func registerRoutes(m *web.Router) {
 			m.Get("/branch/*", context.RepoRefByType(context.RepoRefBranch), repo.SingleDownload)
 			m.Get("/tag/*", context.RepoRefByType(context.RepoRefTag), repo.SingleDownload)
 			m.Get("/commit/*", context.RepoRefByType(context.RepoRefCommit), repo.SingleDownload)
-			m.Get("/blob/{sha}", context.RepoRefByType(context.RepoRefBlob), repo.DownloadByID)
+			m.Get("/blob/{sha}", repo.DownloadByID)
 			// "/*" route is deprecated, and kept for backward compatibility
 			m.Get("/*", context.RepoRefByType(context.RepoRefUnknown), repo.SingleDownload)
 		}, repo.MustBeNotEmpty)
@@ -1542,7 +1542,7 @@ func registerRoutes(m *web.Router) {
 			m.Get("/branch/*", context.RepoRefByType(context.RepoRefBranch), repo.RenderFile)
 			m.Get("/tag/*", context.RepoRefByType(context.RepoRefTag), repo.RenderFile)
 			m.Get("/commit/*", context.RepoRefByType(context.RepoRefCommit), repo.RenderFile)
-			m.Get("/blob/{sha}", context.RepoRefByType(context.RepoRefBlob), repo.RenderFile)
+			m.Get("/blob/{sha}", repo.RenderFile)
 		}, repo.MustBeNotEmpty)
 
 		m.Group("/commits", func() {

--- a/services/context/repo.go
+++ b/services/context/repo.go
@@ -686,7 +686,6 @@ const (
 	RepoRefBranch
 	RepoRefTag
 	RepoRefCommit
-	RepoRefBlob
 )
 
 const headRefName = "HEAD"
@@ -724,9 +723,6 @@ func getRefNameLegacy(ctx *Base, repo *Repository, reqPath, extraRef string) (st
 		// FIXME: this logic is different from other types. Ideally, it should also try to GetCommit to check if it exists
 		repo.TreePath = strings.Join(reqRefPathParts[1:], "/")
 		return reqRefPathParts[0], RepoRefCommit
-	}
-	if refName := getRefName(ctx, repo, reqPath, RepoRefBlob); refName != "" {
-		return refName, RepoRefBlob
 	}
 	// FIXME: the old code falls back to default branch if "ref" doesn't exist, there could be an edge case:
 	// "README?ref=no-such" would read the README file from the default branch, but the user might expect a 404
@@ -785,12 +781,6 @@ func getRefName(ctx *Base, repo *Repository, path string, pathType RepoRefType) 
 			repo.TreePath = strings.Join(parts[1:], "/")
 			return commit.ID.String()
 		}
-	case RepoRefBlob:
-		_, err := repo.GitRepo.GetBlob(path)
-		if err != nil {
-			return ""
-		}
-		return path
 	default:
 		panic(fmt.Sprintf("Unrecognized path type: %v", pathType))
 	}


### PR DESCRIPTION
1. "blob" is not a "ref", it shouldn't (and not unable to) be handled by `RepoRefByType`
2. the `/blob/{sha}` handle should use the path param "sha" directly