### PR TITLE
Fix code button alignment

### DIFF
--- a/templates/repo/clone_panel.tmpl
+++ b/templates/repo/clone_panel.tmpl
@@ -1,5 +1,6 @@
 <button class="ui primary button js-btn-clone-panel">
-	<span>{{svg "octicon-code" 16}} Code</span>
+	{{svg "octicon-code" 16}}
+	<span>Code</span>
 	{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 </button>
 <div class="clone-panel-popup tippy-target">


### PR DESCRIPTION
Fixes: https://github.com/go-gitea/gitea/issues/33344

Before:
<img width="106" alt="Screenshot 2025-01-22 at 00 40 03" src="https://github.com/user-attachments/assets/98c13e53-d83b-4bd5-96b8-3b6c575ef35f" />

After:
<img width="104" alt="Screenshot 2025-01-22 at 00 39 51" src="https://github.com/user-attachments/assets/eb6801c7-0461-4778-9c34-3196f834b1c4" />

SVGs should not be put into `<span>` as this messes with the parent flexbox alignment.

BTW the string "Code" is not translated. Maybe for another PR to keep this backportable.
