### PR TITLE
Fix bug when visiting comparation page

### DIFF
--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -402,12 +402,11 @@ func ParseCompareInfo(ctx *context.Context) *common.CompareInfo {
 		ci.HeadRepo = ctx.Repo.Repository
 		ci.HeadGitRepo = ctx.Repo.GitRepo
 	} else if has {
-		ci.HeadGitRepo, err = gitrepo.OpenRepository(ctx, ci.HeadRepo)
+		ci.HeadGitRepo, err = gitrepo.RepositoryFromRequestContextOrOpen(ctx, ci.HeadRepo)
 		if err != nil {
-			ctx.ServerError("OpenRepository", err)
+			ctx.ServerError("RepositoryFromRequestContextOrOpen", err)
 			return nil
 		}
-		// if it's not the same git repo, the HeadGitRepo should be closed out of the function
 	} else {
 		ctx.NotFound(nil)
 		return nil
@@ -726,12 +725,6 @@ func getBranchesAndTagsForRepo(ctx gocontext.Context, repo *repo_model.Repositor
 // CompareDiff show different from one commit to another commit
 func CompareDiff(ctx *context.Context) {
 	ci := ParseCompareInfo(ctx)
-	defer func() {
-		// If it's the same repo, the git repo should be managed by the context
-		if !ctx.Repo.PullRequest.SameRepo && ci != nil && ci.HeadGitRepo != nil {
-			ci.HeadGitRepo.Close()
-		}
-	}()
 	if ctx.Written() {
 		return
 	}

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -407,7 +407,7 @@ func ParseCompareInfo(ctx *context.Context) *common.CompareInfo {
 			ctx.ServerError("OpenRepository", err)
 			return nil
 		}
-		defer ci.HeadGitRepo.Close()
+		// if it's not the same git repo, the HeadGitRepo should be closed out of the function
 	} else {
 		ctx.NotFound(nil)
 		return nil
@@ -727,7 +727,8 @@ func getBranchesAndTagsForRepo(ctx gocontext.Context, repo *repo_model.Repositor
 func CompareDiff(ctx *context.Context) {
 	ci := ParseCompareInfo(ctx)
 	defer func() {
-		if ci != nil && ci.HeadGitRepo != nil {
+		// If it's the same repo, the git repo should be managed by the context
+		if !ctx.Repo.PullRequest.SameRepo && ci != nil && ci.HeadGitRepo != nil {
 			ci.HeadGitRepo.Close()
 		}
 	}()

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -1296,11 +1296,6 @@ func CompareAndPullRequestPost(ctx *context.Context) {
 	)
 
 	ci := ParseCompareInfo(ctx)
-	defer func() {
-		if !ctx.Repo.PullRequest.SameRepo && ci != nil && ci.HeadGitRepo != nil {
-			ci.HeadGitRepo.Close()
-		}
-	}()
 	if ctx.Written() {
 		return
 	}

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -1297,7 +1297,7 @@ func CompareAndPullRequestPost(ctx *context.Context) {
 
 	ci := ParseCompareInfo(ctx)
 	defer func() {
-		if ci != nil && ci.HeadGitRepo != nil {
+		if !ctx.Repo.PullRequest.SameRepo && ci != nil && ci.HeadGitRepo != nil {
 			ci.HeadGitRepo.Close()
 		}
 	}()


### PR DESCRIPTION
The `ci.HeadGitRepo` was opened and closed in the function `ParseCompareInfo` but reused in the function `PrepareCompareDiff`.