### PR TITLE
Update katex to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "htmx.org": "2.0.4",
         "idiomorph": "0.3.0",
         "jquery": "3.7.1",
-        "katex": "0.16.11",
+        "katex": "0.16.21",
         "license-checker-webpack-plugin": "0.2.1",
         "mermaid": "11.4.1",
         "mini-css-extract-plugin": "2.9.2",
@@ -11057,9 +11057,9 @@
       "license": "MIT"
     },
     "node_modules/katex": {
-      "version": "0.16.11",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.11.tgz",
-      "integrity": "sha512-RQrI8rlHY92OLf3rho/Ts8i/XvjgguEjOkO1BEXcU3N8BqPpSzBNwV/G0Ukr+P/l3ivvJUE/Fa/CwbS6HesGNQ==",
+      "version": "0.16.21",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.21.tgz",
+      "integrity": "sha512-XvqR7FgOHtWupfMiigNzmh+MgUVmDGU2kXZm899ZkPfcuoPuFxyHmXsgATDpFZDAXCI8tvinaVcDo8PIIJSo4A==",
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "htmx.org": "2.0.4",
     "idiomorph": "0.3.0",
     "jquery": "3.7.1",
-    "katex": "0.16.11",
+    "katex": "0.16.21",
     "license-checker-webpack-plugin": "0.2.1",
     "mermaid": "11.4.1",
     "mini-css-extract-plugin": "2.9.2",


### PR DESCRIPTION
Partial backport of https://github.com/go-gitea/gitea/pull/33359. Upgrade katex because there were a number of security problems fixed in recent versions.