### PR TITLE
remove context from mail struct

### DIFF
--- a/services/mailer/mail_comment.go
+++ b/services/mailer/mail_comment.go
@@ -25,9 +25,8 @@ func MailParticipantsComment(ctx context.Context, c *issues_model.Comment, opTyp
 	if c.Type == issues_model.CommentTypePullRequestPush {
 		content = ""
 	}
-	if err := mailIssueCommentToParticipants(
-		&mailCommentContext{
-			Context:    ctx,
+	if err := mailIssueCommentToParticipants(ctx,
+		&mailComment{
 			Issue:      issue,
 			Doer:       c.Poster,
 			ActionType: opType,
@@ -48,9 +47,8 @@ func MailMentionsComment(ctx context.Context, pr *issues_model.PullRequest, c *i
 
 	visited := make(container.Set[int64], len(mentions)+1)
 	visited.Add(c.Poster.ID)
-	if err = mailIssueCommentBatch(
-		&mailCommentContext{
-			Context:    ctx,
+	if err = mailIssueCommentBatch(ctx,
+		&mailComment{
 			Issue:      pr.Issue,
 			Doer:       c.Poster,
 			ActionType: activities_model.ActionCommentPull,

--- a/services/mailer/mail_issue.go
+++ b/services/mailer/mail_issue.go
@@ -24,15 +24,15 @@ const MailBatchSize = 100 // batch size used in mailIssueCommentBatch
 // This function sends two list of emails:
 // 1. Repository watchers (except for WIP pull requests) and users who are participated in comments.
 // 2. Users who are not in 1. but get mentioned in current issue/comment.
-func mailIssueCommentToParticipants(ctx *mailCommentContext, mentions []*user_model.User) error {
+func mailIssueCommentToParticipants(ctx context.Context, comment *mailComment, mentions []*user_model.User) error {
 	// Required by the mail composer; make sure to load these before calling the async function
-	if err := ctx.Issue.LoadRepo(ctx); err != nil {
+	if err := comment.Issue.LoadRepo(ctx); err != nil {
 		return fmt.Errorf("LoadRepo: %w", err)
 	}
-	if err := ctx.Issue.LoadPoster(ctx); err != nil {
+	if err := comment.Issue.LoadPoster(ctx); err != nil {
 		return fmt.Errorf("LoadPoster: %w", err)
 	}
-	if err := ctx.Issue.LoadPullRequest(ctx); err != nil {
+	if err := comment.Issue.LoadPullRequest(ctx); err != nil {
 		return fmt.Errorf("LoadPullRequest: %w", err)
 	}
 
@@ -40,35 +40,35 @@ func mailIssueCommentToParticipants(ctx *mailCommentContext, mentions []*user_mo
 	unfiltered := make([]int64, 1, 64)
 
 	// =========== Original poster ===========
-	unfiltered[0] = ctx.Issue.PosterID
+	unfiltered[0] = comment.Issue.PosterID
 
 	// =========== Assignees ===========
-	ids, err := issues_model.GetAssigneeIDsByIssue(ctx, ctx.Issue.ID)
+	ids, err := issues_model.GetAssigneeIDsByIssue(ctx, comment.Issue.ID)
 	if err != nil {
-		return fmt.Errorf("GetAssigneeIDsByIssue(%d): %w", ctx.Issue.ID, err)
+		return fmt.Errorf("GetAssigneeIDsByIssue(%d): %w", comment.Issue.ID, err)
 	}
 	unfiltered = append(unfiltered, ids...)
 
 	// =========== Participants (i.e. commenters, reviewers) ===========
-	ids, err = issues_model.GetParticipantsIDsByIssueID(ctx, ctx.Issue.ID)
+	ids, err = issues_model.GetParticipantsIDsByIssueID(ctx, comment.Issue.ID)
 	if err != nil {
-		return fmt.Errorf("GetParticipantsIDsByIssueID(%d): %w", ctx.Issue.ID, err)
+		return fmt.Errorf("GetParticipantsIDsByIssueID(%d): %w", comment.Issue.ID, err)
 	}
 	unfiltered = append(unfiltered, ids...)
 
 	// =========== Issue watchers ===========
-	ids, err = issues_model.GetIssueWatchersIDs(ctx, ctx.Issue.ID, true)
+	ids, err = issues_model.GetIssueWatchersIDs(ctx, comment.Issue.ID, true)
 	if err != nil {
-		return fmt.Errorf("GetIssueWatchersIDs(%d): %w", ctx.Issue.ID, err)
+		return fmt.Errorf("GetIssueWatchersIDs(%d): %w", comment.Issue.ID, err)
 	}
 	unfiltered = append(unfiltered, ids...)
 
 	// =========== Repo watchers ===========
 	// Make repo watchers last, since it's likely the list with the most users
-	if !(ctx.Issue.IsPull && ctx.Issue.PullRequest.IsWorkInProgress(ctx) && ctx.ActionType != activities_model.ActionCreatePullRequest) {
-		ids, err = repo_model.GetRepoWatchersIDs(ctx, ctx.Issue.RepoID)
+	if !(comment.Issue.IsPull && comment.Issue.PullRequest.IsWorkInProgress(ctx) && comment.ActionType != activities_model.ActionCreatePullRequest) {
+		ids, err = repo_model.GetRepoWatchersIDs(ctx, comment.Issue.RepoID)
 		if err != nil {
-			return fmt.Errorf("GetRepoWatchersIDs(%d): %w", ctx.Issue.RepoID, err)
+			return fmt.Errorf("GetRepoWatchersIDs(%d): %w", comment.Issue.RepoID, err)
 		}
 		unfiltered = append(ids, unfiltered...)
 	}
@@ -76,19 +76,19 @@ func mailIssueCommentToParticipants(ctx *mailCommentContext, mentions []*user_mo
 	visited := make(container.Set[int64], len(unfiltered)+len(mentions)+1)
 
 	// Avoid mailing the doer
-	if ctx.Doer.EmailNotificationsPreference != user_model.EmailNotificationsAndYourOwn && !ctx.ForceDoerNotification {
-		visited.Add(ctx.Doer.ID)
+	if comment.Doer.EmailNotificationsPreference != user_model.EmailNotificationsAndYourOwn && !comment.ForceDoerNotification {
+		visited.Add(comment.Doer.ID)
 	}
 
 	// =========== Mentions ===========
-	if err = mailIssueCommentBatch(ctx, mentions, visited, true); err != nil {
+	if err = mailIssueCommentBatch(ctx, comment, mentions, visited, true); err != nil {
 		return fmt.Errorf("mailIssueCommentBatch() mentions: %w", err)
 	}
 
 	// Avoid mailing explicit unwatched
-	ids, err = issues_model.GetIssueWatchersIDs(ctx, ctx.Issue.ID, false)
+	ids, err = issues_model.GetIssueWatchersIDs(ctx, comment.Issue.ID, false)
 	if err != nil {
-		return fmt.Errorf("GetIssueWatchersIDs(%d): %w", ctx.Issue.ID, err)
+		return fmt.Errorf("GetIssueWatchersIDs(%d): %w", comment.Issue.ID, err)
 	}
 	visited.AddMultiple(ids...)
 
@@ -96,16 +96,16 @@ func mailIssueCommentToParticipants(ctx *mailCommentContext, mentions []*user_mo
 	if err != nil {
 		return err
 	}
-	if err = mailIssueCommentBatch(ctx, unfilteredUsers, visited, false); err != nil {
+	if err = mailIssueCommentBatch(ctx, comment, unfilteredUsers, visited, false); err != nil {
 		return fmt.Errorf("mailIssueCommentBatch(): %w", err)
 	}
 
 	return nil
 }
 
-func mailIssueCommentBatch(ctx *mailCommentContext, users []*user_model.User, visited container.Set[int64], fromMention bool) error {
+func mailIssueCommentBatch(ctx context.Context, comment *mailComment, users []*user_model.User, visited container.Set[int64], fromMention bool) error {
 	checkUnit := unit.TypeIssues
-	if ctx.Issue.IsPull {
+	if comment.Issue.IsPull {
 		checkUnit = unit.TypePullRequests
 	}
 
@@ -129,7 +129,7 @@ func mailIssueCommentBatch(ctx *mailCommentContext, users []*user_model.User, vi
 		}
 
 		// test if this user is allowed to see the issue/pull
-		if !access_model.CheckRepoUnitUser(ctx, ctx.Issue.Repo, user, checkUnit) {
+		if !access_model.CheckRepoUnitUser(ctx, comment.Issue.Repo, user, checkUnit) {
 			continue
 		}
 
@@ -141,7 +141,7 @@ func mailIssueCommentBatch(ctx *mailCommentContext, users []*user_model.User, vi
 		// working backwards from the last (possibly) incomplete batch. If len(receivers) can be 0 this
 		// starting condition will need to be changed slightly
 		for i := ((len(receivers) - 1) / MailBatchSize) * MailBatchSize; i >= 0; i -= MailBatchSize {
-			msgs, err := composeIssueCommentMessages(ctx, lang, receivers[i:], fromMention, "issue comments")
+			msgs, err := composeIssueCommentMessages(ctx, comment, lang, receivers[i:], fromMention, "issue comments")
 			if err != nil {
 				return err
 			}
@@ -168,9 +168,8 @@ func MailParticipants(ctx context.Context, issue *issues_model.Issue, doer *user
 		content = ""
 	}
 	forceDoerNotification := opType == activities_model.ActionAutoMergePullRequest
-	if err := mailIssueCommentToParticipants(
-		&mailCommentContext{
-			Context:               ctx,
+	if err := mailIssueCommentToParticipants(ctx,
+		&mailComment{
 			Issue:                 issue,
 			Doer:                  doer,
 			ActionType:            opType,
@@ -205,8 +204,7 @@ func SendIssueAssignedMail(ctx context.Context, issue *issues_model.Issue, doer 
 	}
 
 	for lang, tos := range langMap {
-		msgs, err := composeIssueCommentMessages(&mailCommentContext{
-			Context:    ctx,
+		msgs, err := composeIssueCommentMessages(ctx, &mailComment{
 			Issue:      issue,
 			Doer:       doer,
 			ActionType: activities_model.ActionType(0),

--- a/services/mailer/mail_test.go
+++ b/services/mailer/mail_test.go
@@ -110,9 +110,8 @@ func TestComposeIssueComment(t *testing.T) {
 	bodyTemplates = template.Must(template.New("issue/comment").Parse(bodyTpl))
 
 	recipients := []*user_model.User{{Name: "Test", Email: "test@gitea.com"}, {Name: "Test2", Email: "test2@gitea.com"}}
-	msgs, err := composeIssueCommentMessages(&mailCommentContext{
-		Context: t.Context(),
-		Issue:   issue, Doer: doer, ActionType: activities_model.ActionCommentIssue,
+	msgs, err := composeIssueCommentMessages(t.Context(), &mailComment{
+		Issue: issue, Doer: doer, ActionType: activities_model.ActionCommentIssue,
 		Content: fmt.Sprintf("test @%s %s#%d body", doer.Name, issue.Repo.FullName(), issue.Index),
 		Comment: comment,
 	}, "en-US", recipients, false, "issue comment")
@@ -157,9 +156,8 @@ func TestComposeIssueMessage(t *testing.T) {
 	bodyTemplates = template.Must(template.New("issue/new").Parse(bodyTpl))
 
 	recipients := []*user_model.User{{Name: "Test", Email: "test@gitea.com"}, {Name: "Test2", Email: "test2@gitea.com"}}
-	msgs, err := composeIssueCommentMessages(&mailCommentContext{
-		Context: t.Context(),
-		Issue:   issue, Doer: doer, ActionType: activities_model.ActionCreateIssue,
+	msgs, err := composeIssueCommentMessages(t.Context(), &mailComment{
+		Issue: issue, Doer: doer, ActionType: activities_model.ActionCreateIssue,
 		Content: "test body",
 	}, "en-US", recipients, false, "issue create")
 	assert.NoError(t, err)
@@ -204,32 +202,28 @@ func TestTemplateSelection(t *testing.T) {
 		assert.Contains(t, wholemsg, expBody)
 	}
 
-	msg := testComposeIssueCommentMessage(t, &mailCommentContext{
-		Context: t.Context(),
-		Issue:   issue, Doer: doer, ActionType: activities_model.ActionCreateIssue,
+	msg := testComposeIssueCommentMessage(t, &mailComment{
+		Issue: issue, Doer: doer, ActionType: activities_model.ActionCreateIssue,
 		Content: "test body",
 	}, recipients, false, "TestTemplateSelection")
 	expect(t, msg, "issue/new/subject", "issue/new/body")
 
-	msg = testComposeIssueCommentMessage(t, &mailCommentContext{
-		Context: t.Context(),
-		Issue:   issue, Doer: doer, ActionType: activities_model.ActionCommentIssue,
+	msg = testComposeIssueCommentMessage(t, &mailComment{
+		Issue: issue, Doer: doer, ActionType: activities_model.ActionCommentIssue,
 		Content: "test body", Comment: comment,
 	}, recipients, false, "TestTemplateSelection")
 	expect(t, msg, "issue/default/subject", "issue/default/body")
 
 	pull := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{ID: 2, Repo: repo, Poster: doer})
 	comment = unittest.AssertExistsAndLoadBean(t, &issues_model.Comment{ID: 4, Issue: pull})
-	msg = testComposeIssueCommentMessage(t, &mailCommentContext{
-		Context: t.Context(),
-		Issue:   pull, Doer: doer, ActionType: activities_model.ActionCommentPull,
+	msg = testComposeIssueCommentMessage(t, &mailComment{
+		Issue: pull, Doer: doer, ActionType: activities_model.ActionCommentPull,
 		Content: "test body", Comment: comment,
 	}, recipients, false, "TestTemplateSelection")
 	expect(t, msg, "pull/comment/subject", "pull/comment/body")
 
-	msg = testComposeIssueCommentMessage(t, &mailCommentContext{
-		Context: t.Context(),
-		Issue:   issue, Doer: doer, ActionType: activities_model.ActionCloseIssue,
+	msg = testComposeIssueCommentMessage(t, &mailComment{
+		Issue: issue, Doer: doer, ActionType: activities_model.ActionCloseIssue,
 		Content: "test body", Comment: comment,
 	}, recipients, false, "TestTemplateSelection")
 	expect(t, msg, "Re: [user2/repo1] issue1 (#1)", "issue/close/body")
@@ -246,9 +240,8 @@ func TestTemplateServices(t *testing.T) {
 		bodyTemplates = template.Must(template.New("issue/default").Parse(tplBody))
 
 		recipients := []*user_model.User{{Name: "Test", Email: "test@gitea.com"}}
-		msg := testComposeIssueCommentMessage(t, &mailCommentContext{
-			Context: t.Context(),
-			Issue:   issue, Doer: doer, ActionType: actionType,
+		msg := testComposeIssueCommentMessage(t, &mailComment{
+			Issue: issue, Doer: doer, ActionType: actionType,
 			Content: "test body", Comment: comment,
 		}, recipients, fromMention, "TestTemplateServices")
 
@@ -280,8 +273,8 @@ func TestTemplateServices(t *testing.T) {
 		"//Re: //")
 }
 
-func testComposeIssueCommentMessage(t *testing.T, ctx *mailCommentContext, recipients []*user_model.User, fromMention bool, info string) *sender_service.Message {
-	msgs, err := composeIssueCommentMessages(ctx, "en-US", recipients, fromMention, info)
+func testComposeIssueCommentMessage(t *testing.T, ctx *mailComment, recipients []*user_model.User, fromMention bool, info string) *sender_service.Message {
+	msgs, err := composeIssueCommentMessages(t.Context(), ctx, "en-US", recipients, fromMention, info)
 	assert.NoError(t, err)
 	assert.Len(t, msgs, 1)
 	return msgs[0]
@@ -290,10 +283,10 @@ func testComposeIssueCommentMessage(t *testing.T, ctx *mailCommentContext, recip
 func TestGenerateAdditionalHeaders(t *testing.T) {
 	doer, _, issue, _ := prepareMailerTest(t)
 
-	ctx := &mailCommentContext{Context: t.Context(), Issue: issue, Doer: doer}
+	comment := &mailComment{Issue: issue, Doer: doer}
 	recipient := &user_model.User{Name: "test", Email: "test@gitea.com"}
 
-	headers := generateAdditionalHeaders(ctx, "dummy-reason", recipient)
+	headers := generateAdditionalHeaders(comment, "dummy-reason", recipient)
 
 	expected := map[string]string{
 		"List-ID":                   "user2/repo1 <repo1.user2.localhost>",
@@ -480,7 +473,7 @@ func TestFromDisplayName(t *testing.T) {
 
 func TestEmbedBase64Images(t *testing.T) {
 	user, repo, issue, att1, att2 := prepareMailerBase64Test(t)
-	ctx := &mailCommentContext{Context: t.Context(), Issue: issue, Doer: user}
+	// comment := &mailComment{Issue: issue, Doer: user}
 
 	imgExternalURL := "https://via.placeholder.com/10"
 	imgExternalImg := fmt.Sprintf(`<img src="%s"/>`, imgExternalURL)
@@ -509,8 +502,7 @@ func TestEmbedBase64Images(t *testing.T) {
 		require.NoError(t, issues_model.UpdateIssueCols(t.Context(), issue, "content"))
 
 		recipients := []*user_model.User{{Name: "Test", Email: "test@gitea.com"}}
-		msgs, err := composeIssueCommentMessages(&mailCommentContext{
-			Context:    t.Context(),
+		msgs, err := composeIssueCommentMessages(t.Context(), &mailComment{
 			Issue:      issue,
 			Doer:       user,
 			ActionType: activities_model.ActionCreateIssue,
@@ -526,7 +518,7 @@ func TestEmbedBase64Images(t *testing.T) {
 		mailBody := "<html><head></head><body><p>Test1</p>" + imgExternalImg + "<p>Test2</p>" + att1Img + "<p>Test3</p></body></html>"
 		expectedMailBody := "<html><head></head><body><p>Test1</p>" + imgExternalImg + "<p>Test2</p>" + att1ImgBase64 + "<p>Test3</p></body></html>"
 		b64embedder := newMailAttachmentBase64Embedder(user, repo, 1024)
-		resultMailBody, err := b64embedder.Base64InlineImages(ctx, template.HTML(mailBody))
+		resultMailBody, err := b64embedder.Base64InlineImages(t.Context(), template.HTML(mailBody))
 		require.NoError(t, err)
 		assert.Equal(t, expectedMailBody, string(resultMailBody))
 	})
@@ -534,13 +526,13 @@ func TestEmbedBase64Images(t *testing.T) {
 	t.Run("LimitedEmailBodySize", func(t *testing.T) {
 		mailBody := fmt.Sprintf("<html><head></head><body>%s%s</body></html>", att1Img, att2Img)
 		b64embedder := newMailAttachmentBase64Embedder(user, repo, 1024)
-		resultMailBody, err := b64embedder.Base64InlineImages(ctx, template.HTML(mailBody))
+		resultMailBody, err := b64embedder.Base64InlineImages(t.Context(), template.HTML(mailBody))
 		require.NoError(t, err)
 		expected := fmt.Sprintf("<html><head></head><body>%s%s</body></html>", att1ImgBase64, att2Img)
 		assert.Equal(t, expected, string(resultMailBody))
 
 		b64embedder = newMailAttachmentBase64Embedder(user, repo, 4096)
-		resultMailBody, err = b64embedder.Base64InlineImages(ctx, template.HTML(mailBody))
+		resultMailBody, err = b64embedder.Base64InlineImages(t.Context(), template.HTML(mailBody))
 		require.NoError(t, err)
 		expected = fmt.Sprintf("<html><head></head><body>%s%s</body></html>", att1ImgBase64, att2ImgBase64)
 		assert.Equal(t, expected, string(resultMailBody))


### PR DESCRIPTION
it can be passed by argument instead

---

~~pending adding some more tests to improve coverage~~ Done. Not the greatest but it's something.