### PR TITLE
Fix wrong review requests when updating the pull request

### DIFF
--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -463,12 +463,7 @@ func AddTestPullRequestTask(opts TestPullRequestOptions) {
 					}
 
 					if !pr.IsWorkInProgress(ctx) {
-						var reviewNotifiers []*issue_service.ReviewRequestNotifier
-						if opts.IsForcePush {
-							reviewNotifiers, err = issue_service.PullRequestCodeOwnersReview(ctx, pr)
-						} else {
-							reviewNotifiers, err = issue_service.PullRequestCodeOwnersReviewSpecialCommits(ctx, pr, opts.OldCommitID, opts.NewCommitID)
-						}
+						reviewNotifiers, err := issue_service.PullRequestCodeOwnersReview(ctx, pr)
 						if err != nil {
 							log.Error("PullRequestCodeOwnersReview: %v", err)
 						}


### PR DESCRIPTION
Fix #34224

The previous implementation in #33744 will get the pushed commits changed files. But it's not always right when push a merged commit. This PR reverted the logic in #33744 and will always get the PR's changed files and get code owners.