### PR TITLE
fix: add missing locale (#33641)

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1690,6 +1690,8 @@ issues.start_tracking_history = started working %s
 issues.tracker_auto_close = Timer will be stopped automatically when this issue gets closed
 issues.tracking_already_started = `You have already started time tracking on <a href="%s">another issue</a>!`
 issues.stop_tracking_history = worked for <b>%s</b> %s
+issues.stop_tracking = Stop Timer
+issues.cancel_tracking = Discard
 issues.cancel_tracking_history = `canceled time tracking %s`
 issues.del_time = Delete this time log
 issues.add_time_history = added spent time <b>%s</b> %s


### PR DESCRIPTION
Backport #33641

This removed in #23113 but still using in `head_navbar.tmpl`
