### PR TITLE
Removing unwanted ui container

### DIFF
--- a/templates/user/auth/signin_inner.tmpl
+++ b/templates/user/auth/signin_inner.tmpl
@@ -59,6 +59,7 @@
 	</div>
 </div>
 
+{{if or .EnablePasskeyAuth .ShowRegistrationButton}}
 <div class="ui container fluid">
 	<div class="ui attached segment header top tw-max-w-2xl tw-m-auto tw-flex tw-flex-col tw-items-center">
 		{{if .EnablePasskeyAuth}}
@@ -74,3 +75,4 @@
 		{{end}}
 	</div>
 </div>
+{{end}}


### PR DESCRIPTION
when the passkey auth and register was disabled the un wanted ui container was show

![image](https://github.com/user-attachments/assets/c745e6af-f417-4bd7-8d65-23e0a3008d50)

