### PR TITLE
Switch back to `vue-tsc`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,6 @@
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "4.4.1",
         "@playwright/test": "1.49.1",
-        "@silverwind/vue-tsc": "2.1.13",
         "@stoplight/spectral-cli": "6.14.2",
         "@stylistic/eslint-plugin-js": "2.12.1",
         "@stylistic/stylelint-plugin": "3.1.1",
@@ -112,7 +111,8 @@
         "type-fest": "4.30.2",
         "updates": "16.4.1",
         "vite-string-plugin": "1.3.4",
-        "vitest": "2.1.8"
+        "vitest": "2.1.8",
+        "vue-tsc": "2.2.0"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -3643,24 +3643,6 @@
       "hasInstallScript": true,
       "license": "Apache-2.0"
     },
-    "node_modules/@silverwind/vue-tsc": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/@silverwind/vue-tsc/-/vue-tsc-2.1.13.tgz",
-      "integrity": "sha512-ejFxz1KZiUGAESbC+eURnjqt0N95qkU9eZU7W15wgF9zV+v2FEu3ZLduuXTC7D/Sg6lL1R/QjPfUbxbAbBQOsw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@volar/typescript": "~2.4.11",
-        "@vue/language-core": "2.1.10",
-        "semver": "^7.5.4"
-      },
-      "bin": {
-        "vue-tsc": "bin/vue-tsc.js"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.0"
-      }
-    },
     "node_modules/@silverwind/vue3-calendar-heatmap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@silverwind/vue3-calendar-heatmap/-/vue3-calendar-heatmap-2.0.6.tgz",
@@ -5251,17 +5233,17 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.1.10.tgz",
-      "integrity": "sha512-DAI289d0K3AB5TUG3xDp9OuQ71CnrujQwJrQnfuZDwo6eGNf0UoRlPuaVNO+Zrn65PC3j0oB2i7mNmVPggeGeQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.0.tgz",
+      "integrity": "sha512-O1ZZFaaBGkKbsRfnVH1ifOK1/1BUkyK+3SQsfnh6PmMmD4qJcTU8godCeA96jjDRTL6zgnK7YzCHfaUlH2r0Mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@volar/language-core": "~2.4.8",
+        "@volar/language-core": "~2.4.11",
         "@vue/compiler-dom": "^3.5.0",
         "@vue/compiler-vue2": "^2.7.16",
         "@vue/shared": "^3.5.0",
-        "alien-signals": "^0.2.0",
+        "alien-signals": "^0.4.9",
         "minimatch": "^9.0.3",
         "muggle-string": "^0.4.1",
         "path-browserify": "^1.0.1"
@@ -5664,9 +5646,9 @@
       }
     },
     "node_modules/alien-signals": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-0.2.2.tgz",
-      "integrity": "sha512-cZIRkbERILsBOXTQmMrxc9hgpxglstn69zm+F1ARf4aPAzdAFYd6sBq87ErO0Fj3DV94tglcyHG5kQz9nDC/8A==",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-0.4.14.tgz",
+      "integrity": "sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -14524,6 +14506,23 @@
         "vue": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.0.tgz",
+      "integrity": "sha512-gtmM1sUuJ8aSb0KoAFmK9yMxb8TxjewmxqTJ1aKphD5Cbu0rULFY6+UQT51zW7SpUcenfPUuflKyVwyx9Qdnxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/typescript": "~2.4.11",
+        "@vue/language-core": "2.2.0"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
       }
     },
     "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "4.4.1",
     "@playwright/test": "1.49.1",
-    "@silverwind/vue-tsc": "2.1.13",
     "@stoplight/spectral-cli": "6.14.2",
     "@stylistic/eslint-plugin-js": "2.12.1",
     "@stylistic/stylelint-plugin": "3.1.1",
@@ -111,7 +110,8 @@
     "type-fest": "4.30.2",
     "updates": "16.4.1",
     "vite-string-plugin": "1.3.4",
-    "vitest": "2.1.8"
+    "vitest": "2.1.8",
+    "vue-tsc": "2.2.0"
   },
   "browserslist": [
     "defaults"


### PR DESCRIPTION
It supports Typescript 5.7 now, so we can switch back to the official version.