### PR TITLE
Improve log format

### DIFF
--- a/models/db/engine_hook.go
+++ b/models/db/engine_hook.go
@@ -41,7 +41,7 @@ func (h *EngineHook) AfterProcess(c *contexts.ContextHook) error {
 		// 8 is the amount of skips passed to runtime.Caller, so that in the log the correct function
 		// is being displayed (the function that ultimately wants to execute the query in the code)
 		// instead of the function of the slow query hook being called.
-		h.Logger.Log(8, log.WARN, "[Slow SQL Query] %s %v - %v", c.SQL, c.Args, c.ExecuteTime)
+		h.Logger.Log(8, &log.Event{Level: log.WARN}, "[Slow SQL Query] %s %v - %v", c.SQL, c.Args, c.ExecuteTime)
 	}
 	return nil
 }

--- a/models/db/log.go
+++ b/models/db/log.go
@@ -29,7 +29,7 @@ const stackLevel = 8
 
 // Log a message with defined skip and at logging level
 func (l *XORMLogBridge) Log(skip int, level log.Level, format string, v ...any) {
-	l.logger.Log(skip+1, level, format, v...)
+	l.logger.Log(skip+1, &log.Event{Level: level}, format, v...)
 }
 
 // Debug show debug log

--- a/modules/log/logger.go
+++ b/modules/log/logger.go
@@ -24,7 +24,7 @@ package log
 
 // BaseLogger provides the basic logging functions
 type BaseLogger interface {
-	Log(skip int, level Level, format string, v ...any)
+	Log(skip int, event *Event, format string, v ...any)
 	GetLevel() Level
 }
 

