### PR TITLE
Simplify emoji rendering

### DIFF
--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -989,6 +989,7 @@ table th[data-sortt-desc] .svg {
   box-shadow: 0 0 0 1px var(--color-secondary) inset;
 }
 
+/* for "image" emojis like ":git:"  ":gitea:" and ":github:" (see CUSTOM_EMOJIS config option) */
 .emoji img {
   border-width: 0 !important;
   margin: 0 !important;

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -989,14 +989,6 @@ table th[data-sortt-desc] .svg {
   box-shadow: 0 0 0 1px var(--color-secondary) inset;
 }
 
-.emoji {
-  font-size: 1.25em;
-  line-height: var(--line-height-default);
-  font-style: normal !important;
-  font-weight: var(--font-weight-normal) !important;
-  vertical-align: -0.075em;
-}
-
 .emoji img {
   border-width: 0 !important;
   margin: 0 !important;

--- a/web_src/css/markup/content.css
+++ b/web_src/css/markup/content.css
@@ -338,7 +338,6 @@
 
 .markup .emoji {
   max-width: none;
-  vertical-align: text-top;
 }
 
 .markup span.frame {

--- a/web_src/css/markup/content.css
+++ b/web_src/css/markup/content.css
@@ -336,10 +336,6 @@
   padding-right: 28px;
 }
 
-.markup .emoji {
-  max-width: none;
-}
-
 .markup span.frame {
   display: block;
   overflow: hidden;


### PR DESCRIPTION
It seems like most of our custom styles around the .emoji class are useless and we can just make them render like any other text. Rendering should now match GitHub.

Fixes: https://github.com/go-gitea/gitea/issues/34019

Also see https://github.com/go-gitea/gitea/pull/11541 and https://github.com/go-gitea/gitea/pull/12317 for some context. I think browser emoji rendering has improved in recent years so these hacks are no longer needed.

Gitea:

<img width="182" alt="image" src="https://github.com/user-attachments/assets/0442bc8e-e0a1-4728-8c85-7e241534d893" />

GitHub:

<img width="189" alt="image" src="https://github.com/user-attachments/assets/e4423a99-970f-4fb7-bf64-58fb2681af57" />
