### PR TITLE
Fix typo in HTML attribute

### DIFF
--- a/web_src/js/components/DashboardRepoList.vue
+++ b/web_src/js/components/DashboardRepoList.vue
@@ -445,7 +445,7 @@ export default defineComponent({
               class="item navigation tw-py-1" :class="{'disabled': page === 1}"
               @click="changePage(page - 1)" :title="textPreviousPage"
             >
-              <svg-icon name="octicon-chevron-left" :size="16" clsas="tw-mr-1"/>
+              <svg-icon name="octicon-chevron-left" :size="16" class="tw-mr-1"/>
             </a>
             <a class="active item tw-py-1">{{ page }}</a>
             <a


### PR DESCRIPTION
No real impact but was still a bug:

<img width="392" alt="image" src="https://github.com/user-attachments/assets/51b8b168-8c0e-4ed0-9904-1323f445fa15" />