### PR TITLE
Fix markup content overflow

### DIFF
--- a/web_src/css/markup/content.css
+++ b/web_src/css/markup/content.css
@@ -2,11 +2,7 @@
   overflow: hidden;
   font-size: 16px;
   line-height: 1.5 !important;
-  overflow-wrap: break-word;
-}
-
-.conversation-holder .markup {
-  overflow-wrap: anywhere; /* prevent overflow in code comments. TODO: properly restrict .conversation-holder width and remove this */
+  overflow-wrap: anywhere;
 }
 
 .markup > *:first-child {


### PR DESCRIPTION
Fix #34069:  use `overflow-wrap: anywhere` to correctly wrap overflowed content.

