### PR TITLE
Use tag's database num commits instead of read the commit counts from git data

### DIFF
--- a/models/repo/release.go
+++ b/models/repo/release.go
@@ -161,6 +161,11 @@ func UpdateRelease(ctx context.Context, rel *Release) error {
 	return err
 }
 
+func UpdateReleaseNumCommits(ctx context.Context, rel *Release) error {
+	_, err := db.GetEngine(ctx).ID(rel.ID).Cols("num_commits").Update(rel)
+	return err
+}
+
 // AddReleaseAttachments adds a release attachments
 func AddReleaseAttachments(ctx context.Context, releaseID int64, attachmentUUIDs []string) (err error) {
 	// Check attachments

--- a/services/context/repo.go
+++ b/services/context/repo.go
@@ -938,6 +938,18 @@ func RepoRefByType(detectRefType git.RefType) func(*Context) {
 				ctx.ServerError("GetRelease", err)
 				return
 			}
+			// for mirror tags, the number of commist may not be set
+			if rel.NumCommits <= 0 {
+				rel.NumCommits, err = ctx.Repo.GetCommitsCount()
+				if err != nil {
+					ctx.ServerError("GetCommitsCount", err)
+					return
+				}
+				if err := repo_model.UpdateReleaseNumCommits(ctx, rel); err != nil {
+					ctx.ServerError("UpdateReleaseNumCommits", err)
+					return
+				}
+			}
 			ctx.Repo.CommitsCount = rel.NumCommits
 		} else {
 			ctx.Repo.CommitsCount, err = ctx.Repo.GetCommitsCount()

--- a/services/context/repo.go
+++ b/services/context/repo.go
@@ -920,11 +920,8 @@ func RepoRefByType(detectRefType git.RefType) func(*Context) {
 		ctx.Data["RefFullName"] = ctx.Repo.RefFullName
 		ctx.Data["RefTypeNameSubURL"] = ctx.Repo.RefTypeNameSubURL()
 		ctx.Data["TreePath"] = ctx.Repo.TreePath
-
 		ctx.Data["BranchName"] = ctx.Repo.BranchName
-
 		ctx.Data["CommitID"] = ctx.Repo.CommitID
-
 		ctx.Data["CanCreateBranch"] = ctx.Repo.CanCreateBranch() // only used by the branch selector dropdown: AllowCreateNewRef
 
 		// if it's a tag, we just get the commits count from database
@@ -957,9 +954,9 @@ func RepoRefByType(detectRefType git.RefType) func(*Context) {
 				ctx.ServerError("GetCommitsCount", err)
 				return
 			}
-			ctx.Data["CommitsCount"] = ctx.Repo.CommitsCount
-			ctx.Repo.GitRepo.LastCommitCache = git.NewLastCommitCache(ctx.Repo.CommitsCount, ctx.Repo.Repository.FullName(), ctx.Repo.GitRepo, cache.GetCache())
 		}
+		ctx.Data["CommitsCount"] = ctx.Repo.CommitsCount
+		ctx.Repo.GitRepo.LastCommitCache = git.NewLastCommitCache(ctx.Repo.CommitsCount, ctx.Repo.Repository.FullName(), ctx.Repo.GitRepo, cache.GetCache())
 	}
 }
 


### PR DESCRIPTION
It will be slow to get the commits count for a tag of a big repository. But the commits count has been stored in the table `release` of the database. We could just use that value.

```
 git-run duration=1.4821s func.caller=git.CommitsCount git.command="/usr/bin/git ...global... rev-list --count 1aa3f624c40852b36a14c479daae1fc879f3d3bf"
```