--- a/modules/log/logger_global.go
+++ b/modules/log/logger_global.go
@@ -18,7 +18,7 @@ func GetLevel() Level {
 }
 
 func Log(skip int, level Level, format string, v ...any) {
-	GetLogger(DEFAULT).Log(skip+1, level, format, v...)
+	GetLogger(DEFAULT).Log(skip+1, &Event{Level: level}, format, v...)
 }
 
 func Trace(format string, v ...any) {

--- a/modules/log/manager_test.go
+++ b/modules/log/manager_test.go
@@ -37,6 +37,6 @@ func TestSharedWorker(t *testing.T) {
 
 	m.Close()
 
-	logs := w.(*dummyWriter).GetLogs()
+	logs := w.(*dummyWriter).FetchLogs()
 	assert.Equal(t, []string{"msg-1\n", "msg-2\n", "msg-3\n"}, logs)
 }

--- a/modules/log/misc.go
+++ b/modules/log/misc.go
@@ -19,8 +19,8 @@ func BaseLoggerToGeneralLogger(b BaseLogger) Logger {
 
 var _ Logger = (*baseToLogger)(nil)
 
-func (s *baseToLogger) Log(skip int, level Level, format string, v ...any) {
-	s.base.Log(skip+1, level, format, v...)
+func (s *baseToLogger) Log(skip int, event *Event, format string, v ...any) {
+	s.base.Log(skip+1, event, format, v...)
 }
 
 func (s *baseToLogger) GetLevel() Level {
@@ -32,27 +32,27 @@ func (s *baseToLogger) LevelEnabled(level Level) bool {
 }
 
 func (s *baseToLogger) Trace(format string, v ...any) {
-	s.base.Log(1, TRACE, format, v...)
+	s.base.Log(1, &Event{Level: TRACE}, format, v...)
 }
 
 func (s *baseToLogger) Debug(format string, v ...any) {
-	s.base.Log(1, DEBUG, format, v...)
+	s.base.Log(1, &Event{Level: DEBUG}, format, v...)
 }
 
 func (s *baseToLogger) Info(format string, v ...any) {
-	s.base.Log(1, INFO, format, v...)
+	s.base.Log(1, &Event{Level: INFO}, format, v...)
 }
 
 func (s *baseToLogger) Warn(format string, v ...any) {
-	s.base.Log(1, WARN, format, v...)
+	s.base.Log(1, &Event{Level: WARN}, format, v...)
 }
 
 func (s *baseToLogger) Error(format string, v ...any) {
-	s.base.Log(1, ERROR, format, v...)
+	s.base.Log(1, &Event{Level: ERROR}, format, v...)
 }
 
 func (s *baseToLogger) Critical(format string, v ...any) {
-	s.base.Log(1, CRITICAL, format, v...)
+	s.base.Log(1, &Event{Level: CRITICAL}, format, v...)
 }
 
 type PrintfLogger struct {

--- a/services/context/access_log.go
+++ b/services/context/access_log.go
@@ -92,7 +92,7 @@ func (lr *accessLogRecorder) record(start time.Time, respWriter ResponseWriter, 
 		log.Error("Could not execute access logger template: %v", err.Error())
 	}
 
-	lr.logger.Log(1, log.INFO, "%s", buf.String())
+	lr.logger.Log(1, &log.Event{Level: log.INFO}, "%s", buf.String())
 }
 
 func newAccessLogRecorder() *accessLogRecorder {

--- a/services/context/access_log_test.go
+++ b/services/context/access_log_test.go
@@ -20,7 +20,7 @@ type testAccessLoggerMock struct {
 	logs []string
 }
 
-func (t *testAccessLoggerMock) Log(skip int, level log.Level, format string, v ...any) {
+func (t *testAccessLoggerMock) Log(skip int, event *log.Event, format string, v ...any) {
 	t.logs = append(t.logs, fmt.Sprintf(format, v...))
 }
 

--- a/services/doctor/doctor.go
+++ b/services/doctor/doctor.go
@@ -48,7 +48,7 @@ type doctorCheckLogger struct {
 
 var _ log.BaseLogger = (*doctorCheckLogger)(nil)
 
-func (d *doctorCheckLogger) Log(skip int, level log.Level, format string, v ...any) {
+func (d *doctorCheckLogger) Log(skip int, event *log.Event, format string, v ...any) {
 	_, _ = fmt.Fprintf(os.Stdout, format+"\n", v...)
 }
 
@@ -62,11 +62,11 @@ type doctorCheckStepLogger struct {
 
 var _ log.BaseLogger = (*doctorCheckStepLogger)(nil)
 
-func (d *doctorCheckStepLogger) Log(skip int, level log.Level, format string, v ...any) {
-	levelChar := fmt.Sprintf("[%s]", strings.ToUpper(level.String()[0:1]))
+func (d *doctorCheckStepLogger) Log(skip int, event *log.Event, format string, v ...any) {
+	levelChar := fmt.Sprintf("[%s]", strings.ToUpper(event.Level.String()[0:1]))
 	var levelArg any = levelChar
 	if d.colorize {
-		levelArg = log.NewColoredValue(levelChar, level.ColorAttributes()...)
+		levelArg = log.NewColoredValue(levelChar, event.Level.ColorAttributes()...)
 	}
 	args := append([]any{levelArg}, v...)
 	_, _ = fmt.Fprintf(os.Stdout, " - %s "+format+"\n", args...)


### PR DESCRIPTION
Old:

```
2025/03/06 22:21:06 ...er/issues/indexer.go:76:func1() [I] PID 88713: Initializing Issue Indexer: bleve
2025/03/06 22:21:12 ...eb/routing/logger.go:102:func1() [I] router: completed GET / for [::1]:52693, 200 OK in 15.9ms @ web/home.go:32(web.Home)
```

New:

```
2025/03/06 22:20:20 .../indexer/issues/indexer.go:76:InitIssueIndexer.1() [I] PID 88595: Initializing Issue Indexer: bleve
2025/03/06 22:20:35 HTTPRequest [I] router: completed GET / for [::1]:52631, 200 OK in 7.5ms @ web/home.go:32(web.Home)
```

## :warning: BREAKING :warning:

Actually it isn't really breaking for most users.

If some users use some filters (regexp) to parse the log output, please make the filters work with the new log format.
