### PR TITLE
GPG keys should show all emails

### DIFF
--- a/models/asymkey/gpg_key.go
+++ b/models/asymkey/gpg_key.go
@@ -163,13 +163,17 @@ func parseGPGKey(ctx context.Context, ownerID int64, e *openpgp.Entity, verified
 		if ident.Revoked(time.Now()) {
 			continue
 		}
-		email := strings.ToLower(strings.TrimSpace(ident.UserId.Email))
+		emailAddr := &user_model.EmailAddress{
+			Email:       ident.UserId.Email,
+			LowerEmail:  strings.ToLower(strings.TrimSpace(ident.UserId.Email)),
+			IsActivated: false,
+		}
 		for _, e := range userEmails {
-			if e.IsActivated && e.LowerEmail == email {
-				emails = append(emails, e)
-				break
+			if e.LowerEmail == emailAddr.LowerEmail {
+				emailAddr.IsActivated = true
 			}
 		}
+		emails = append(emails, emailAddr)
 	}
 
 	if !verified {

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -839,6 +839,7 @@ add_new_principal = Add Principal
 ssh_key_been_used = This SSH key has already been added to the server.
 ssh_key_name_used = An SSH key with same name already exists on your account.
 ssh_principal_been_used = This principal has already been added to the server.
+gpg_email_unverified = Unverified
 gpg_key_id_used = A public GPG key with same ID already exists.
 gpg_no_key_email_found = This GPG key does not match any activated email address associated with your account. It may still be added if you sign the provided token.
 gpg_key_matched_identities = Matched Identities:

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -839,6 +839,7 @@ add_new_principal = Add Principal
 ssh_key_been_used = This SSH key has already been added to the server.
 ssh_key_name_used = An SSH key with same name already exists on your account.
 ssh_principal_been_used = This principal has already been added to the server.
+gpg_email_addresses = Email addresses:
 gpg_email_unverified = Unverified
 gpg_key_id_used = A public GPG key with same ID already exists.
 gpg_no_key_email_found = This GPG key does not match any activated email address associated with your account. It may still be added if you sign the provided token.

--- a/templates/user/settings/keys_gpg.tmpl
+++ b/templates/user/settings/keys_gpg.tmpl
@@ -56,7 +56,7 @@
 						<span class="flex-text-block" data-tooltip-content="{{ctx.Locale.Tr "settings.gpg_key_verified_long"}}">{{svg "octicon-verified"}} <strong>{{ctx.Locale.Tr "settings.gpg_key_verified"}}</strong></span>
 					{{end}}
 					{{if .Emails}}
-						<span class="flex-text-block" data-tooltip-content="{{ctx.Locale.Tr "settings.gpg_key_matched_identities_long"}}">{{svg "octicon-mail"}} {{ctx.Locale.Tr "settings.gpg_key_matched_identities"}} {{range .Emails}}<strong>{{.Email}} </strong> {{if not .IsActivated}}<span class="ui label">{{ctx.Locale.Tr "settings.gpg_email_unverified"}}</span>{{end}}{{end}}</span>
+						<span class="flex-text-block" data-tooltip-content="{{ctx.Locale.Tr "settings.gpg_key_matched_identities_long"}}">{{svg "octicon-mail"}} {{ctx.Locale.Tr "settings.gpg_email_addresses"}} {{range .Emails}}<strong>{{.Email}} </strong> {{if not .IsActivated}}<span class="ui label">{{ctx.Locale.Tr "settings.gpg_email_unverified"}}</span>{{end}}{{end}}</span>
 					{{end}}
 					<div class="flex-item-body">
 						<b>{{ctx.Locale.Tr "settings.key_id"}}:</b> {{.PaddedKeyID}}

--- a/templates/user/settings/keys_gpg.tmpl
+++ b/templates/user/settings/keys_gpg.tmpl
@@ -56,7 +56,7 @@
 						<span class="flex-text-block" data-tooltip-content="{{ctx.Locale.Tr "settings.gpg_key_verified_long"}}">{{svg "octicon-verified"}} <strong>{{ctx.Locale.Tr "settings.gpg_key_verified"}}</strong></span>
 					{{end}}
 					{{if .Emails}}
-						<span class="flex-text-block" data-tooltip-content="{{ctx.Locale.Tr "settings.gpg_key_matched_identities_long"}}">{{svg "octicon-mail"}} {{ctx.Locale.Tr "settings.gpg_key_matched_identities"}} {{range .Emails}}<strong>{{.Email}} </strong>{{end}}</span>
+						<span class="flex-text-block" data-tooltip-content="{{ctx.Locale.Tr "settings.gpg_key_matched_identities_long"}}">{{svg "octicon-mail"}} {{ctx.Locale.Tr "settings.gpg_key_matched_identities"}} {{range .Emails}}<strong>{{.Email}} </strong> {{if not .IsActivated}}<span class="ui label">{{ctx.Locale.Tr "settings.gpg_email_unverified"}}</span>{{end}}{{end}}</span>
 					{{end}}
 					<div class="flex-item-body">
 						<b>{{ctx.Locale.Tr "settings.key_id"}}:</b> {{.PaddedKeyID}}


### PR DESCRIPTION
Fix #33212 
Before the change, the GPG key only displayed email addresses added to the user's profile. After the change, all addresses are displayed. Those addresses that are not in the user's profile have the suffix "Unverified" same as on Github