### PR TITLE
Fix OCI image.version annotation for releases to use full semver

### DIFF
--- a/.github/workflows/release-tag-version.yml
+++ b/.github/workflows/release-tag-version.yml
@@ -88,9 +88,9 @@ jobs:
           # 1.2
           # 1.2.3
           tags: |
+            type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{version}}
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -126,9 +126,9 @@ jobs:
           # 1.2
           # 1.2.3
           tags: |
+            type=semver,pattern={{version}}
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{version}}
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
This commit fixes the docker build workflow such that semver-tagged releases use the full semver for the OCI `org.opencontainers.image.version` annotation, instead of using the major version only.

This is done by changing the order of the tags that the `docker/metadata-action` action is told to generate. Since the tags that the action is told to generate are all of the same priority, the first in the list will be used to set the annotation.

There is no need to fix the other two docker build workflows, i.e., (i) the nightly releases and (ii) the rc-tagged releases. This is because (i) the nightly releases do not get tagged with a semver, so the issue does not exist, and (ii) rc-tagged releases only get built with one tag, so the issue of needing to set an order of how tags are generated is irrelevant.

Resolves go-gitea/gitea#33697.
