### PR TITLE
Adjust appearence of commit status webhook

### DIFF
--- a/services/webhook/general.go
+++ b/services/webhook/general.go
@@ -11,6 +11,7 @@ import (
 
 	user_model "code.gitea.io/gitea/models/user"
 	webhook_model "code.gitea.io/gitea/models/webhook"
+	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/setting"
 	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/util"
@@ -309,7 +310,7 @@ func getPackagePayloadInfo(p *api.PackagePayload, linkFormatter linkFormatter, w
 }
 
 func getStatusPayloadInfo(p *api.CommitStatusPayload, linkFormatter linkFormatter, withSender bool) (text string, color int) {
-	refLink := linkFormatter(p.TargetURL, fmt.Sprintf("%s [%s]", p.Context, p.SHA[:7]))
+	refLink := linkFormatter(p.TargetURL, fmt.Sprintf("%s [%s]", p.Context, base.ShortSha(p.SHA)))
 
 	text = fmt.Sprintf("Commit Status changed: %s - %s", refLink, p.Description)
 	color = greenColor

--- a/services/webhook/general.go
+++ b/services/webhook/general.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strings"
 
+	user_model "code.gitea.io/gitea/models/user"
 	webhook_model "code.gitea.io/gitea/models/webhook"
 	"code.gitea.io/gitea/modules/setting"
 	api "code.gitea.io/gitea/modules/structs"
@@ -308,12 +309,16 @@ func getPackagePayloadInfo(p *api.PackagePayload, linkFormatter linkFormatter, w
 }
 
 func getStatusPayloadInfo(p *api.CommitStatusPayload, linkFormatter linkFormatter, withSender bool) (text string, color int) {
-	refLink := linkFormatter(p.TargetURL, p.Context+"["+p.SHA+"]:"+p.Description)
+	refLink := linkFormatter(p.TargetURL, fmt.Sprintf("%s [%s]", p.Context, p.SHA[:7]))
 
-	text = fmt.Sprintf("Commit Status changed: %s", refLink)
+	text = fmt.Sprintf("Commit Status changed: %s - %s", refLink, p.Description)
 	color = greenColor
 	if withSender {
-		text += fmt.Sprintf(" by %s", linkFormatter(setting.AppURL+url.PathEscape(p.Sender.UserName), p.Sender.UserName))
+		if user_model.IsGiteaActionsUserName(p.Sender.UserName) {
+			text += fmt.Sprintf(" by %s", p.Sender.FullName)
+		} else {
+			text += fmt.Sprintf(" by %s", linkFormatter(setting.AppURL+url.PathEscape(p.Sender.UserName), p.Sender.UserName))
+		}
 	}
 
 	return text, color

--- a/services/webhook/matrix.go
+++ b/services/webhook/matrix.go
@@ -245,8 +245,8 @@ func (m matrixConvertor) Package(p *api.PackagePayload) (MatrixPayload, error) {
 }
 
 func (m matrixConvertor) Status(p *api.CommitStatusPayload) (MatrixPayload, error) {
-	refLink := htmlLinkFormatter(p.TargetURL, p.Context+"["+p.SHA+"]:"+p.Description)
-	text := fmt.Sprintf("Commit Status changed: %s", refLink)
+	refLink := htmlLinkFormatter(p.TargetURL, fmt.Sprintf("%s [%s]", p.Context, p.SHA[:7]))
+	text := fmt.Sprintf("Commit Status changed: %s - %s", refLink, p.Description)
 
 	return m.newPayload(text)
 }

--- a/services/webhook/matrix.go
+++ b/services/webhook/matrix.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	webhook_model "code.gitea.io/gitea/models/webhook"
+	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/json"
 	"code.gitea.io/gitea/modules/log"
@@ -245,7 +246,7 @@ func (m matrixConvertor) Package(p *api.PackagePayload) (MatrixPayload, error) {
 }
 
 func (m matrixConvertor) Status(p *api.CommitStatusPayload) (MatrixPayload, error) {
-	refLink := htmlLinkFormatter(p.TargetURL, fmt.Sprintf("%s [%s]", p.Context, p.SHA[:7]))
+	refLink := htmlLinkFormatter(p.TargetURL, fmt.Sprintf("%s [%s]", p.Context, base.ShortSha(p.SHA)))
 	text := fmt.Sprintf("Commit Status changed: %s - %s", refLink, p.Description)
 
 	return m.newPayload(text)


### PR DESCRIPTION
Some visual improvement for the commit status webhook message introduced by #33320 

- use short commit SHA as already done in e. g. commit webhook
- fix spacing, link text
- do not set user link for internal gitea-actions user

Before: 
![grafik](https://github.com/user-attachments/assets/9c460846-c350-444c-89b5-8a0d5e26cb86)

After:
![grafik](https://github.com/user-attachments/assets/05519cd8-6d8f-432b-bd9d-082de558a55a)
