### PR TITLE
Fix dropdown delegating and some UI problems

### DIFF
--- a/modules/templates/util_avatar.go
+++ b/modules/templates/util_avatar.go
@@ -34,7 +34,7 @@ func AvatarHTML(src string, size int, class, name string) template.HTML {
 		name = "avatar"
 	}
 
-	return template.HTML(`<img loading="lazy" class="` + class + `" src="` + src + `" title="` + html.EscapeString(name) + `" width="` + sizeStr + `" height="` + sizeStr + `"/>`)
+	return template.HTML(`<img loading="lazy" alt="" class="` + class + `" src="` + src + `" title="` + html.EscapeString(name) + `" width="` + sizeStr + `" height="` + sizeStr + `"/>`)
 }
 
 // Avatar renders user avatars. args: user, size (int), class (string)

--- a/modules/templates/util_avatar.go
+++ b/modules/templates/util_avatar.go
@@ -34,6 +34,7 @@ func AvatarHTML(src string, size int, class, name string) template.HTML {
 		name = "avatar"
 	}
 
+	// use empty alt, otherwise if the image fails to load, the width will follow the "alt" text's width
 	return template.HTML(`<img loading="lazy" alt="" class="` + class + `" src="` + src + `" title="` + html.EscapeString(name) + `" width="` + sizeStr + `" height="` + sizeStr + `"/>`)
 }
 

--- a/templates/repo/icon.tmpl
+++ b/templates/repo/icon.tmpl
@@ -1,6 +1,6 @@
 {{$avatarLink := (.RelAvatarLink ctx)}}
 {{if $avatarLink}}
-	<img class="ui avatar tw-align-middle" src="{{$avatarLink}}" width="24" height="24" alt="{{.FullName}}">
+	<img class="ui avatar tw-align-middle" src="{{$avatarLink}}" width="24" height="24" alt="" aria-hidden="true">
 {{else if $.IsMirror}}
 	{{svg "octicon-mirror" 24}}
 {{else if $.IsFork}}

