### PR TITLE
POC: Rework update file via git fast-import

### DIFF
--- a/modules/git/attribute/attribute.go
+++ b/modules/git/attribute/attribute.go
@@ -88,6 +88,10 @@ func (attrs *Attributes) GetLinguistLanguage() optional.Option[string] {
 	return attrs.Get(LinguistLanguage).ToString()
 }
 
+func (attrs *Attributes) MatchLFS() bool {
+	return attrs.Get(Filter).ToString().Value() == "lfs"
+}
+
 func (attrs *Attributes) GetGitlabLanguage() optional.Option[string] {
 	attrStr := attrs.Get(GitlabLanguage).ToString()
 	if attrStr.Has() {

--- a/routers/api/v1/repo/file.go
+++ b/routers/api/v1/repo/file.go
@@ -485,25 +485,17 @@ func ChangeFiles(ctx *context.APIContext) {
 		Message:   apiOpts.Message,
 		OldBranch: apiOpts.BranchName,
 		NewBranch: apiOpts.NewBranchName,
-		Committer: &files_service.IdentityOptions{
-			GitUserName:  apiOpts.Committer.Name,
-			GitUserEmail: apiOpts.Committer.Email,
+		Committer: &git.Signature{
+			Name:  apiOpts.Committer.Name,
+			Email: apiOpts.Committer.Email,
+			When:  apiOpts.Dates.Committer,
 		},
-		Author: &files_service.IdentityOptions{
-			GitUserName:  apiOpts.Author.Name,
-			GitUserEmail: apiOpts.Author.Email,
-		},
-		Dates: &files_service.CommitDateOptions{
-			Author:    apiOpts.Dates.Author,
-			Committer: apiOpts.Dates.Committer,
+		Author: &git.Signature{
+			Name:  apiOpts.Author.Name,
+			Email: apiOpts.Author.Email,
+			When:  apiOpts.Dates.Author,
 		},
 		Signoff: apiOpts.Signoff,
-	}
-	if opts.Dates.Author.IsZero() {
-		opts.Dates.Author = time.Now()
-	}
-	if opts.Dates.Committer.IsZero() {
-		opts.Dates.Committer = time.Now()
 	}
 
 	if opts.Message == "" {
@@ -582,25 +574,17 @@ func CreateFile(ctx *context.APIContext) {
 		Message:   apiOpts.Message,
 		OldBranch: apiOpts.BranchName,
 		NewBranch: apiOpts.NewBranchName,
-		Committer: &files_service.IdentityOptions{
-			GitUserName:  apiOpts.Committer.Name,
-			GitUserEmail: apiOpts.Committer.Email,
+		Committer: &git.Signature{
+			Name:  apiOpts.Committer.Name,
+			Email: apiOpts.Committer.Email,
+			When:  apiOpts.Dates.Committer,
 		},
-		Author: &files_service.IdentityOptions{
-			GitUserName:  apiOpts.Author.Name,
-			GitUserEmail: apiOpts.Author.Email,
-		},
-		Dates: &files_service.CommitDateOptions{
-			Author:    apiOpts.Dates.Author,
-			Committer: apiOpts.Dates.Committer,
+		Author: &git.Signature{
+			Name:  apiOpts.Author.Name,
+			Email: apiOpts.Author.Email,
+			When:  apiOpts.Dates.Author,
 		},
 		Signoff: apiOpts.Signoff,
-	}
-	if opts.Dates.Author.IsZero() {
-		opts.Dates.Author = time.Now()
-	}
-	if opts.Dates.Committer.IsZero() {
-		opts.Dates.Committer = time.Now()
 	}
 
 	if opts.Message == "" {
@@ -685,25 +669,17 @@ func UpdateFile(ctx *context.APIContext) {
 		Message:   apiOpts.Message,
 		OldBranch: apiOpts.BranchName,
 		NewBranch: apiOpts.NewBranchName,
-		Committer: &files_service.IdentityOptions{
-			GitUserName:  apiOpts.Committer.Name,
-			GitUserEmail: apiOpts.Committer.Email,
+		Committer: &git.Signature{
+			Name:  apiOpts.Committer.Name,
+			Email: apiOpts.Committer.Email,
+			When:  apiOpts.Dates.Committer,
 		},
-		Author: &files_service.IdentityOptions{
-			GitUserName:  apiOpts.Author.Name,
-			GitUserEmail: apiOpts.Author.Email,
-		},
-		Dates: &files_service.CommitDateOptions{
-			Author:    apiOpts.Dates.Author,
-			Committer: apiOpts.Dates.Committer,
+		Author: &git.Signature{
+			Name:  apiOpts.Author.Name,
+			Email: apiOpts.Author.Email,
+			When:  apiOpts.Dates.Author,
 		},
 		Signoff: apiOpts.Signoff,
-	}
-	if opts.Dates.Author.IsZero() {
-		opts.Dates.Author = time.Now()
-	}
-	if opts.Dates.Committer.IsZero() {
-		opts.Dates.Committer = time.Now()
 	}
 
 	if opts.Message == "" {
@@ -844,25 +820,17 @@ func DeleteFile(ctx *context.APIContext) {
 		Message:   apiOpts.Message,
 		OldBranch: apiOpts.BranchName,
 		NewBranch: apiOpts.NewBranchName,
-		Committer: &files_service.IdentityOptions{
-			GitUserName:  apiOpts.Committer.Name,
-			GitUserEmail: apiOpts.Committer.Email,
+		Committer: &git.Signature{
+			Name:  apiOpts.Committer.Name,
+			Email: apiOpts.Committer.Email,
+			When:  apiOpts.Dates.Committer,
 		},
-		Author: &files_service.IdentityOptions{
-			GitUserName:  apiOpts.Author.Name,
-			GitUserEmail: apiOpts.Author.Email,
-		},
-		Dates: &files_service.CommitDateOptions{
-			Author:    apiOpts.Dates.Author,
-			Committer: apiOpts.Dates.Committer,
+		Author: &git.Signature{
+			Name:  apiOpts.Author.Name,
+			Email: apiOpts.Author.Email,
+			When:  apiOpts.Dates.Author,
 		},
 		Signoff: apiOpts.Signoff,
-	}
-	if opts.Dates.Author.IsZero() {
-		opts.Dates.Author = time.Now()
-	}
-	if opts.Dates.Committer.IsZero() {
-		opts.Dates.Committer = time.Now()
 	}
 
 	if opts.Message == "" {

--- a/routers/web/repo/editor.go
+++ b/routers/web/repo/editor.go
@@ -296,9 +296,15 @@ func editFilePost(ctx *context.Context, form forms.EditRepoFileForm, isNewFile b
 				ContentReader: strings.NewReader(strings.ReplaceAll(form.Content, "\r", "")),
 			},
 		},
-		Signoff:   form.Signoff,
-		Author:    gitCommitter,
-		Committer: gitCommitter,
+		Signoff: form.Signoff,
+		Author: &git.Signature{
+			Name:  gitCommitter.GitUserName,
+			Email: gitCommitter.GitUserEmail,
+		},
+		Committer: &git.Signature{
+			Name:  gitCommitter.GitUserName,
+			Email: gitCommitter.GitUserEmail,
+		},
 	}); err != nil {
 		// This is where we handle all the errors thrown by files_service.ChangeRepoFiles
 		if git.IsErrNotExist(err) {
@@ -512,10 +518,16 @@ func DeleteFilePost(ctx *context.Context) {
 				TreePath:  ctx.Repo.TreePath,
 			},
 		},
-		Message:   message,
-		Signoff:   form.Signoff,
-		Author:    gitCommitter,
-		Committer: gitCommitter,
+		Message: message,
+		Signoff: form.Signoff,
+		Author: &git.Signature{
+			Name:  gitCommitter.GitUserName,
+			Email: gitCommitter.GitUserEmail,
+		},
+		Committer: &git.Signature{
+			Name:  gitCommitter.GitUserName,
+			Email: gitCommitter.GitUserEmail,
+		},
 	}); err != nil {
 		// This is where we handle all the errors thrown by repofiles.DeleteRepoFile
 		if git.IsErrNotExist(err) || files_service.IsErrRepoFileDoesNotExist(err) {

--- a/services/repository/files/content_test.go
+++ b/services/repository/files/content_test.go
@@ -20,10 +20,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMain(m *testing.M) {
-	unittest.MainTest(m)
-}
-
 func getExpectedReadmeContentsResponse() *api.ContentsResponse {
 	treePath := "README.md"
 	sha := "4b4851ad51df6a7d9f25c979345979eaeb5b349f"

--- a/services/repository/files/fast_import.go
+++ b/services/repository/files/fast_import.go
@@ -1,0 +1,259 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package files
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/git"
+	"code.gitea.io/gitea/modules/tempdir"
+	"code.gitea.io/gitea/modules/util"
+)
+
+// IdentityOptions for a person's identity like an author or committer
+type IdentityOptions struct {
+	GitUserName  string // to match "git config user.name"
+	GitUserEmail string // to match "git config user.email"
+}
+
+// CommitDateOptions store dates for GIT_AUTHOR_DATE and GIT_COMMITTER_DATE
+type CommitDateOptions struct {
+	Author    time.Time
+	Committer time.Time
+}
+
+type ChangeRepoFile struct {
+	Operation     string // "create", "update", or "delete"
+	TreePath      string
+	FromTreePath  string
+	ContentReader io.ReadSeeker
+	FileSize      int64
+	SHA           string
+	Options       *RepoFileOptions
+}
+
+// ChangeRepoFilesOptions holds the repository files update options
+type ChangeRepoFilesOptions struct {
+	LastCommitID string
+	OldBranch    string
+	NewBranch    string
+	Message      string
+	Files        []*ChangeRepoFile
+	Author       *IdentityOptions
+	Committer    *IdentityOptions
+	Dates        *CommitDateOptions
+	Signoff      bool
+}
+
+type RepoFileOptions struct {
+	treePath     string
+	fromTreePath string
+	executable   bool
+}
+
+// UpdateRepoBranch updates the specified branch in the given repository with the provided file changes.
+// It uses the fast-import command to perform the update efficiently. So that we can avoid to clone the whole repo.
+// TODO: add support for LFS
+// TODO: add support for GPG signing
+func UpdateRepoBranch(ctx context.Context, doer *user_model.User, repoPath string, opts ChangeRepoFilesOptions) error {
+	fPath, cancel, err := generateFastImportFile(doer, opts)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		cancel()
+	}()
+
+	f, err := os.Open(fPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, _, err = git.NewCommand("fast-import").
+		RunStdString(ctx, &git.RunOpts{
+			Stdin: f,
+			Dir:   repoPath,
+		})
+	return err
+}
+
+const commitFileHead = `commit refs/heads/%s
+author %s <%s> %d %s
+committer %s <%s> %d %s
+data %d
+%s
+
+%s`
+
+func getReadSeekerSize(r io.ReadSeeker) (int64, error) {
+	if file, ok := r.(*os.File); ok {
+		stat, err := file.Stat()
+		if err != nil {
+			return 0, err
+		}
+		return stat.Size(), nil
+	}
+
+	size, err := r.Seek(0, io.SeekEnd)
+	if err != nil {
+		return 0, err
+	}
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return 0, err
+	}
+	return size, nil
+}
+
+func getZoneOffsetStr(t time.Time) string {
+	// Get the timezone offset in hours and minutes
+	_, offset := t.Zone()
+	return fmt.Sprintf("%+03d%02d", offset/3600, (offset%3600)/60)
+}
+
+func writeCommit(f io.Writer, doer *user_model.User, opts *ChangeRepoFilesOptions) error {
+	_, err := fmt.Fprintf(f, "commit refs/heads/%s\n", util.Iif(opts.NewBranch != "", opts.NewBranch, opts.OldBranch))
+	return err
+}
+
+func writeAuthor(f io.Writer, doer *user_model.User, opts *ChangeRepoFilesOptions) error {
+	_, err := fmt.Fprintf(f, "author %s <%s> %d %s\n",
+		opts.Author.GitUserName,
+		opts.Author.GitUserEmail,
+		opts.Dates.Author.Unix(),
+		getZoneOffsetStr(opts.Dates.Author))
+	return err
+}
+
+func writeCommitter(f io.Writer, doer *user_model.User, opts *ChangeRepoFilesOptions) error {
+	_, err := fmt.Fprintf(f, "committer %s <%s> %d %s\n",
+		opts.Committer.GitUserName,
+		opts.Committer.GitUserEmail,
+		opts.Dates.Committer.Unix(),
+		getZoneOffsetStr(opts.Dates.Committer))
+	return err
+}
+
+func writeMessage(f io.Writer, doer *user_model.User, opts *ChangeRepoFilesOptions) error {
+	messageBytes := new(bytes.Buffer)
+	if _, err := messageBytes.WriteString(opts.Message); err != nil {
+		return err
+	}
+
+	committerSig := makeGitUserSignature(doer, opts.Committer, opts.Author)
+
+	if opts.Signoff {
+		// Signed-off-by
+		_, _ = messageBytes.WriteString("\n")
+		_, _ = messageBytes.WriteString("Signed-off-by: ")
+		_, _ = messageBytes.WriteString(committerSig.String())
+	}
+	_, err := fmt.Fprintf(f, "data %d\n%s\n", messageBytes.Len()+1, messageBytes.String())
+	return err
+}
+
+func writeFrom(f io.Writer, doer *user_model.User, opts *ChangeRepoFilesOptions) error {
+	var fromStatement string
+	if opts.LastCommitID != "" && opts.LastCommitID != "HEAD" {
+		fromStatement = fmt.Sprintf("from %s\n", opts.LastCommitID)
+	} else if opts.OldBranch != "" {
+		fromStatement = fmt.Sprintf("from refs/heads/%s^0\n", opts.OldBranch)
+	} // if this is a new branch, so we cannot add from refs/heads/newbranch^0
+
+	if len(fromStatement) == 0 {
+		return nil
+	}
+	_, err := fmt.Fprint(f, fromStatement)
+	return err
+}
+
+// generateFastImportFile generates a fast-import file based on the provided options.
+func generateFastImportFile(doer *user_model.User, opts ChangeRepoFilesOptions) (fPath string, cancel func(), err error) {
+	if opts.OldBranch == "" && opts.NewBranch == "" {
+		return "", nil, fmt.Errorf("both old and new branches are empty")
+	}
+	if opts.OldBranch == opts.NewBranch {
+		opts.NewBranch = ""
+	}
+
+	writeFuncs := []func(io.Writer, *user_model.User, *ChangeRepoFilesOptions) error{
+		writeCommit,
+		writeAuthor,
+		writeCommitter,
+		writeMessage,
+		// TODO: add support for Gpg signing
+		writeFrom,
+	}
+
+	f, cancel, err := tempdir.OsTempDir("gitea-fast-import-").CreateTempFileRandom("fast-import-*.txt")
+	if err != nil {
+		return "", nil, err
+	}
+	defer func() {
+		if err != nil {
+			cancel()
+		}
+	}()
+
+	for _, writeFunc := range writeFuncs {
+		if err := writeFunc(f, doer, &opts); err != nil {
+			return "", nil, err
+		}
+	}
+
+	// Write the file changes to the fast-import file
+	for _, file := range opts.Files {
+		switch file.Operation {
+		case "create", "update":
+			// delete the old file if it exists
+			if file.FromTreePath != file.TreePath && file.FromTreePath != "" {
+				if _, err := fmt.Fprintf(f, "D %s\n", file.FromTreePath); err != nil {
+					return "", nil, err
+				}
+			}
+
+			fileMask := "100644"
+			if file.Options != nil && file.Options.executable {
+				fileMask = "100755"
+			}
+
+			if _, err := fmt.Fprintf(f, "M %s inline %s\n", fileMask, file.TreePath); err != nil {
+				return "", nil, err
+			}
+			size := file.FileSize
+			if size == 0 {
+				size, err = getReadSeekerSize(file.ContentReader)
+				if err != nil {
+					return "", nil, err
+				}
+			}
+			if _, err := fmt.Fprintf(f, "data %d\n", size+1); err != nil {
+				return "", nil, err
+			}
+			if _, err := io.Copy(f, file.ContentReader); err != nil {
+				return "", nil, err
+			}
+			if _, err := fmt.Fprintln(f); err != nil {
+				return "", nil, err
+			}
+		case "delete":
+			if file.FromTreePath == "" {
+				return "", nil, fmt.Errorf("delete operation requires FromTreePath")
+			}
+			if _, err := fmt.Fprintf(f, "D %s\n", file.FromTreePath); err != nil {
+				return "", nil, err
+			}
+		default:
+			return "", nil, fmt.Errorf("unknown operation: %s", file.Operation)
+		}
+	}
+
+	return f.Name(), cancel, nil
+}

--- a/services/repository/files/fast_import_test.go
+++ b/services/repository/files/fast_import_test.go
@@ -1,0 +1,322 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package files
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"testing"
+	"time"
+
+	"code.gitea.io/gitea/models/unittest"
+	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/git"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFastImport(t *testing.T) {
+	unittest.PrepareTestEnv(t)
+
+	// Initialize the repository
+	repoPath, err := os.MkdirTemp("", "test-repo-*.git")
+	assert.NoError(t, err)
+	defer os.RemoveAll(repoPath)
+
+	_, _, err = git.NewCommand("init", "--bare").RunStdString(t.Context(),
+		&git.RunOpts{
+			Dir: repoPath,
+		})
+	assert.NoError(t, err)
+
+	// Create a temporary directory for the test
+	tempDir, err := os.MkdirTemp("", "fast_import_test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Create a test file
+	testFilePath := fmt.Sprintf("%s/testfile.txt", tempDir)
+	err = os.WriteFile(testFilePath, []byte("Hello, World!"), 0o644)
+	assert.NoError(t, err)
+
+	f, err := os.Open(testFilePath)
+	assert.NoError(t, err)
+	defer f.Close()
+
+	doer, err := user_model.GetUserByID(t.Context(), 1)
+	assert.NoError(t, err)
+
+	// 1 - Create the commit file
+	t.Run("Create commit file", func(t *testing.T) {
+		// Prepare the ChangeRepoFilesOptions
+		options := ChangeRepoFilesOptions{
+			LastCommitID: "HEAD",
+			NewBranch:    "test-branch",
+			Message:      "Test commit",
+			Files: []*ChangeRepoFile{
+				{
+					Operation:     "create",
+					TreePath:      "testfile.txt",
+					ContentReader: f,
+				},
+			},
+			Author: &IdentityOptions{
+				GitUserName:  "Test User",
+				GitUserEmail: "testuser@gitea.com",
+			},
+			Committer: &IdentityOptions{
+				GitUserName:  "Test Committer",
+				GitUserEmail: "testuser@gitea.com",
+			},
+			Dates: &CommitDateOptions{
+				Author:    time.Now(),
+				Committer: time.Now(),
+			},
+		}
+
+		err = UpdateRepoBranch(t.Context(), doer, repoPath, options)
+		assert.NoError(t, err)
+
+		gitRepo, err := git.OpenRepository(t.Context(), repoPath)
+		assert.NoError(t, err)
+		defer gitRepo.Close()
+
+		branches, total, err := gitRepo.GetBranchNames(0, 0)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, total)
+		assert.Equal(t, 1, len(branches))
+		assert.Equal(t, "test-branch", branches[0])
+
+		commit, err := gitRepo.GetBranchCommit("test-branch")
+		assert.NoError(t, err)
+		assert.Equal(t, "Test commit\n", commit.Message())
+		entries, err := commit.Tree.ListEntries()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(entries))
+		assert.Equal(t, "testfile.txt", entries[0].Name())
+		content, err := entries[0].Blob().GetBlobContent(entries[0].Blob().Size())
+		assert.NoError(t, err)
+		assert.Equal(t, "Hello, World!\n", content)
+	})
+
+	// 2 - Add a new file and update the existing one in a new branch
+	t.Run("Add and update files", func(t *testing.T) {
+		f2 := bytes.NewReader([]byte("Hello, World! 1"))
+		_, err = f.Seek(0, io.SeekStart)
+		assert.NoError(t, err)
+		options := ChangeRepoFilesOptions{
+			LastCommitID: "HEAD",
+			OldBranch:    "test-branch",
+			NewBranch:    "test-branch-2",
+			Message:      "Test commit-2",
+			Files: []*ChangeRepoFile{
+				{
+					Operation:     "create",
+					TreePath:      "testfile2.txt",
+					ContentReader: f,
+				},
+				{
+					Operation:     "update",
+					TreePath:      "testfile.txt",
+					ContentReader: f2,
+				},
+			},
+			Author: &IdentityOptions{
+				GitUserName:  "Test User",
+				GitUserEmail: "testuser@gitea.com",
+			},
+			Committer: &IdentityOptions{
+				GitUserName:  "Test Committer",
+				GitUserEmail: "testuser@gitea.com",
+			},
+			Dates: &CommitDateOptions{
+				Author:    time.Now(),
+				Committer: time.Now(),
+			},
+		}
+		err = UpdateRepoBranch(t.Context(), doer, repoPath, options)
+		assert.NoError(t, err)
+
+		gitRepo, err := git.OpenRepository(t.Context(), repoPath)
+		assert.NoError(t, err)
+		defer gitRepo.Close()
+
+		branches, total, err := gitRepo.GetBranchNames(0, 0)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, total)
+		assert.Equal(t, 2, len(branches))
+		assert.Equal(t, "test-branch", branches[0])
+		assert.Equal(t, "test-branch-2", branches[1])
+
+		commit, err := gitRepo.GetBranchCommit("test-branch-2")
+		assert.NoError(t, err)
+		assert.Equal(t, "Test commit-2\n", commit.Message())
+		entries, err := commit.Tree.ListEntries()
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(entries))
+		assert.Equal(t, "testfile.txt", entries[0].Name())
+		assert.Equal(t, "testfile2.txt", entries[1].Name())
+		content, err := entries[0].Blob().GetBlobContent(entries[0].Blob().Size())
+		assert.NoError(t, err)
+		assert.Equal(t, "Hello, World! 1\n", content)
+
+		content, err = entries[1].Blob().GetBlobContent(entries[1].Blob().Size())
+		assert.NoError(t, err)
+		assert.Equal(t, "Hello, World!\n", content)
+	})
+
+	// 3 - Delete the file
+	t.Run("Delete file in the same branch", func(t *testing.T) {
+		options := ChangeRepoFilesOptions{
+			OldBranch: "test-branch-2",
+			Message:   "Test commit-3",
+			Files: []*ChangeRepoFile{
+				{
+					Operation:    "delete",
+					FromTreePath: "testfile.txt",
+				},
+			},
+			Author: &IdentityOptions{
+				GitUserName:  "Test User",
+				GitUserEmail: "testuser@gitea.com",
+			},
+			Committer: &IdentityOptions{
+				GitUserName:  "Test Committer",
+				GitUserEmail: "testuser@gitea.com",
+			},
+			Dates: &CommitDateOptions{
+				Author:    time.Now(),
+				Committer: time.Now(),
+			},
+		}
+		err = UpdateRepoBranch(t.Context(), doer, repoPath, options)
+		assert.NoError(t, err)
+
+		gitRepo, err := git.OpenRepository(t.Context(), repoPath)
+		assert.NoError(t, err)
+		defer gitRepo.Close()
+
+		branches, total, err := gitRepo.GetBranchNames(0, 0)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, total)
+		assert.Equal(t, 2, len(branches))
+		assert.Equal(t, "test-branch", branches[0])
+		assert.Equal(t, "test-branch-2", branches[1])
+
+		commit, err := gitRepo.GetBranchCommit("test-branch-2")
+		assert.NoError(t, err)
+		assert.Equal(t, "Test commit-3\n", commit.Message())
+		entries, err := commit.Tree.ListEntries()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(entries))
+		assert.Equal(t, "testfile2.txt", entries[0].Name())
+		content, err := entries[0].Blob().GetBlobContent(entries[0].Blob().Size())
+		assert.NoError(t, err)
+		assert.Equal(t, "Hello, World!\n", content)
+	})
+
+	// 4 - Delete the file in a new branch
+	t.Run("Delete file in a new branch", func(t *testing.T) {
+		options := ChangeRepoFilesOptions{
+			OldBranch: "test-branch-2",
+			NewBranch: "test-branch-3",
+			Message:   "Test commit-4",
+			Files: []*ChangeRepoFile{
+				{
+					Operation:    "delete",
+					FromTreePath: "testfile2.txt",
+				},
+			},
+			Author: &IdentityOptions{
+				GitUserName:  "Test User",
+				GitUserEmail: "testuser@gitea.com",
+			},
+			Committer: &IdentityOptions{
+				GitUserName:  "Test Committer",
+				GitUserEmail: "testuser@gitea.com",
+			},
+			Dates: &CommitDateOptions{
+				Author:    time.Now(),
+				Committer: time.Now(),
+			},
+		}
+		err = UpdateRepoBranch(t.Context(), doer, repoPath, options)
+		assert.NoError(t, err)
+
+		gitRepo, err := git.OpenRepository(t.Context(), repoPath)
+		assert.NoError(t, err)
+		defer gitRepo.Close()
+
+		branches, total, err := gitRepo.GetBranchNames(0, 0)
+		assert.NoError(t, err)
+		assert.Equal(t, 3, total)
+		assert.Equal(t, 3, len(branches))
+		assert.True(t, slices.Equal(branches, []string{"test-branch", "test-branch-2", "test-branch-3"}))
+
+		commit, err := gitRepo.GetBranchCommit("test-branch-3")
+		assert.NoError(t, err)
+		assert.Equal(t, "Test commit-4\n", commit.Message())
+		entries, err := commit.Tree.ListEntries()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(entries))
+	})
+
+	// 5 - add/delete the file in a new branch from test-branch-2
+	t.Run("Add/Delete file in a new branch", func(t *testing.T) {
+		options := ChangeRepoFilesOptions{
+			OldBranch: "test-branch-2",
+			NewBranch: "test-branch-4",
+			Message:   "Test commit-5",
+			Files: []*ChangeRepoFile{
+				{
+					Operation:     "create",
+					TreePath:      "testfile3.txt",
+					ContentReader: bytes.NewReader([]byte("Hello, World! 3")),
+				},
+				{
+					Operation:    "delete",
+					FromTreePath: "testfile2.txt",
+				},
+			},
+			Author: &IdentityOptions{
+				GitUserName:  "Test User",
+				GitUserEmail: "testuser@gitea.com",
+			},
+			Committer: &IdentityOptions{
+				GitUserName:  "Test Committer",
+				GitUserEmail: "testuser@gitea.com",
+			},
+			Dates: &CommitDateOptions{
+				Author:    time.Now(),
+				Committer: time.Now(),
+			},
+		}
+		err = UpdateRepoBranch(t.Context(), doer, repoPath, options)
+		assert.NoError(t, err)
+
+		gitRepo, err := git.OpenRepository(t.Context(), repoPath)
+		assert.NoError(t, err)
+		defer gitRepo.Close()
+
+		branches, total, err := gitRepo.GetBranchNames(0, 0)
+		assert.NoError(t, err)
+		assert.Equal(t, 4, total)
+		assert.Equal(t, 4, len(branches))
+		assert.True(t, slices.Equal(branches, []string{"test-branch", "test-branch-2", "test-branch-3", "test-branch-4"}))
+
+		commit, err := gitRepo.GetBranchCommit("test-branch-4")
+		assert.NoError(t, err)
+		assert.Equal(t, "Test commit-5\n", commit.Message())
+		entries, err := commit.Tree.ListEntries()
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(entries))
+		assert.Equal(t, "testfile3.txt", entries[0].Name())
+		content, err := entries[0].Blob().GetBlobContent(entries[0].Blob().Size())
+		assert.NoError(t, err)
+		assert.Equal(t, "Hello, World! 3\n", content)
+	})
+}

--- a/services/repository/files/fast_import_test.go
+++ b/services/repository/files/fast_import_test.go
@@ -64,21 +64,19 @@ func TestFastImport(t *testing.T) {
 					ContentReader: f,
 				},
 			},
-			Author: &IdentityOptions{
-				GitUserName:  "Test User",
-				GitUserEmail: "testuser@gitea.com",
+			Author: &git.Signature{
+				Name:  "Test User",
+				Email: "testuser@gitea.com",
+				When:  time.Now(),
 			},
-			Committer: &IdentityOptions{
-				GitUserName:  "Test Committer",
-				GitUserEmail: "testuser@gitea.com",
-			},
-			Dates: &CommitDateOptions{
-				Author:    time.Now(),
-				Committer: time.Now(),
+			Committer: &git.Signature{
+				Name:  "Test Committer",
+				Email: "testuser@gitea.com",
+				When:  time.Now(),
 			},
 		}
 
-		err = UpdateRepoBranch(t.Context(), doer, repoPath, options)
+		err = UpdateRepoBranch(t.Context(), doer, repoPath, true, options)
 		assert.NoError(t, err)
 
 		gitRepo, err := git.OpenRepository(t.Context(), repoPath)
@@ -100,7 +98,7 @@ func TestFastImport(t *testing.T) {
 		assert.Equal(t, "testfile.txt", entries[0].Name())
 		content, err := entries[0].Blob().GetBlobContent(entries[0].Blob().Size())
 		assert.NoError(t, err)
-		assert.Equal(t, "Hello, World!\n", content)
+		assert.Equal(t, "Hello, World!", content)
 	})
 
 	// 2 - Add a new file and update the existing one in a new branch
@@ -125,20 +123,18 @@ func TestFastImport(t *testing.T) {
 					ContentReader: f2,
 				},
 			},
-			Author: &IdentityOptions{
-				GitUserName:  "Test User",
-				GitUserEmail: "testuser@gitea.com",
+			Author: &git.Signature{
+				Name:  "Test User",
+				Email: "testuser@gitea.com",
+				When:  time.Now(),
 			},
-			Committer: &IdentityOptions{
-				GitUserName:  "Test Committer",
-				GitUserEmail: "testuser@gitea.com",
-			},
-			Dates: &CommitDateOptions{
-				Author:    time.Now(),
-				Committer: time.Now(),
+			Committer: &git.Signature{
+				Name:  "Test Committer",
+				Email: "testuser@gitea.com",
+				When:  time.Now(),
 			},
 		}
-		err = UpdateRepoBranch(t.Context(), doer, repoPath, options)
+		err = UpdateRepoBranch(t.Context(), doer, repoPath, true, options)
 		assert.NoError(t, err)
 
 		gitRepo, err := git.OpenRepository(t.Context(), repoPath)
@@ -149,8 +145,7 @@ func TestFastImport(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 2, total)
 		assert.Equal(t, 2, len(branches))
-		assert.Equal(t, "test-branch", branches[0])
-		assert.Equal(t, "test-branch-2", branches[1])
+		assert.True(t, slices.Equal(branches, []string{"test-branch", "test-branch-2"}))
 
 		commit, err := gitRepo.GetBranchCommit("test-branch-2")
 		assert.NoError(t, err)
@@ -162,11 +157,11 @@ func TestFastImport(t *testing.T) {
 		assert.Equal(t, "testfile2.txt", entries[1].Name())
 		content, err := entries[0].Blob().GetBlobContent(entries[0].Blob().Size())
 		assert.NoError(t, err)
-		assert.Equal(t, "Hello, World! 1\n", content)
+		assert.Equal(t, "Hello, World! 1", content)
 
 		content, err = entries[1].Blob().GetBlobContent(entries[1].Blob().Size())
 		assert.NoError(t, err)
-		assert.Equal(t, "Hello, World!\n", content)
+		assert.Equal(t, "Hello, World!", content)
 	})
 
 	// 3 - Delete the file
@@ -180,20 +175,18 @@ func TestFastImport(t *testing.T) {
 					FromTreePath: "testfile.txt",
 				},
 			},
