### PR TITLE
Hide activity contributors, recent commits and code frequrency left tabs if there is no code permission (#34053)

### DIFF
--- a/routers/web/repo/code_frequency.go
+++ b/routers/web/repo/code_frequency.go
@@ -34,7 +34,7 @@ func CodeFrequencyData(ctx *context.Context) {
 			ctx.Status(http.StatusAccepted)
 			return
 		}
-		ctx.ServerError("GetCodeFrequencyData", err)
+		ctx.ServerError("GetContributorStats", err)
 	} else {
 		ctx.JSON(http.StatusOK, contributorStats["total"].Weeks)
 	}

--- a/routers/web/repo/recent_commits.go
+++ b/routers/web/repo/recent_commits.go
@@ -4,12 +4,10 @@
 package repo
 
 import (
-	"errors"
 	"net/http"
 
 	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/services/context"
-	contributors_service "code.gitea.io/gitea/services/repository"
 )
 
 const (
@@ -25,17 +23,4 @@ func RecentCommits(ctx *context.Context) {
 	ctx.PageData["repoLink"] = ctx.Repo.RepoLink
 
 	ctx.HTML(http.StatusOK, tplRecentCommits)
-}
-
-// RecentCommitsData returns JSON of recent commits data
-func RecentCommitsData(ctx *context.Context) {
-	if contributorStats, err := contributors_service.GetContributorStats(ctx, ctx.Cache, ctx.Repo.Repository, ctx.Repo.CommitID); err != nil {
-		if errors.Is(err, contributors_service.ErrAwaitGeneration) {
-			ctx.Status(http.StatusAccepted)
-			return
-		}
-		ctx.ServerError("RecentCommitsData", err)
-	} else {
-		ctx.JSON(http.StatusOK, contributorStats["total"].Weeks)
-	}
 }

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1454,18 +1454,21 @@ func registerRoutes(m *web.Router) {
 	m.Group("/{username}/{reponame}/activity", func() {
 		m.Get("", repo.Activity)
 		m.Get("/{period}", repo.Activity)
-		m.Group("/contributors", func() {
-			m.Get("", repo.Contributors)
-			m.Get("/data", repo.ContributorsData)
-		})
-		m.Group("/code-frequency", func() {
-			m.Get("", repo.CodeFrequency)
-			m.Get("/data", repo.CodeFrequencyData)
-		})
-		m.Group("/recent-commits", func() {
-			m.Get("", repo.RecentCommits)
-			m.Get("/data", repo.RecentCommitsData)
-		})
+
+		m.Group("", func() {
+			m.Group("/contributors", func() {
+				m.Get("", repo.Contributors)
+				m.Get("/data", repo.ContributorsData)
+			})
+			m.Group("/code-frequency", func() {
+				m.Get("", repo.CodeFrequency)
+				m.Get("/data", repo.CodeFrequencyData)
+			})
+			m.Group("/recent-commits", func() {
+				m.Get("", repo.RecentCommits)
+				m.Get("/data", repo.CodeFrequencyData) // "recent-commits" also uses the same data as "code-frequency"
+			})
+		}, reqRepoCodeReader)
 	},
 		optSignIn, context.RepoAssignment, context.RequireRepoReaderOr(unit.TypePullRequests, unit.TypeIssues, unit.TypeReleases),
 		context.RepoRef(), repo.MustBeNotEmpty,

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1470,7 +1470,7 @@ func registerRoutes(m *web.Router) {
 			})
 		}, reqRepoCodeReader)
 	},
-		optSignIn, context.RepoAssignment, context.RequireRepoReaderOr(unit.TypePullRequests, unit.TypeIssues, unit.TypeReleases),
+		optSignIn, context.RepoAssignment, context.RequireRepoReaderOr(unit.TypeCode, unit.TypePullRequests, unit.TypeIssues, unit.TypeReleases),
 		context.RepoRef(), repo.MustBeNotEmpty,
 	)
 	// end "/{username}/{reponame}/activity"

--- a/templates/repo/navbar.tmpl
+++ b/templates/repo/navbar.tmpl
@@ -1,14 +1,18 @@
+{{$canReadCode := $.Permission.CanRead ctx.Consts.RepoUnitTypeCode}}
+
 <div class="ui fluid vertical menu">
 	<a class="{{if .PageIsPulse}}active {{end}}item" href="{{.RepoLink}}/activity">
 		{{ctx.Locale.Tr "repo.activity.navbar.pulse"}}
 	</a>
-	<a class="{{if .PageIsContributors}}active {{end}}item" href="{{.RepoLink}}/activity/contributors">
-		{{ctx.Locale.Tr "repo.activity.navbar.contributors"}}
-	</a>
-	<a class="{{if .PageIsCodeFrequency}}active{{end}} item" href="{{.RepoLink}}/activity/code-frequency">
-		{{ctx.Locale.Tr "repo.activity.navbar.code_frequency"}}
-	</a>
-	<a class="{{if .PageIsRecentCommits}}active{{end}} item" href="{{.RepoLink}}/activity/recent-commits">
-		{{ctx.Locale.Tr "repo.activity.navbar.recent_commits"}}
-	</a>
+	{{if $canReadCode}}
+		<a class="{{if .PageIsContributors}}active {{end}}item" href="{{.RepoLink}}/activity/contributors">
+			{{ctx.Locale.Tr "repo.activity.navbar.contributors"}}
+		</a>
+		<a class="{{if .PageIsCodeFrequency}}active{{end}} item" href="{{.RepoLink}}/activity/code-frequency">
+			{{ctx.Locale.Tr "repo.activity.navbar.code_frequency"}}
+		</a>
+		<a class="{{if .PageIsRecentCommits}}active{{end}} item" href="{{.RepoLink}}/activity/recent-commits">
+			{{ctx.Locale.Tr "repo.activity.navbar.recent_commits"}}
+		</a>
+	{{end}}
 </div>


### PR DESCRIPTION
Backport #34053 

When a team have no code unit permission of a repository, the member of the team should not view activity contributors, recent commits and code frequrency.
