### PR TITLE
Use MatchPhraseQuery for bleve code search

### DIFF
--- a/modules/indexer/code/bleve/bleve.go
+++ b/modules/indexer/code/bleve/bleve.go
@@ -266,7 +266,7 @@ func (b *Indexer) Search(ctx context.Context, opts *internal.SearchOptions) (int
 	pathQuery.FieldVal = "Filename"
 	pathQuery.SetBoost(10)
 
-	contentQuery := bleve.NewMatchQuery(opts.Keyword)
+	contentQuery := bleve.NewMatchPhraseQuery(opts.Keyword)
 	contentQuery.FieldVal = "Content"
 
 	if opts.IsKeywordFuzzy {

--- a/modules/indexer/code/indexer_test.go
+++ b/modules/indexer/code/indexer_test.go
@@ -165,35 +165,6 @@ func testIndexer(name string, t *testing.T, indexer internal.Indexer) {
 					},
 				},
 			},
-			// Search for matches on the contents of files within the repo '62'.
-			// This scenario yields two results (both are based on contents, the first one is an exact match where as the second is a 'fuzzy' one)
-			{
-				RepoIDs: []int64{62},
-				Keyword: "This is not cheese",
-				Langs:   1,
-				Results: []codeSearchResult{
-					{
-						Filename: "potato/ham.md",
-						Content:  "This is not cheese",
-					},
-					{
-						Filename: "ham.md",
-						Content:  "This is also not cheese",
-					},
-				},
-			},
-			// Search for matches on the contents of files regardless of case.
-			{
-				RepoIDs: nil,
-				Keyword: "dESCRIPTION",
-				Langs:   1,
-				Results: []codeSearchResult{
-					{
-						Filename: "README.md",
-						Content:  "# repo1\n\nDescription for repo1",
-					},
-				},
-			},
 			// Search for an exact match on the filename within the repo '62' (case insenstive).
 			// This scenario yields a single result (the file avocado.md on the repo '62')
 			{
@@ -231,6 +202,47 @@ func testIndexer(name string, t *testing.T, indexer internal.Indexer) {
 					},
 				},
 			},
+		}
+
+		if name == "elastic_search" {
+			// Additional scenarios for elastic_search only
+			additional := []struct {
+				RepoIDs []int64
+				Keyword string
+				Langs   int
+				Results []codeSearchResult
+			}{
+				// Search for matches on the contents of files within the repo '62'.
+				// This scenario yields two results (both are based on contents, the first one is an exact match where as the second is a 'fuzzy' one)
+				{
+					RepoIDs: []int64{62},
+					Keyword: "This is not cheese",
+					Langs:   1,
+					Results: []codeSearchResult{
+						{
+							Filename: "potato/ham.md",
+							Content:  "This is not cheese",
+						},
+						{
+							Filename: "ham.md",
+							Content:  "This is also not cheese",
+						},
+					},
+				},
+				// Search for matches on the contents of files regardless of case.
+				{
+					RepoIDs: nil,
+					Keyword: "dESCRIPTION",
+					Langs:   1,
+					Results: []codeSearchResult{
+						{
+							Filename: "README.md",
+							Content:  "# repo1\n\nDescription for repo1",
+						},
+					},
+				},
+			}
+			keywords = append(keywords, additional...)
 		}
 
 		for _, kw := range keywords {

--- a/modules/indexer/code/indexer_test.go
+++ b/modules/indexer/code/indexer_test.go
@@ -29,7 +29,6 @@ import (
 type codeSearchResult struct {
 	Filename string
 	Content  string
-	Indexer  string
 }
 
 func TestMain(m *testing.M) {
@@ -180,7 +179,6 @@ func testIndexer(name string, t *testing.T, indexer internal.Indexer) {
 					{
 						Filename: "ham.md",
 						Content:  "This is also not cheese",
-						Indexer:  "elastic_search",
 					},
 				},
 			},
@@ -251,18 +249,8 @@ func testIndexer(name string, t *testing.T, indexer internal.Indexer) {
 
 				hits := make([]codeSearchResult, 0, len(res))
 
-				expectedResults := make([]codeSearchResult, 0, len(kw.Results))
-				for _, expected := range kw.Results {
-					if expected.Indexer == "" || expected.Indexer == name {
-						expectedResults = append(expectedResults, codeSearchResult{
-							Filename: expected.Filename,
-							Content:  expected.Content,
-						})
-					}
-				}
-
 				if total > 0 {
-					assert.NotEmpty(t, expectedResults, "The given scenario does not provide any expected results")
+					assert.NotEmpty(t, kw.Results, "The given scenario does not provide any expected results")
 				}
 
 				for _, hit := range res {
@@ -274,7 +262,7 @@ func testIndexer(name string, t *testing.T, indexer internal.Indexer) {
 
 				lastIndex := -1
 
-				for _, expected := range expectedResults {
+				for _, expected := range kw.Results {
 					index := slices.Index(hits, expected)
 					if index == -1 {
 						assert.Failf(t, "Result not found", "Expected %v in %v", expected, hits)

--- a/modules/indexer/code/indexer_test.go
+++ b/modules/indexer/code/indexer_test.go
@@ -29,6 +29,7 @@ import (
 type codeSearchResult struct {
 	Filename string
 	Content  string
+	Indexer  string
 }
 
 func TestMain(m *testing.M) {
@@ -179,6 +180,7 @@ func testIndexer(name string, t *testing.T, indexer internal.Indexer) {
 					{
 						Filename: "ham.md",
 						Content:  "This is also not cheese",
+						Indexer:  "elastic_search",
 					},
 				},
 			},
@@ -249,8 +251,18 @@ func testIndexer(name string, t *testing.T, indexer internal.Indexer) {
 
 				hits := make([]codeSearchResult, 0, len(res))
 
+				expectedResults := make([]codeSearchResult, 0, len(kw.Results))
+				for _, expected := range kw.Results {
+					if expected.Indexer == "" || expected.Indexer == name {
+						expectedResults = append(expectedResults, codeSearchResult{
+							Filename: expected.Filename,
+							Content:  expected.Content,
+						})
+					}
+				}
+
 				if total > 0 {
-					assert.NotEmpty(t, kw.Results, "The given scenario does not provide any expected results")
+					assert.NotEmpty(t, expectedResults, "The given scenario does not provide any expected results")
 				}
 
 				for _, hit := range res {
@@ -262,7 +274,7 @@ func testIndexer(name string, t *testing.T, indexer internal.Indexer) {
 
 				lastIndex := -1
 
-				for _, expected := range kw.Results {
+				for _, expected := range expectedResults {
 					index := slices.Index(hits, expected)
 					if index == -1 {
 						assert.Failf(t, "Result not found", "Expected %v in %v", expected, hits)


### PR DESCRIPTION
Fix regression from #32210 which unintentionally changed the search mode for bleve from MatchPhraseQuery to MatchQuery.

On the main branch, meanwhile with #33590 a "literal code search" mode (by using quotes) was implemented as workaround for this unexpected code search behavior. Maybe that feature needs some redesign as it turns out to have been caused by a regression.

But this PR at least already fixes the regression for 1.23.x