### PR TITLE
Fix the issue with error message logging for the `check-attr` command on Windows OS.

### DIFF
--- a/modules/git/command.go
+++ b/modules/git/command.go
@@ -350,9 +350,10 @@ func (c *Command) run(ctx context.Context, skip int, opts *RunOpts) error {
 	// We need to check if the context is canceled by the program on Windows.
 	// This is because Windows does not have signal checking when terminating the process.
 	// It always returns exit code 1, unlike Linux, which has many exit codes for signals.
+	// `err.Error()` returns "exit status 1" when using the `git check-attr` command after the context is canceled.
 	if runtime.GOOS == "windows" &&
 		err != nil &&
-		err.Error() == "" &&
+		(err.Error() == "" || err.Error() == "exit status 1") &&
 		cmd.ProcessState.ExitCode() == 1 &&
 		ctx.Err() == context.Canceled {
 		return ctx.Err()


### PR DESCRIPTION
Close #34022 , #33550 

This error message always appears when using the `check-attr` command, even though it works correctly. 
The issue occurs when the stdin writer is closed, so I added a special case to handle and check the error message when the exit code is 1.