### PR TITLE
Improve "not found" error messages for API

### DIFF
--- a/routers/api/v1/repo/commits.go
+++ b/routers/api/v1/repo/commits.go
@@ -75,7 +75,7 @@ func getCommit(ctx *context.APIContext, identifier string, toCommitOpts convert.
 	commit, err := ctx.Repo.GitRepo.GetCommit(identifier)
 	if err != nil {
 		if git.IsErrNotExist(err) {
-			ctx.APIErrorNotFound(identifier)
+			ctx.APIErrorNotFound("commit doesn't exist: " + identifier)
 			return
 		}
 		ctx.APIErrorInternal(err)
@@ -310,7 +310,7 @@ func DownloadCommitDiffOrPatch(ctx *context.APIContext) {
 
 	if err := git.GetRawDiff(ctx.Repo.GitRepo, sha, diffType, ctx.Resp); err != nil {
 		if git.IsErrNotExist(err) {
-			ctx.APIErrorNotFound(sha)
+			ctx.APIErrorNotFound("commit doesn't exist: " + sha)
 			return
 		}
 		ctx.APIErrorInternal(err)

--- a/routers/api/v1/repo/issue_tracked_time.go
+++ b/routers/api/v1/repo/issue_tracked_time.go
@@ -5,7 +5,6 @@ package repo
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -367,7 +366,7 @@ func DeleteTime(ctx *context.APIContext) {
 		return
 	}
 	if time.Deleted {
-		ctx.APIErrorNotFound(fmt.Errorf("tracked time [%d] already deleted", time.ID))
+		ctx.APIErrorNotFound("tracked time was already deleted")
 		return
 	}
 

--- a/routers/api/v1/repo/notes.go
+++ b/routers/api/v1/repo/notes.go
@@ -79,7 +79,7 @@ func getNote(ctx *context.APIContext, identifier string) {
 	var note git.Note
 	if err := git.GetNote(ctx, ctx.Repo.GitRepo, commitID.String(), &note); err != nil {
 		if git.IsErrNotExist(err) {
-			ctx.APIErrorNotFound(identifier)
+			ctx.APIErrorNotFound("commit doesn't exist: " + identifier)
 			return
 		}
 		ctx.APIErrorInternal(err)

--- a/routers/api/v1/repo/tag.go
+++ b/routers/api/v1/repo/tag.go
@@ -150,7 +150,7 @@ func GetTag(ctx *context.APIContext) {
 
 	tag, err := ctx.Repo.GitRepo.GetTag(tagName)
 	if err != nil {
-		ctx.APIErrorNotFound(tagName)
+		ctx.APIErrorNotFound("tag doesn't exist: " + tagName)
 		return
 	}
 	ctx.JSON(http.StatusOK, convert.ToTag(ctx.Repo.Repository, tag))

--- a/services/context/api.go
+++ b/services/context/api.go
@@ -313,7 +313,7 @@ func RepoRefForAPI(next http.Handler) http.Handler {
 			ctx.Repo.Commit, err = ctx.Repo.GitRepo.GetCommit(refName)
 		}
 		if ctx.Repo.Commit == nil || errors.Is(err, util.ErrNotExist) {
-			ctx.APIErrorNotFound(fmt.Errorf("not exist: '%s'", ctx.PathParam("*")))
+			ctx.APIErrorNotFound("unable to find a git ref")
 			return
 		} else if err != nil {
 			ctx.APIErrorInternal(err)


### PR DESCRIPTION
Make the message clear, for example: #34266