### PR TITLE
Show confirmation dialog if release created with existing tag

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -2679,6 +2679,12 @@ release.add_tag_msg = Use the title and content of release as tag message.
 release.add_tag = Create Tag Only
 release.releases_for = Releases for %s
 release.tags_for = Tags for %s
+release.existing_tag_header = New release with an old tag
+release.existing_tag_draft_header = Draft release with an old tag
+release.existing_tag = You are about to create a new release with an <b>existing tag</b>. Make sure that the tag is pointing to the right commit.
+release.existing_draft_tag = You are about to create a draft release with an <b>existing tag</b>. Make sure that the tag is pointing to the right commit.
+release.create_confirmation = Do you want to continue with the release creation?
+release.create_draft_confirmation = Do you want to continue with the release draft creation?
 
 branch.name = Branch Name
 branch.already_exists = A branch named "%s" already exists.

--- a/routers/web/repo/release.go
+++ b/routers/web/repo/release.go
@@ -330,9 +330,9 @@ func newReleaseCommon(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("repo.release.new_release")
 	ctx.Data["PageIsReleaseList"] = true
 
-	tags, err := repo_model.GetTagNamesByRepoID(ctx, ctx.Repo.Repository.ID)
+	tags, err := repo_model.GetTagMappingsByRepoID(ctx, ctx.Repo.Repository.ID)
 	if err != nil {
-		ctx.ServerError("GetTagNamesByRepoID", err)
+		ctx.ServerError("GetTagMappingsByRepoID", err)
 		return
 	}
 	ctx.Data["Tags"] = tags

--- a/templates/repo/release/new.tmpl
+++ b/templates/repo/release/new.tmpl
@@ -38,6 +38,9 @@
 								</div>
 							</div>
 						</div>
+						<div id="tag-warning" class="gt-dib gt-hidden" data-commit-url-stub="{{.RepoLink}}/commit">
+							{{svg "octicon-alert-fill" 16}} Existing tag referencing <span class="gt-px-3">{{svg "octicon-git-commit" 16}} <a target="_blank" rel="noopener noreferrer" class="tag-warning-detail"></a></span>
+						</div>
 						<div>
 							<span id="tag-helper" class="help tw-mt-2 tw-pb-0">{{ctx.Locale.Tr "repo.release.tag_helper"}}</span>
 						</div>
@@ -118,14 +121,37 @@
 							{{if .ShowCreateTagOnlyButton}}
 								<button class="ui small button" name="tag_only" value="1">{{ctx.Locale.Tr "repo.release.add_tag"}}</button>
 							{{end}}
-							<button class="ui small button" name="draft" value="1">{{ctx.Locale.Tr "repo.release.save_draft"}}</button>
-							<button class="ui small primary button">{{ctx.Locale.Tr "repo.release.publish"}}</button>
+							<button class="ui small button tag-confirm tag-draft" name="draft" value="1">{{ctx.Locale.Tr "repo.release.save_draft"}}</button>
+							<button class="ui small primary button tag-confirm">{{ctx.Locale.Tr "repo.release.publish"}}</button>
 						{{end}}
 					</div>
 				</div>
 			</div>
 		</form>
 	</div>
+</div>
+
+<div id="tag-confirm-modal" class="ui g-modal-confirm modal">
+	<div class="header">
+		{{ctx.Locale.Tr "repo.release.existing_tag_header"}}
+	</div>
+	<div class="content">
+		<p>{{svg "octicon-alert-fill" 16}} Existing tag referencing <span class="gt-px-3">{{svg "octicon-git-commit" 16}} <a target="_blank" rel="noopener noreferrer" class="tag-warning-detail"></a></span></p>
+		<p>{{ctx.Locale.Tr "repo.release.existing_tag"}}</p>
+		<p>{{ctx.Locale.Tr "repo.release.create_confirmation"}}</p>
+	</div>
+	{{template "base/modal_actions_confirm" .}}
+</div>
+<div id="tag-confirm-draft-modal" class="ui g-modal-confirm modal">
+	<div class="header">
+		{{ctx.Locale.Tr "repo.release.existing_tag_draft_header"}}
+	</div>
+	<div class="content">
+		<p>{{svg "octicon-alert-fill" 16}} Existing tag referencing <span class="gt-px-3">{{svg "octicon-git-commit" 16}} <a target="_blank" rel="noopener noreferrer" class="tag-warning-detail"></a></span></p>
+		<p>{{ctx.Locale.Tr "repo.release.existing_draft_tag"}}</p>
+		<p>{{ctx.Locale.Tr "repo.release.create_draft_confirmation"}}</p>
+	</div>
+	{{template "base/modal_actions_confirm" .}}
 </div>
 
 {{if .PageIsEditRelease}}

--- a/web_src/js/features/repo-release.ts
+++ b/web_src/js/features/repo-release.ts
@@ -1,4 +1,5 @@
 import {hideElem, showElem, type DOMEvent} from '../utils/dom.ts';
+import {fomanticQuery} from "../modules/fomantic/base";
 
 export function initRepoRelease() {
   document.addEventListener('click', (e: DOMEvent<MouseEvent>) => {
@@ -21,24 +22,65 @@ function initTagNameEditor() {
   const el = document.querySelector('#tag-name-editor');
   if (!el) return;
 
+  const tagWarning = document.querySelector('#tag-warning');
+  const tagWarningDetailLinks = Array.from(document.getElementsByClassName('tag-warning-detail'));
   const existingTags = JSON.parse(el.getAttribute('data-existing-tags'));
   if (!Array.isArray(existingTags)) return;
 
   const defaultTagHelperText = el.getAttribute('data-tag-helper');
   const newTagHelperText = el.getAttribute('data-tag-helper-new');
   const existingTagHelperText = el.getAttribute('data-tag-helper-existing');
+  const tagURLStub = tagWarning.getAttribute('data-commit-url-stub');
+  const tagConfirmDraftModal = document.querySelector('#tag-confirm-draft-modal');
+  const tagConfirmModal = document.querySelector('#tag-confirm-modal');
+
+  // show the confirmation modal if release is using an existing tag
+  let requiresConfirmation = false;
+  $('.tag-confirm').on('click', (event) => {
+    if (requiresConfirmation) {
+      event.preventDefault();
+      if ($(event.target).hasClass('tag-draft')) {
+        fomanticQuery(tagConfirmDraftModal).modal({
+          onApprove() {
+            // need to add hidden input with draft form value
+            // (triggering form submission doesn't include the button data)
+            $('<input>').attr({
+              type: 'hidden',
+              name: 'draft',
+              value: '1'
+            }).appendTo(event.target.form);
+            $(event.target.form).trigger('submit');
+          },
+        }).modal('show');
+      } else {
+        fomanticQuery(tagConfirmModal).modal({
+          onApprove() {
+            $(event.target.form).trigger('submit');
+          },
+        }).modal('show');
+      }
+    }
+  });
 
   const tagNameInput = document.querySelector<HTMLInputElement>('#tag-name');
   const hideTargetInput = function(tagNameInput: HTMLInputElement) {
     const value = tagNameInput.value;
     const tagHelper = document.querySelector('#tag-helper');
-    if (existingTags.includes(value)) {
+    if (value in existingTags) {
       // If the tag already exists, hide the target branch selector.
       hideElem('#tag-target-selector');
       tagHelper.textContent = existingTagHelperText;
+      showElem('#tag-warning');
+      for (const detail of tagWarningDetailLinks) {
+        detail.href = `${tagURLStub}/${existingTags[value]}`;
+        detail.textContent = existingTags[value].substring(0, 10);
+      }
+      requiresConfirmation = true;
     } else {
       showElem('#tag-target-selector');
       tagHelper.textContent = value ? newTagHelperText : defaultTagHelperText;
+      hideElem('#tag-warning');
+      requiresConfirmation = false;
     }
   };
   hideTargetInput(tagNameInput); // update on page load because the input may have a value

--- a/web_src/js/features/repo-release.ts
+++ b/web_src/js/features/repo-release.ts
@@ -1,5 +1,5 @@
 import {hideElem, showElem, type DOMEvent} from '../utils/dom.ts';
-import {fomanticQuery} from "../modules/fomantic/base";
+import {fomanticQuery} from '../modules/fomantic/base.ts';
 
 export function initRepoRelease() {
   document.addEventListener('click', (e: DOMEvent<MouseEvent>) => {
@@ -25,7 +25,6 @@ function initTagNameEditor() {
   const tagWarning = document.querySelector('#tag-warning');
   const tagWarningDetailLinks = Array.from(document.getElementsByClassName('tag-warning-detail'));
   const existingTags = JSON.parse(el.getAttribute('data-existing-tags'));
-  if (!Array.isArray(existingTags)) return;
 
   const defaultTagHelperText = el.getAttribute('data-tag-helper');
   const newTagHelperText = el.getAttribute('data-tag-helper-new');

--- a/web_src/js/features/repo-release.ts
+++ b/web_src/js/features/repo-release.ts
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import {hideElem, showElem, type DOMEvent} from '../utils/dom.ts';
 import {fomanticQuery} from '../modules/fomantic/base.ts';
 
@@ -23,7 +24,7 @@ function initTagNameEditor() {
   if (!el) return;
 
   const tagWarning = document.querySelector('#tag-warning');
-  const tagWarningDetailLinks = Array.from(document.getElementsByClassName('tag-warning-detail'));
+  const tagWarningDetailLinks = Array.from(document.querySelectorAll('.tag-warning-detail'));
   const existingTags = JSON.parse(el.getAttribute('data-existing-tags'));
 
   const defaultTagHelperText = el.getAttribute('data-tag-helper');
@@ -38,23 +39,24 @@ function initTagNameEditor() {
   $('.tag-confirm').on('click', (event) => {
     if (requiresConfirmation) {
       event.preventDefault();
-      if ($(event.target).hasClass('tag-draft')) {
+      const form = event.target.closest('form');
+      if (event.target.classList.contains('tag-draft')) {
         fomanticQuery(tagConfirmDraftModal).modal({
           onApprove() {
             // need to add hidden input with draft form value
             // (triggering form submission doesn't include the button data)
-            $('<input>').attr({
-              type: 'hidden',
-              name: 'draft',
-              value: '1'
-            }).appendTo(event.target.form);
-            $(event.target.form).trigger('submit');
+            const input = document.createElement('input');
+            input.type = 'hidden';
+            input.name = 'draft';
+            input.value = '1';
+            form.append(input);
+            $(form).trigger('submit');
           },
         }).modal('show');
       } else {
         fomanticQuery(tagConfirmModal).modal({
           onApprove() {
-            $(event.target.form).trigger('submit');
+            $(form).trigger('submit');
           },
         }).modal('show');
       }
@@ -71,8 +73,9 @@ function initTagNameEditor() {
       tagHelper.textContent = existingTagHelperText;
       showElem('#tag-warning');
       for (const detail of tagWarningDetailLinks) {
-        detail.href = `${tagURLStub}/${existingTags[value]}`;
-        detail.textContent = existingTags[value].substring(0, 10);
+        const anchor = detail as HTMLAnchorElement;
+        anchor.href = `${tagURLStub}/${existingTags[value]}`;
+        anchor.textContent = existingTags[value].substring(0, 10);
       }
       requiresConfirmation = true;
     } else {


### PR DESCRIPTION
When creating a new release, a user may accidentally select an old tag. The current warning against this is fairly subtle. This PR adds a more descriptive warning and a confirmation dialog.

## Screenshots
<img width="338" alt="Screen Shot 2025-01-17 at 1 14 21 PM" src="https://github.com/user-attachments/assets/9a7cb707-b703-4c00-ae55-6211c6c19f34" />
<img width="673" alt="Screen Shot 2025-01-17 at 1 13 59 PM" src="https://github.com/user-attachments/assets/d9ef038a-38f8-4157-81b4-66a59d6c2a91" />
<img width="712" alt="Screen Shot 2025-01-17 at 1 17 27 PM" src="https://github.com/user-attachments/assets/4cab6b69-418b-463e-a553-6a58d4afdc0a" />
