### PR TITLE
Fix some trivial problems

### DIFF
--- a/routers/api/packages/swift/swift.go
+++ b/routers/api/packages/swift/swift.go
@@ -304,7 +304,7 @@ func formFileOptionalReadCloser(ctx *context.Context, formKey string) (io.ReadCl
 	if content == "" {
 		return nil, nil
 	}
-	return io.NopCloser(strings.NewReader(ctx.Req.FormValue(formKey))), nil
+	return io.NopCloser(strings.NewReader(content)), nil
 }
 
 // UploadPackageFile refers to https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/PackageRegistry/Registry.md#endpoint-6

--- a/templates/repo/tag/name.tmpl
+++ b/templates/repo/tag/name.tmpl
@@ -1,3 +1,3 @@
-<a class="ui label basic tiny button{{if .IsRelease}} primary{{end}}" href="{{.RepoLink}}/src/tag/{{.TagName|PathEscape}}">
+<a class="ui basic label tw-p-1 {{if .IsRelease}}primary{{end}}" href="{{.RepoLink}}/src/tag/{{.TagName|PathEscape}}">
 {{svg "octicon-tag"}} {{.TagName}}
 </a>


### PR DESCRIPTION
1. Using existing "content" variable in `swift.go` (it was not wrong but not good, it was caused by my copy-paste mistake).
2. Do not report 500 server error in `GetPullDiffStats` middleware, otherwise a PR missing ref won't be able to view.
3. Fix the abused "label button" when listing commits, there was too much padding space, see the screenshot below.