### PR TITLE
Replace text-align classes with tailwind

### DIFF
--- a/templates/admin/dashboard.tmpl
+++ b/templates/admin/dashboard.tmpl
@@ -15,57 +15,57 @@
 					<tbody>
 						<tr>
 							<td>{{ctx.Locale.Tr "admin.dashboard.delete_inactive_accounts"}}</td>
-							<td class="text right"><button type="submit" class="ui primary button" name="op" value="delete_inactive_accounts">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td class="tw-text-right"><button type="submit" class="ui primary button" name="op" value="delete_inactive_accounts">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
 							<td>{{ctx.Locale.Tr "admin.dashboard.delete_repo_archives"}}</td>
-							<td class="text right"><button type="submit" class="ui primary button" name="op" value="delete_repo_archives">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td class="tw-text-right"><button type="submit" class="ui primary button" name="op" value="delete_repo_archives">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
 							<td>{{ctx.Locale.Tr "admin.dashboard.delete_missing_repos"}}</td>
-							<td class="text right"><button type="submit" class="ui primary button" name="op" value="delete_missing_repos">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td class="tw-text-right"><button type="submit" class="ui primary button" name="op" value="delete_missing_repos">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
 							<td>{{ctx.Locale.Tr "admin.dashboard.git_gc_repos"}}</td>
-							<td class="text right"><button type="submit" class="ui primary button" name="op" value="git_gc_repos">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td class="tw-text-right"><button type="submit" class="ui primary button" name="op" value="git_gc_repos">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						{{if and (not .SSH.Disabled) (not .SSH.StartBuiltinServer)}}
 							<tr>
 								<td>{{ctx.Locale.Tr "admin.dashboard.resync_all_sshkeys"}}</td>
-								<td class="text right"><button type="submit" class="ui primary button" name="op" value="resync_all_sshkeys">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
+								<td class="tw-text-right"><button type="submit" class="ui primary button" name="op" value="resync_all_sshkeys">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
 							</tr>
 							<tr>
 								<td>{{ctx.Locale.Tr "admin.dashboard.resync_all_sshprincipals"}}</td>
