### PR TITLE
Simplify context ref name

### DIFF
--- a/routers/web/repo/branch.go
+++ b/routers/web/repo/branch.go
@@ -193,11 +193,11 @@ func CreateBranch(ctx *context.Context) {
 
 	if form.CreateTag {
 		target := ctx.Repo.CommitID
-		if ctx.Repo.IsViewBranch {
+		if ctx.Repo.RefFullName.IsBranch() {
 			target = ctx.Repo.BranchName
 		}
 		err = release_service.CreateNewTag(ctx, ctx.Doer, ctx.Repo.Repository, target, form.NewBranchName, "")
-	} else if ctx.Repo.IsViewBranch {
+	} else if ctx.Repo.RefFullName.IsBranch() {
 		err = repo_service.CreateNewBranch(ctx, ctx.Doer, ctx.Repo.Repository, ctx.Repo.GitRepo, ctx.Repo.BranchName, form.NewBranchName)
 	} else {
 		err = repo_service.CreateNewBranchFromCommit(ctx, ctx.Doer, ctx.Repo.Repository, ctx.Repo.GitRepo, ctx.Repo.CommitID, form.NewBranchName)

--- a/routers/web/repo/commit.go
+++ b/routers/web/repo/commit.go
@@ -390,12 +390,6 @@ func Diff(ctx *context.Context) {
 		}
 	}
 
-	ctx.Data["BranchName"], err = commit.GetBranchName()
-	if err != nil {
-		ctx.ServerError("commit.GetBranchName", err)
-		return
-	}
-
 	ctx.HTML(http.StatusOK, tplCommitPage)
 }
 

--- a/routers/web/repo/release.go
+++ b/routers/web/repo/release.go
@@ -148,8 +148,6 @@ func getReleaseInfos(ctx *context.Context, opts *repo_model.FindReleasesOptions)
 func Releases(ctx *context.Context) {
 	ctx.Data["PageIsReleaseList"] = true
 	ctx.Data["Title"] = ctx.Tr("repo.release.releases")
-	ctx.Data["IsViewBranch"] = false
-	ctx.Data["IsViewTag"] = true
 
 	listOptions := db.ListOptions{
 		Page:     ctx.FormInt("page"),
@@ -194,8 +192,6 @@ func Releases(ctx *context.Context) {
 func TagsList(ctx *context.Context) {
 	ctx.Data["PageIsTagList"] = true
 	ctx.Data["Title"] = ctx.Tr("repo.release.tags")
-	ctx.Data["IsViewBranch"] = false
-	ctx.Data["IsViewTag"] = true
 	ctx.Data["CanCreateRelease"] = ctx.Repo.CanWrite(unit.TypeReleases) && !ctx.Repo.Repository.IsArchived
 
 	namePattern := ctx.FormTrim("q")

--- a/routers/web/repo/view_file.go
+++ b/routers/web/repo/view_file.go
@@ -232,7 +232,7 @@ func prepareToRenderFile(ctx *context.Context, entry *git.TreeEntry) {
 					ctx.Data["CanEditFile"] = true
 					ctx.Data["EditFileTooltip"] = ctx.Tr("repo.editor.edit_this_file")
 				}
-			} else if !ctx.Repo.IsViewBranch {
+			} else if !ctx.Repo.RefFullName.IsBranch() {
 				ctx.Data["EditFileTooltip"] = ctx.Tr("repo.editor.must_be_on_a_branch")
 			} else if !ctx.Repo.CanWriteToBranch(ctx, ctx.Doer, ctx.Repo.BranchName) {
 				ctx.Data["EditFileTooltip"] = ctx.Tr("repo.editor.fork_before_edit")
@@ -305,7 +305,7 @@ func prepareToRenderFile(ctx *context.Context, entry *git.TreeEntry) {
 			ctx.Data["CanDeleteFile"] = true
 			ctx.Data["DeleteFileTooltip"] = ctx.Tr("repo.editor.delete_this_file")
 		}
-	} else if !ctx.Repo.IsViewBranch {
+	} else if !ctx.Repo.RefFullName.IsBranch() {
 		ctx.Data["DeleteFileTooltip"] = ctx.Tr("repo.editor.must_be_on_a_branch")
 	} else if !ctx.Repo.CanWriteToBranch(ctx, ctx.Doer, ctx.Repo.BranchName) {
 		ctx.Data["DeleteFileTooltip"] = ctx.Tr("repo.editor.must_have_write_access")

--- a/routers/web/repo/view_home.go
+++ b/routers/web/repo/view_home.go
@@ -178,7 +178,7 @@ func prepareHomeSidebarLatestRelease(ctx *context.Context) {
 }
 
 func prepareUpstreamDivergingInfo(ctx *context.Context) {
-	if !ctx.Repo.Repository.IsFork || !ctx.Repo.IsViewBranch || ctx.Repo.TreePath != "" {
+	if !ctx.Repo.Repository.IsFork || !ctx.Repo.RefFullName.IsBranch() || ctx.Repo.TreePath != "" {
 		return
 	}
 	upstreamDivergingInfo, err := repo_service.GetUpstreamDivergingInfo(ctx, ctx.Repo.Repository, ctx.Repo.BranchName)

--- a/templates/repo/blame.tmpl
+++ b/templates/repo/blame.tmpl
@@ -18,7 +18,7 @@
 		<div class="file-header-right file-actions tw-flex tw-items-center tw-flex-wrap">
 			<div class="ui buttons">
 				<a class="ui tiny button" href="{{$.RawFileLink}}">{{ctx.Locale.Tr "repo.file_raw"}}</a>
-				{{if not .IsViewCommit}}
+				{{if or .RefFullName.IsBranch .RefFullName.IsTag}}
 					<a class="ui tiny button" href="{{.RepoLink}}/src/commit/{{.CommitID | PathEscape}}/{{.TreePath | PathEscapeSegments}}">{{ctx.Locale.Tr "repo.file_permalink"}}</a>
 				{{end}}
 				<a class="ui tiny button" href="{{.RepoLink}}/src/{{.RefTypeNameSubURL}}/{{.TreePath | PathEscapeSegments}}">{{ctx.Locale.Tr "repo.normal_view"}}</a>

--- a/templates/repo/commit_page.tmpl
+++ b/templates/repo/commit_page.tmpl
@@ -54,13 +54,11 @@
 											<p id="cherry-pick-content" class="branch-dropdown"></p>
 
 											<form method="get">
-												{{/*FIXME: CurrentRefShortName seems not making sense here (old code),
-												because the "commit page" has no "$.BranchName" info, so only using DefaultBranch should be enough */}}
 												{{template "repo/branch_dropdown" dict
 													"Repository" .Repository
 													"ShowTabBranches" true
 													"CurrentRefType" "branch"
-													"CurrentRefShortName" (or $.BranchName $.Repository.DefaultBranch)
+													"CurrentRefShortName" $.Repository.DefaultBranch
 													"RefFormActionTemplate" (print "{RepoLink}/_cherrypick/" .CommitID "/{RefShortName}")
 												}}
 												<input type="hidden" id="cherry-pick-type" name="cherry-pick-type"><br>

--- a/templates/repo/commits.tmpl
+++ b/templates/repo/commits.tmpl
@@ -5,24 +5,13 @@
 		{{template "repo/sub_menu" .}}
 		<div class="repo-button-row">
 			<div class="repo-button-row-left">
-				{{- /* for /owner/repo/commits/branch/the-name */ -}}
-				{{- $branchDropdownCurrentRefType := "branch" -}}
-				{{- $branchDropdownCurrentRefShortName := .BranchName -}}
-				{{- if .IsViewTag -}}
-					{{- /* for /owner/repo/commits/tag/the-name */ -}}
-					{{- $branchDropdownCurrentRefType = "tag" -}}
-					{{- $branchDropdownCurrentRefShortName = .TagName -}}
-				{{- else if .IsViewCommit -}}
-					{{- /* for /owner/repo/commits/commit/000000 */ -}}
-					{{- $branchDropdownCurrentRefType = "commit" -}}
-					{{- $branchDropdownCurrentRefShortName = ShortSha .CommitID -}}
-				{{- end -}}
+				{{- /* for /owner/repo/commits/{RefType}/{RefShortName} */ -}}
 				{{- template "repo/branch_dropdown" dict
 					"Repository" .Repository
 					"ShowTabBranches" true
 					"ShowTabTags" true
-					"CurrentRefType" $branchDropdownCurrentRefType
-					"CurrentRefShortName" $branchDropdownCurrentRefShortName
+					"CurrentRefType" .RefFullName.RefType
+					"CurrentRefShortName" .RefFullName.ShortName
 					"CurrentTreePath" .TreePath
 					"RefLinkTemplate" "{RepoLink}/commits/{RefType}/{RefShortName}/{TreePath}"
 					"AllowCreateNewRef" .CanCreateBranch

--- a/templates/repo/home.tmpl
+++ b/templates/repo/home.tmpl
@@ -24,30 +24,19 @@
 				{{template "repo/sub_menu" .}}
 				<div class="repo-button-row">
 					<div class="repo-button-row-left">
-						{{- /* for repo home (default branch) and /owner/repo/src/branch/the-name */ -}}
-						{{- $branchDropdownCurrentRefType := "branch" -}}
-						{{- $branchDropdownCurrentRefShortName := .BranchName -}}
-						{{- if .IsViewTag -}}
-							{{- /* for /owner/repo/src/tag/the-name */ -}}
-							{{- $branchDropdownCurrentRefType = "tag" -}}
-							{{- $branchDropdownCurrentRefShortName = .TagName -}}
-						{{- else if .IsViewCommit -}}
-							{{- /* for /owner/repo/src/commit/000000 */ -}}
-							{{- $branchDropdownCurrentRefType = "commit" -}}
-							{{- $branchDropdownCurrentRefShortName = ShortSha .CommitID -}}
-						{{- end -}}
+						{{- /* for repo home (default branch) and /owner/repo/src/{RefType}/{RefShortName} */ -}}
 						{{- template "repo/branch_dropdown" dict
 							"Repository" .Repository
 							"ShowTabBranches" true
 							"ShowTabTags" true
-							"CurrentRefType" $branchDropdownCurrentRefType
-							"CurrentRefShortName" $branchDropdownCurrentRefShortName
+							"CurrentRefType" .RefFullName.RefType
+							"CurrentRefShortName" .RefFullName.ShortName
 							"CurrentTreePath" .TreePath
 							"RefLinkTemplate" "{RepoLink}/src/{RefType}/{RefShortName}/{TreePath}"
 							"AllowCreateNewRef" .CanCreateBranch
 							"ShowViewAllRefsEntry" true
 						-}}
-						{{if and .CanCompareOrPull .IsViewBranch (not .Repository.IsArchived)}}
+						{{if and .CanCompareOrPull .RefFullName.IsBranch (not .Repository.IsArchived)}}
 							{{$cmpBranch := ""}}
 							{{if ne .Repository.ID .BaseRepo.ID}}
 								{{$cmpBranch = printf "%s/%s:" (.Repository.OwnerName|PathEscape) (.Repository.Name|PathEscape)}}
@@ -65,7 +54,7 @@
 							<a href="{{.Repository.Link}}/find/{{.RefTypeNameSubURL}}" class="ui compact basic button">{{ctx.Locale.Tr "repo.find_file.go_to_file"}}</a>
 						{{end}}
 
-						{{if and .CanWriteCode .IsViewBranch (not .Repository.IsMirror) (not .Repository.IsArchived) (not .IsViewFile)}}
+						{{if and .CanWriteCode .RefFullName.IsBranch (not .Repository.IsMirror) (not .Repository.IsArchived) (not .IsViewFile)}}
 							<button class="ui dropdown basic compact jump button"{{if not .Repository.CanEnableEditor}} disabled{{end}}>
 								{{ctx.Locale.Tr "repo.editor.add_file"}}
 								{{svg "octicon-triangle-down" 14 "dropdown icon"}}

--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -24,7 +24,7 @@
 								"Repository" $.Repository
 								"ShowTabTags" true
 								"DropdownFixedText" (ctx.Locale.Tr "repo.release.compare")
-								"RefLinkTemplate" (print "{RepoLink}/compare/{RefShortName}..." (PathEscapeSegments $compareTarget))
+								"RefLinkTemplate" (print "{RepoLink}/compare/{RefShortName}" "..." (PathEscapeSegments $compareTarget))
 							}}
 						{{end}}
 					</div>

--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -42,7 +42,7 @@
 			{{if not .ReadmeInList}}
 				<div class="ui buttons tw-mr-1">
 					<a class="ui mini basic button" href="{{$.RawFileLink}}">{{ctx.Locale.Tr "repo.file_raw"}}</a>
-					{{if not .IsViewCommit}}
+					{{if or .RefFullName.IsBranch .RefFullName.IsTag}}
 						<a class="ui mini basic button" href="{{.RepoLink}}/src/commit/{{PathEscape .CommitID}}/{{PathEscapeSegments .TreePath}}">{{ctx.Locale.Tr "repo.file_permalink"}}</a>
 					{{end}}
 					{{if .IsRepresentableAsText}}


### PR DESCRIPTION
By using the new design, the code could be simplified and clearer than before.

* `IsViewBranch`: replaced by `RefFullName.IsBranch`
* `IsViewTag`: replaced by `RefFullName.IsTag`
