### PR TITLE
Fix 500 error when error occurred in migration page

### DIFF
--- a/templates/repo/migrate/codebase.tmpl
+++ b/templates/repo/migrate/codebase.tmpl
@@ -2,14 +2,16 @@
 <div role="main" aria-label="{{.Title}}" class="page-content repository new migrate">
 	<div class="ui container medium-width">
 		<h3 class="ui top attached header">
-			{{ctx.Locale.Tr "repo.migrate.migrate" .service.Title}}
-			<input id="service_type" type="hidden" name="service" value="{{.service}}">
+			{{ctx.Locale.Tr "repo.migrate.migrate" .service.Title}}	
 		</h3>
 		<div class="ui attached segment">
 			{{template "base/alert" .}}
 			<form class="ui form left-right-form" action="{{.Link}}" method="post">
 				{{template "base/disable_form_autofill"}}
 				{{.CsrfTokenHtml}}
+
+				<input id="service_type" type="hidden" name="service" value="{{.service}}">
+				
 				<div class="inline required field {{if .Err_CloneAddr}}error{{end}}">
 					<label for="clone_addr">{{ctx.Locale.Tr "repo.migrate.clone_address"}}</label>
 					<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>

--- a/templates/repo/migrate/codebase.tmpl
+++ b/templates/repo/migrate/codebase.tmpl
@@ -2,7 +2,7 @@
 <div role="main" aria-label="{{.Title}}" class="page-content repository new migrate">
 	<div class="ui container medium-width">
 		<h3 class="ui top attached header">
-			{{ctx.Locale.Tr "repo.migrate.migrate" .service.Title}}	
+			{{ctx.Locale.Tr "repo.migrate.migrate" .service.Title}}
 		</h3>
 		<div class="ui attached segment">
 			{{template "base/alert" .}}

--- a/templates/repo/migrate/codebase.tmpl
+++ b/templates/repo/migrate/codebase.tmpl
@@ -11,7 +11,7 @@
 				{{.CsrfTokenHtml}}
 
 				<input id="service_type" type="hidden" name="service" value="{{.service}}">
-				
+
 				<div class="inline required field {{if .Err_CloneAddr}}error{{end}}">
 					<label for="clone_addr">{{ctx.Locale.Tr "repo.migrate.clone_address"}}</label>
 					<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>

--- a/templates/repo/migrate/codecommit.tmpl
+++ b/templates/repo/migrate/codecommit.tmpl
@@ -3,13 +3,15 @@
 	<div class="ui container medium-width">
 		<h3 class="ui top attached header">
 			{{ctx.Locale.Tr "repo.migrate.migrate" .service.Title}}
-			<input id="service_type" type="hidden" name="service" value="{{.service}}">
 		</h3>
 		<div class="ui attached segment">
 			{{template "base/alert" .}}
 			<form class="ui form left-right-form" action="{{.Link}}" method="post">
 				{{template "base/disable_form_autofill"}}
 				{{.CsrfTokenHtml}}
+
+				<input id="service_type" type="hidden" name="service" value="{{.service}}">
+
 				<div class="inline required field {{if .Err_CloneAddr}}error{{end}}">
 					<label for="clone_addr">{{ctx.Locale.Tr "repo.migrate.clone_address"}}</label>
 					<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>

--- a/templates/repo/migrate/git.tmpl
+++ b/templates/repo/migrate/git.tmpl
@@ -3,13 +3,15 @@
 	<div class="ui container medium-width">
 		<h3 class="ui top attached header">
 			{{ctx.Locale.Tr "repo.migrate.migrate" .service.Title}}
-			<input id="service_type" type="hidden" name="service" value="{{.service}}">
 		</h3>
 		<div class="ui attached segment">
 			{{template "base/alert" .}}
 			<form class="ui form left-right-form" action="{{.Link}}" method="post">
 				{{template "base/disable_form_autofill"}}
 				{{.CsrfTokenHtml}}
+
+				<input id="service_type" type="hidden" name="service" value="{{.service}}">
+
 				<div class="inline required field {{if .Err_CloneAddr}}error{{end}}">
 					<label for="clone_addr">{{ctx.Locale.Tr "repo.migrate.clone_address"}}</label>
 					<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>

--- a/templates/repo/migrate/gitbucket.tmpl
+++ b/templates/repo/migrate/gitbucket.tmpl
@@ -11,7 +11,7 @@
 				{{.CsrfTokenHtml}}
 
 				<input id="service_type" type="hidden" name="service" value="{{.service}}">
-				
+
 				<div class="inline required field {{if .Err_CloneAddr}}error{{end}}">
 					<label for="clone_addr">{{ctx.Locale.Tr "repo.migrate.clone_address"}}</label>
 					<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>

--- a/templates/repo/migrate/gitbucket.tmpl
+++ b/templates/repo/migrate/gitbucket.tmpl
@@ -3,13 +3,15 @@
 	<div class="ui container medium-width">
 		<h3 class="ui top attached header">
 			{{ctx.Locale.Tr "repo.migrate.migrate" .service.Title}}
-			<input id="service_type" type="hidden" name="service" value="{{.service}}">
 		</h3>
 		<div class="ui attached segment">
 			{{template "base/alert" .}}
 			<form class="ui form left-right-form" action="{{.Link}}" method="post">
 				{{template "base/disable_form_autofill"}}
 				{{.CsrfTokenHtml}}
+
+				<input id="service_type" type="hidden" name="service" value="{{.service}}">
+				
 				<div class="inline required field {{if .Err_CloneAddr}}error{{end}}">
 					<label for="clone_addr">{{ctx.Locale.Tr "repo.migrate.clone_address"}}</label>
 					<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>

