### PR TITLE
Actions FetchTask concurrently picked jobs is an error for the runner

### DIFF
--- a/models/actions/task.go
+++ b/models/actions/task.go
@@ -317,7 +317,7 @@ func CreateTaskForRunner(ctx context.Context, runner *ActionRunner) (*ActionTask
 	if n, err := UpdateRunJob(ctx, job, builder.Eq{"task_id": 0}); err != nil {
 		return nil, false, err
 	} else if n != 1 {
-		return nil, false, nil
+		return nil, false, fmt.Errorf("other runner picked up our job")
 	}
 
 	task.Job = job


### PR DESCRIPTION
* Before this Gitea claimed no job is available to be picked in this case
* The runner had to wait for an external taskversion increment
* Now act_runner is notified about an error and retries the request later without updating its taskversion

Closes #33492
