### PR TITLE
Focus the input element after clicking the Code button or its tabs

### DIFF
--- a/web_src/js/features/repo-common.ts
+++ b/web_src/js/features/repo-common.ts
@@ -1,4 +1,4 @@
-import {queryElems, type DOMEvent} from '../utils/dom.ts';
+import {addDelegatedEventListener, queryElems, type DOMEvent} from '../utils/dom.ts';
 import {POST} from '../modules/fetch.ts';
 import {showErrorToast} from '../modules/toast.ts';
 import {sleep} from '../utils.ts';
@@ -141,6 +141,12 @@ function initClonePanelButton(btn: HTMLButtonElement) {
     interactive: true,
     hideOnClick: true,
     arrow: false,
+    onMount: (instance) => { // focus input on open and on tab click
+      instance.popper.querySelector<HTMLInputElement>('.js-clone-url')?.focus();
+      addDelegatedEventListener(instance.popper, 'click', '.clone-panel-tab .item', () => {
+        instance.popper.querySelector<HTMLInputElement>('.js-clone-url')?.focus();
+      });
+    },
   });
 }
 


### PR DESCRIPTION
Small convenience that saves me one click. When opening the Code popup, automatically focus the URL `<input>` element so it can be copied with CTRL-C. Also re-focus when switching the tabs.

<img width="395" alt="image" src="https://github.com/user-attachments/assets/5bf5fc04-232c-42b8-a359-f60fa9098a78" />