### PR TITLE
Fix only text/* being viewable in web UI

### DIFF
--- a/routers/web/repo/editor.go
+++ b/routers/web/repo/editor.go
@@ -165,7 +165,7 @@ func editFile(ctx *context.Context, isNewFile bool) {
 		ctx.Data["FileSize"] = blob.Size()
 
 		// Only some file types are editable online as text.
-		if !fInfo.isTextFile || fInfo.isLFSFile {
+		if !fInfo.st.IsRepresentableAsText() || fInfo.isLFSFile {
 			ctx.NotFound(nil)
 			return
 		}


### PR DESCRIPTION
Regression from #34356, files like SVGs should be editable too (https://github.com/go-gitea/gitea/pull/34356#discussion_r2072766240).