-			Author: &IdentityOptions{
-				GitUserName:  "Test User",
-				GitUserEmail: "testuser@gitea.com",
+			Author: &git.Signature{
+				Name:  "Test User",
+				Email: "testuser@gitea.com",
+				When:  time.Now(),
 			},
-			Committer: &IdentityOptions{
-				GitUserName:  "Test Committer",
-				GitUserEmail: "testuser@gitea.com",
-			},
-			Dates: &CommitDateOptions{
-				Author:    time.Now(),
-				Committer: time.Now(),
+			Committer: &git.Signature{
+				Name:  "Test Committer",
+				Email: "testuser@gitea.com",
+				When:  time.Now(),
 			},
 		}
-		err = UpdateRepoBranch(t.Context(), doer, repoPath, options)
+		err = UpdateRepoBranch(t.Context(), doer, repoPath, true, options)
 		assert.NoError(t, err)
 
 		gitRepo, err := git.OpenRepository(t.Context(), repoPath)
@@ -204,8 +197,7 @@ func TestFastImport(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 2, total)
 		assert.Equal(t, 2, len(branches))
-		assert.Equal(t, "test-branch", branches[0])
-		assert.Equal(t, "test-branch-2", branches[1])
+		assert.True(t, slices.Equal(branches, []string{"test-branch", "test-branch-2"}))
 
 		commit, err := gitRepo.GetBranchCommit("test-branch-2")
 		assert.NoError(t, err)
@@ -216,7 +208,7 @@ func TestFastImport(t *testing.T) {
 		assert.Equal(t, "testfile2.txt", entries[0].Name())
 		content, err := entries[0].Blob().GetBlobContent(entries[0].Blob().Size())
 		assert.NoError(t, err)
-		assert.Equal(t, "Hello, World!\n", content)
+		assert.Equal(t, "Hello, World!", content)
 	})
 
 	// 4 - Delete the file in a new branch
