### PR TITLE
Use lfs label for lfs file rather than a long description

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1305,7 +1305,6 @@ file_copy_permalink = Copy Permalink
 view_git_blame = View Git Blame
 video_not_supported_in_browser = Your browser does not support the HTML5 'video' tag.
 audio_not_supported_in_browser = Your browser does not support the HTML5 'audio' tag.
-stored_lfs = Stored with Git LFS
 symbolic_link = Symbolic link
 executable_file = Executable File
 vendored = Vendored

--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -101,8 +101,8 @@
 									{{end}}
 								</div>
 								<span class="file tw-flex tw-items-center tw-font-mono tw-flex-1"><a class="muted file-link" title="{{if $file.IsRenamed}}{{$file.OldName}} → {{end}}{{$file.Name}}" href="#diff-{{$file.NameHash}}">{{if $file.IsRenamed}}{{$file.OldName}} → {{end}}{{$file.Name}}</a>
-									{{if .IsLFSFile}} ({{ctx.Locale.Tr "repo.stored_lfs"}}){{end}}
 									<button class="btn interact-fg tw-p-2" data-clipboard-text="{{$file.Name}}" data-tooltip-content="{{ctx.Locale.Tr "copy_path"}}">{{svg "octicon-copy" 14}}</button>
+									{{if .IsLFSFile}}<span class="ui label">LFS</span>{{end}}
 									{{if $file.IsGenerated}}
 										<span class="ui label">{{ctx.Locale.Tr "repo.diff.generated"}}</span>
 									{{end}}

--- a/templates/repo/file_info.tmpl
+++ b/templates/repo/file_info.tmpl
@@ -11,7 +11,7 @@
 	{{end}}
 	{{if ne .FileSize nil}}
 		<div class="file-info-entry">
-			{{FileSize .FileSize}}{{if .IsLFSFile}} ({{ctx.Locale.Tr "repo.stored_lfs"}}){{end}}
+			{{FileSize .FileSize}}{{if .IsLFSFile}}<span class="ui label">LFS</span>{{end}}
 		</div>
 	{{end}}
 	{{if .LFSLock}}

--- a/tests/integration/lfs_view_test.go
+++ b/tests/integration/lfs_view_test.go
@@ -38,7 +38,7 @@ func TestLFSRender(t *testing.T) {
 		doc := NewHTMLParser(t, resp.Body).doc
 
 		fileInfo := doc.Find("div.file-info-entry").First().Text()
-		assert.Contains(t, fileInfo, "Stored with Git LFS")
+		assert.Contains(t, fileInfo, "LFS")
 
 		content := doc.Find("div.file-view").Text()
 		assert.Contains(t, content, "Testing documents in LFS")
@@ -54,7 +54,7 @@ func TestLFSRender(t *testing.T) {
 		doc := NewHTMLParser(t, resp.Body).doc
 
 		fileInfo := doc.Find("div.file-info-entry").First().Text()
-		assert.Contains(t, fileInfo, "Stored with Git LFS")
+		assert.Contains(t, fileInfo, "LFS")
 
 		src, exists := doc.Find(".file-view img").Attr("src")
 		assert.True(t, exists, "The image should be in an <img> tag")
@@ -71,7 +71,7 @@ func TestLFSRender(t *testing.T) {
 		doc := NewHTMLParser(t, resp.Body).doc
 
 		fileInfo := doc.Find("div.file-info-entry").First().Text()
-		assert.Contains(t, fileInfo, "Stored with Git LFS")
+		assert.Contains(t, fileInfo, "LFS")
 
 		rawLink, exists := doc.Find("div.file-view > div.view-raw > a").Attr("href")
 		assert.True(t, exists, "Download link should render instead of content because this is a binary file")


### PR DESCRIPTION
Before

![image](https://github.com/user-attachments/assets/ed6c9221-5a6a-4717-8178-e5528fd180bf)

After

![image](https://github.com/user-attachments/assets/baa94350-ead4-46bf-b4b7-1bfd3aa5dcac)
