### PR TITLE
Enable `@typescript-eslint/no-use-before-define`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -336,7 +336,7 @@ module.exports = {
     '@typescript-eslint/no-unsafe-unary-minus': [2],
     '@typescript-eslint/no-unused-expressions': [0],
     '@typescript-eslint/no-unused-vars': [2, {vars: 'all', args: 'all', caughtErrors: 'all', ignoreRestSiblings: false, argsIgnorePattern: '^_', varsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_', destructuredArrayIgnorePattern: '^_'}],
-    '@typescript-eslint/no-use-before-define': [0],
+    '@typescript-eslint/no-use-before-define': [2, {functions: false, classes: true, variables: true, allowNamedExports: true, typedefs: false, enums: false, ignoreTypeReferences: true}],
     '@typescript-eslint/no-useless-constructor': [0],
     '@typescript-eslint/no-useless-empty-export': [0],
     '@typescript-eslint/no-wrapper-object-types': [2],
@@ -693,7 +693,7 @@ module.exports = {
     'no-unused-labels': [2],
     'no-unused-private-class-members': [2],
     'no-unused-vars': [0], // handled by @typescript-eslint/no-unused-vars
-    'no-use-before-define': [2, {functions: false, classes: true, variables: true, allowNamedExports: true}],
+    'no-use-before-define': [0], // handled by @typescript-eslint/no-use-before-define
     'no-use-extend-native/no-use-extend-native': [2],
     'no-useless-backreference': [2],
     'no-useless-call': [2],


### PR DESCRIPTION
The [rule](https://typescript-eslint.io/rules/no-use-before-define/) is a superset of the eslint base rule, and I tested it with https://github.com/go-gitea/gitea/pull/33514#discussion_r1969795271 where it does not raise an error for cyclic types.