### PR TITLE
Refactor initRepoBranchTagSelector to use new init framework

### DIFF
--- a/templates/repo/branch_dropdown.tmpl
+++ b/templates/repo/branch_dropdown.tmpl
@@ -14,7 +14,7 @@
 
 Search "repo/branch_dropdown" in the template directory to find all occurrences.
 */}}
-<div class="js-branch-tag-selector {{if .ContainerClasses}}{{.ContainerClasses}}{{end}}"
+<div class="js-branch-tag-selector data-global-init="initRepoBranchTagSelector" {{if .ContainerClasses}}{{.ContainerClasses}}{{end}}"
 	data-text-release-compare="{{ctx.Locale.Tr "repo.release.compare"}}"
 	data-text-branches="{{ctx.Locale.Tr "repo.branches"}}"
 	data-text-tags="{{ctx.Locale.Tr "repo.tags"}}"

--- a/templates/repo/branch_dropdown.tmpl
+++ b/templates/repo/branch_dropdown.tmpl
@@ -14,7 +14,8 @@
 
 Search "repo/branch_dropdown" in the template directory to find all occurrences.
 */}}
-<div class="js-branch-tag-selector data-global-init="initRepoBranchTagSelector" {{if .ContainerClasses}}{{.ContainerClasses}}{{end}}"
+<div class="{{if .ContainerClasses}}{{.ContainerClasses}}{{end}}"
+	data-global-init="initRepoBranchTagSelector"
 	data-text-release-compare="{{ctx.Locale.Tr "repo.release.compare"}}"
 	data-text-branches="{{ctx.Locale.Tr "repo.branches"}}"
 	data-text-tags="{{ctx.Locale.Tr "repo.tags"}}"

--- a/templates/repo/release/list.tmpl
+++ b/templates/repo/release/list.tmpl
@@ -21,6 +21,7 @@
 								{{$compareTarget = $release.Sha1}}
 							{{end}}
 							{{template "repo/branch_dropdown" dict
+								"ContainerClasses" "release-branch-tag-selector"
 								"Repository" $.Repository
 								"ShowTabTags" true
 								"DropdownFixedText" (ctx.Locale.Tr "repo.release.compare")

--- a/web_src/css/repo/release-tag.css
+++ b/web_src/css/repo/release-tag.css
@@ -45,7 +45,7 @@
     display: flex;
     align-items: center;
   }
-  #release-list .js-branch-tag-selector {
+  #release-list .release-branch-tag-selector {
     margin-left: auto;
   }
   #release-list .branch-selector-dropdown .menu { /* open menu to left */

--- a/web_src/js/features/repo-legacy.ts
+++ b/web_src/js/features/repo-legacy.ts
@@ -1,3 +1,4 @@
+import {registerGlobalInitFunc} from '../modules/observer.ts';
 import {
   initRepoCommentFormAndSidebar,
   initRepoIssueBranchSelect, initRepoIssueCodeCommentCancel, initRepoIssueCommentDelete,
@@ -20,10 +21,10 @@ import {initRepoNew} from './repo-new.ts';
 import {createApp} from 'vue';
 import RepoBranchTagSelector from '../components/RepoBranchTagSelector.vue';
 
-function initRepoBranchTagSelector(selector: string) {
-  for (const elRoot of document.querySelectorAll(selector)) {
-    createApp(RepoBranchTagSelector, {elRoot}).mount(elRoot);
-  }
+function initRepoBranchTagSelector() {
+  registerGlobalInitFunc('initRepoBranchTagSelector', async (el: HTMLInputElement) => {
+    createApp(RepoBranchTagSelector, {el}).mount(el);
+  });
 }
 
 export function initBranchSelectorTabs() {
@@ -42,7 +43,7 @@ export function initRepository() {
   const pageContent = document.querySelector('.page-content.repository');
   if (!pageContent) return;
 
-  initRepoBranchTagSelector('.js-branch-tag-selector');
+  initRepoBranchTagSelector();
   initRepoCommentFormAndSidebar();
 
   // Labels

--- a/web_src/js/features/repo-legacy.ts
+++ b/web_src/js/features/repo-legacy.ts
@@ -22,8 +22,8 @@ import {createApp} from 'vue';
 import RepoBranchTagSelector from '../components/RepoBranchTagSelector.vue';
 
 function initRepoBranchTagSelector() {
-  registerGlobalInitFunc('initRepoBranchTagSelector', async (el: HTMLInputElement) => {
-    createApp(RepoBranchTagSelector, {el}).mount(el);
+  registerGlobalInitFunc('initRepoBranchTagSelector', async (elRoot: HTMLInputElement) => {
+    createApp(RepoBranchTagSelector, {elRoot}).mount(elRoot);
   });
 }
 


### PR DESCRIPTION
Make "initRepoBranchTagSelector" to use new init framework and fix the abused "js-branch-tag-selector" styles