-								<td class="text right"><button type="submit" class="ui primary button" name="op" value="resync_all_sshprincipals">{{svg "octicon-play" 16}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
+								<td class="tw-text-right"><button type="submit" class="ui primary button" name="op" value="resync_all_sshprincipals">{{svg "octicon-play" 16}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
 							</tr>
 						{{end}}
 						<tr>
 							<td>{{ctx.Locale.Tr "admin.dashboard.resync_all_hooks"}}</td>
-							<td class="text right"><button type="submit" class="ui primary button" name="op" value="resync_all_hooks">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td class="tw-text-right"><button type="submit" class="ui primary button" name="op" value="resync_all_hooks">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
 							<td>{{ctx.Locale.Tr "admin.dashboard.reinit_missing_repos"}}</td>
-							<td class="text right"><button type="submit" class="ui primary button" name="op" value="reinit_missing_repos">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td class="tw-text-right"><button type="submit" class="ui primary button" name="op" value="reinit_missing_repos">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
 							<td>{{ctx.Locale.Tr "admin.dashboard.sync_external_users"}}</td>
-							<td class="text right"><button type="submit" class="ui primary button" name="op" value="sync_external_users">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td class="tw-text-right"><button type="submit" class="ui primary button" name="op" value="sync_external_users">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
 							<td>{{ctx.Locale.Tr "admin.dashboard.repo_health_check"}}</td>
-							<td class="text right"><button type="submit" class="ui primary button" name="op" value="repo_health_check">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td class="tw-text-right"><button type="submit" class="ui primary button" name="op" value="repo_health_check">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
 							<td>{{ctx.Locale.Tr "admin.dashboard.delete_generated_repository_avatars"}}</td>
-							<td class="text right"><button type="submit" class="ui primary button" name="op" value="delete_generated_repository_avatars">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td class="tw-text-right"><button type="submit" class="ui primary button" name="op" value="delete_generated_repository_avatars">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
 							<td>{{ctx.Locale.Tr "admin.dashboard.sync_repo_branches"}}</td>
-							<td class="text right"><button type="submit" class="ui primary button" name="op" value="sync_repo_branches">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td class="tw-text-right"><button type="submit" class="ui primary button" name="op" value="sync_repo_branches">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 						<tr>
 							<td>{{ctx.Locale.Tr "admin.dashboard.sync_repo_tags"}}</td>
-							<td class="text right"><button type="submit" class="ui primary button" name="op" value="sync_repo_tags">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
+							<td class="tw-text-right"><button type="submit" class="ui primary button" name="op" value="sync_repo_tags">{{svg "octicon-play"}} {{ctx.Locale.Tr "admin.dashboard.operation_run"}}</button></td>
 						</tr>
 					</tbody>
 				</table>

--- a/templates/devtest/fomantic-modal.tmpl
+++ b/templates/devtest/fomantic-modal.tmpl
@@ -49,6 +49,16 @@
 		</form>
 	</div>
 
+	<div id="test-modal-form-5" class="ui mini modal">
+		<div class="header">Form dialog (layout 5)</div>
+		<div class="content">
+			<form method="post">
+				<div class="ui input tw-w-full"><input name="user_input"></div>
+				{{template "base/modal_actions_confirm" (dict "ModalButtonTypes" "confirm")}}
+			</form>
+		</div>
+	</div>
+
 	<div class="ui g-modal-confirm modal" id="test-modal-default">
 		<div class="header">{{svg "octicon-file"}} Default dialog <span>title</span></div>
 		<div class="content">

--- a/templates/install.tmpl
+++ b/templates/install.tmpl
@@ -1,7 +1,7 @@
 {{template "base/head" .}}
 <div role="main" aria-label="{{.Title}}" class="page-content install">
 	<div class="ui grid install-config-container">
-		<div class="sixteen wide center aligned centered column">
+		<div class="sixteen wide tw-text-center centered column">
 			<h3 class="ui top attached header">
 				{{ctx.Locale.Tr "install.title"}}
 			</h3>

--- a/templates/org/team/new.tmpl
+++ b/templates/org/team/new.tmpl
@@ -77,11 +77,11 @@
 									<thead>
 										<tr>
 											<th>{{ctx.Locale.Tr "units.unit"}}</th>
-											<th class="center aligned">{{ctx.Locale.Tr "org.teams.none_access"}}
+											<th class="tw-text-center">{{ctx.Locale.Tr "org.teams.none_access"}}
 											<span class="tw-align-middle" data-tooltip-content="{{ctx.Locale.Tr "org.teams.none_access_helper"}}">{{svg "octicon-question" 16 "tw-ml-1"}}</span></th>
-											<th class="center aligned">{{ctx.Locale.Tr "org.teams.read_access"}}
+											<th class="tw-text-center">{{ctx.Locale.Tr "org.teams.read_access"}}
 											<span class="tw-align-middle" data-tooltip-content="{{ctx.Locale.Tr "org.teams.read_access_helper"}}">{{svg "octicon-question" 16 "tw-ml-1"}}</span></th>
-											<th class="center aligned">{{ctx.Locale.Tr "org.teams.write_access"}}
+											<th class="tw-text-center">{{ctx.Locale.Tr "org.teams.write_access"}}
 											<span class="tw-align-middle" data-tooltip-content="{{ctx.Locale.Tr "org.teams.write_access_helper"}}">{{svg "octicon-question" 16 "tw-ml-1"}}</span></th>
 										</tr>
 									</thead>
@@ -97,17 +97,17 @@
 															</div>
 														</div>
 													</td>
-													<td class="center aligned">
+													<td class="tw-text-center">
 														<div class="ui radio checkbox">
 															<input type="radio" name="unit_{{$unit.Type.Value}}" value="0"{{if or ($unit.Type.UnitGlobalDisabled) (eq ($.Team.UnitAccessMode ctx $unit.Type) 0)}} checked{{end}} title="{{ctx.Locale.Tr "org.teams.none_access"}}">
 														</div>
 													</td>
-													<td class="center aligned">
+													<td class="tw-text-center">
 														<div class="ui radio checkbox">
 															<input type="radio" name="unit_{{$unit.Type.Value}}" value="1"{{if or (eq $.Team.ID 0) (eq ($.Team.UnitAccessMode ctx $unit.Type) 1)}} checked{{end}} {{if $unit.Type.UnitGlobalDisabled}}disabled{{end}} title="{{ctx.Locale.Tr "org.teams.read_access"}}">
 														</div>
 													</td>
-													<td class="center aligned">
+													<td class="tw-text-center">
 														<div class="ui radio checkbox">
 															<input type="radio" name="unit_{{$unit.Type.Value}}" value="2"{{if (ge ($.Team.UnitAccessMode ctx $unit.Type) 2)}} checked{{end}} {{if $unit.Type.UnitGlobalDisabled}}disabled{{end}} title="{{ctx.Locale.Tr "org.teams.write_access"}}">
 														</div>

--- a/templates/org/team/teams.tmpl
+++ b/templates/org/team/teams.tmpl
@@ -4,7 +4,7 @@
 	<div class="ui container">
 		{{template "base/alert" .}}
 		{{if .IsOrganizationOwner}}
-			<div class="text right">
+			<div class="tw-text-right">
 				<a class="ui primary button" href="{{.OrgLink}}/teams/new">{{svg "octicon-plus"}} {{ctx.Locale.Tr "org.create_new_team"}}</a>
 			</div>
 			<div class="divider"></div>

--- a/templates/projects/view.tmpl
+++ b/templates/projects/view.tmpl
@@ -135,7 +135,7 @@
 					{{template "repo/issue/label_precolors"}}
 				</div>
 			</div>
-			<div class="actions tw-text-right">
+			<div class="actions">
 				<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
 				<button type="submit" class="ui primary button project-column-button-save">save</button>
 			</div>

--- a/templates/repo/branch/list.tmpl
+++ b/templates/repo/branch/list.tmpl
@@ -30,7 +30,7 @@
 								<p class="info tw-flex tw-items-center tw-my-1">{{svg "octicon-git-commit" 16 "tw-mr-1"}}<a href="{{.RepoLink}}/commit/{{PathEscape .DefaultBranchBranch.DBBranch.CommitID}}">{{ShortSha .DefaultBranchBranch.DBBranch.CommitID}}</a> · <span class="commit-message">{{ctx.RenderUtils.RenderCommitMessage .DefaultBranchBranch.DBBranch.CommitMessage (.Repository.ComposeMetas ctx)}}</span> · {{ctx.Locale.Tr "org.repo_updated"}} {{DateUtils.TimeSince .DefaultBranchBranch.DBBranch.CommitTime}}{{if .DefaultBranchBranch.DBBranch.Pusher}} &nbsp;{{template "shared/user/avatarlink" dict "user" .DefaultBranchBranch.DBBranch.Pusher}}{{template "shared/user/namelink" .DefaultBranchBranch.DBBranch.Pusher}}{{end}}</p>
 							</td>
 							{{/* FIXME: here and below, the tw-overflow-visible is not quite right but it is still needed the moment: to show the important buttons when the width is narrow */}}
-							<td class="right aligned middle aligned tw-overflow-visible">
+							<td class="tw-text-right tw-overflow-visible">
 								{{if and $.IsWriter (not $.Repository.IsArchived) (not .IsDeleted)}}
 									<button class="btn interact-bg show-create-branch-modal tw-p-2"
 										data-modal="#create-branch-modal"
@@ -121,7 +121,7 @@
 								</div>
 								{{end}}
 							</td>
-							<td class="two wide right aligned">
+							<td class="two wide tw-text-right">
 								{{if not .LatestPullRequest}}
 									{{if .IsIncluded}}
 										<span class="ui orange large label" data-tooltip-content="{{ctx.Locale.Tr "repo.branch.included_desc"}}">
@@ -150,7 +150,7 @@
 								{{end}}
 							</td>
 							{{/* FIXME: here and above, the tw-overflow-visible is not quite right */}}
-							<td class="three wide right aligned tw-overflow-visible">
+							<td class="three wide tw-text-right tw-overflow-visible">
 								{{if and $.IsWriter (not $.Repository.IsArchived) (not .DBBranch.IsDeleted)}}
 									<button class="btn interact-bg tw-p-2 show-modal show-create-branch-modal"
 										data-branch-from="{{.DBBranch.Name}}"

--- a/templates/repo/commit_page.tmpl
+++ b/templates/repo/commit_page.tmpl
@@ -83,7 +83,7 @@
 													<input id="new_branch_name" name="new_branch_name" required>
 												</div>
 
-												<div class="text right actions">
+												<div class="tw-text-right actions">
 													<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
 													<button class="ui primary button">{{ctx.Locale.Tr "repo.branch.confirm_create_branch"}}</button>
 												</div>
@@ -108,7 +108,7 @@
 													<input id="new_branch_name" name="new_branch_name" required>
 												</div>
 
-												<div class="text right actions">
+												<div class="tw-text-right actions">
 													<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
 													<button class="ui primary button">{{ctx.Locale.Tr "repo.tag.confirm_create_tag"}}</button>
 												</div>

--- a/templates/repo/commit_page.tmpl
+++ b/templates/repo/commit_page.tmpl
@@ -83,7 +83,7 @@
 													<input id="new_branch_name" name="new_branch_name" required>
 												</div>
 
-												<div class="tw-text-right actions">
+												<div class="actions">
 													<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
 													<button class="ui primary button">{{ctx.Locale.Tr "repo.branch.confirm_create_branch"}}</button>
 												</div>
@@ -108,7 +108,7 @@
 													<input id="new_branch_name" name="new_branch_name" required>
 												</div>
 
-												<div class="tw-text-right actions">
+												<div class="actions">
 													<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
 													<button class="ui primary button">{{ctx.Locale.Tr "repo.tag.confirm_create_tag"}}</button>
 												</div>

--- a/templates/repo/commits_list.tmpl
+++ b/templates/repo/commits_list.tmpl
@@ -5,7 +5,7 @@
 				<th class="three wide">{{ctx.Locale.Tr "repo.commits.author"}}</th>
 				<th class="two wide sha">{{StringUtils.ToUpper $.Repository.ObjectFormatName}}</th>
 				<th class="eight wide message">{{ctx.Locale.Tr "repo.commits.message"}}</th>
-				<th class="two wide right aligned">{{ctx.Locale.Tr "repo.commits.date"}}</th>
+				<th class="two wide tw-text-right">{{ctx.Locale.Tr "repo.commits.date"}}</th>
 				<th class="one wide"></th>
 			</tr>
 		</thead>
@@ -61,11 +61,11 @@
 						{{end}}
 					</td>
 					{{if .Committer}}
-						<td class="tw-text-right aligned">{{DateUtils.TimeSince .Committer.When}}</td>
+						<td class="tw-text-right">{{DateUtils.TimeSince .Committer.When}}</td>
 					{{else}}
-						<td class="tw-text-right aligned">{{DateUtils.TimeSince .Author.When}}</td>
+						<td class="tw-text-right">{{DateUtils.TimeSince .Author.When}}</td>
 					{{end}}
-					<td class="tw-text-right aligned tw-py-0">
+					<td class="tw-text-right tw-py-0">
 						<button class="btn interact-bg tw-p-2 copy-commit-id" data-tooltip-content="{{ctx.Locale.Tr "copy_hash"}}" data-clipboard-text="{{.ID}}">{{svg "octicon-copy"}}</button>
 						{{/* at the moment, wiki doesn't support these "view" links like "view at history point" */}}
 						{{if not $.PageIsWiki}}

--- a/templates/repo/commits_list.tmpl
+++ b/templates/repo/commits_list.tmpl
@@ -61,11 +61,11 @@
 						{{end}}
 					</td>
 					{{if .Committer}}
-						<td class="text right aligned">{{DateUtils.TimeSince .Committer.When}}</td>
+						<td class="tw-text-right aligned">{{DateUtils.TimeSince .Committer.When}}</td>
 					{{else}}
-						<td class="text right aligned">{{DateUtils.TimeSince .Author.When}}</td>
+						<td class="tw-text-right aligned">{{DateUtils.TimeSince .Author.When}}</td>
 					{{end}}
-					<td class="text right aligned tw-py-0">
+					<td class="tw-text-right aligned tw-py-0">
 						<button class="btn interact-bg tw-p-2 copy-commit-id" data-tooltip-content="{{ctx.Locale.Tr "copy_hash"}}" data-clipboard-text="{{.ID}}">{{svg "octicon-copy"}}</button>
 						{{/* at the moment, wiki doesn't support these "view" links like "view at history point" */}}
 						{{if not $.PageIsWiki}}

--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -235,7 +235,7 @@
 						{{template "repo/upload" .}}
 					</div>
 				{{end}}
-				<div class="text right edit buttons">
+				<div class="tw-text-right edit buttons">
 					<button class="ui cancel button">{{ctx.Locale.Tr "repo.issues.cancel"}}</button>
 					<button class="ui primary button">{{ctx.Locale.Tr "repo.issues.save"}}</button>
 				</div>

--- a/templates/repo/issue/choose.tmpl
+++ b/templates/repo/issue/choose.tmpl
@@ -10,11 +10,11 @@
 		{{range .IssueTemplates}}
 			<div class="ui attached segment">
 				<div class="ui two column grid">
-					<div class="column left aligned">
+					<div class="column">
 						<strong>{{.Name}}</strong>
 						<br>{{.About}}
 					</div>
-					<div class="column right aligned">
+					<div class="column tw-text-right">
 						<a href="{{$.RepoLink}}/issues/new?template={{.FileName}}{{if $.milestone}}&milestone={{$.milestone}}{{end}}{{if $.project}}&project={{$.project}}{{end}}" class="ui primary button">{{ctx.Locale.Tr "repo.issues.choose.get_started"}}</a>
 					</div>
 				</div>
@@ -23,11 +23,11 @@
 		{{range .IssueConfig.ContactLinks}}
 			<div class="ui attached segment">
 				<div class="ui two column grid">
-					<div class="column left aligned">
+					<div class="column">
 						<strong>{{.Name}}</strong>
 						<br>{{.About}}
 					</div>
-					<div class="column right aligned">
+					<div class="column tw-text-right">
 						<a href="{{.URL}}" class="ui primary button">{{svg "octicon-link-external"}} {{ctx.Locale.Tr "repo.issues.choose.open_external_link"}}</a>
 					</div>
 				</div>
@@ -36,11 +36,11 @@
 		{{if .IssueConfig.BlankIssuesEnabled}}
 			<div class="ui attached segment">
 				<div class="ui two column grid">
-					<div class="column left aligned">
+					<div class="column">
 						<strong>{{ctx.Locale.Tr "repo.issues.choose.blank"}}</strong>
 						<br/>{{ctx.Locale.Tr "repo.issues.choose.blank_about"}}
 					</div>
-					<div class="column right aligned">
+					<div class="column tw-text-right">
 						<a href="{{.RepoLink}}/issues/new?{{if .milestone}}&milestone={{.milestone}}{{end}}{{if $.project}}&project={{$.project}}{{end}}" class="ui primary button">{{ctx.Locale.Tr "repo.issues.choose.get_started"}}</a>
 					</div>
 				</div>

--- a/templates/repo/issue/milestone_issues.tmpl
+++ b/templates/repo/issue/milestone_issues.tmpl
@@ -6,7 +6,7 @@
 		<div class="tw-flex">
 			<h1 class="tw-mb-2">{{.Milestone.Name}}</h1>
 			{{if not .Repository.IsArchived}}
-				<div class="text right tw-flex-1">
+				<div class="tw-text-right tw-flex-1">
 					{{if or .CanWriteIssues .CanWritePulls}}
 						{{if .Milestone.IsClosed}}
 							<a class="ui primary basic button link-action" href data-url="{{$.RepoLink}}/milestones/{{.MilestoneID}}/open">{{ctx.Locale.Tr "repo.milestones.open"}}

--- a/templates/repo/issue/new_form.tmpl
+++ b/templates/repo/issue/new_form.tmpl
@@ -33,7 +33,7 @@
 					{{else}}
 						{{template "repo/issue/comment_tab" .}}
 					{{end}}
-					<div class="text right">
+					<div class="tw-text-right">
 						<button class="ui primary button">
 							{{if .PageIsComparePull}}
 								{{ctx.Locale.Tr "repo.pulls.create"}}

--- a/templates/repo/issue/sidebar/issue_management.tmpl
+++ b/templates/repo/issue/sidebar/issue_management.tmpl
@@ -76,7 +76,7 @@
 					</div>
 				{{end}}
 
-				<div class="tw-text-right actions">
+				<div class="actions">
 					<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
 					<button class="ui red button">
 						{{if .Issue.IsLocked}}

--- a/templates/repo/issue/sidebar/issue_management.tmpl
+++ b/templates/repo/issue/sidebar/issue_management.tmpl
@@ -76,7 +76,7 @@
 					</div>
 				{{end}}
 
-				<div class="text right actions">
+				<div class="tw-text-right actions">
 					<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
 					<button class="ui red button">
 						{{if .Issue.IsLocked}}

--- a/templates/repo/issue/sidebar/reviewer_list.tmpl
+++ b/templates/repo/issue/sidebar/reviewer_list.tmpl
@@ -121,7 +121,7 @@
 					<label for="issue-sidebar-dismiss-review-message">{{ctx.Locale.Tr "action.review_dismissed_reason"}}</label>
 					<input id="issue-sidebar-dismiss-review-message" name="message">
 				</div>
-				<div class="text right actions">
+				<div class="tw-text-right actions">
 					<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
 					<button class="ui red button" type="submit">{{ctx.Locale.Tr "ok"}}</button>
 				</div>

--- a/templates/repo/issue/sidebar/reviewer_list.tmpl
+++ b/templates/repo/issue/sidebar/reviewer_list.tmpl
@@ -121,7 +121,7 @@
 					<label for="issue-sidebar-dismiss-review-message">{{ctx.Locale.Tr "action.review_dismissed_reason"}}</label>
 					<input id="issue-sidebar-dismiss-review-message" name="message">
 				</div>
-				<div class="tw-text-right actions">
+				<div class="actions">
 					<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
 					<button class="ui red button" type="submit">{{ctx.Locale.Tr "ok"}}</button>
 				</div>

--- a/templates/repo/issue/view_content.tmpl
+++ b/templates/repo/issue/view_content.tmpl
@@ -83,7 +83,7 @@
 								{{template "repo/issue/comment_tab" .}}
 								{{.CsrfTokenHtml}}
 								<div class="field footer">
-									<div class="text right">
+									<div class="tw-text-right">
 										{{if and (or .HasIssuesOrPullsWritePermission .IsIssuePoster) (not .DisableStatusChange)}}
 											{{if .Issue.IsClosed}}
 												<button id="status-button" class="ui primary basic button" data-status="{{ctx.Locale.Tr "repo.issues.reopen_issue"}}" data-status-and-comment="{{ctx.Locale.Tr "repo.issues.reopen_comment_issue"}}" name="status" value="reopen">
@@ -157,7 +157,7 @@
 		{{end}}
 
 		<div class="field">
-			<div class="text right edit">
+			<div class="tw-text-right edit">
 				<button type="button" class="ui cancel button">{{ctx.Locale.Tr "repo.issues.cancel"}}</button>
 				<button type="submit" class="ui primary button">{{ctx.Locale.Tr "repo.issues.save"}}</button>
 			</div>

--- a/templates/repo/issue/view_content/reference_issue_dialog.tmpl
+++ b/templates/repo/issue/view_content/reference_issue_dialog.tmpl
@@ -20,7 +20,7 @@
 				<label><strong>{{ctx.Locale.Tr "repo.issues.reference_issue.body"}}</strong></label>
 				<textarea name="content"></textarea>
 			</div>
-			<div class="text right">
+			<div class="tw-text-right">
 				<button class="ui primary button">{{ctx.Locale.Tr "repo.issues.create"}}</button>
 			</div>
 		</form>

--- a/templates/repo/migrate/migrating.tmpl
+++ b/templates/repo/migrate/migrating.tmpl
@@ -77,7 +77,7 @@
 				<input id="repo_name_to_delete" name="repo_name" required>
 			</div>
 
-			<div class="text right actions">
+			<div class="tw-text-right actions">
 				<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
 				<button class="ui red button">{{ctx.Locale.Tr "repo.settings.confirm_delete"}}</button>
 			</div>

--- a/templates/repo/migrate/migrating.tmpl
+++ b/templates/repo/migrate/migrating.tmpl
@@ -77,7 +77,7 @@
 				<input id="repo_name_to_delete" name="repo_name" required>
 			</div>
 
-			<div class="tw-text-right actions">
+			<div class="actions">
 				<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
 				<button class="ui red button">{{ctx.Locale.Tr "repo.settings.confirm_delete"}}</button>
 			</div>

--- a/templates/repo/migrate/migrating.tmpl
+++ b/templates/repo/migrate/migrating.tmpl
@@ -7,19 +7,19 @@
 				{{template "base/alert" .}}
 				<div class="home">
 					<div class="ui stackable middle very relaxed page grid">
-						<div id="repo_migrating" class="sixteen wide center aligned centered column" data-migrating-repo-link="{{.Link}}">
+						<div id="repo_migrating" class="sixteen wide tw-text-center centered column" data-migrating-repo-link="{{.Link}}">
 							<div>
 								<img src="{{AssetUrlPrefix}}/img/loading.png">
 							</div>
 						</div>
-						<div id="repo_migrating_failed_image" class="sixteen wide center aligned centered column tw-hidden">
+						<div id="repo_migrating_failed_image" class="sixteen wide tw-text-center centered column tw-hidden">
 							<div>
 								<img src="{{AssetUrlPrefix}}/img/failed.png">
 							</div>
 						</div>
 					</div>
 					<div class="ui stackable middle very relaxed page grid">
-						<div class="sixteen wide center aligned centered column">
+						<div class="sixteen wide tw-text-center centered column">
 							<div id="repo_migrating_progress">
 								<p>{{ctx.Locale.Tr "repo.migrate.migrating" .CloneAddr}}</p>
 								<p id="repo_migrating_progress_message"></p>

--- a/templates/repo/pulse.tmpl
+++ b/templates/repo/pulse.tmpl
@@ -82,7 +82,7 @@
 
 {{if .Permission.CanRead ctx.Consts.RepoUnitTypeCode}}
 	{{if eq .Activity.Code.CommitCountInAllBranches 0}}
-		<div class="ui center aligned segment">
+		<div class="ui tw-text-center segment">
 		<h4 class="ui header">{{ctx.Locale.Tr "repo.activity.no_git_activity"}}</h4>
 		</div>
 	{{end}}

--- a/templates/repo/settings/branches.tmpl
+++ b/templates/repo/settings/branches.tmpl
@@ -56,7 +56,7 @@
 							</div>
 						</div>
 					{{else}}
-						<div class="flex-item center aligned">
+						<div class="flex-item tw-text-center">
 							{{ctx.Locale.Tr "repo.settings.no_protected_branch"}}
 						</div>
 					{{end}}

--- a/templates/repo/settings/lfs.tmpl
+++ b/templates/repo/settings/lfs.tmpl
@@ -18,7 +18,7 @@
 						</td>
 						<td>{{FileSize .Size}}</td>
 						<td>{{DateUtils.TimeSince .CreatedUnix}}</td>
-						<td class="right aligned">
+						<td class="tw-text-right">
 							<a class="ui primary button" href="{{$.Link}}/find?oid={{.Oid}}&size={{.Size}}">{{ctx.Locale.Tr "repo.settings.lfs_findcommits"}}</a>
 							<button class="ui basic show-modal icon button red" data-modal="#delete-{{.Oid}}">
 								<span class="btn-octicon btn-octicon-danger" data-tooltip-content="{{ctx.Locale.Tr "repo.editor.delete_this_file"}}">{{svg "octicon-trash"}}</span>

--- a/templates/repo/settings/lfs_locks.tmpl
+++ b/templates/repo/settings/lfs_locks.tmpl
@@ -36,7 +36,7 @@
 								</a>
 							</td>
 							<td>{{DateUtils.TimeSince .Created}}</td>
-							<td class="right aligned">
+							<td class="tw-text-right">
 								<form action="{{$.LFSFilesLink}}/locks/{{$lock.ID}}/unlock" method="post">
 									{{$.CsrfTokenHtml}}
 									<button class="ui primary button"><span class="btn-octicon">{{svg "octicon-lock"}}</span>{{ctx.Locale.Tr "repo.settings.lfs_force_unlock"}}</button>

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -117,7 +117,7 @@
 								<td>{{.PullMirror.RemoteAddress}}</td>
 								<td>{{ctx.Locale.Tr "repo.settings.mirror_settings.direction.pull"}}</td>
 								<td>{{DateUtils.FullTime .PullMirror.UpdatedUnix}}</td>
-								<td class="right aligned">
+								<td class="tw-text-right">
 									<form method="post" class="tw-inline-block">
 										{{.CsrfTokenHtml}}
 										<input type="hidden" name="action" value="mirror-sync">
@@ -214,7 +214,7 @@
 										{{if .LastError}}<span class="ui red label" data-tooltip-content="{{.LastError}}">{{ctx.Locale.Tr "error"}}</span>{{end}}
 									</span>
 								</td>
-								<td class="right aligned">
+								<td class="tw-text-right">
 									<button
 										class="ui tiny button show-modal"
 										data-modal="#push-mirror-edit-modal"

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -936,7 +936,7 @@
 						<input name="repo_name" required maxlength="100">
 					</div>
 
-					<div class="text right actions">
+					<div class="tw-text-right actions">
 						<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
 						<button class="ui red button">{{ctx.Locale.Tr "repo.settings.convert_confirm"}}</button>
 					</div>
@@ -967,7 +967,7 @@
 						<input name="repo_name" required>
 					</div>
 
-					<div class="text right actions">
+					<div class="tw-text-right actions">
 						<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
 						<button class="ui red button">{{ctx.Locale.Tr "repo.settings.convert_fork_confirm"}}</button>
 					</div>
@@ -1004,7 +1004,7 @@
 					<input id="new_owner_name" name="new_owner_name" required>
 				</div>
 
-				<div class="text right actions">
+				<div class="tw-text-right actions">
 					<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
 					<button class="ui red button">{{ctx.Locale.Tr "repo.settings.transfer_perform"}}</button>
 				</div>
@@ -1038,7 +1038,7 @@
 					<input id="repo_name_to_delete" name="repo_name" required>
 				</div>
 
-				<div class="text right actions">
+				<div class="tw-text-right actions">
 					<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
 					<button class="ui red button">{{ctx.Locale.Tr "repo.settings.confirm_delete"}}</button>
 				</div>
@@ -1098,7 +1098,7 @@
 					<input name="repo_name" required>
 				</div>
 
-				<div class="text right actions">
+				<div class="tw-text-right actions">
 					<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
 					<button class="ui red button">{{ctx.Locale.Tr "repo.settings.confirm_wiki_delete"}}</button>
 				</div>

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -936,7 +936,7 @@
 						<input name="repo_name" required maxlength="100">
 					</div>
 
-					<div class="tw-text-right actions">
+					<div class="actions">
 						<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
 						<button class="ui red button">{{ctx.Locale.Tr "repo.settings.convert_confirm"}}</button>
 					</div>
@@ -967,7 +967,7 @@
 						<input name="repo_name" required>
 					</div>
 
-					<div class="tw-text-right actions">
+					<div class="actions">
 						<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
 						<button class="ui red button">{{ctx.Locale.Tr "repo.settings.convert_fork_confirm"}}</button>
 					</div>
@@ -1004,7 +1004,7 @@
 					<input id="new_owner_name" name="new_owner_name" required>
 				</div>
 
-				<div class="tw-text-right actions">
+				<div class="actions">
 					<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
 					<button class="ui red button">{{ctx.Locale.Tr "repo.settings.transfer_perform"}}</button>
 				</div>
@@ -1038,7 +1038,7 @@
 					<input id="repo_name_to_delete" name="repo_name" required>
 				</div>
 
-				<div class="tw-text-right actions">
+				<div class="actions">
 					<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
 					<button class="ui red button">{{ctx.Locale.Tr "repo.settings.confirm_delete"}}</button>
 				</div>
@@ -1098,7 +1098,7 @@
 					<input name="repo_name" required>
 				</div>
 
-				<div class="tw-text-right actions">
+				<div class="actions">
 					<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
 					<button class="ui red button">{{ctx.Locale.Tr "repo.settings.confirm_wiki_delete"}}</button>
 				</div>

--- a/templates/repo/settings/tags.tmpl
+++ b/templates/repo/settings/tags.tmpl
@@ -104,7 +104,7 @@
 												{{ctx.Locale.Tr "repo.settings.tags.protection.allowed.noone"}}
 											{{end}}
 										</td>
-										<td class="right aligned">
+										<td class="tw-text-right">
 											<a class="ui tiny primary button" href="{{$.RepoLink}}/settings/tags/{{.ID}}">{{ctx.Locale.Tr "edit"}}</a>
 											<form class="tw-inline-block" action="{{$.RepoLink}}/settings/tags/delete" method="post">
 												{{$.CsrfTokenHtml}}
@@ -114,7 +114,7 @@
 										</td>
 									</tr>
 								{{else}}
-									<tr class="center aligned"><td colspan="3">{{ctx.Locale.Tr "repo.settings.tags.protection.none"}}</td></tr>
+									<tr class="tw-text-center"><td colspan="3">{{ctx.Locale.Tr "repo.settings.tags.protection.none"}}</td></tr>
 								{{end}}
 							</tbody>
 						</table>

--- a/templates/repo/wiki/new.tmpl
+++ b/templates/repo/wiki/new.tmpl
@@ -35,7 +35,7 @@
 				<input name="message" aria-label="{{ctx.Locale.Tr "repo.wiki.default_commit_message"}}" placeholder="{{ctx.Locale.Tr "repo.wiki.default_commit_message"}}">
 			</div>
 			<div class="divider"></div>
-			<div class="text right">
+			<div class="tw-text-right">
 				<a class="ui basic cancel button" href="{{.Link}}">{{ctx.Locale.Tr "cancel"}}</a>
 				<button class="ui primary button">{{ctx.Locale.Tr "repo.wiki.save_page"}}</button>
 			</div>

--- a/templates/repo/wiki/pages.tmpl
+++ b/templates/repo/wiki/pages.tmpl
@@ -21,7 +21,7 @@
 							<a class="wiki-git-entry" href="{{$.RepoLink}}/wiki/{{.GitEntryName | PathEscape}}" data-tooltip-content="{{ctx.Locale.Tr "repo.wiki.original_git_entry_tooltip"}}">{{svg "octicon-chevron-right"}}</a>
 						</td>
 						{{$timeSince := DateUtils.TimeSince .UpdatedUnix}}
-						<td class="text right">{{ctx.Locale.Tr "repo.wiki.last_updated" $timeSince}}</td>
+						<td class="tw-text-right">{{ctx.Locale.Tr "repo.wiki.last_updated" $timeSince}}</td>
 					</tr>
 				{{end}}
 			</tbody>

--- a/templates/repo/wiki/revision.tmpl
+++ b/templates/repo/wiki/revision.tmpl
@@ -14,7 +14,7 @@
 					</div>
 				</div>
 			</div>
-			<div class="ui eight wide column text right">
+			<div class="ui eight wide column tw-text-right">
 				{{template "repo/clone_panel" .}}
 			</div>
 		</div>

--- a/templates/shared/actions/runner_list.tmpl
+++ b/templates/shared/actions/runner_list.tmpl
@@ -87,7 +87,7 @@
 					{{end}}
 				{{else}}
 					<tr>
-						<td class="center aligned" colspan="8">{{ctx.Locale.Tr "actions.runners.none"}}</td>
+						<td class="tw-text-center" colspan="8">{{ctx.Locale.Tr "actions.runners.none"}}</td>
 					</tr>
 				{{end}}
 			</tbody>

--- a/templates/shared/user/block_user_dialog.tmpl
+++ b/templates/shared/user/block_user_dialog.tmpl
@@ -14,7 +14,7 @@
 				<input id="block-note" name="note">
 				<p class="help">{{ctx.Locale.Tr "user.block.note.info"}}</p>
 			</div>
-			<div class="text right actions">
+			<div class="tw-text-right actions">
 				<button class="ui cancel button">{{ctx.Locale.Tr "cancel"}}</button>
 				<button class="ui red button">{{ctx.Locale.Tr "user.block.block"}}</button>
 			</div>

--- a/templates/shared/user/block_user_dialog.tmpl
+++ b/templates/shared/user/block_user_dialog.tmpl
@@ -14,7 +14,7 @@
 				<input id="block-note" name="note">
 				<p class="help">{{ctx.Locale.Tr "user.block.note.info"}}</p>
 			</div>
-			<div class="tw-text-right actions">
+			<div class="actions">
 				<button class="ui cancel button">{{ctx.Locale.Tr "cancel"}}</button>
 				<button class="ui red button">{{ctx.Locale.Tr "user.block.block"}}</button>
 			</div>

--- a/templates/shared/user/blocked_users.tmpl
+++ b/templates/shared/user/blocked_users.tmpl
@@ -74,7 +74,7 @@
 				<input name="note" class="modal-note" />
 				<p class="help">{{ctx.Locale.Tr "user.block.note.info"}}</p>
 			</div>
-			<div class="tw-text-right actions">
+			<div class="actions">
 				<button class="ui cancel button">{{ctx.Locale.Tr "cancel"}}</button>
 				<button class="ui primary button">{{ctx.Locale.Tr "save"}}</button>
 			</div>

--- a/templates/shared/user/blocked_users.tmpl
+++ b/templates/shared/user/blocked_users.tmpl
@@ -74,7 +74,7 @@
 				<input name="note" class="modal-note" />
 				<p class="help">{{ctx.Locale.Tr "user.block.note.info"}}</p>
 			</div>
-			<div class="text right actions">
+			<div class="tw-text-right actions">
 				<button class="ui cancel button">{{ctx.Locale.Tr "cancel"}}</button>
 				<button class="ui primary button">{{ctx.Locale.Tr "save"}}</button>
 			</div>

--- a/templates/user/auth/grant.tmpl
+++ b/templates/user/auth/grant.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div role="main" aria-label="{{.Title}}" class="page-content ui one column stackable center aligned page grid oauth2-authorize-application-box">
+<div role="main" aria-label="{{.Title}}" class="page-content ui one column stackable tw-text-center page grid oauth2-authorize-application-box">
 	<div class="column seven wide">
 		<div class="ui middle centered raised segments">
 			<h3 class="ui top attached header">

--- a/templates/user/auth/grant_error.tmpl
+++ b/templates/user/auth/grant_error.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div role="main" aria-label="{{.Title}}" class="page-content ui one column stackable center aligned page grid oauth2-authorize-application-box {{if .IsRepo}}repository{{end}}">
+<div role="main" aria-label="{{.Title}}" class="page-content ui one column stackable tw-text-center page grid oauth2-authorize-application-box {{if .IsRepo}}repository{{end}}">
 	{{if .IsRepo}}{{template "repo/header" .}}{{end}}
 	<div class="column seven wide">
 		<div class="ui middle centered raised segments">

--- a/templates/user/auth/webauthn.tmpl
+++ b/templates/user/auth/webauthn.tmpl
@@ -1,7 +1,7 @@
 {{template "base/head" .}}
 <div role="main" aria-label="{{.Title}}" class="page-content user signin webauthn-prompt">
 	<div class="ui page grid">
-		<div class="column center aligned">
+		<div class="column tw-text-center">
 			{{template "user/auth/webauthn_error" .}}
 			<h3 class="ui top attached header">{{ctx.Locale.Tr "twofa"}}</h3>
 			<div class="ui attached segment">

--- a/templates/user/notification/notification_subscriptions.tmpl
+++ b/templates/user/notification/notification_subscriptions.tmpl
@@ -28,7 +28,7 @@
 						</div>
 					</div>
 					<div class="tw-flex tw-justify-between">
-						<div class="ui right aligned secondary filter menu labels">
+						<div class="ui secondary filter menu labels">
 							<!-- Type -->
 								<div class="ui dropdown type jump item">
 									<span class="text">

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -580,14 +580,6 @@ img.ui.avatar,
   box-shadow: 0 6px 18px var(--color-shadow) !important;
 }
 
-.ui .text.left {
-  text-align: left !important;
-}
-
-.ui .text.right {
-  text-align: right !important;
-}
-
 .ui .text.truncate {
   overflow-x: hidden;
   text-overflow: ellipsis;

--- a/web_src/css/modules/container.css
+++ b/web_src/css/modules/container.css
@@ -14,7 +14,3 @@
 .ui.container.medium-width {
   width: 800px;
 }
-
-.ui[class*="center aligned"].container {
-  text-align: center;
-}

--- a/web_src/css/modules/grid.css
+++ b/web_src/css/modules/grid.css
@@ -403,36 +403,6 @@
   align-self: center !important;
 }
 
-.ui[class*="left aligned"].grid > .column,
-.ui[class*="left aligned"].grid > .row > .column,
-.ui.grid > [class*="left aligned"].row > .column,
-.ui.grid > [class*="left aligned"].column.column,
-.ui.grid > .row > [class*="left aligned"].column.column {
-  text-align: left;
-  align-self: inherit;
-}
-
-.ui[class*="center aligned"].grid > .column,
-.ui[class*="center aligned"].grid > .row > .column,
-.ui.grid > [class*="center aligned"].row > .column,
-.ui.grid > [class*="center aligned"].column.column,
-.ui.grid > .row > [class*="center aligned"].column.column {
-  text-align: center;
-  align-self: inherit;
-}
-.ui[class*="center aligned"].grid {
-  justify-content: center;
-}
-
-.ui[class*="right aligned"].grid > .column,
-.ui[class*="right aligned"].grid > .row > .column,
-.ui.grid > [class*="right aligned"].row > .column,
-.ui.grid > [class*="right aligned"].column.column,
-.ui.grid > .row > [class*="right aligned"].column.column {
-  text-align: right;
-  align-self: inherit;
-}
-
 .ui[class*="equal width"].grid > .column:not(.row),
 .ui[class*="equal width"].grid > .row > .column,
 .ui.grid > [class*="equal width"].row > .column {

--- a/web_src/css/modules/modal.css
+++ b/web_src/css/modules/modal.css
@@ -63,12 +63,15 @@ These inconsistent layouts should be refactored to simple ones.
   background: var(--color-secondary-bg);
   border-color: var(--color-secondary);
   padding: 1rem;
-  text-align: right;
   border-radius: 0 0 var(--border-radius) var(--border-radius);
 }
 
 .ui.modal .content > .actions {
   padding-top: 1em; /* if the "actions" is in the "content", some paddings are already added by the "content" */
+  text-align: right;
+}
+
+.ui.modal .actions {
   text-align: right;
 }
 

--- a/web_src/css/modules/modal.css
+++ b/web_src/css/modules/modal.css
@@ -63,15 +63,13 @@ These inconsistent layouts should be refactored to simple ones.
   background: var(--color-secondary-bg);
   border-color: var(--color-secondary);
   padding: 1rem;
+  text-align: right;
   border-radius: 0 0 var(--border-radius) var(--border-radius);
 }
 
