### PR TITLE
Fix contributors related page may leak resources

### DIFF
--- a/routers/web/repo/code_frequency.go
+++ b/routers/web/repo/code_frequency.go
@@ -4,7 +4,6 @@
 package repo
 
 import (
-	"errors"
 	"net/http"
 
 	"code.gitea.io/gitea/modules/templates"
@@ -30,11 +29,7 @@ func CodeFrequency(ctx *context.Context) {
 // CodeFrequencyData returns JSON of code frequency data
 func CodeFrequencyData(ctx *context.Context) {
 	if contributorStats, err := contributors_service.GetContributorStats(ctx, ctx.Cache, ctx.Repo.Repository, ctx.Repo.Repository.DefaultBranch); err != nil {
-		if errors.Is(err, contributors_service.ErrAwaitGeneration) {
-			ctx.Status(http.StatusAccepted)
-			return
-		}
-		ctx.ServerError("GetContributorStats", err)
+		ctx.ServerError("GetCodeFrequencyData", err)
 	} else {
 		ctx.JSON(http.StatusOK, contributorStats["total"].Weeks)
 	}

--- a/routers/web/repo/contributors.go
+++ b/routers/web/repo/contributors.go
@@ -4,8 +4,6 @@
 package repo
 
 import (
-	std_ctx "context"
-	"errors"
 	"net/http"
 
 	"code.gitea.io/gitea/modules/templates"
@@ -28,10 +26,6 @@ func Contributors(ctx *context.Context) {
 // ContributorsData renders JSON of contributors along with their weekly commit statistics
 func ContributorsData(ctx *context.Context) {
 	if contributorStats, err := contributors_service.GetContributorStats(ctx, ctx.Cache, ctx.Repo.Repository, ctx.Repo.Repository.DefaultBranch); err != nil {
-		if errors.Is(err, contributors_service.ErrAwaitGeneration) || errors.Is(err, std_ctx.DeadlineExceeded) {
-			ctx.Status(http.StatusAccepted)
-			return
-		}
 		ctx.ServerError("GetContributorStats", err)
 	} else {
 		ctx.JSON(http.StatusOK, contributorStats)

--- a/routers/web/repo/contributors.go
+++ b/routers/web/repo/contributors.go
@@ -4,6 +4,7 @@
 package repo
 
 import (
+	std_ctx "context"
 	"errors"
 	"net/http"
 
@@ -27,7 +28,7 @@ func Contributors(ctx *context.Context) {
 // ContributorsData renders JSON of contributors along with their weekly commit statistics
 func ContributorsData(ctx *context.Context) {
 	if contributorStats, err := contributors_service.GetContributorStats(ctx, ctx.Cache, ctx.Repo.Repository, ctx.Repo.Repository.DefaultBranch); err != nil {
-		if errors.Is(err, contributors_service.ErrAwaitGeneration) {
+		if errors.Is(err, contributors_service.ErrAwaitGeneration) || errors.Is(err, std_ctx.DeadlineExceeded) {
 			ctx.Status(http.StatusAccepted)
 			return
 		}

--- a/services/repository/contributors_graph.go
+++ b/services/repository/contributors_graph.go
@@ -102,7 +102,7 @@ func GetContributorStats(ctx context.Context, cache cache.StringCache, repo *rep
 	}
 
 	// run generation async
-	res, err := generateContributorStats(ctx, cache, cacheKey, repo, revision)
+	res, err := generateContributorStats(ctx, repo, revision)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func GetContributorStats(ctx context.Context, cache cache.StringCache, repo *rep
 }
 
 // getExtendedCommitStats return the list of *ExtendedCommitStats for the given revision
-func getExtendedCommitStats(ctx context.Context, repoPath string, baseCommit *git.Commit, revision string /*, limit int */) ([]*ExtendedCommitStats, error) {
+func getExtendedCommitStats(ctx context.Context, repoPath string, baseCommit *git.Commit) ([]*ExtendedCommitStats, error) {
 	stdoutReader, stdoutWriter, err := os.Pipe()
 	if err != nil {
 		return nil, err
@@ -202,7 +202,7 @@ func getExtendedCommitStats(ctx context.Context, repoPath string, baseCommit *gi
 	return extendedCommitStats, nil
 }
 
-func generateContributorStats(ctx context.Context, cache cache.StringCache, cacheKey string, repo *repo_model.Repository, revision string) (map[string]*ContributorData, error) {
+func generateContributorStats(ctx context.Context, repo *repo_model.Repository, revision string) (map[string]*ContributorData, error) {
 	gitRepo, closer, err := gitrepo.RepositoryFromContextOrOpen(ctx, repo)
 	if err != nil {
 		return nil, err
@@ -216,7 +216,7 @@ func generateContributorStats(ctx context.Context, cache cache.StringCache, cach
 	if err != nil {
 		return nil, err
 	}
-	extendedCommitStats, err := getExtendedCommitStats(ctx, repo.RepoPath(), baseCommit, revision)
+	extendedCommitStats, err := getExtendedCommitStats(ctx, repo.RepoPath(), baseCommit)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously, when users visited the contributors-related page and closed it immediately, some subprocesses were never properly cleaned up. If the user refreshed the page multiple times, this could lead to a buildup of orphaned subprocesses running in the background.

This PR refactors the original design. The server no longer relies on timeouts to manage subprocesses. Instead, background subprocesses are now properly released when the page is closed or reloaded.