### PR TITLE
Decouple context from repository related structs

### DIFF
--- a/models/activities/action.go
+++ b/models/activities/action.go
@@ -529,8 +529,8 @@ func ActivityQueryCondition(ctx context.Context, opts GetFeedsOptions) (builder.
 	}
 
 	if opts.RequestedTeam != nil {
-		env := repo_model.AccessibleTeamReposEnv(ctx, organization.OrgFromUser(opts.RequestedUser), opts.RequestedTeam)
-		teamRepoIDs, err := env.RepoIDs(1, opts.RequestedUser.NumRepos)
+		env := repo_model.AccessibleTeamReposEnv(organization.OrgFromUser(opts.RequestedUser), opts.RequestedTeam)
+		teamRepoIDs, err := env.RepoIDs(ctx, 1, opts.RequestedUser.NumRepos)
 		if err != nil {
 			return nil, fmt.Errorf("GetTeamRepositories: %w", err)
 		}

--- a/models/organization/org_test.go
+++ b/models/organization/org_test.go
@@ -320,7 +320,7 @@ func TestAccessibleReposEnv_CountRepos(t *testing.T) {
 	testSuccess := func(userID, expectedCount int64) {
 		env, err := repo_model.AccessibleReposEnv(db.DefaultContext, org, userID)
 		assert.NoError(t, err)
-		count, err := env.CountRepos()
+		count, err := env.CountRepos(db.DefaultContext)
 		assert.NoError(t, err)
 		assert.EqualValues(t, expectedCount, count)
 	}
@@ -334,7 +334,7 @@ func TestAccessibleReposEnv_RepoIDs(t *testing.T) {
 	testSuccess := func(userID int64, expectedRepoIDs []int64) {
 		env, err := repo_model.AccessibleReposEnv(db.DefaultContext, org, userID)
 		assert.NoError(t, err)
-		repoIDs, err := env.RepoIDs(1, 100)
+		repoIDs, err := env.RepoIDs(db.DefaultContext, 1, 100)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedRepoIDs, repoIDs)
 	}
@@ -348,7 +348,7 @@ func TestAccessibleReposEnv_Repos(t *testing.T) {
 	testSuccess := func(userID int64, expectedRepoIDs []int64) {
 		env, err := repo_model.AccessibleReposEnv(db.DefaultContext, org, userID)
 		assert.NoError(t, err)
-		repos, err := env.Repos(1, 100)
+		repos, err := env.Repos(db.DefaultContext, 1, 100)
 		assert.NoError(t, err)
 		expectedRepos := make(repo_model.RepositoryList, len(expectedRepoIDs))
 		for i, repoID := range expectedRepoIDs {
@@ -367,7 +367,7 @@ func TestAccessibleReposEnv_MirrorRepos(t *testing.T) {
 	testSuccess := func(userID int64, expectedRepoIDs []int64) {
 		env, err := repo_model.AccessibleReposEnv(db.DefaultContext, org, userID)
 		assert.NoError(t, err)
-		repos, err := env.MirrorRepos()
+		repos, err := env.MirrorRepos(db.DefaultContext)
 		assert.NoError(t, err)
 		expectedRepos := make(repo_model.RepositoryList, len(expectedRepoIDs))
 		for i, repoID := range expectedRepoIDs {

--- a/models/repo/org_repo.go
+++ b/models/repo/org_repo.go
@@ -47,10 +47,10 @@ func GetTeamRepositories(ctx context.Context, opts *SearchTeamRepoOptions) (Repo
 // AccessibleReposEnvironment operations involving the repositories that are
 // accessible to a particular user
 type AccessibleReposEnvironment interface {
-	CountRepos() (int64, error)
-	RepoIDs(page, pageSize int) ([]int64, error)
-	Repos(page, pageSize int) (RepositoryList, error)
-	MirrorRepos() (RepositoryList, error)
+	CountRepos(ctx context.Context) (int64, error)
+	RepoIDs(ctx context.Context, page, pageSize int) ([]int64, error)
+	Repos(ctx context.Context, page, pageSize int) (RepositoryList, error)
+	MirrorRepos(ctx context.Context) (RepositoryList, error)
 	AddKeyword(keyword string)
 	SetSort(db.SearchOrderBy)
 }
@@ -60,7 +60,6 @@ type accessibleReposEnv struct {
 	user    *user_model.User
 	team    *org_model.Team
 	teamIDs []int64
-	ctx     context.Context
 	keyword string
 	orderBy db.SearchOrderBy
 }
@@ -86,18 +85,16 @@ func AccessibleReposEnv(ctx context.Context, org *org_model.Organization, userID
 		org:     org,
 		user:    user,
 		teamIDs: teamIDs,
-		ctx:     ctx,
 		orderBy: db.SearchOrderByRecentUpdated,
 	}, nil
 }
 
 // AccessibleTeamReposEnv an AccessibleReposEnvironment for the repositories in `org`
 // that are accessible to the specified team.
-func AccessibleTeamReposEnv(ctx context.Context, org *org_model.Organization, team *org_model.Team) AccessibleReposEnvironment {
+func AccessibleTeamReposEnv(org *org_model.Organization, team *org_model.Team) AccessibleReposEnvironment {
 	return &accessibleReposEnv{
 		org:     org,
 		team:    team,
-		ctx:     ctx,
 		orderBy: db.SearchOrderByRecentUpdated,
 	}
 }
@@ -123,8 +120,8 @@ func (env *accessibleReposEnv) cond() builder.Cond {
 	return cond
 }
 
-func (env *accessibleReposEnv) CountRepos() (int64, error) {
-	repoCount, err := db.GetEngine(env.ctx).
+func (env *accessibleReposEnv) CountRepos(ctx context.Context) (int64, error) {
+	repoCount, err := db.GetEngine(ctx).
 		Join("INNER", "team_repo", "`team_repo`.repo_id=`repository`.id").
 		Where(env.cond()).
 		Distinct("`repository`.id").
@@ -135,13 +132,13 @@ func (env *accessibleReposEnv) CountRepos() (int64, error) {
 	return repoCount, nil
 }
 
-func (env *accessibleReposEnv) RepoIDs(page, pageSize int) ([]int64, error) {
+func (env *accessibleReposEnv) RepoIDs(ctx context.Context, page, pageSize int) ([]int64, error) {
 	if page <= 0 {
 		page = 1
 	}
 
 	repoIDs := make([]int64, 0, pageSize)
-	return repoIDs, db.GetEngine(env.ctx).
+	return repoIDs, db.GetEngine(ctx).
 		Table("repository").
 		Join("INNER", "team_repo", "`team_repo`.repo_id=`repository`.id").
 		Where(env.cond()).
@@ -152,8 +149,8 @@ func (env *accessibleReposEnv) RepoIDs(page, pageSize int) ([]int64, error) {
 		Find(&repoIDs)
 }
 
-func (env *accessibleReposEnv) Repos(page, pageSize int) (RepositoryList, error) {
-	repoIDs, err := env.RepoIDs(page, pageSize)
+func (env *accessibleReposEnv) Repos(ctx context.Context, page, pageSize int) (RepositoryList, error) {
+	repoIDs, err := env.RepoIDs(ctx, page, pageSize)
 	if err != nil {
 		return nil, fmt.Errorf("GetUserRepositoryIDs: %w", err)
 	}
@@ -163,15 +160,15 @@ func (env *accessibleReposEnv) Repos(page, pageSize int) (RepositoryList, error)
 		return repos, nil
 	}
 
-	return repos, db.GetEngine(env.ctx).
+	return repos, db.GetEngine(ctx).
 		In("`repository`.id", repoIDs).
 		OrderBy(string(env.orderBy)).
 		Find(&repos)
 }
 
-func (env *accessibleReposEnv) MirrorRepoIDs() ([]int64, error) {
+func (env *accessibleReposEnv) MirrorRepoIDs(ctx context.Context) ([]int64, error) {
 	repoIDs := make([]int64, 0, 10)
-	return repoIDs, db.GetEngine(env.ctx).
+	return repoIDs, db.GetEngine(ctx).
 		Table("repository").
 		Join("INNER", "team_repo", "`team_repo`.repo_id=`repository`.id AND `repository`.is_mirror=?", true).
 		Where(env.cond()).
@@ -181,8 +178,8 @@ func (env *accessibleReposEnv) MirrorRepoIDs() ([]int64, error) {
 		Find(&repoIDs)
 }
 
-func (env *accessibleReposEnv) MirrorRepos() (RepositoryList, error) {
-	repoIDs, err := env.MirrorRepoIDs()
+func (env *accessibleReposEnv) MirrorRepos(ctx context.Context) (RepositoryList, error) {
+	repoIDs, err := env.MirrorRepoIDs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("MirrorRepoIDs: %w", err)
 	}
@@ -192,7 +189,7 @@ func (env *accessibleReposEnv) MirrorRepos() (RepositoryList, error) {
 		return repos, nil
 	}
 
-	return repos, db.GetEngine(env.ctx).
+	return repos, db.GetEngine(ctx).
 		In("`repository`.id", repoIDs).
 		Find(&repos)
 }

--- a/services/org/user.go
+++ b/services/org/user.go
@@ -64,7 +64,7 @@ func RemoveOrgUser(ctx context.Context, org *organization.Organization, user *us
 	if err != nil {
 		return fmt.Errorf("AccessibleReposEnv: %w", err)
 	}
-	repoIDs, err := env.RepoIDs(1, org.NumRepos)
+	repoIDs, err := env.RepoIDs(ctx, 1, org.NumRepos)
 	if err != nil {
 		return fmt.Errorf("GetUserRepositories [%d]: %w", user.ID, err)
 	}

--- a/services/repository/files/cherry_pick.go
+++ b/services/repository/files/cherry_pick.go
@@ -39,18 +39,18 @@ func CherryPick(ctx context.Context, repo *repo_model.Repository, doer *user_mod
 	}
 	message := strings.TrimSpace(opts.Message)
 
-	t, err := NewTemporaryUploadRepository(ctx, repo)
+	t, err := NewTemporaryUploadRepository(repo)
 	if err != nil {
 		log.Error("NewTemporaryUploadRepository failed: %v", err)
 	}
 	defer t.Close()
-	if err := t.Clone(opts.OldBranch, false); err != nil {
+	if err := t.Clone(ctx, opts.OldBranch, false); err != nil {
 		return nil, err
 	}
-	if err := t.SetDefaultIndex(); err != nil {
+	if err := t.SetDefaultIndex(t.gitRepo.Ctx); err != nil {
 		return nil, err
 	}
-	if err := t.RefreshIndex(); err != nil {
+	if err := t.RefreshIndex(ctx); err != nil {
 		return nil, err
 	}
 
@@ -103,7 +103,7 @@ func CherryPick(ctx context.Context, repo *repo_model.Repository, doer *user_mod
 		return nil, fmt.Errorf("failed to merge due to conflicts")
 	}
 
-	treeHash, err := t.WriteTree()
+	treeHash, err := t.WriteTree(ctx)
 	if err != nil {
 		// likely non-sensical tree due to merge conflicts...
 		return nil, err
@@ -124,13 +124,13 @@ func CherryPick(ctx context.Context, repo *repo_model.Repository, doer *user_mod
 	if opts.Dates != nil {
 		commitOpts.AuthorTime, commitOpts.CommitterTime = &opts.Dates.Author, &opts.Dates.Committer
 	}
-	commitHash, err := t.CommitTree(commitOpts)
+	commitHash, err := t.CommitTree(ctx, commitOpts)
 	if err != nil {
 		return nil, err
 	}
 
 	// Then push this tree to NewBranch
-	if err := t.Push(doer, commitHash, opts.NewBranch); err != nil {
+	if err := t.Push(ctx, doer, commitHash, opts.NewBranch); err != nil {
 		return nil, err
 	}
 

--- a/services/repository/files/cherry_pick.go
+++ b/services/repository/files/cherry_pick.go
@@ -47,7 +47,7 @@ func CherryPick(ctx context.Context, repo *repo_model.Repository, doer *user_mod
 	if err := t.Clone(ctx, opts.OldBranch, false); err != nil {
 		return nil, err
 	}
-	if err := t.SetDefaultIndex(t.gitRepo.Ctx); err != nil {
+	if err := t.SetDefaultIndex(ctx); err != nil {
 		return nil, err
 	}
 	if err := t.RefreshIndex(ctx); err != nil {

--- a/services/repository/files/diff.go
+++ b/services/repository/files/diff.go
@@ -16,27 +16,27 @@ func GetDiffPreview(ctx context.Context, repo *repo_model.Repository, branch, tr
 	if branch == "" {
 		branch = repo.DefaultBranch
 	}
-	t, err := NewTemporaryUploadRepository(ctx, repo)
+	t, err := NewTemporaryUploadRepository(repo)
 	if err != nil {
 		return nil, err
 	}
 	defer t.Close()
-	if err := t.Clone(branch, true); err != nil {
+	if err := t.Clone(ctx, branch, true); err != nil {
 		return nil, err
 	}
-	if err := t.SetDefaultIndex(); err != nil {
+	if err := t.SetDefaultIndex(ctx); err != nil {
 		return nil, err
 	}
 
 	// Add the object to the database
-	objectHash, err := t.HashObject(strings.NewReader(content))
+	objectHash, err := t.HashObject(ctx, strings.NewReader(content))
 	if err != nil {
 		return nil, err
 	}
 
 	// Add the object to the index
-	if err := t.AddObjectToIndex("100644", objectHash, treePath); err != nil {
+	if err := t.AddObjectToIndex(ctx, "100644", objectHash, treePath); err != nil {
 		return nil, err
 	}
-	return t.DiffIndex()
+	return t.DiffIndex(ctx)
 }

--- a/services/repository/files/temp_repo.go
+++ b/services/repository/files/temp_repo.go
@@ -26,19 +26,18 @@ import (
 
 // TemporaryUploadRepository is a type to wrap our upload repositories as a shallow clone
 type TemporaryUploadRepository struct {
-	ctx      context.Context
 	repo     *repo_model.Repository
 	gitRepo  *git.Repository
 	basePath string
 }
 
 // NewTemporaryUploadRepository creates a new temporary upload repository
-func NewTemporaryUploadRepository(ctx context.Context, repo *repo_model.Repository) (*TemporaryUploadRepository, error) {
+func NewTemporaryUploadRepository(repo *repo_model.Repository) (*TemporaryUploadRepository, error) {
 	basePath, err := repo_module.CreateTemporaryPath("upload")
 	if err != nil {
 		return nil, err
 	}
-	t := &TemporaryUploadRepository{ctx: ctx, repo: repo, basePath: basePath}
+	t := &TemporaryUploadRepository{repo: repo, basePath: basePath}
 	return t, nil
 }
 
@@ -51,13 +50,13 @@ func (t *TemporaryUploadRepository) Close() {
 }
 
 // Clone the base repository to our path and set branch as the HEAD
-func (t *TemporaryUploadRepository) Clone(branch string, bare bool) error {
+func (t *TemporaryUploadRepository) Clone(ctx context.Context, branch string, bare bool) error {
 	cmd := git.NewCommand("clone", "-s", "-b").AddDynamicArguments(branch, t.repo.RepoPath(), t.basePath)
 	if bare {
 		cmd.AddArguments("--bare")
 	}
 
-	if _, _, err := cmd.RunStdString(t.ctx, nil); err != nil {
+	if _, _, err := cmd.RunStdString(ctx, nil); err != nil {
 		stderr := err.Error()
 		if matched, _ := regexp.MatchString(".*Remote branch .* not found in upstream origin.*", stderr); matched {
 			return git.ErrBranchNotExist{
@@ -73,7 +72,7 @@ func (t *TemporaryUploadRepository) Clone(branch string, bare bool) error {
 		}
 		return fmt.Errorf("Clone: %w %s", err, stderr)
 	}
-	gitRepo, err := git.OpenRepository(t.ctx, t.basePath)
+	gitRepo, err := git.OpenRepository(ctx, t.basePath)
 	if err != nil {
 		return err
 	}
@@ -82,11 +81,11 @@ func (t *TemporaryUploadRepository) Clone(branch string, bare bool) error {
 }
 
 // Init the repository
-func (t *TemporaryUploadRepository) Init(objectFormatName string) error {
-	if err := git.InitRepository(t.ctx, t.basePath, false, objectFormatName); err != nil {
+func (t *TemporaryUploadRepository) Init(ctx context.Context, objectFormatName string) error {
+	if err := git.InitRepository(ctx, t.basePath, false, objectFormatName); err != nil {
 		return err
 	}
-	gitRepo, err := git.OpenRepository(t.ctx, t.basePath)
+	gitRepo, err := git.OpenRepository(ctx, t.basePath)
 	if err != nil {
 		return err
 	}
@@ -95,28 +94,28 @@ func (t *TemporaryUploadRepository) Init(objectFormatName string) error {
 }
 
 // SetDefaultIndex sets the git index to our HEAD
-func (t *TemporaryUploadRepository) SetDefaultIndex() error {
-	if _, _, err := git.NewCommand("read-tree", "HEAD").RunStdString(t.ctx, &git.RunOpts{Dir: t.basePath}); err != nil {
+func (t *TemporaryUploadRepository) SetDefaultIndex(ctx context.Context) error {
+	if _, _, err := git.NewCommand("read-tree", "HEAD").RunStdString(ctx, &git.RunOpts{Dir: t.basePath}); err != nil {
 		return fmt.Errorf("SetDefaultIndex: %w", err)
 	}
 	return nil
 }
 
 // RefreshIndex looks at the current index and checks to see if merges or updates are needed by checking stat() information.
-func (t *TemporaryUploadRepository) RefreshIndex() error {
-	if _, _, err := git.NewCommand("update-index", "--refresh").RunStdString(t.ctx, &git.RunOpts{Dir: t.basePath}); err != nil {
+func (t *TemporaryUploadRepository) RefreshIndex(ctx context.Context) error {
+	if _, _, err := git.NewCommand("update-index", "--refresh").RunStdString(ctx, &git.RunOpts{Dir: t.basePath}); err != nil {
 		return fmt.Errorf("RefreshIndex: %w", err)
 	}
 	return nil
 }
 
 // LsFiles checks if the given filename arguments are in the index
-func (t *TemporaryUploadRepository) LsFiles(filenames ...string) ([]string, error) {
+func (t *TemporaryUploadRepository) LsFiles(ctx context.Context, filenames ...string) ([]string, error) {
 	stdOut := new(bytes.Buffer)
 	stdErr := new(bytes.Buffer)
 
 	if err := git.NewCommand("ls-files", "-z").AddDashesAndList(filenames...).
-		Run(t.ctx, &git.RunOpts{
+		Run(ctx, &git.RunOpts{
 			Dir:    t.basePath,
 			Stdout: stdOut,
 			Stderr: stdErr,
@@ -135,7 +134,7 @@ func (t *TemporaryUploadRepository) LsFiles(filenames ...string) ([]string, erro
 }
 
 // RemoveFilesFromIndex removes the given files from the index
-func (t *TemporaryUploadRepository) RemoveFilesFromIndex(filenames ...string) error {
+func (t *TemporaryUploadRepository) RemoveFilesFromIndex(ctx context.Context, filenames ...string) error {
 	objFmt, err := t.gitRepo.GetObjectFormat()
 	if err != nil {
 		return fmt.Errorf("unable to get object format for temporary repo: %q, error: %w", t.repo.FullName(), err)
@@ -152,7 +151,7 @@ func (t *TemporaryUploadRepository) RemoveFilesFromIndex(filenames ...string) er
 	}
 
 	if err := git.NewCommand("update-index", "--remove", "-z", "--index-info").
-		Run(t.ctx, &git.RunOpts{
+		Run(ctx, &git.RunOpts{
 			Dir:    t.basePath,
 			Stdin:  stdIn,
 			Stdout: stdOut,
@@ -164,12 +163,12 @@ func (t *TemporaryUploadRepository) RemoveFilesFromIndex(filenames ...string) er
 }
 
 // HashObject writes the provided content to the object db and returns its hash
-func (t *TemporaryUploadRepository) HashObject(content io.Reader) (string, error) {
+func (t *TemporaryUploadRepository) HashObject(ctx context.Context, content io.Reader) (string, error) {
 	stdOut := new(bytes.Buffer)
 	stdErr := new(bytes.Buffer)
 
 	if err := git.NewCommand("hash-object", "-w", "--stdin").
-		Run(t.ctx, &git.RunOpts{
+		Run(ctx, &git.RunOpts{
 			Dir:    t.basePath,
 			Stdin:  content,
 			Stdout: stdOut,
@@ -183,8 +182,8 @@ func (t *TemporaryUploadRepository) HashObject(content io.Reader) (string, error
 }
 
 // AddObjectToIndex adds the provided object hash to the index with the provided mode and path
-func (t *TemporaryUploadRepository) AddObjectToIndex(mode, objectHash, objectPath string) error {
-	if _, _, err := git.NewCommand("update-index", "--add", "--replace", "--cacheinfo").AddDynamicArguments(mode, objectHash, objectPath).RunStdString(t.ctx, &git.RunOpts{Dir: t.basePath}); err != nil {
+func (t *TemporaryUploadRepository) AddObjectToIndex(ctx context.Context, mode, objectHash, objectPath string) error {
+	if _, _, err := git.NewCommand("update-index", "--add", "--replace", "--cacheinfo").AddDynamicArguments(mode, objectHash, objectPath).RunStdString(ctx, &git.RunOpts{Dir: t.basePath}); err != nil {
 		stderr := err.Error()
 		if matched, _ := regexp.MatchString(".*Invalid path '.*", stderr); matched {
 			return ErrFilePathInvalid{
@@ -199,8 +198,8 @@ func (t *TemporaryUploadRepository) AddObjectToIndex(mode, objectHash, objectPat
 }
 
 // WriteTree writes the current index as a tree to the object db and returns its hash
-func (t *TemporaryUploadRepository) WriteTree() (string, error) {
-	stdout, _, err := git.NewCommand("write-tree").RunStdString(t.ctx, &git.RunOpts{Dir: t.basePath})
+func (t *TemporaryUploadRepository) WriteTree(ctx context.Context) (string, error) {
+	stdout, _, err := git.NewCommand("write-tree").RunStdString(ctx, &git.RunOpts{Dir: t.basePath})
 	if err != nil {
 		log.Error("Unable to write tree in temporary repo: %s(%s): Error: %v", t.repo.FullName(), t.basePath, err)
 		return "", fmt.Errorf("Unable to write-tree in temporary repo for: %s Error: %w", t.repo.FullName(), err)
@@ -209,16 +208,16 @@ func (t *TemporaryUploadRepository) WriteTree() (string, error) {
 }
 
 // GetLastCommit gets the last commit ID SHA of the repo
-func (t *TemporaryUploadRepository) GetLastCommit() (string, error) {
-	return t.GetLastCommitByRef("HEAD")
+func (t *TemporaryUploadRepository) GetLastCommit(ctx context.Context) (string, error) {
+	return t.GetLastCommitByRef(ctx, "HEAD")
 }
 
 // GetLastCommitByRef gets the last commit ID SHA of the repo by ref
-func (t *TemporaryUploadRepository) GetLastCommitByRef(ref string) (string, error) {
+func (t *TemporaryUploadRepository) GetLastCommitByRef(ctx context.Context, ref string) (string, error) {
 	if ref == "" {
 		ref = "HEAD"
 	}
-	stdout, _, err := git.NewCommand("rev-parse").AddDynamicArguments(ref).RunStdString(t.ctx, &git.RunOpts{Dir: t.basePath})
+	stdout, _, err := git.NewCommand("rev-parse").AddDynamicArguments(ref).RunStdString(ctx, &git.RunOpts{Dir: t.basePath})
 	if err != nil {
 		log.Error("Unable to get last ref for %s in temporary repo: %s(%s): Error: %v", ref, t.repo.FullName(), t.basePath, err)
 		return "", fmt.Errorf("Unable to rev-parse %s in temporary repo for: %s Error: %w", ref, t.repo.FullName(), err)
@@ -259,7 +258,7 @@ func makeGitUserSignature(doer *user_model.User, identity, other *IdentityOption
 }
 
 // CommitTree creates a commit from a given tree for the user with provided message
-func (t *TemporaryUploadRepository) CommitTree(opts *CommitTreeUserOptions) (string, error) {
+func (t *TemporaryUploadRepository) CommitTree(ctx context.Context, opts *CommitTreeUserOptions) (string, error) {
 	authorSig := makeGitUserSignature(opts.DoerUser, opts.AuthorIdentity, opts.CommitterIdentity)
 	committerSig := makeGitUserSignature(opts.DoerUser, opts.CommitterIdentity, opts.AuthorIdentity)
 
@@ -295,9 +294,9 @@ func (t *TemporaryUploadRepository) CommitTree(opts *CommitTreeUserOptions) (str
 	var keyID string
 	var signer *git.Signature
 	if opts.ParentCommitID != "" {
-		sign, keyID, signer, _ = asymkey_service.SignCRUDAction(t.ctx, t.repo.RepoPath(), opts.DoerUser, t.basePath, opts.ParentCommitID)
+		sign, keyID, signer, _ = asymkey_service.SignCRUDAction(ctx, t.repo.RepoPath(), opts.DoerUser, t.basePath, opts.ParentCommitID)
 	} else {
-		sign, keyID, signer, _ = asymkey_service.SignInitialCommit(t.ctx, t.repo.RepoPath(), opts.DoerUser)
+		sign, keyID, signer, _ = asymkey_service.SignInitialCommit(ctx, t.repo.RepoPath(), opts.DoerUser)
 	}
 	if sign {
 		cmdCommitTree.AddOptionFormat("-S%s", keyID)
@@ -333,7 +332,7 @@ func (t *TemporaryUploadRepository) CommitTree(opts *CommitTreeUserOptions) (str
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 	if err := cmdCommitTree.
-		Run(t.ctx, &git.RunOpts{
+		Run(ctx, &git.RunOpts{
 			Env:    env,
 			Dir:    t.basePath,
 			Stdin:  messageBytes,
@@ -349,10 +348,10 @@ func (t *TemporaryUploadRepository) CommitTree(opts *CommitTreeUserOptions) (str
 }
 
 // Push the provided commitHash to the repository branch by the provided user
-func (t *TemporaryUploadRepository) Push(doer *user_model.User, commitHash, branch string) error {
+func (t *TemporaryUploadRepository) Push(ctx context.Context, doer *user_model.User, commitHash, branch string) error {
 	// Because calls hooks we need to pass in the environment
 	env := repo_module.PushingEnvironment(doer, t.repo)
-	if err := git.Push(t.ctx, t.basePath, git.PushOptions{
+	if err := git.Push(ctx, t.basePath, git.PushOptions{
 		Remote: t.repo.RepoPath(),
 		Branch: strings.TrimSpace(commitHash) + ":" + git.BranchPrefix + strings.TrimSpace(branch),
 		Env:    env,
@@ -374,7 +373,7 @@ func (t *TemporaryUploadRepository) Push(doer *user_model.User, commitHash, bran
 }
 
 // DiffIndex returns a Diff of the current index to the head
-func (t *TemporaryUploadRepository) DiffIndex() (*gitdiff.Diff, error) {
+func (t *TemporaryUploadRepository) DiffIndex(ctx context.Context) (*gitdiff.Diff, error) {
 	stdoutReader, stdoutWriter, err := os.Pipe()
 	if err != nil {
 		return nil, fmt.Errorf("unable to open stdout pipe: %w", err)
@@ -386,7 +385,7 @@ func (t *TemporaryUploadRepository) DiffIndex() (*gitdiff.Diff, error) {
 	stderr := new(bytes.Buffer)
 	var diff *gitdiff.Diff
 	err = git.NewCommand("diff-index", "--src-prefix=\\a/", "--dst-prefix=\\b/", "--cached", "-p", "HEAD").
-		Run(t.ctx, &git.RunOpts{
+		Run(ctx, &git.RunOpts{
 			Timeout: 30 * time.Second,
 			Dir:     t.basePath,
 			Stdout:  stdoutWriter,
@@ -395,7 +394,7 @@ func (t *TemporaryUploadRepository) DiffIndex() (*gitdiff.Diff, error) {
 				_ = stdoutWriter.Close()
 				defer cancel()
 				var diffErr error
-				diff, diffErr = gitdiff.ParsePatch(t.ctx, setting.Git.MaxGitDiffLines, setting.Git.MaxGitDiffLineCharacters, setting.Git.MaxGitDiffFiles, stdoutReader, "")
+				diff, diffErr = gitdiff.ParsePatch(ctx, setting.Git.MaxGitDiffLines, setting.Git.MaxGitDiffLineCharacters, setting.Git.MaxGitDiffFiles, stdoutReader, "")
 				_ = stdoutReader.Close()
 				if diffErr != nil {
 					// if the diffErr is not nil, it will be returned as the error of "Run()"
@@ -409,7 +408,7 @@ func (t *TemporaryUploadRepository) DiffIndex() (*gitdiff.Diff, error) {
 		return nil, fmt.Errorf("unable to run diff-index pipeline in temporary repo: %w", err)
 	}
 
-	diff.NumFiles, diff.TotalAddition, diff.TotalDeletion, err = git.GetDiffShortStat(t.ctx, t.basePath, git.TrustedCmdArgs{"--cached"}, "HEAD")
+	diff.NumFiles, diff.TotalAddition, diff.TotalDeletion, err = git.GetDiffShortStat(ctx, t.basePath, git.TrustedCmdArgs{"--cached"}, "HEAD")
 	if err != nil {
 		return nil, err
 	}

--- a/services/repository/files/update.go
+++ b/services/repository/files/update.go
@@ -160,13 +160,13 @@ func ChangeRepoFiles(ctx context.Context, repo *repo_model.Repository, doer *use
 
 	message := strings.TrimSpace(opts.Message)
 
-	t, err := NewTemporaryUploadRepository(ctx, repo)
+	t, err := NewTemporaryUploadRepository(repo)
 	if err != nil {
 		log.Error("NewTemporaryUploadRepository failed: %v", err)
 	}
 	defer t.Close()
 	hasOldBranch := true
-	if err := t.Clone(opts.OldBranch, true); err != nil {
+	if err := t.Clone(ctx, opts.OldBranch, true); err != nil {
 		for _, file := range opts.Files {
 			if file.Operation == "delete" {
 				return nil, err
@@ -175,14 +175,14 @@ func ChangeRepoFiles(ctx context.Context, repo *repo_model.Repository, doer *use
 		if !git.IsErrBranchNotExist(err) || !repo.IsEmpty {
 			return nil, err
 		}
-		if err := t.Init(repo.ObjectFormatName); err != nil {
+		if err := t.Init(ctx, repo.ObjectFormatName); err != nil {
 			return nil, err
 		}
 		hasOldBranch = false
 		opts.LastCommitID = ""
 	}
 	if hasOldBranch {
-		if err := t.SetDefaultIndex(); err != nil {
+		if err := t.SetDefaultIndex(ctx); err != nil {
 			return nil, err
 		}
 	}
@@ -190,7 +190,7 @@ func ChangeRepoFiles(ctx context.Context, repo *repo_model.Repository, doer *use
 	for _, file := range opts.Files {
 		if file.Operation == "delete" {
 			// Get the files in the index
-			filesInIndex, err := t.LsFiles(file.TreePath)
+			filesInIndex, err := t.LsFiles(ctx, file.TreePath)
 			if err != nil {
 				return nil, fmt.Errorf("DeleteRepoFile: %w", err)
 			}
@@ -245,7 +245,7 @@ func ChangeRepoFiles(ctx context.Context, repo *repo_model.Repository, doer *use
 			}
 		case "delete":
 			// Remove the file from the index
-			if err := t.RemoveFilesFromIndex(file.TreePath); err != nil {
+			if err := t.RemoveFilesFromIndex(ctx, file.TreePath); err != nil {
 				return nil, err
 			}
 		default:
@@ -254,7 +254,7 @@ func ChangeRepoFiles(ctx context.Context, repo *repo_model.Repository, doer *use
 	}
 
 	// Now write the tree
-	treeHash, err := t.WriteTree()
+	treeHash, err := t.WriteTree(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -274,13 +274,13 @@ func ChangeRepoFiles(ctx context.Context, repo *repo_model.Repository, doer *use
 	if opts.Dates != nil {
 		commitOpts.AuthorTime, commitOpts.CommitterTime = &opts.Dates.Author, &opts.Dates.Committer
 	}
-	commitHash, err := t.CommitTree(commitOpts)
+	commitHash, err := t.CommitTree(ctx, commitOpts)
 	if err != nil {
 		return nil, err
 	}
 
 	// Then push this tree to NewBranch
-	if err := t.Push(doer, commitHash, opts.NewBranch); err != nil {
+	if err := t.Push(ctx, doer, commitHash, opts.NewBranch); err != nil {
 		log.Error("%T %v", err, err)
 		return nil, err
 	}
@@ -453,7 +453,7 @@ func handleCheckErrors(file *ChangeRepoFile, commit *git.Commit, opts *ChangeRep
 // CreateOrUpdateFile handles creating or updating a file for ChangeRepoFiles
 func CreateOrUpdateFile(ctx context.Context, t *TemporaryUploadRepository, file *ChangeRepoFile, contentStore *lfs.ContentStore, repoID int64, hasOldBranch bool) error {
 	// Get the two paths (might be the same if not moving) from the index if they exist
-	filesInIndex, err := t.LsFiles(file.TreePath, file.FromTreePath)
+	filesInIndex, err := t.LsFiles(ctx, file.TreePath, file.FromTreePath)
 	if err != nil {
 		return fmt.Errorf("UpdateRepoFile: %w", err)
 	}
@@ -472,7 +472,7 @@ func CreateOrUpdateFile(ctx context.Context, t *TemporaryUploadRepository, file 
 	if file.Options.fromTreePath != file.Options.treePath && len(filesInIndex) > 0 {
 		for _, indexFile := range filesInIndex {
 			if indexFile == file.Options.fromTreePath {
-				if err := t.RemoveFilesFromIndex(file.FromTreePath); err != nil {
+				if err := t.RemoveFilesFromIndex(ctx, file.FromTreePath); err != nil {
 					return err
 				}
 			}
@@ -504,18 +504,18 @@ func CreateOrUpdateFile(ctx context.Context, t *TemporaryUploadRepository, file 
 	}
 
 	// Add the object to the database
-	objectHash, err := t.HashObject(treeObjectContentReader)
+	objectHash, err := t.HashObject(ctx, treeObjectContentReader)
 	if err != nil {
 		return err
 	}
 
 	// Add the object to the index
 	if file.Options.executable {
-		if err := t.AddObjectToIndex("100755", objectHash, file.Options.treePath); err != nil {
+		if err := t.AddObjectToIndex(ctx, "100755", objectHash, file.Options.treePath); err != nil {
 			return err
 		}
 	} else {
-		if err := t.AddObjectToIndex("100644", objectHash, file.Options.treePath); err != nil {
+		if err := t.AddObjectToIndex(ctx, "100644", objectHash, file.Options.treePath); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Calls that required context implicitly are made to pass it as argument