### PR TITLE
Fix git client accessing renamed repo 

### DIFF
--- a/routers/web/githttp.go
+++ b/routers/web/githttp.go
@@ -4,26 +4,12 @@
 package web
 
 import (
-	"net/http"
-
-	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/web"
 	"code.gitea.io/gitea/routers/web/repo"
 	"code.gitea.io/gitea/services/context"
 )
 
 func addOwnerRepoGitHTTPRouters(m *web.Router) {
-	reqGitSignIn := func(ctx *context.Context) {
-		if !setting.Service.RequireSignInView {
-			return
-		}
-		// rely on the results of Contexter
-		if !ctx.IsSigned {
-			// TODO: support digit auth - which would be Authorization header with digit
-			ctx.Resp.Header().Set("WWW-Authenticate", `Basic realm="Gitea"`)
-			ctx.HTTPError(http.StatusUnauthorized)
-		}
-	}
 	m.Group("/{username}/{reponame}", func() {
 		m.Methods("POST,OPTIONS", "/git-upload-pack", repo.ServiceUploadPack)
 		m.Methods("POST,OPTIONS", "/git-receive-pack", repo.ServiceReceivePack)
@@ -36,5 +22,5 @@ func addOwnerRepoGitHTTPRouters(m *web.Router) {
 		m.Methods("GET,OPTIONS", "/objects/{head:[0-9a-f]{2}}/{hash:[0-9a-f]{38,62}}", repo.GetLooseObject)
 		m.Methods("GET,OPTIONS", "/objects/pack/pack-{file:[0-9a-f]{40,64}}.pack", repo.GetPackFile)
 		m.Methods("GET,OPTIONS", "/objects/pack/pack-{file:[0-9a-f]{40,64}}.idx", repo.GetIdxFile)
-	}, optSignInIgnoreCsrf, reqGitSignIn, repo.HTTPGitEnabledHandler, repo.CorsHandler(), context.UserAssignmentWeb())
+	}, optSignInIgnoreCsrf, repo.HTTPGitEnabledHandler, repo.CorsHandler(), context.UserAssignmentWeb())
 }

--- a/tests/integration/git_smart_http_test.go
+++ b/tests/integration/git_smart_http_test.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"testing"
 
+	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/test"
 	"code.gitea.io/gitea/modules/util"
 
 	"github.com/stretchr/testify/assert"
@@ -16,7 +18,10 @@ import (
 )
 
 func TestGitSmartHTTP(t *testing.T) {
-	onGiteaRun(t, testGitSmartHTTP)
+	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+		testGitSmartHTTP(t, u)
+		testRenamedRepoRedirect(t)
+	})
 }
 
 func testGitSmartHTTP(t *testing.T, u *url.URL) {
@@ -72,4 +77,22 @@ func testGitSmartHTTP(t *testing.T, u *url.URL) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func testRenamedRepoRedirect(t *testing.T) {
+	defer test.MockVariableValue(&setting.Service.RequireSignInView, true)()
+
+	// git client requires to get a 301 redirect response before 401 unauthorized response
+	req := NewRequest(t, "GET", "/user2/oldrepo1/info/refs")
+	resp := MakeRequest(t, req, http.StatusMovedPermanently)
+	redirect := resp.Header().Get("Location")
+	assert.Equal(t, "/user2/repo1/info/refs", redirect)
+
+	req = NewRequest(t, "GET", redirect)
+	resp = MakeRequest(t, req, http.StatusUnauthorized)
+	assert.Equal(t, "Unauthorized\n", resp.Body.String())
+
+	req = NewRequest(t, "GET", redirect).AddBasicAuth("user2")
+	resp = MakeRequest(t, req, http.StatusOK)
+	assert.Contains(t, resp.Body.String(), "65f1bf27bc3bf70f64657658635e66094edbcb4d\trefs/tags/v1.1")
 }


### PR DESCRIPTION
Fix #28460

The `reqGitSignIn` is just copied-pasted code (from githtttp.go) and causes the regression bug.