### PR TITLE
Fail mirroring more gracefully

### DIFF
--- a/services/mirror/mirror_pull_test.go
+++ b/services/mirror/mirror_pull_test.go
@@ -78,6 +78,8 @@ func Test_checkRecoverableSyncError(t *testing.T) {
 		{true, "error: cannot lock ref 'refs/remotes/origin/foo': unable to resolve reference 'refs/remotes/origin/foo': reference broken"},
 		// A race condition in http git-fetch where named refs were force-pushed during the update, would exit status 128
 		{true, "error: cannot lock ref 'refs/pull/123456/merge': is at 988881adc9fc3655077dc2d4d757d480b5ea0e11 but expected 7f894307ffc9553edbd0b671cab829786866f7b2"},
+		// A race condition with other local git operations, such as git-maintenance, would exit status 128 (well, "Unable" the "U" is uppercase)
+		{true, "fatal: Unable to create '/data/gitea-repositories/foo-org/bar-repo.git/./objects/info/commit-graphs/commit-graph-chain.lock': File exists."},
 		// Missing or unauthorized credentials, would exit status 128
 		{false, "fatal: Authentication failed for 'https://example.com/foo-does-not-exist/bar.git/'"},
 		// A non-existent remote repository, would exit status 128

--- a/services/mirror/mirror_pull_test.go
+++ b/services/mirror/mirror_pull_test.go
@@ -66,45 +66,27 @@ func Test_parseRemoteUpdateOutput(t *testing.T) {
 }
 
 func Test_checkRecoverableSyncError(t *testing.T) {
-	recoverableDescription := " should be marked as recoverable."
-	fatalDescription := " should be considered fatal and not recoverable."
+	cases := []struct {
+		recoverable bool
+		message     string
+	}{
+		// A race condition in http git-fetch where certain refs were listed on the remote and are no longer there, would exit status 128
+		{true, "fatal: remote error: upload-pack: not our ref 988881adc9fc3655077dc2d4d757d480b5ea0e11"},
+		// A race condition where a local gc/prune removes a named ref during a git-fetch  would exit status 1
+		{true, "cannot lock ref 'refs/pull/123456/merge': unable to resolve reference 'refs/pull/134153/merge'"},
+		// A race condition in http git-fetch where named refs were listed on the remote and are no longer there
+		{true, "error: cannot lock ref 'refs/remotes/origin/foo': unable to resolve reference 'refs/remotes/origin/foo': reference broken"},
+		// A race condition in http git-fetch where named refs were force-pushed during the update, would exit status 128
+		{true, "error: cannot lock ref 'refs/pull/123456/merge': is at 988881adc9fc3655077dc2d4d757d480b5ea0e11 but expected 7f894307ffc9553edbd0b671cab829786866f7b2"},
+		// Missing or unauthorized credentials, would exit status 128
+		{false, "fatal: Authentication failed for 'https://example.com/foo-does-not-exist/bar.git/'"},
+		// A non-existent remote repository, would exit status 128
+		{false, "fatal: Could not read from remote repository."},
+		// A non-functioning proxy, would exit status 128
+		{false, "fatal: unable to access 'https://example.com/foo-does-not-exist/bar.git/': Failed to connect to configured-https-proxy port 1080 after 0 ms: Couldn't connect to server"},
+	}
 
-	// would exit status 128
-	description := "A race condition in http git-fetch where certain refs were listed on the remote and are no longer there"
-	stderr := "fatal: remote error: upload-pack: not our ref 988881adc9fc3655077dc2d4d757d480b5ea0e11"
-	assert.True(t, checkRecoverableSyncError(stderr), description+recoverableDescription)
-
-	// would exit status 1
-	description = "A race condition where a local gc/prune removes a named ref during a git-fetch"
-	stderr = "cannot lock ref 'refs/pull/123456/merge': unable to resolve reference 'refs/pull/134153/merge'"
-	assert.True(t, checkRecoverableSyncError(stderr), description+recoverableDescription)
-
-	description = "A race condition in http git-fetch where named refs were listed on the remote and are no longer there"
-	stderr = "error: cannot lock ref 'refs/remotes/origin/foo': unable to resolve reference 'refs/remotes/origin/foo': reference broken"
-	assert.True(t, checkRecoverableSyncError(stderr), description+recoverableDescription)
-
-	// would exit status 128
-	description = "A race condition in http git-fetch where named refs were force-pushed during the update"
-	stderr = "error: cannot lock ref 'refs/pull/123456/merge': is at 988881adc9fc3655077dc2d4d757d480b5ea0e11 but expected 7f894307ffc9553edbd0b671cab829786866f7b2"
-	assert.True(t, checkRecoverableSyncError(stderr), description+recoverableDescription)
-
-	// would exit status 128
-	description = "A race condition with other local git operations, such as git-maintenance,"
-	stderr = "fatal: Unable to create '/data/gitea-repositories/foo-org/bar-repo.git/./objects/info/commit-graphs/commit-graph-chain.lock': File exists."
-	assert.True(t, checkRecoverableSyncError(stderr), description+recoverableDescription)
-
-	// would exit status 128
-	description = "Missing or unauthorized credentials"
-	stderr = "fatal: Authentication failed for 'https://example.com/foo-does-not-exist/bar.git/'"
-	assert.False(t, checkRecoverableSyncError(stderr), description+fatalDescription)
-
-	// would exit status 128
-	description = "A non-existent remote repository"
-	stderr = "fatal: Could not read from remote repository."
-	assert.False(t, checkRecoverableSyncError(stderr), description+fatalDescription)
-
-	// would exit status 128
-	description = "A non-functioning proxy"
-	stderr = "fatal: unable to access 'https://example.com/foo-does-not-exist/bar.git/': Failed to connect to configured-https-proxy port 1080 after 0 ms: Couldn't connect to server"
-	assert.False(t, checkRecoverableSyncError(stderr), description+fatalDescription)
+	for _, c := range cases {
+		assert.Equal(t, c.recoverable, checkRecoverableSyncError(c.message), "test case: %s", c.message)
+	}
 }


### PR DESCRIPTION
* reuse recoverable error checks across mirror_pull
* add new cases for 'cannot lock ref/not our ref' (race condition in fetch) and 'Unable to create/lock"
* move lfs sync right after commit graph write, and before other maintenance which may fail
* try a prune for 'broken reference' as well as 'not our ref'
* always sync LFS right after commit graph write, and before other maintenance which may fail

This handles a few cases where our very large and very active repositories could serve mirrored git refs, but be missing lfs files:

## Case 1 (multiple variants): Race condition in git fetch
There was already a check for 'unable to resolve reference' on a failed git fetch, after which a git prune and then subsequent fetch are performed. This is to work around a race condition where the git remote tells Gitea about a ref for some HEAD of a branch, then fails a few seconds later because the remote branch was deleted, or the ref was updated (force push).

There are two more variants to the error message you can get, but for the same kind of race condition. These *may* be related to the git binary version Gitea has access to (in my case, it was 2.48.1).

## Case 2: githttp.go can serve updated git refs before it's synced lfs oids

There is probably a more aggressive refactor we could do here to have the cat-file loop use FETCH_HEAD instead of relying on the commit graphs to be committed locally (and thus serveable to clients of Gitea), but a simple reduction in the occurrences of this for me was to move the lfs sync block immediately after the commit-graph write and before any other time-consuming (or potentially erroring/exiting) blocks.