### PR TITLE
Adding Github Theme to Gitea and Setting It as the Default Theme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ FOMANTIC_WORK_DIR := web_src/fomantic
 
 WEBPACK_SOURCES := $(shell find web_src/js web_src/css -type f)
 WEBPACK_CONFIGS := webpack.config.js tailwind.config.js
-WEBPACK_DEST := public/assets/js/index.js public/assets/css/index.css
+WEBPACK_DEST := public/assets/js/index.js public/assets/css/index.css public/assets/css/theme-github.css
 WEBPACK_DEST_ENTRIES := public/assets/js public/assets/css public/assets/fonts
 
 BINDATA_DEST := modules/public/bindata.go modules/options/bindata.go modules/templates/bindata.go
@@ -866,6 +866,8 @@ $(WEBPACK_DEST): $(WEBPACK_SOURCES) $(WEBPACK_CONFIGS) package-lock.json
 	@rm -rf $(WEBPACK_DEST_ENTRIES)
 	@echo "Running webpack..."
 	@BROWSERSLIST_IGNORE_OLD_DATA=true npx webpack
+	@wget -c -O "public/assets/css/theme-github.css" \
+		"https://github.com/lutinglt/gitea-github-theme/releases/latest/download/theme-github.css"
 	@touch $(WEBPACK_DEST)
 
 .PHONY: svg

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1288,7 +1288,7 @@ LEVEL = Info
 ;SHOW_USER_EMAIL = true
 ;;
 ;; Set the default theme for the Gitea install
-;DEFAULT_THEME = gitea-auto
+;DEFAULT_THEME = github
 ;;
 ;; All available themes. Allow users select personalized themes regardless of the value of `DEFAULT_THEME`.
 ;; Leave it empty to allow users to select any theme from "{CustomPath}/public/assets/css/theme-*.css"

--- a/modules/setting/ui.go
+++ b/modules/setting/ui.go
@@ -83,7 +83,7 @@ var UI = struct {
 	CodeCommentLines:        4,
 	ReactionMaxUserNum:      10,
 	MaxDisplayFileSize:      8388608,
-	DefaultTheme:            `gitea-auto`,
+	DefaultTheme:            `github`,
 	Reactions:               []string{`+1`, `-1`, `laugh`, `hooray`, `confused`, `heart`, `rocket`, `eyes`},
 	CustomEmojis:            []string{`git`, `gitea`, `codeberg`, `gitlab`, `github`, `gogs`},
 	CustomEmojisMap:         map[string]string{"git": ":git:", "gitea": ":gitea:", "codeberg": ":codeberg:", "gitlab": ":gitlab:", "github": ":github:", "gogs": ":gogs:"},


### PR DESCRIPTION
**Presumptuous Attempt, Do Not Merge**

Include https://github.com/lutinglt/gitea-github-theme in Gitea and set it as default theme.


