### PR TITLE
Fix "toAbsoluteLocaleDate" test when system locale is not en-US

### DIFF
--- a/web_src/js/webcomponents/absolute-date.test.ts
+++ b/web_src/js/webcomponents/absolute-date.test.ts
@@ -20,7 +20,7 @@ test('toAbsoluteLocaleDate', () => {
   // test different timezone
   const oldTZ = process.env.TZ;
   process.env.TZ = 'America/New_York';
-  expect(new Date('2024-03-15').toLocaleString()).toEqual('3/14/2024, 8:00:00 PM');
-  expect(toAbsoluteLocaleDate('2024-03-15')).toEqual('3/15/2024, 12:00:00 AM');
+  expect(new Date('2024-03-15').toLocaleString('en-US')).toEqual('3/14/2024, 8:00:00 PM');
+  expect(toAbsoluteLocaleDate('2024-03-15', 'en-US')).toEqual('3/15/2024, 12:00:00 AM');
   process.env.TZ = oldTZ;
 });


### PR DESCRIPTION
<!-- start tips 
Please check the following:
1. Make sure you are targeting the `main` branch, pull requests on release branches are only allowed for backports.
2. Make sure you have read contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md .
3. For documentations contribution, please go to https://gitea.com/gitea/docs
4. Describe what your pull request does and which issue you're targeting (if any).
5. It is recommended to enable "Allow edits by maintainers", so maintainers can help more easily.
6. Your input here will be included in the commit message when this PR has been merged. If you don't want some content to be included, please separate them with a line like `---`.
7. Delete all these tips before posting.
 end tips -->

Fixes #33937

When the system locale is not en-US, the test `toAbsoluteLocaleDate` fails because it assumes the locale is en-US. This pull request sets the locale for the test.