--- a/templates/repo/migrate/gitea.tmpl
+++ b/templates/repo/migrate/gitea.tmpl
@@ -3,12 +3,14 @@
 	<div class="ui container medium-width">
 		<h3 class="ui top attached header">
 			{{ctx.Locale.Tr "repo.migrate.migrate" .service.Title}}
-			<input id="service_type" type="hidden" name="service" value="{{.service}}">
 		</h3>
 		<div class="ui attached segment">
 			{{template "base/alert" .}}
 			<form class="ui form left-right-form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
+
+				<input id="service_type" type="hidden" name="service" value="{{.service}}">
+
 				<div class="inline required field {{if .Err_CloneAddr}}error{{end}}">
 					<label for="clone_addr">{{ctx.Locale.Tr "repo.migrate.clone_address"}}</label>
 					<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>

--- a/templates/repo/migrate/github.tmpl
+++ b/templates/repo/migrate/github.tmpl
@@ -3,12 +3,14 @@
 	<div class="ui container medium-width">
 		<h3 class="ui top attached header">
 			{{ctx.Locale.Tr "repo.migrate.migrate" .service.Title}}
-			<input id="service_type" type="hidden" name="service" value="{{.service}}">
 		</h3>
 		<div class="ui attached segment">
 			{{template "base/alert" .}}
 			<form class="ui form left-right-form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
+
+				<input id="service_type" type="hidden" name="service" value="{{.service}}">
+
 				<div class="inline required field {{if .Err_CloneAddr}}error{{end}}">
 					<label for="clone_addr">{{ctx.Locale.Tr "repo.migrate.clone_address"}}</label>
 					<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>

--- a/templates/repo/migrate/gitlab.tmpl
+++ b/templates/repo/migrate/gitlab.tmpl
@@ -3,12 +3,14 @@
 	<div class="ui container medium-width">
 		<h3 class="ui top attached header">
 			{{ctx.Locale.Tr "repo.migrate.migrate" .service.Title}}
-			<input id="service_type" type="hidden" name="service" value="{{.service}}">
 		</h3>
 		<div class="ui attached segment">
 			{{template "base/alert" .}}
 			<form class="ui form left-right-form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
+
+				<input id="service_type" type="hidden" name="service" value="{{.service}}">
+
 				<div class="inline required field {{if .Err_CloneAddr}}error{{end}}">
 					<label for="clone_addr">{{ctx.Locale.Tr "repo.migrate.clone_address"}}</label>
 					<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>

--- a/templates/repo/migrate/gogs.tmpl
+++ b/templates/repo/migrate/gogs.tmpl
@@ -3,12 +3,14 @@
 	<div class="ui container medium-width">
 		<h3 class="ui top attached header">
 			{{ctx.Locale.Tr "repo.migrate.migrate" .service.Title}}
-			<input id="service_type" type="hidden" name="service" value="{{.service}}">
 		</h3>
 		<div class="ui attached segment">
 			{{template "base/alert" .}}
 			<form class="ui form left-right-form" action="{{.Link}}" method="post">
 				{{.CsrfTokenHtml}}
+
+				<input id="service_type" type="hidden" name="service" value="{{.service}}">
+
 				<div class="inline required field {{if .Err_CloneAddr}}error{{end}}">
 					<label for="clone_addr">{{ctx.Locale.Tr "repo.migrate.clone_address"}}</label>
 					<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>

--- a/templates/repo/migrate/onedev.tmpl
+++ b/templates/repo/migrate/onedev.tmpl
@@ -3,13 +3,15 @@
 	<div class="ui container medium-width">
 		<h3 class="ui top attached header">
 			{{ctx.Locale.Tr "repo.migrate.migrate" .service.Title}}
-			<input id="service_type" type="hidden" name="service" value="{{.service}}">
 		</h3>
 		<div class="ui attached segment">
 			{{template "base/alert" .}}
 			<form class="ui form left-right-form" action="{{.Link}}" method="post">
 				{{template "base/disable_form_autofill"}}
 				{{.CsrfTokenHtml}}
+
+				<input id="service_type" type="hidden" name="service" value="{{.service}}">
+
 				<div class="inline required field {{if .Err_CloneAddr}}error{{end}}">
 					<label for="clone_addr">{{ctx.Locale.Tr "repo.migrate.clone_address"}}</label>
 					<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>

--- a/tests/integration/migrate_test.go
+++ b/tests/integration/migrate_test.go
@@ -79,8 +79,12 @@ func TestMigrateGiteaForm(t *testing.T) {
 		resp := session.MakeRequest(t, req, http.StatusOK)
 		// Step 2: load the form
 		htmlDoc := NewHTMLParser(t, resp.Body)
-		link, exists := htmlDoc.doc.Find(`form.ui.form[action^="/repo/migrate"]`).Attr("action")
+		form := htmlDoc.doc.Find(`form.ui.form[action^="/repo/migrate"]`)
+		link, exists := form.Attr("action")
 		assert.True(t, exists, "The template has changed")
+		serviceInput, exists := form.Find(`input[name="service"]`).Attr("value")
+		assert.True(t, exists)
+		assert.EqualValues(t, fmt.Sprintf("%d", structs.GiteaService), serviceInput)
 		// Step 4: submit the migration to only migrate issues
 		migratedRepoName := "otherrepo"
 		req = NewRequestWithValues(t, "POST", link, map[string]string{


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/1dd1b981-daee-4abf-8190-34afcf197ad1)

After:
![image](https://github.com/user-attachments/assets/8f9382b0-fe03-4395-a705-6497b4fd071d)

Reason:
the template should be `repo/migrate/{service type}`
But input element `service` is not in the form.

Related: #33081