### PR TITLE
Fix repo search input height

### DIFF
--- a/templates/shared/repo_search.tmpl
+++ b/templates/shared/repo_search.tmpl
@@ -1,5 +1,5 @@
 <div class="ui small secondary filter menu">
-	<form id="repo-search-form" class="ui form ignore-dirty tw-flex-1 tw-flex tw-gap-x-2">
+	<form id="repo-search-form" class="ui form ignore-dirty tw-flex-1 tw-flex tw-items-center tw-gap-x-2">
 		{{if .Language}}<input type="hidden" name="language" value="{{.Language}}">{{end}}
 		{{if .PageIsExploreRepositories}}<input type="hidden" name="only_show_relevant" value="{{.OnlyShowRelevant}}">{{end}}
 		{{if .TabName}}<input type="hidden" name="tab" value="{{.TabName}}">{{end}}


### PR DESCRIPTION
before:
![before](https://github.com/user-attachments/assets/1abdcb8a-d005-4f35-8d2e-1581fde26e0c)

after:
![after](https://github.com/user-attachments/assets/41dab645-c5a7-4c45-9215-1340fb411130)


The difference is minimal, only a few pixels above and beneath, but it stands out when switching fast between the tabs on the explore route.