### PR TITLE
Fix some UI bugs and clean up unused tests

### DIFF
--- a/modules/fileicon/material.go
+++ b/modules/fileicon/material.go
@@ -99,12 +99,9 @@ func (m *MaterialIconProvider) FileIcon(ctx reqctx.RequestContext, entry *git.Tr
 	}
 
 	name := m.findIconNameByGit(entry)
-	if name == "folder" {
-		// the material icon pack's "folder" icon doesn't look good, so use our built-in one
-		// keep the old "octicon-xxx" class name to make some "theme plugin selector" could still work
-		return svg.RenderHTML("material-folder-generic", 16, "octicon-file-directory-fill")
-	}
-	if iconSVG, ok := m.svgs[name]; ok && iconSVG != "" {
+	// the material icon pack's "folder" icon doesn't look good, so use our built-in one
+	// keep the old "octicon-xxx" class name to make some "theme plugin selector" could still work
+	if iconSVG, ok := m.svgs[name]; ok && name != "folder" && iconSVG != "" {
 		// keep the old "octicon-xxx" class name to make some "theme plugin selector" could still work
 		extraClass := "octicon-file"
 		switch {
@@ -115,7 +112,8 @@ func (m *MaterialIconProvider) FileIcon(ctx reqctx.RequestContext, entry *git.Tr
 		}
 		return m.renderFileIconSVG(ctx, name, iconSVG, extraClass)
 	}
-	return svg.RenderHTML("octicon-file")
+	// TODO: use an interface or wrapper for git.Entry to make the code testable.
+	return BasicThemeIcon(entry)
 }
 
 func (m *MaterialIconProvider) findIconNameWithLangID(s string) string {

--- a/web_src/js/utils/dom.test.ts
+++ b/web_src/js/utils/dom.test.ts
@@ -1,4 +1,10 @@
-import {createElementFromAttrs, createElementFromHTML, queryElemChildren, querySingleVisibleElem} from './dom.ts';
+import {
+  createElementFromAttrs,
+  createElementFromHTML,
+  queryElemChildren,
+  querySingleVisibleElem,
+  toggleElem,
+} from './dom.ts';
 
 test('createElementFromHTML', () => {
   expect(createElementFromHTML('<a>foo<span>bar</span></a>').outerHTML).toEqual('<a>foo<span>bar</span></a>');
@@ -31,4 +37,14 @@ test('queryElemChildren', () => {
   const el = createElementFromHTML('<div><span class="a">a</span><span class="b">b</span></div>');
   const children = queryElemChildren(el, '.a');
   expect(children.length).toEqual(1);
+});
+
+test('toggleElem', () => {
+  const el = createElementFromHTML('<p><div>a</div><div class="tw-hidden">b</div></p>');
+  toggleElem(el.children);
+  expect(el.outerHTML).toEqual('<p><div class="tw-hidden">a</div><div class="">b</div></p>');
+  toggleElem(el.children, false);
+  expect(el.outerHTML).toEqual('<p><div class="tw-hidden">a</div><div class="tw-hidden">b</div></p>');
+  toggleElem(el.children, true);
+  expect(el.outerHTML).toEqual('<p><div class="">a</div><div class="">b</div></p>');
 });

--- a/web_src/js/utils/dom.ts
+++ b/web_src/js/utils/dom.ts
@@ -44,7 +44,7 @@ export function toggleClass(el: ElementArg, className: string, force?: boolean) 
  * @param force force=true to show or force=false to hide, undefined to toggle
  */
 export function toggleElem(el: ElementArg, force?: boolean) {
-  toggleClass(el, 'tw-hidden', !force);
+  toggleClass(el, 'tw-hidden', force === undefined ? force : !force);
 }
 
 export function showElem(el: ElementArg) {


### PR DESCRIPTION
1. Make the material icon falls back to basic theme correctly (see screenshot below)
2. Remove `TestAttributeReader`, the problem has been resolved.
3. Fix `toggleElem` bug and add tests


Before:

<details>

<summary>The New PR button doesn't work, and the icon for some folders are not right</summary>

![image](https://github.com/user-attachments/assets/c4eeab50-60f7-46d5-b72a-42b8f988c7cd)

![image](https://github.com/user-attachments/assets/f40657bc-bae0-4697-8b35-811b76bc7c24)

</details>

After:


<details>

![image](https://github.com/user-attachments/assets/908e1e40-0d23-482b-989c-a92f18fa6e22)

</details>