### PR TITLE
Fix mirror bug

### DIFF
--- a/services/mirror/mirror_pull.go
+++ b/services/mirror/mirror_pull.go
@@ -126,7 +126,9 @@ func parseRemoteUpdateOutput(output, remoteName string) []*mirrorSyncResult {
 		case strings.HasPrefix(lines[i], " - "): // Delete reference
 			isTag := !strings.HasPrefix(refName, remoteName+"/")
 			var refFullName git.RefName
-			if isTag {
+			if strings.HasPrefix(refName, "refs/") {
+				refFullName = git.RefName(refName)
+			} else if isTag {
 				refFullName = git.RefNameFromTag(refName)
 			} else {
 				refFullName = git.RefNameFromBranch(strings.TrimPrefix(refName, remoteName+"/"))

--- a/services/mirror/mirror_pull.go
+++ b/services/mirror/mirror_pull.go
@@ -149,8 +149,15 @@ func parseRemoteUpdateOutput(output, remoteName string) []*mirrorSyncResult {
 				log.Error("Expect two SHAs but not what found: %q", lines[i])
 				continue
 			}
+			var refFullName git.RefName
+			if strings.HasPrefix(refName, "refs/") {
+				refFullName = git.RefName(refName)
+			} else {
+				refFullName = git.RefNameFromBranch(strings.TrimPrefix(refName, remoteName+"/"))
+			}
+
 			results = append(results, &mirrorSyncResult{
-				refName:     git.RefNameFromBranch(strings.TrimPrefix(refName, remoteName+"/")),
+				refName:     refFullName,
 				oldCommitID: shas[0],
 				newCommitID: shas[1],
 			})

--- a/services/mirror/mirror_test.go
+++ b/services/mirror/mirror_test.go
@@ -17,9 +17,13 @@ func Test_parseRemoteUpdateOutput(t *testing.T) {
  - [deleted]         (none)     -> tag1
  + f895a1e...957a993 test2      -> origin/test2  (forced update)
    957a993..a87ba5f  test3      -> origin/test3
+ * [new ref]               refs/pull/26595/head  -> refs/pull/26595/head
+ * [new ref]               refs/pull/26595/merge -> refs/pull/26595/merge
+   e0639e38fb..6db2410489  refs/pull/25873/head  -> refs/pull/25873/head
+ + 1c97ebc746...976d27d52f refs/pull/25873/merge -> refs/pull/25873/merge  (forced update)
 `
 	results := parseRemoteUpdateOutput(output, "origin")
-	assert.Len(t, results, 6)
+	assert.Len(t, results, 10)
 	assert.EqualValues(t, "refs/tags/v0.1.8", results[0].refName.String())
 	assert.EqualValues(t, gitShortEmptySha, results[0].oldCommitID)
 	assert.EqualValues(t, "", results[0].newCommitID)
@@ -43,4 +47,20 @@ func Test_parseRemoteUpdateOutput(t *testing.T) {
 	assert.EqualValues(t, "refs/heads/test3", results[5].refName.String())
 	assert.EqualValues(t, "957a993", results[5].oldCommitID)
 	assert.EqualValues(t, "a87ba5f", results[5].newCommitID)
+
+	assert.EqualValues(t, "refs/pull/26595/head", results[6].refName.String())
+	assert.EqualValues(t, gitShortEmptySha, results[6].oldCommitID)
+	assert.EqualValues(t, "", results[6].newCommitID)
+
+	assert.EqualValues(t, "refs/pull/26595/merge", results[7].refName.String())
+	assert.EqualValues(t, gitShortEmptySha, results[7].oldCommitID)
+	assert.EqualValues(t, "", results[7].newCommitID)
+
+	assert.EqualValues(t, "refs/pull/25873/head", results[8].refName.String())
+	assert.EqualValues(t, "e0639e38fb", results[8].oldCommitID)
+	assert.EqualValues(t, "6db2410489", results[8].newCommitID)
+
+	assert.EqualValues(t, "refs/pull/25873/merge", results[9].refName.String())
+	assert.EqualValues(t, "1c97ebc746", results[9].oldCommitID)
+	assert.EqualValues(t, "976d27d52f", results[9].newCommitID)
 }


### PR DESCRIPTION
follows-up be4e961240883778c44d9651eaaf9ab8723bbbb0

This is the same modification as https://github.com/go-gitea/gitea/commit/be4e961240883778c44d9651eaaf9ab8723bbbb0 but for force-pushes.
It is needed, because `git fetch` reveals force pushes for github mirrors:
```
$ git fetch --tags origin
remote: Enumerating objects: 22, done.
remote: Counting objects: 100% (22/22), done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 9 (delta 5), reused 8 (delta 5), pack-reused 0 (from 0)
Unpacking objects: 100% (9/9), 1.70 KiB | 12.00 KiB/s, done.
From https://github.com/conan-io/conan-center-index
   729f0f1b8f..48184eddeb  refs/pull/26595/head  -> refs/pull/26595/head
 + 0c31ab60a3...1283cca9e7 refs/pull/26595/merge -> refs/pull/26595/merge  (forced update)
```

Fix https://github.com/go-gitea/gitea/issues/33200

PS: I did not test the modification, but it is the exact same change as the last hunk in https://github.com/go-gitea/gitea/pull/33224/files#diff-bb5cdb90db0f0e7f6716c0e6d0b9cbb67f08d82052b03ab3a7b5e23a1d76aed7 , just moved to the previous case of the switch

I think it could and should be back-ported to 1.23