+.ui.modal .content > form > .actions,
 .ui.modal .content > .actions {
   padding-top: 1em; /* if the "actions" is in the "content", some paddings are already added by the "content" */
-  text-align: right;
-}
-
-.ui.modal .actions {
   text-align: right;
 }
 

--- a/web_src/css/modules/segment.css
+++ b/web_src/css/modules/segment.css
@@ -123,13 +123,6 @@
   clear: both;
 }
 
-.ui[class*="left aligned"].segment {
-  text-align: left;
-}
-.ui[class*="center aligned"].segment {
-  text-align: center;
-}
-
 .ui.secondary.segment {
   background: var(--color-secondary-bg);
   color: var(--color-text-light);

--- a/web_src/css/modules/table.css
+++ b/web_src/css/modules/table.css
@@ -152,21 +152,6 @@
   }
 }
 
-.ui.table[class*="left aligned"],
-.ui.table [class*="left aligned"] {
-  text-align: left;
-}
-
-.ui.table[class*="center aligned"],
-.ui.table [class*="center aligned"] {
-  text-align: center;
-}
-
-.ui.table[class*="right aligned"],
-.ui.table [class*="right aligned"] {
-  text-align: right;
-}
-
 .ui.table[class*="top aligned"],
 .ui.table [class*="top aligned"] {
   vertical-align: top;


### PR DESCRIPTION
Small refactor to remove these CSS classes in favor of tailwind.

i have ran `rg ui | rg text | rg right` and `rg ui | rg text | rg left` and then did the replacement with `perl -p -i -e 's#text right#tw-text-right#g' templates/**/*` and verified a few places.