### PR TITLE
When a repository is broken but git repository could be open, then mark it as normal

### DIFF
--- a/models/repo/repo.go
+++ b/models/repo/repo.go
@@ -320,6 +320,19 @@ func (repo *Repository) MarkAsBrokenEmpty() {
 	repo.IsEmpty = true
 }
 
+func (repo *Repository) MarkAsNormal() {
+	repo.IsEmpty = false
+	repo.Status = RepositoryReady
+}
+
+func MarkBrokenRepoAsNormal(ctx context.Context, repo *Repository) error {
+	repo.MarkAsNormal()
+	if _, err := db.GetEngine(ctx).ID(repo.ID).Cols("status", "is_empty").Update(repo); err != nil {
+		return fmt.Errorf("update repository: %w", err)
+	}
+	return nil
+}
+
 // AfterLoad is invoked from XORM after setting the values of all fields of this object.
 func (repo *Repository) AfterLoad() {
 	repo.NumOpenIssues = repo.NumIssues - repo.NumClosedIssues

--- a/services/context/repo.go
+++ b/services/context/repo.go
@@ -567,7 +567,7 @@ func RepoAssignment(ctx *Context) {
 		ctx.Link == ctx.Repo.RepoLink+"/-/migrate/status"
 
 	// Disable everything when the repo is being created
-	if ctx.Repo.Repository.IsBeingCreated() || ctx.Repo.Repository.IsBroken() {
+	if ctx.Repo.Repository.IsBeingCreated() {
 		if !isHomeOrSettings {
 			ctx.Redirect(ctx.Repo.RepoLink)
 		}
@@ -593,6 +593,13 @@ func RepoAssignment(ctx *Context) {
 		}
 		ctx.ServerError("RepoAssignment Invalid repo "+repo.FullName(), err)
 		return
+	}
+
+	// The repository can be open but marked as broken
+	if ctx.Repo.Repository.IsBroken() {
+		if err = repo_model.MarkBrokenRepoAsNormal(ctx, ctx.Repo.Repository); err != nil {
+			log.Error("MarkBrokenRepoAsNormal: %v", err)
+		}
 	}
 
 	// Stop at this point when the repo is empty.


### PR DESCRIPTION
Some repositories will be marked as broken because of temporary disk access problems and can not be recovered except to update the database.

This PR will mark a broken repository as normal if the git repository could be open normally.

Try to fix #34424