### PR TITLE
remove hardcoded 'code' string in clone_panel.tmpl

### DIFF
--- a/templates/repo/clone_panel.tmpl
+++ b/templates/repo/clone_panel.tmpl
@@ -1,6 +1,6 @@
 <button class="ui primary button js-btn-clone-panel">
 	{{svg "octicon-code" 16}}
-	<span>Code</span>
+	<span>{{ctx.Locale.Tr "repo.code"}}</span>
 	{{svg "octicon-triangle-down" 14 "dropdown icon"}}
 </button>
 <div class="clone-panel-popup tippy-target">


### PR DESCRIPTION
This commit replaces the hardcoded string "code" in the clone panel button with the i18n local for repo.code.  
