### PR TITLE
feat: return time of last usage for public keys and access tokens in the api

### DIFF
--- a/modules/structs/user_app.go
+++ b/modules/structs/user_app.go
@@ -17,7 +17,7 @@ type AccessToken struct {
 	TokenLastEight string    `json:"token_last_eight"`
 	Scopes         []string  `json:"scopes"`
 	Created        time.Time `json:"created_at"`
-	Updated        time.Time `json:"updated_at"`
+	Updated        time.Time `json:"last_used_at"`
 }
 
 // AccessTokenList represents a list of API access token.

--- a/modules/structs/user_app.go
+++ b/modules/structs/user_app.go
@@ -11,11 +11,13 @@ import (
 // AccessToken represents an API access token.
 // swagger:response AccessToken
 type AccessToken struct {
-	ID             int64    `json:"id"`
-	Name           string   `json:"name"`
-	Token          string   `json:"sha1"`
-	TokenLastEight string   `json:"token_last_eight"`
-	Scopes         []string `json:"scopes"`
+	ID             int64     `json:"id"`
+	Name           string    `json:"name"`
+	Token          string    `json:"sha1"`
+	TokenLastEight string    `json:"token_last_eight"`
+	Scopes         []string  `json:"scopes"`
+	Created        time.Time `json:"created_at"`
+	Updated        time.Time `json:"updated_at"`
 }
 
 // AccessTokenList represents a list of API access token.

--- a/modules/structs/user_key.go
+++ b/modules/structs/user_key.go
@@ -16,7 +16,7 @@ type PublicKey struct {
 	Fingerprint string `json:"fingerprint,omitempty"`
 	// swagger:strfmt date-time
 	Created  time.Time `json:"created_at,omitempty"`
-	Updated  time.Time `json:"updated_at,omitempty"`
+	Updated  time.Time `json:"last_used_at,omitempty"`
 	Owner    *User     `json:"user,omitempty"`
 	ReadOnly bool      `json:"read_only,omitempty"`
 	KeyType  string    `json:"key_type,omitempty"`

--- a/modules/structs/user_key.go
+++ b/modules/structs/user_key.go
@@ -16,6 +16,7 @@ type PublicKey struct {
 	Fingerprint string `json:"fingerprint,omitempty"`
 	// swagger:strfmt date-time
 	Created  time.Time `json:"created_at,omitempty"`
+	Updated  time.Time `json:"updated_at,omitempty"`
 	Owner    *User     `json:"user,omitempty"`
 	ReadOnly bool      `json:"read_only,omitempty"`
 	KeyType  string    `json:"key_type,omitempty"`

--- a/routers/api/v1/user/app.go
+++ b/routers/api/v1/user/app.go
@@ -62,6 +62,8 @@ func ListAccessTokens(ctx *context.APIContext) {
 			Name:           tokens[i].Name,
 			TokenLastEight: tokens[i].TokenLastEight,
 			Scopes:         tokens[i].Scope.StringSlice(),
+			Created:        tokens[i].CreatedUnix.AsTime(),
+			Updated:        tokens[i].UpdatedUnix.AsTime(),
 		}
 	}
 

--- a/services/convert/convert.go
+++ b/services/convert/convert.go
@@ -307,6 +307,7 @@ func ToPublicKey(apiLink string, key *asymkey_model.PublicKey) *api.PublicKey {
 		Title:       key.Name,
 		Fingerprint: key.Fingerprint,
 		Created:     key.CreatedUnix.AsTime(),
+		Updated:     key.UpdatedUnix.AsTime(),
 	}
 }
 

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -19978,6 +19978,11 @@
       "type": "object",
       "title": "AccessToken represents an API access token.",
       "properties": {
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "Created"
+        },
         "id": {
           "type": "integer",
           "format": "int64",
@@ -20001,11 +20006,6 @@
         "token_last_eight": {
           "type": "string",
           "x-go-name": "TokenLastEight"
-        },
-        "created_at": {
-          "type": "string",
-          "format": "date-time",
-          "x-go-name": "Created"
         },
         "updated_at": {
           "type": "string",

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -19988,6 +19988,11 @@
           "format": "int64",
           "x-go-name": "ID"
         },
+        "last_used_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "Updated"
+        },
         "name": {
           "type": "string",
           "x-go-name": "Name"
@@ -20006,11 +20011,6 @@
         "token_last_eight": {
           "type": "string",
           "x-go-name": "TokenLastEight"
-        },
-        "updated_at": {
-          "type": "string",
-          "format": "date-time",
-          "x-go-name": "Updated"
         }
       },
       "x-go-package": "code.gitea.io/gitea/modules/structs"
@@ -25487,6 +25487,11 @@
           "type": "string",
           "x-go-name": "KeyType"
         },
+        "last_used_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "Updated"
+        },
         "read_only": {
           "type": "boolean",
           "x-go-name": "ReadOnly"
@@ -25494,11 +25499,6 @@
         "title": {
           "type": "string",
           "x-go-name": "Title"
-        },
-        "updated_at": {
-          "type": "string",
-          "format": "date-time",
-          "x-go-name": "Updated"
         },
         "url": {
           "type": "string",

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -20001,6 +20001,16 @@
         "token_last_eight": {
           "type": "string",
           "x-go-name": "TokenLastEight"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "Created"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "Updated"
         }
       },
       "x-go-package": "code.gitea.io/gitea/modules/structs"

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -25495,6 +25495,11 @@
           "type": "string",
           "x-go-name": "Title"
         },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "Updated"
+        },
         "url": {
           "type": "string",
           "x-go-name": "URL"


### PR DESCRIPTION
In the Gitea GUI, the user can see the time that _AccessTokens_ and _PublicKeys_ were last used. This information is not returned by the _/users/{username}/tokens_ and _/user/keys_ endpoints in the API. This PR adds the missing data.

The time of last usage for for _tokens_  & _keys_ seem to be stored in the _Updated_ field of the structs internally. For consistency, I have used the name _updated_at_ for the new field returned by the _API_. However, for the _API_ user, I don't think that name reflects the data returned, as I believe it is the time of last usage. I propose that we use the name _last_used_at_ instead. Let's hear reviewers opinion on that. 

* PublicKey
  1. _last_used_at_: string($date-time)
* AccessToken
  1. _created_at_: string($date-time) (for parity with public keys)
  2. _last_used_at_: string($date-time)

Fix #34313 
