### PR TITLE
Update `@github/text-expander-element` to 2.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@citation-js/plugin-software-formats": "0.6.1",
         "@github/markdown-toolbar-element": "2.2.3",
         "@github/relative-time-element": "4.4.5",
-        "@github/text-expander-element": "2.8.0",
+        "@github/text-expander-element": "2.9.0",
         "@mcaptcha/vanilla-glue": "0.1.0-alpha-3",
         "@primer/octicons": "19.14.0",
         "@silverwind/vue3-calendar-heatmap": "2.0.6",
@@ -2850,9 +2850,9 @@
       "license": "MIT"
     },
     "node_modules/@github/text-expander-element": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@github/text-expander-element/-/text-expander-element-2.8.0.tgz",
-      "integrity": "sha512-kkS2rZ/CG8HGKblpLDQ8vcK/K7l/Jsvzi/N4ovwPAsFSOImcIbJh2MgCv9tzqE3wAm/qXlscvh3Ms4Hh1vtZvw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@github/text-expander-element/-/text-expander-element-2.9.0.tgz",
+      "integrity": "sha512-NjoFiQ/3955XyefrkmtUpZvrgDl0MGyncv2QJBrUZ1+oOFOu+UmCR/ybkcuTgNg0O6AGcl8rUEXStUfrRPUCVQ==",
       "license": "MIT",
       "dependencies": {
         "@github/combobox-nav": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@citation-js/plugin-software-formats": "0.6.1",
     "@github/markdown-toolbar-element": "2.2.3",
     "@github/relative-time-element": "4.4.5",
-    "@github/text-expander-element": "2.8.0",
+    "@github/text-expander-element": "2.9.0",
     "@mcaptcha/vanilla-glue": "0.1.0-alpha-3",
     "@primer/octicons": "19.14.0",
     "@silverwind/vue3-calendar-heatmap": "2.0.6",

--- a/web_src/js/features/comp/TextExpander.ts
+++ b/web_src/js/features/comp/TextExpander.ts
@@ -6,21 +6,9 @@ import {createElementFromAttrs, createElementFromHTML} from '../../utils/dom.ts'
 import {getIssueColor, getIssueIcon} from '../issue.ts';
 import {debounce} from 'perfect-debounce';
 import type TextExpanderElement from '@github/text-expander-element';
+import type {TextExpanderChangeEvent, TextExpanderResult} from '@github/text-expander-element/dist/text-expander-element.d.ts';
 
-type TextExpanderProvideResult = {
-  matched: boolean,
-  fragment?: HTMLElement,
-}
-
-type TextExpanderChangeEvent = Event & {
-  detail?: {
-    key: string,
-    text: string,
-    provide: (result: TextExpanderProvideResult | Promise<TextExpanderProvideResult>) => void,
-  }
-}
-
-async function fetchIssueSuggestions(key: string, text: string): Promise<TextExpanderProvideResult> {
+async function fetchIssueSuggestions(key: string, text: string): Promise<TextExpanderResult> {
   const issuePathInfo = parseIssueHref(window.location.href);
   if (!issuePathInfo.ownerName) {
     const repoOwnerPathInfo = parseRepoOwnerPathInfo(window.location.pathname);
@@ -59,7 +47,7 @@ export function initTextExpander(expander: TextExpanderElement) {
     return keyStart > lineStart;
   };
 
-  const debouncedIssueSuggestions = debounce(async (key: string, text: string): Promise<TextExpanderProvideResult> => {
+  const debouncedIssueSuggestions = debounce(async (key: string, text: string): Promise<TextExpanderResult> => {
     // https://github.com/github/text-expander-element/issues/71
     // Upstream bug: when using "multiword+promise", TextExpander will get wrong "key" position.
     // To reproduce, comment out the "shouldShowIssueSuggestions" check, use the "await sleep" below,


### PR DESCRIPTION
Update and use their newly exported types. Tested, works.

The import path is a bit suboptimal, to be fixed once https://github.com/github/text-expander-element/pull/75 is merged and released.