--- a/web_src/fomantic/build/components/dropdown.js
+++ b/web_src/fomantic/build/components/dropdown.js
@@ -752,6 +752,7 @@ $.fn.dropdown = function(parameters) {
               if(module.is.searchSelection() && module.can.show() && module.is.focusedOnSearch() ) {
                 module.show();
               }
+              settings.onAfterFiltered.call(element); // GITEA-PATCH: callback to correctly handle the filtered items
             }
           ;
           if(settings.useLabels && module.has.maxSelections()) {
@@ -3991,6 +3992,8 @@ $.fn.dropdown.settings = {
   onNoResults   : function(searchTerm) { return true; },
   onShow        : function(){},
   onHide        : function(){},
+
+  onAfterFiltered: function(){}, // GITEA-PATCH: callback to correctly handle the filtered items
 
   /* Component */
   name           : 'Dropdown',

--- a/web_src/js/modules/fomantic/dropdown.test.ts
+++ b/web_src/js/modules/fomantic/dropdown.test.ts
@@ -15,9 +15,9 @@ test('hideScopedEmptyDividers-simple', () => {
   expect(container.innerHTML).toEqual(`
 <div class="divider hidden transition"></div>
 <div class="item">a</div>
+<div class="divider hidden transition"></div>
+<div class="divider hidden transition"></div>
 <div class="divider"></div>
-<div class="divider hidden transition"></div>
-<div class="divider hidden transition"></div>
 <div class="item">b</div>
 <div class="divider hidden transition"></div>
 `);
@@ -35,10 +35,10 @@ test('hideScopedEmptyDividers-items-all-filtered', () => {
   hideScopedEmptyDividers(container);
   expect(container.innerHTML).toEqual(`
 <div class="any"></div>
-<div class="divider"></div>
+<div class="divider hidden transition"></div>
 <div class="item filtered">a</div>
 <div class="item filtered">b</div>
-<div class="divider hidden transition"></div>
+<div class="divider"></div>
 <div class="any"></div>
 `);
 });

--- a/web_src/js/modules/fomantic/dropdown.test.ts
+++ b/web_src/js/modules/fomantic/dropdown.test.ts
@@ -15,15 +15,35 @@ test('hideScopedEmptyDividers-simple', () => {
   expect(container.innerHTML).toEqual(`
 <div class="divider hidden transition"></div>
 <div class="item">a</div>
-<div class="divider hidden transition"></div>
-<div class="divider hidden transition"></div>
 <div class="divider"></div>
+<div class="divider hidden transition"></div>
+<div class="divider hidden transition"></div>
 <div class="item">b</div>
 <div class="divider hidden transition"></div>
 `);
 });
 
-test('hideScopedEmptyDividers-hidden1', () => {
+test('hideScopedEmptyDividers-items-all-filtered', () => {
+  const container = createElementFromHTML(`<div>
+<div class="any"></div>
+<div class="divider"></div>
+<div class="item filtered">a</div>
+<div class="item filtered">b</div>
+<div class="divider"></div>
+<div class="any"></div>
+</div>`);
+  hideScopedEmptyDividers(container);
+  expect(container.innerHTML).toEqual(`
+<div class="any"></div>
+<div class="divider"></div>
+<div class="item filtered">a</div>
+<div class="item filtered">b</div>
+<div class="divider hidden transition"></div>
+<div class="any"></div>
+`);
+});
+
+test('hideScopedEmptyDividers-hide-last', () => {
   const container = createElementFromHTML(`<div>
 <div class="item">a</div>
 <div class="divider" data-scope="b"></div>
@@ -37,7 +57,7 @@ test('hideScopedEmptyDividers-hidden1', () => {
 `);
 });
 
-test('hideScopedEmptyDividers-hidden2', () => {
+test('hideScopedEmptyDividers-scoped-items', () => {
   const container = createElementFromHTML(`<div>
 <div class="item" data-scope="">a</div>
 <div class="divider" data-scope="b"></div>

--- a/web_src/js/modules/fomantic/dropdown.ts
+++ b/web_src/js/modules/fomantic/dropdown.ts
@@ -341,7 +341,7 @@ export function hideScopedEmptyDividers(container: Element) {
   // no need to update "visibleItems" array since this is the last loop
   for (let i = 0; i < visibleItems.length - 1; i++) {
     if (!visibleItems[i].matches('.divider')) continue;
-    if (visibleItems[i + 1].matches('.divider')) hideDivider(visibleItems[i + 1]);
+    if (visibleItems[i + 1].matches('.divider')) hideDivider(visibleItems[i]);
   }
 }
 

--- a/web_src/js/modules/fomantic/dropdown.ts
+++ b/web_src/js/modules/fomantic/dropdown.ts
@@ -77,15 +77,6 @@ function processMenuItems($dropdown: any, dropdownCall: any) {
 function delegateDropdownModule($dropdown: any) {
   const dropdownCall = fomanticDropdownFn.bind($dropdown);
 
-  // If there is a "search input" in the "menu", Fomantic will only "focus the input" but not "toggle the menu" when the "dropdown icon" is clicked.
-  // Actually, Fomantic UI doesn't support such layout/usage. It needs to patch the "focusSearch" / "blurSearch" functions to make sure it toggles the menu.
-  const oldFocusSearch = dropdownCall('internal', 'focusSearch');
-  const oldBlurSearch = dropdownCall('internal', 'blurSearch');
-  // * If the "dropdown icon" is clicked, Fomantic calls "focusSearch", so show the menu
-  dropdownCall('internal', 'focusSearch', function (this: any) { dropdownCall('show'); oldFocusSearch.call(this) });
-  // * If the "dropdown icon" is clicked again when the menu is visible, Fomantic calls "blurSearch", so hide the menu
-  dropdownCall('internal', 'blurSearch', function (this: any) { oldBlurSearch.call(this); dropdownCall('hide') });
-
   const oldFilterItems = dropdownCall('internal', 'filterItems');
   dropdownCall('internal', 'filterItems', function (this: any, ...args: any[]) {
     oldFilterItems.call(this, ...args);
@@ -171,7 +162,6 @@ function attachStaticElements(dropdown: HTMLElement, focusable: HTMLElement, men
 
 function attachInitElements(dropdown: HTMLElement) {
   (dropdown as any)[ariaPatchKey] = {};
-  if (dropdown.classList.contains('custom')) return;
 
   // Dropdown has 2 different focusing behaviors
   // * with search input: the input is focused, and it works with aria-activedescendant pointing another sibling element.

--- a/web_src/js/modules/observer.ts
+++ b/web_src/js/modules/observer.ts
@@ -46,9 +46,11 @@ function callGlobalInitFunc(el: HTMLElement) {
   const func = globalInitFuncs[initFunc];
   if (!func) throw new Error(`Global init function "${initFunc}" not found`);
 
+  // when an element node is removed and added again, it should not be re-initialized again.
   type GiteaGlobalInitElement = Partial<HTMLElement> & {_giteaGlobalInited: boolean};
-  if ((el as GiteaGlobalInitElement)._giteaGlobalInited) throw new Error(`Global init function "${initFunc}" already executed`);
+  if ((el as GiteaGlobalInitElement)._giteaGlobalInited) return;
   (el as GiteaGlobalInitElement)._giteaGlobalInited = true;
+
   func(el);
 }
 


### PR DESCRIPTION
The old logic is incomplete. See the comment for the improved logic.

Fix #34011

And more fixes:

1. use empty "alt" for images, otherwise the width is not right when the image fails to load
2. remove the "dropdown icon" patch, because it has been clearly done in "dropdown.js" now
3. remove the "dropdown filtered item" patch, added a clear callback, and improve the logic
4. fix global init when a node is removed and added back gain (eg: the "cherry pick" dialog with a dropdown)