### PR TITLE
Change "rejected" to "changes requested" in 3rd party PR review notification

### DIFF
--- a/services/webhook/discord.go
+++ b/services/webhook/discord.go
@@ -305,7 +305,7 @@ func parseHookPullRequestEventType(event webhook_module.HookEventType) (string, 
 	case webhook_module.HookEventPullRequestReviewApproved:
 		return "approved", nil
 	case webhook_module.HookEventPullRequestReviewRejected:
-		return "rejected", nil
+		return "requested changes", nil
 	case webhook_module.HookEventPullRequestReviewComment:
 		return "comment", nil
 	default:


### PR DESCRIPTION
This PR changes 3rd party notifications wording on a PR review that requests changes and can be considered a follow up for #5858 to also fix #5857 in 3rd party notifications.

The difference in the actual notification would be the following:

```diff
- Pull request review rejected
+ Pull request review changes requested
```

While this is a simple string change at first look, it has a deeper UX meaning.

# Motivation

We could observe that some developers are hesitant to press the "Request changes" button since their peers first see that their changes were rejected, thus a more appropriate wording that also falls in line with the meaning and UI would be beneficial.

## Meaning

Pressing the `Request changes` button in a PR review means that as a reviewer you are willing to merge the general change in a PR if changes requested review comments are implemented.
Rejecting a PR on the other hand would be equivalent with closing it since that change isn't welcome at all (e.g. out of scope feature).

## Sync with UI

The UI button says `request changes` and the other options 

![image](https://github.com/user-attachments/assets/3766cc89-40d7-4c5e-9ff7-a0e1f6991ea6)



## Considered Problems

This might break some automation for users who rely on string matching.