### PR TITLE
Fix incorrect ref commit ID usage

### DIFF
--- a/routers/web/repo/code_frequency.go
+++ b/routers/web/repo/code_frequency.go
@@ -29,7 +29,7 @@ func CodeFrequency(ctx *context.Context) {
 
 // CodeFrequencyData returns JSON of code frequency data
 func CodeFrequencyData(ctx *context.Context) {
-	if contributorStats, err := contributors_service.GetContributorStats(ctx, ctx.Cache, ctx.Repo.Repository, ctx.Repo.CommitID); err != nil {
+	if contributorStats, err := contributors_service.GetContributorStats(ctx, ctx.Cache, ctx.Repo.Repository, ctx.Repo.Repository.DefaultBranch); err != nil {
 		if errors.Is(err, contributors_service.ErrAwaitGeneration) {
 			ctx.Status(http.StatusAccepted)
 			return

--- a/routers/web/repo/contributors.go
+++ b/routers/web/repo/contributors.go
@@ -26,7 +26,7 @@ func Contributors(ctx *context.Context) {
 
 // ContributorsData renders JSON of contributors along with their weekly commit statistics
 func ContributorsData(ctx *context.Context) {
-	if contributorStats, err := contributors_service.GetContributorStats(ctx, ctx.Cache, ctx.Repo.Repository, ctx.Repo.CommitID); err != nil {
+	if contributorStats, err := contributors_service.GetContributorStats(ctx, ctx.Cache, ctx.Repo.Repository, ctx.Repo.Repository.DefaultBranch); err != nil {
 		if errors.Is(err, contributors_service.ErrAwaitGeneration) {
 			ctx.Status(http.StatusAccepted)
 			return

--- a/routers/web/repo/recent_commits.go
+++ b/routers/web/repo/recent_commits.go
@@ -29,7 +29,7 @@ func RecentCommits(ctx *context.Context) {
 
 // RecentCommitsData returns JSON of recent commits data
 func RecentCommitsData(ctx *context.Context) {
-	if contributorStats, err := contributors_service.GetContributorStats(ctx, ctx.Cache, ctx.Repo.Repository, ctx.Repo.CommitID); err != nil {
+	if contributorStats, err := contributors_service.GetContributorStats(ctx, ctx.Cache, ctx.Repo.Repository, ctx.Repo.Repository.DefaultBranch); err != nil {
 		if errors.Is(err, contributors_service.ErrAwaitGeneration) {
 			ctx.Status(http.StatusAccepted)
 			return

--- a/routers/web/repo/search.go
+++ b/routers/web/repo/search.go
@@ -81,7 +81,7 @@ func Search(ctx *context.Context) {
 		}
 		commitID, err := ctx.Repo.GitRepo.GetRefCommitID(searchRefName.String())
 		if err != nil {
-			ctx.ServerError("GrepSearch", err)
+			ctx.ServerError("GetRefCommitID", err)
 			return
 		}
 		total = len(res)

--- a/routers/web/repo/search.go
+++ b/routers/web/repo/search.go
@@ -67,14 +67,20 @@ func Search(ctx *context.Context) {
 			ctx.Data["CodeIndexerUnavailable"] = !code_indexer.IsAvailable(ctx)
 		}
 	} else {
+		searchRefName := git.RefNameFromBranch(ctx.Repo.Repository.DefaultBranch) // BranchName should be default branch or the first existing branch
 		res, err := git.GrepSearch(ctx, ctx.Repo.GitRepo, prepareSearch.Keyword, git.GrepOptions{
 			ContextLineNumber: 1,
 			IsFuzzy:           prepareSearch.IsFuzzy,
-			RefName:           git.RefNameFromBranch(ctx.Repo.Repository.DefaultBranch).String(), // BranchName should be default branch or the first existing branch
+			RefName:           searchRefName.String(),
 			PathspecList:      indexSettingToGitGrepPathspecList(),
 		})
 		if err != nil {
 			// TODO: if no branch exists, it reports: exit status 128, fatal: this operation must be run in a work tree.
+			ctx.ServerError("GrepSearch", err)
+			return
+		}
+		commitID, err := ctx.Repo.GitRepo.GetRefCommitID(searchRefName.String())
+		if err != nil {
 			ctx.ServerError("GrepSearch", err)
 			return
 		}
@@ -86,7 +92,7 @@ func Search(ctx *context.Context) {
 			searchResults = append(searchResults, &code_indexer.Result{
 				RepoID:   ctx.Repo.Repository.ID,
 				Filename: r.Filename,
-				CommitID: ctx.Repo.CommitID,
+				CommitID: commitID,
 				// UpdatedUnix: not supported yet
 				// Language:    not supported yet
 				// Color:       not supported yet

--- a/routers/web/repo/setting/webhook.go
+++ b/routers/web/repo/setting/webhook.go
@@ -654,6 +654,8 @@ func TestWebhook(ctx *context.Context) {
 	}
 
 	// Grab latest commit or fake one if it's empty repository.
+	// Note: in old code, the "ctx.Repo.Commit" is the last commit of the default branch.
+	// New code doesn't set that commit, so it always uses the fake commit to test webhook.
 	commit := ctx.Repo.Commit
 	if commit == nil {
 		ghost := user_model.NewGhostUser()

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1146,7 +1146,7 @@ func registerRoutes(m *web.Router) {
 			m.Post("/cancel", repo.MigrateCancelPost)
 		})
 	},
-		reqSignIn, context.RepoAssignment, reqRepoAdmin, context.RepoRef(),
+		reqSignIn, context.RepoAssignment, reqRepoAdmin,
 		ctxDataSet("PageIsRepoSettings", true, "LFSStartServer", setting.LFS.StartServer),
 	)
 	// end "/{username}/{reponame}/settings"
@@ -1513,7 +1513,7 @@ func registerRoutes(m *web.Router) {
 		m.Group("/activity_author_data", func() {
 			m.Get("", repo.ActivityAuthors)
 			m.Get("/{period}", repo.ActivityAuthors)
-		}, context.RepoRef(), repo.MustBeNotEmpty)
+		}, repo.MustBeNotEmpty)
 
 		m.Group("/archive", func() {
 			m.Get("/*", repo.Download)


### PR DESCRIPTION
After the RefName refactoring, the `ctx.Repo.CommitID` is only set when there is a `RepoRefByType` middleware.

Many handlers do not use that middleware and they only use "default branch"