### PR TITLE
Fix maven panic when no package exists

### DIFF
--- a/routers/api/packages/maven/maven.go
+++ b/routers/api/packages/maven/maven.go
@@ -98,6 +98,11 @@ func serveMavenMetadata(ctx *context.Context, params parameters) {
 	}
 	pvs = append(pvsLegacy, pvs...)
 
+	if len(pvs) == 0 {
+		apiError(ctx, http.StatusNotFound, packages_model.ErrPackageNotExist)
+		return
+	}
+
 	pds, err := packages_model.GetPackageDescriptors(ctx, pvs)
 	if err != nil {
 		apiError(ctx, http.StatusInternalServerError, err)


### PR DESCRIPTION
Fix #33886

Restore the old logic from #16510, which was incorrectly removed by #33678