### PR TITLE
Fix LFS files being editable in web UI

### DIFF
--- a/routers/web/repo/editor.go
+++ b/routers/web/repo/editor.go
@@ -20,7 +20,6 @@ import (
 	"code.gitea.io/gitea/modules/markup"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/templates"
-	"code.gitea.io/gitea/modules/typesniffer"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/modules/web"
 	"code.gitea.io/gitea/routers/utils"
@@ -151,9 +150,13 @@ func editFile(ctx *context.Context, isNewFile bool) {
 			return
 		}
 
-		dataRc, err := blob.DataAsync()
+		buf, dataRc, fInfo, err := getFileReader(ctx, ctx.Repo.Repository.ID, blob)
 		if err != nil {
-			ctx.NotFound(err)
+			if git.IsErrNotExist(err) {
+				ctx.NotFound(err)
+			} else {
+				ctx.ServerError("getFileReader", err)
+			}
 			return
 		}
 
@@ -161,12 +164,8 @@ func editFile(ctx *context.Context, isNewFile bool) {
 
 		ctx.Data["FileSize"] = blob.Size()
 
-		buf := make([]byte, 1024)
-		n, _ := util.ReadAtMost(dataRc, buf)
-		buf = buf[:n]
-
 		// Only some file types are editable online as text.
-		if !typesniffer.DetectContentType(buf).IsRepresentableAsText() {
+		if !fInfo.isTextFile || fInfo.isLFSFile {
 			ctx.NotFound(nil)
 			return
 		}


### PR DESCRIPTION
It's possible to edit "raw" lfs files in the web UI when accessing the path manually.

![image](https://github.com/user-attachments/assets/62610e9e-24db-45ec-ad04-28062073164c)