@@ -231,20 +223,18 @@ func TestFastImport(t *testing.T) {
 					FromTreePath: "testfile2.txt",
 				},
 			},
-			Author: &IdentityOptions{
-				GitUserName:  "Test User",
-				GitUserEmail: "testuser@gitea.com",
+			Author: &git.Signature{
+				Name:  "Test User",
+				Email: "testuser@gitea.com",
+				When:  time.Now(),
 			},
-			Committer: &IdentityOptions{
-				GitUserName:  "Test Committer",
-				GitUserEmail: "testuser@gitea.com",
-			},
-			Dates: &CommitDateOptions{
-				Author:    time.Now(),
-				Committer: time.Now(),
+			Committer: &git.Signature{
+				Name:  "Test Committer",
+				Email: "testuser@gitea.com",
+				When:  time.Now(),
 			},
 		}
-		err = UpdateRepoBranch(t.Context(), doer, repoPath, options)
+		err = UpdateRepoBranch(t.Context(), doer, repoPath, true, options)
 		assert.NoError(t, err)
 
 		gitRepo, err := git.OpenRepository(t.Context(), repoPath)
@@ -282,20 +272,18 @@ func TestFastImport(t *testing.T) {
 					FromTreePath: "testfile2.txt",
 				},
 			},
-			Author: &IdentityOptions{
-				GitUserName:  "Test User",
-				GitUserEmail: "testuser@gitea.com",
+			Author: &git.Signature{
+				Name:  "Test User",
+				Email: "testuser@gitea.com",
+				When:  time.Now(),
 			},
-			Committer: &IdentityOptions{
-				GitUserName:  "Test Committer",
-				GitUserEmail: "testuser@gitea.com",
-			},
-			Dates: &CommitDateOptions{
-				Author:    time.Now(),
-				Committer: time.Now(),
+			Committer: &git.Signature{
+				Name:  "Test Committer",
+				Email: "testuser@gitea.com",
+				When:  time.Now(),
 			},
 		}
-		err = UpdateRepoBranch(t.Context(), doer, repoPath, options)
+		err = UpdateRepoBranch(t.Context(), doer, repoPath, true, options)
 		assert.NoError(t, err)
 
 		gitRepo, err := git.OpenRepository(t.Context(), repoPath)
@@ -317,6 +305,6 @@ func TestFastImport(t *testing.T) {
 		assert.Equal(t, "testfile3.txt", entries[0].Name())
 		content, err := entries[0].Blob().GetBlobContent(entries[0].Blob().Size())
 		assert.NoError(t, err)
-		assert.Equal(t, "Hello, World! 3\n", content)
+		assert.Equal(t, "Hello, World! 3", content)
 	})
 }

