### PR TITLE
 Add R-HNF to the TRANSLATORS file

### DIFF
--- a/options/locale/TRANSLATORS
+++ b/options/locale/TRANSLATORS
@@ -66,6 +66,7 @@ Piotr Orzechowski <piotr AT orzechowski DOT tech>
 Richard Bukovansky <richard DOT bukovansky AT gmail DOT com>
 Robert Nuske <robert DOT nuske AT web DOT de>
 Robin Hübner <profan AT prfn DOT se>
+Ryo Hanafusa <ryo7gumi AT gmail DOT com>
 SeongJae Park <sj38 DOT park AT gmail DOT com>
 Thiago Avelino <thiago AT avelino DOT xxx>
 Thomas Fanninger <gogs DOT thomas AT fanninger DOT at>


### PR DESCRIPTION
I would like to be added to the TRANSLATORS file.

Here are my related activities:
* https://crowdin.com/profile/R-HNF/activity
* commit: [skip ci] Updated translations via Crowdin 319d03fbc049de34a6fa0bc3019107ec5b724ff2

I also referred to the following PRs:
* #8451
* #8292