### PR TITLE
Cover `go.mod` and `go.sum` in `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,9 @@ insert_final_newline = true
 [*.{go,tmpl,html}]
 indent_style = tab
 
+[go.*]
+indent_style = tab
+
 [templates/custom/*.tmpl]
 insert_final_newline = false
 


### PR DESCRIPTION
These files were previously set to use spaces for indendation but they are supposed to use tabs, so set this in editorconfig.