--- a/services/repository/files/main_test.go
+++ b/services/repository/files/main_test.go
@@ -1,0 +1,15 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package files
+
+import (
+	"testing"
+
+	"code.gitea.io/gitea/models/unittest"
+	_ "code.gitea.io/gitea/models/user"
+)
+
+func TestMain(m *testing.M) {
+	unittest.MainTest(m)
+}

--- a/services/repository/files/temp_repo.go
+++ b/services/repository/files/temp_repo.go
@@ -166,21 +166,7 @@ func (t *TemporaryUploadRepository) RemoveFilesFromIndex(ctx context.Context, fi
 
 // HashObject writes the provided content to the object db and returns its hash
 func (t *TemporaryUploadRepository) HashObject(ctx context.Context, content io.Reader) (string, error) {
-	stdOut := new(bytes.Buffer)
-	stdErr := new(bytes.Buffer)
-
-	if err := git.NewCommand("hash-object", "-w", "--stdin").
-		Run(ctx, &git.RunOpts{
-			Dir:    t.basePath,
-			Stdin:  content,
-			Stdout: stdOut,
-			Stderr: stdErr,
-		}); err != nil {
-		log.Error("Unable to hash-object to temporary repo: %s (%s) Error: %v\nstdout: %s\nstderr: %s", t.repo.FullName(), t.basePath, err, stdOut.String(), stdErr.String())
-		return "", fmt.Errorf("Unable to hash-object to temporary repo: %s Error: %w\nstdout: %s\nstderr: %s", t.repo.FullName(), err, stdOut.String(), stdErr.String())
-	}
-
-	return strings.TrimSpace(stdOut.String()), nil
+	return hashObject(ctx, t.basePath, content)
 }
 
 // AddObjectToIndex adds the provided object hash to the index with the provided mode and path

--- a/services/repository/files/update.go
+++ b/services/repository/files/update.go
@@ -227,18 +227,17 @@ func ChangeRepoFiles(ctx context.Context, repo *repo_model.Repository, doer *use
 
 	// Now commit the tree
 	commitOpts := &CommitTreeUserOptions{
-		ParentCommitID:    opts.LastCommitID,
-		TreeHash:          treeHash,
-		CommitMessage:     message,
-		SignOff:           opts.Signoff,
-		DoerUser:          doer,
-		AuthorIdentity:    opts.Author,
-		AuthorTime:        nil,
-		CommitterIdentity: opts.Committer,
-		CommitterTime:     nil,
-	}
-	if opts.Dates != nil {
-		commitOpts.AuthorTime, commitOpts.CommitterTime = &opts.Dates.Author, &opts.Dates.Committer
+		ParentCommitID: opts.LastCommitID,
+		TreeHash:       treeHash,
+		CommitMessage:  message,
+		SignOff:        opts.Signoff,
+		DoerUser:       doer,
+		// FIXME:
+		// AuthorIdentity:    opts.Author,
+		AuthorTime: &opts.Author.When,
+		// FIXME:
+		// CommitterIdentity: opts.Committer,
+		CommitterTime: &opts.Committer.When,
 	}
 	commitHash, err := t.CommitTree(ctx, commitOpts)
 	if err != nil {

--- a/services/repository/files/update.go
+++ b/services/repository/files/update.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"path"
 	"strings"
-	"time"
 
 	git_model "code.gitea.io/gitea/models/git"
 	repo_model "code.gitea.io/gitea/models/repo"
@@ -26,46 +25,6 @@ import (
 	asymkey_service "code.gitea.io/gitea/services/asymkey"
 	pull_service "code.gitea.io/gitea/services/pull"
 )
-
-// IdentityOptions for a person's identity like an author or committer
-type IdentityOptions struct {
-	GitUserName  string // to match "git config user.name"
-	GitUserEmail string // to match "git config user.email"
-}
-
-// CommitDateOptions store dates for GIT_AUTHOR_DATE and GIT_COMMITTER_DATE
-type CommitDateOptions struct {
-	Author    time.Time
-	Committer time.Time
-}
-
-type ChangeRepoFile struct {
-	Operation     string
-	TreePath      string
-	FromTreePath  string
-	ContentReader io.ReadSeeker
-	SHA           string
-	Options       *RepoFileOptions
-}
-
-// ChangeRepoFilesOptions holds the repository files update options
-type ChangeRepoFilesOptions struct {
-	LastCommitID string
-	OldBranch    string
-	NewBranch    string
-	Message      string
-	Files        []*ChangeRepoFile
-	Author       *IdentityOptions
-	Committer    *IdentityOptions
-	Dates        *CommitDateOptions
-	Signoff      bool
-}
-
-type RepoFileOptions struct {
-	treePath     string
-	fromTreePath string
-	executable   bool
-}
 
 // ErrRepoFileDoesNotExist represents a "RepoFileDoesNotExist" kind of error.
 type ErrRepoFileDoesNotExist struct {

--- a/services/repository/files/upload.go
+++ b/services/repository/files/upload.go
@@ -184,7 +184,7 @@ func copyUploadedLFSFileIntoRepository(ctx context.Context, info *uploadInfo, at
 	defer file.Close()
 
 	var objectHash string
-	if setting.LFS.StartServer && attributesMap[info.upload.Name] != nil && attributesMap[info.upload.Name].Get(attribute.Filter).ToString().Value() == "lfs" {
+	if setting.LFS.StartServer && attributesMap[info.upload.Name] != nil && attributesMap[info.upload.Name].MatchLFS() {
 		// Handle LFS
 		// FIXME: Inefficient! this should probably happen in models.Upload
 		pointer, err := lfs.GeneratePointer(file)


### PR DESCRIPTION
This PR introduced a new implementation for online files changes.

The previous implementation will clone the repository and use git index. This will take much time if the repository is big.
The new implementation is based on `git fast-import` which can run in bare repository and without checkout.

## Pros
- High performance when importing many files

## Cons
- Hooks will not be triggered directly by git
- No git transaction guaranteed. i.e. Gitea needs the hooks to sync branches names to database
