### PR TITLE
Bump go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module code.gitea.io/gitea
 
-go 1.23.6
+go 1.23.8
 
 // rfc5280 said: "The serial number is an integer assigned by the CA to each certificate."
 // But some CAs use negative serial number, just relax the check. related:


### PR DESCRIPTION
Fixes: https://pkg.go.dev/vuln/GO-2025-3563

Because of a bug in go, we can not remove the minor version in go.mod without `make tidy` introducing a potentially harmful `toolchain` directive, so just bump the go version here. From what I gather, this will be fixed in go 1.25.