### PR TITLE
fix: do not return archive download URLs in API if downloads are disabled

### DIFF
--- a/modules/structs/repo_tag.go
+++ b/modules/structs/repo_tag.go
@@ -11,8 +11,8 @@ type Tag struct {
 	Message    string      `json:"message"`
 	ID         string      `json:"id"`
 	Commit     *CommitMeta `json:"commit"`
-	ZipballURL string      `json:"zipball_url"`
-	TarballURL string      `json:"tarball_url"`
+	ZipballURL string      `json:"zipball_url,omitempty"`
+	TarballURL string      `json:"tarball_url,omitempty"`
 }
 
 // AnnotatedTag represents an annotated tag

--- a/services/convert/convert.go
+++ b/services/convert/convert.go
@@ -197,13 +197,22 @@ func ToBranchProtection(ctx context.Context, bp *git_model.ProtectedBranch, repo
 
 // ToTag convert a git.Tag to an api.Tag
 func ToTag(repo *repo_model.Repository, t *git.Tag) *api.Tag {
+	tarballURL := util.URLJoin(repo.HTMLURL(), "archive", t.Name+".tar.gz")
+	zipballURL := util.URLJoin(repo.HTMLURL(), "archive", t.Name+".zip")
+
+	// Archive URLs are "" if the download feature is disabled
+	if setting.Repository.DisableDownloadSourceArchives {
+		tarballURL = ""
+		zipballURL = ""
+	}
+
 	return &api.Tag{
 		Name:       t.Name,
 		Message:    strings.TrimSpace(t.Message),
 		ID:         t.ID.String(),
 		Commit:     ToCommitMeta(repo, t),
-		ZipballURL: util.URLJoin(repo.HTMLURL(), "archive", t.Name+".zip"),
-		TarballURL: util.URLJoin(repo.HTMLURL(), "archive", t.Name+".tar.gz"),
+		ZipballURL: zipballURL,
+		TarballURL: tarballURL,
 	}
 }
 


### PR DESCRIPTION
If archive downloads are are disabled using _DISABLE_DOWNLOAD_SOURCE_ARCHIVES_, archive links are still returned by the API.

This PR changes the data returned, so the fields _zipball_url_ and _tarball_url_ are omitted if archive downloads have been disabled.

Resolve #32159

 