### PR TITLE
Enable eslint for commonjs

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,4 +1,4 @@
-const vitestPlugin = require("@vitest/eslint-plugin");
+const vitestPlugin = require('@vitest/eslint-plugin');
 const restrictedSyntax = ['WithStatement', 'ForInStatement', 'LabeledStatement', 'SequenceExpression'];
 
 module.exports = {
@@ -46,6 +46,13 @@ module.exports = {
   },
   overrides: [
     {
+      files: ['**/*.cjs'],
+      rules: {
+        'import-x/no-commonjs': [0],
+        '@typescript-eslint/no-require-imports': [0],
+      },
+    },
+    {
       files: ['web_src/**/*'],
       globals: {
         __webpack_public_path__: true,
@@ -81,7 +88,7 @@ module.exports = {
     },
     {
       files: ['**/*.test.*', 'web_src/js/test/setup.ts'],
-      plugins: ["@vitest/eslint-plugin"],
+      plugins: ['@vitest/eslint-plugin'],
       globals: vitestPlugin.environments.env.globals,
       rules: {
         '@vitest/consistent-test-filename': [0],
@@ -161,7 +168,7 @@ module.exports = {
     {
       files: ['tests/e2e/**'],
       plugins: [
-        'eslint-plugin-playwright'
+        'eslint-plugin-playwright',
       ],
       extends: [
         'plugin:playwright/recommended',

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ TAR_EXCLUDES := .git data indexers queues log node_modules $(EXECUTABLE) $(FOMAN
 GO_DIRS := build cmd models modules routers services tests
 WEB_DIRS := web_src/js web_src/css
 
-ESLINT_FILES := web_src/js tools *.js *.ts tests/e2e
+ESLINT_FILES := web_src/js tools *.js *.ts *.cjs tests/e2e
 STYLELINT_FILES := web_src/css web_src/js/components/*.vue
 SPELLCHECK_FILES := $(GO_DIRS) $(WEB_DIRS) templates options/locale/locale_en-US.ini .github $(filter-out CHANGELOG.md, $(wildcard *.go *.js *.md *.yml *.yaml *.toml))
 EDITORCONFIG_FILES := templates .github/workflows options/locale/locale_en-US.ini

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "include": [
-    ".*",
-    "*",
-    "tests/e2e/**/*",
-    "tests/e2e/**/.*",
-    "tools/**/*",
-    "tools/**/.*",
-    "web_src/js/**/*",
-    "web_src/js/**/.*",
+    "${configDir}/.*",
+    "${configDir}/*",
+    "${configDir}/tests/e2e/**/*",
+    "${configDir}/tests/e2e/**/.*",
+    "${configDir}/tools/**/*",
+    "${configDir}/tools/**/.*",
+    "${configDir}/web_src/js/**/*",
+    "${configDir}/web_src/js/**/.*",
   ],
   "compilerOptions": {
     "target": "es2020",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,13 @@
 {
   "include": [
+    ".*",
     "*",
     "tests/e2e/**/*",
+    "tests/e2e/**/.*",
     "tools/**/*",
+    "tools/**/.*",
     "web_src/js/**/*",
+    "web_src/js/**/.*",
   ],
   "compilerOptions": {
     "target": "es2020",


### PR DESCRIPTION
1. `.eslintrc.cjs` was not being linted because that file extension was missing in `ESLINT_FILES`, added it.
2. Because we are using `parserOptions.project` for `typescript-eslint`, all linted files must be included in `tsconfig`'s `include` list, but `*` globs there exclude dotfiles (see https://github.com/microsoft/TypeScript/issues/49555 for related discussion regarding dotfiles).
3. Finally, make use of [`${configDir}` option](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#the-configdir-template-variable-for-configuration-files) to make typescript always look up those file paths relative to the configuration file, which is good practice to avoid any ambiguity when typescript resolves these paths.