### PR TITLE
Fix get / delete runner to use consistent http 404 and 500 status

### DIFF
--- a/tests/integration/api_actions_runner_test.go
+++ b/tests/integration/api_actions_runner_test.go
@@ -329,4 +329,12 @@ func testActionsRunnerRepo(t *testing.T) {
 		req := NewRequest(t, "DELETE", fmt.Sprintf("/api/v1/repos/user2/repo1/actions/runners/%d", 34349)).AddTokenAuth(token)
 		MakeRequest(t, req, http.StatusNotFound)
 	})
+
+	t.Run("DeleteAdminRunnerNotFoundUnknownID", func(t *testing.T) {
+		userUsername := "user2"
+		token := getUserToken(t, userUsername, auth_model.AccessTokenScopeWriteRepository)
+		// Verify delete a runner by unknown id is not found
+		req := NewRequest(t, "DELETE", fmt.Sprintf("/api/v1/repos/user2/repo1/actions/runners/%d", 4384797347934)).AddTokenAuth(token)
+		MakeRequest(t, req, http.StatusNotFound)
+	})
 }


### PR DESCRIPTION
* previously deleting an already deleted runner returned http 500
* previously any database error for the get endpoint was http 404 and never 500