### PR TITLE
Reduce paging inconsistency

### DIFF
--- a/models/issues/issue.go
+++ b/models/issues/issue.go
@@ -690,6 +690,7 @@ func (issue *Issue) BlockedByDependencies(ctx context.Context, opts db.ListOptio
 		Where("issue_id = ?", issue.ID).
 		// sort by repo id then created date, with the issues of the same repo at the beginning of the list
 		OrderBy("CASE WHEN issue.repo_id = ? THEN 0 ELSE issue.repo_id END, issue.created_unix DESC", issue.RepoID)
+	// Pagination bypass needed by ViewIssue => prepareIssueViewSidebarDependency
 	if opts.Page > 0 {
 		sess = db.SetSessionPagination(sess, &opts)
 	}

--- a/models/issues/issue_watch.go
+++ b/models/issues/issue_watch.go
@@ -105,12 +105,9 @@ func GetIssueWatchers(ctx context.Context, issueID int64, listOptions db.ListOpt
 		And("`user`.prohibit_login = ?", false).
 		Join("INNER", "`user`", "`user`.id = `issue_watch`.user_id")
 
-	if listOptions.Page > 0 {
-		sess = db.SetSessionPagination(sess, &listOptions)
-		watches := make([]*IssueWatch, 0, listOptions.PageSize)
-		return watches, sess.Find(&watches)
-	}
-	watches := make([]*IssueWatch, 0, 8)
+	listOptions.SetDefaultValues()
+	sess = db.SetSessionPagination(sess, &listOptions)
+	watches := make([]*IssueWatch, 0, listOptions.PageSize)
 	return watches, sess.Find(&watches)
 }
 

--- a/models/issues/label.go
+++ b/models/issues/label.go
@@ -408,6 +408,7 @@ func GetLabelsByRepoID(ctx context.Context, repoID int64, sortType string, listO
 		sess.Asc("name")
 	}
 
+	// Pagination bypass used by some callers
 	if listOptions.Page > 0 {
 		sess = db.SetSessionPagination(sess, &listOptions)
 	}
@@ -483,6 +484,7 @@ func GetLabelsByOrgID(ctx context.Context, orgID int64, sortType string, listOpt
 		sess.Asc("name")
 	}
 
+	// Why can we bypass limits here?
 	if listOptions.Page > 0 {
 		sess = db.SetSessionPagination(sess, &listOptions)
 	}

--- a/models/issues/review.go
+++ b/models/issues/review.go
@@ -389,6 +389,7 @@ func GetCurrentReview(ctx context.Context, reviewer *user_model.User, issue *Iss
 	if reviewer == nil {
 		return nil, nil
 	}
+	// Missing db.ListOptionsAll
 	reviews, err := FindReviews(ctx, FindReviewOptions{
 		Types:      []ReviewType{ReviewTypePending},
 		IssueID:    issue.ID,

--- a/models/issues/review_list.go
+++ b/models/issues/review_list.go
@@ -120,6 +120,7 @@ func (opts *FindReviewOptions) toCond() builder.Cond {
 func FindReviews(ctx context.Context, opts FindReviewOptions) (ReviewList, error) {
 	reviews := make([]*Review, 0, 10)
 	sess := db.GetEngine(ctx).Where(opts.toCond())
+	// Pagination bypass used by some callers
 	if opts.Page > 0 && !opts.IsListAll() {
 		sess = db.SetSessionPagination(sess, &opts)
 	}

--- a/models/issues/stopwatch.go
+++ b/models/issues/stopwatch.go
@@ -91,6 +91,7 @@ func GetUIDsAndStopwatch(ctx context.Context) ([]*UserStopwatch, error) {
 func GetUserStopwatches(ctx context.Context, userID int64, listOptions db.ListOptions) ([]*Stopwatch, error) {
 	sws := make([]*Stopwatch, 0, 8)
 	sess := db.GetEngine(ctx).Where("stopwatch.user_id = ?", userID)
+	// Pagination bypass used by CancelStopwatch
 	if listOptions.Page > 0 {
 		sess = db.SetSessionPagination(sess, &listOptions)
 	}

--- a/models/packages/package_version.go
+++ b/models/packages/package_version.go
@@ -187,6 +187,7 @@ type PackageSearchOptions struct {
 	HasFileWithName string                // only results are found which are associated with a file with the specific name
 	HasFiles        optional.Option[bool] // only results are found which have associated files
 	Sort            VersionSort
+	// Only one with interface
 	db.Paginator
 }
 

--- a/models/repo/star.go
+++ b/models/repo/star.go
@@ -79,6 +79,7 @@ func IsStaring(ctx context.Context, userID, repoID int64) bool {
 func GetStargazers(ctx context.Context, repo *Repository, opts db.ListOptions) ([]*user_model.User, error) {
 	sess := db.GetEngine(ctx).Where("star.repo_id = ?", repo.ID).
 		Join("LEFT", "star", "`user`.id = star.uid")
+	// Paging bypass used by UI
 	if opts.Page > 0 {
 		sess = db.SetSessionPagination(sess, &opts)
 

--- a/models/repo/watch.go
+++ b/models/repo/watch.go
@@ -151,14 +151,9 @@ func GetRepoWatchers(ctx context.Context, repoID int64, opts db.ListOptions) ([]
 	sess := db.GetEngine(ctx).Where("watch.repo_id=?", repoID).
 		Join("LEFT", "watch", "`user`.id=`watch`.user_id").
 		And("`watch`.mode<>?", WatchModeDont)
-	if opts.Page > 0 {
-		sess = db.SetSessionPagination(sess, &opts)
-		users := make([]*user_model.User, 0, opts.PageSize)
+	sess = db.SetSessionPagination(sess, &opts)
+	users := make([]*user_model.User, 0, opts.PageSize)
 
-		return users, sess.Find(&users)
-	}
-
-	users := make([]*user_model.User, 0, 8)
 	return users, sess.Find(&users)
 }
 

--- a/models/user/search.go
+++ b/models/user/search.go
@@ -151,6 +151,7 @@ func SearchUsers(ctx context.Context, opts SearchUserOptions) (users []*User, _ 
 
 	sessQuery := opts.toSearchQueryBase(ctx).OrderBy(opts.OrderBy.String())
 	defer sessQuery.Close()
+	// Pagination bypass used by UI
 	if opts.Page > 0 {
 		sessQuery = db.SetSessionPagination(sessQuery, &opts)
 	}

--- a/models/user/user.go
+++ b/models/user/user.go
@@ -321,15 +321,9 @@ func GetUserFollowers(ctx context.Context, u, viewer *User, listOptions db.ListO
 		And("`user`.type=?", UserTypeIndividual).
 		And(isUserVisibleToViewerCond(viewer))
 
-	if listOptions.Page > 0 {
-		sess = db.SetSessionPagination(sess, &listOptions)
+	sess = db.SetSessionPagination(sess, &listOptions)
 
-		users := make([]*User, 0, listOptions.PageSize)
-		count, err := sess.FindAndCount(&users)
-		return users, count, err
-	}
-
-	users := make([]*User, 0, 8)
+	users := make([]*User, 0, listOptions.PageSize)
 	count, err := sess.FindAndCount(&users)
 	return users, count, err
 }
@@ -343,6 +337,7 @@ func GetUserFollowing(ctx context.Context, u, viewer *User, listOptions db.ListO
 		And("`user`.type IN (?, ?)", UserTypeIndividual, UserTypeOrganization).
 		And(isUserVisibleToViewerCond(viewer))
 
+	// pagination bypass, otherwise 8
 	if listOptions.Page > 0 {
 		sess = db.SetSessionPagination(sess, &listOptions)
 

--- a/modules/git/repo_tag.go
+++ b/modules/git/repo_tag.go
@@ -147,6 +147,7 @@ func (repo *Repository) GetTagInfos(page, pageSize int) ([]*Tag, int, error) {
 
 	sortTagsByTime(tags)
 	tagsTotal := len(tags)
+	// pagination bypass
 	if page != 0 {
 		tags = util.PaginateSlice(tags, page, pageSize).([]*Tag)
 	}

--- a/routers/api/v1/admin/adopt.go
+++ b/routers/api/v1/admin/adopt.go
@@ -41,9 +41,7 @@ func ListUnadoptedRepositories(ctx *context.APIContext) {
 	//     "$ref": "#/responses/forbidden"
 
 	listOptions := utils.GetListOptions(ctx)
-	if listOptions.Page == 0 {
-		listOptions.Page = 1
-	}
+	listOptions.SetDefaultValues()
 	repoNames, count, err := repo_service.ListUnadoptedRepositories(ctx, ctx.FormString("query"), &listOptions)
 	if err != nil {
 		ctx.APIErrorInternal(err)

--- a/routers/api/v1/admin/cron.go
+++ b/routers/api/v1/admin/cron.go
@@ -39,6 +39,7 @@ func ListCronTasks(ctx *context.APIContext) {
 	count := len(tasks)
 
 	listOpts := utils.GetListOptions(ctx)
+	listOpts.SetDefaultValues()
 	tasks = util.PaginateSlice(tasks, listOpts.Page, listOpts.PageSize).(cron.TaskTable)
 
 	res := make([]structs.Cron, len(tasks))

--- a/routers/api/v1/admin/org.go
+++ b/routers/api/v1/admin/org.go
@@ -100,6 +100,8 @@ func GetAllOrgs(ctx *context.APIContext) {
 	//     "$ref": "#/responses/forbidden"
 
 	listOptions := utils.GetListOptions(ctx)
+	// SearchUsers allows pagination bypass
+	listOptions.SetDefaultValues()
 
 	users, maxResults, err := user_model.SearchUsers(ctx, user_model.SearchUserOptions{
 		Actor:       ctx.Doer,

--- a/routers/api/v1/admin/user.go
+++ b/routers/api/v1/admin/user.go
@@ -422,6 +422,8 @@ func SearchUsers(ctx *context.APIContext) {
 	//     "$ref": "#/responses/forbidden"
 
 	listOptions := utils.GetListOptions(ctx)
+	// SearchUsers allows pagination bypass
+	listOptions.SetDefaultValues()
 
 	users, maxResults, err := user_model.SearchUsers(ctx, user_model.SearchUserOptions{
 		Actor:       ctx.Doer,

--- a/routers/api/v1/org/org.go
+++ b/routers/api/v1/org/org.go
@@ -200,6 +200,8 @@ func GetAll(ctx *context.APIContext) {
 	}
 
 	listOptions := utils.GetListOptions(ctx)
+	// SearchUsers allows pagination bypass
+	listOptions.SetDefaultValues()
 
 	publicOrgs, maxResults, err := user_model.SearchUsers(ctx, user_model.SearchUserOptions{
 		Actor:       ctx.Doer,

--- a/routers/api/v1/repo/commits.go
+++ b/routers/api/v1/repo/commits.go
@@ -184,6 +184,7 @@ func GetAllCommits(ctx *context.APIContext) {
 		return
 	}
 
+	// Unusual use of ListOptions, but we need to support pagination
 	listOptions := utils.GetListOptions(ctx)
 	if listOptions.Page <= 0 {
 		listOptions.Page = 1

--- a/routers/api/v1/repo/label.go
+++ b/routers/api/v1/repo/label.go
@@ -49,7 +49,11 @@ func ListLabels(ctx *context.APIContext) {
 	//   "404":
 	//     "$ref": "#/responses/notFound"
 
-	labels, err := issues_model.GetLabelsByRepoID(ctx, ctx.Repo.Repository.ID, ctx.FormString("sort"), utils.GetListOptions(ctx))
+	opts := utils.GetListOptions(ctx)
+	// GetLabelsByRepoID allows pagination bypass
+	opts.SetDefaultValues()
+
+	labels, err := issues_model.GetLabelsByRepoID(ctx, ctx.Repo.Repository.ID, ctx.FormString("sort"), opts)
 	if err != nil {
 		ctx.APIErrorInternal(err)
 		return

--- a/routers/api/v1/repo/mirror.go
+++ b/routers/api/v1/repo/mirror.go
@@ -165,8 +165,11 @@ func ListPushMirrors(ctx *context.APIContext) {
 	}
 
 	repo := ctx.Repo.Repository
+	opts := utils.GetListOptions(ctx)
+	// field opts.PageSize is used below
+	opts.SetDefaultValues()
 	// Get all push mirrors for the specified repository.
-	pushMirrors, count, err := repo_model.GetPushMirrorsByRepoID(ctx, repo.ID, utils.GetListOptions(ctx))
+	pushMirrors, count, err := repo_model.GetPushMirrorsByRepoID(ctx, repo.ID, opts)
 	if err != nil {
 		ctx.APIError(http.StatusNotFound, err)
 		return
@@ -179,7 +182,7 @@ func ListPushMirrors(ctx *context.APIContext) {
 			responsePushMirrors = append(responsePushMirrors, m)
 		}
 	}
-	ctx.SetLinkHeader(len(responsePushMirrors), utils.GetListOptions(ctx).PageSize)
+	ctx.SetLinkHeader(len(responsePushMirrors), opts.PageSize)
 	ctx.SetTotalCountHeader(count)
 	ctx.JSON(http.StatusOK, responsePushMirrors)
 }

--- a/routers/api/v1/repo/pull_review.go
+++ b/routers/api/v1/repo/pull_review.go
@@ -85,6 +85,8 @@ func ListPullReviews(ctx *context.APIContext) {
 		ListOptions: utils.GetListOptions(ctx),
 		IssueID:     pr.IssueID,
 	}
+	// FindReviews allows pagination bypass
+	opts.SetDefaultValues()
 
 	allReviews, err := issues_model.FindReviews(ctx, opts)
 	if err != nil {

--- a/routers/api/v1/repo/star.go
+++ b/routers/api/v1/repo/star.go
@@ -47,7 +47,11 @@ func ListStargazers(ctx *context.APIContext) {
 	//   "403":
 	//     "$ref": "#/responses/forbidden"
 
-	stargazers, err := repo_model.GetStargazers(ctx, ctx.Repo.Repository, utils.GetListOptions(ctx))
+	opts := utils.GetListOptions(ctx)
+	// GetStargazers allows pagination bypass
+	opts.SetDefaultValues()
+
+	stargazers, err := repo_model.GetStargazers(ctx, ctx.Repo.Repository, opts)
 	if err != nil {
 		ctx.APIErrorInternal(err)
 		return

--- a/routers/api/v1/repo/tag.go
+++ b/routers/api/v1/repo/tag.go
@@ -54,6 +54,8 @@ func ListTags(ctx *context.APIContext) {
 	//     "$ref": "#/responses/notFound"
 
 	listOpts := utils.GetListOptions(ctx)
+	// GetTagInfos allows pagination bypass
+	listOpts.SetDefaultValues()
 
 	tags, total, err := ctx.Repo.GitRepo.GetTagInfos(listOpts.Page, listOpts.PageSize)
 	if err != nil {

--- a/routers/api/v1/repo/tree.go
+++ b/routers/api/v1/repo/tree.go
@@ -6,6 +6,7 @@ package repo
 import (
 	"net/http"
 
+	"code.gitea.io/gitea/routers/api/v1/utils"
 	"code.gitea.io/gitea/services/context"
 	files_service "code.gitea.io/gitea/services/repository/files"
 )
@@ -61,7 +62,9 @@ func GetTree(ctx *context.APIContext) {
 		ctx.APIError(http.StatusBadRequest, "sha not provided")
 		return
 	}
-	if tree, err := files_service.GetTreeBySHA(ctx, ctx.Repo.Repository, ctx.Repo.GitRepo, sha, ctx.FormInt("page"), ctx.FormInt("per_page"), ctx.FormBool("recursive")); err != nil {
+	opts := utils.GetListOptions(ctx)
+	opts.SetDefaultValues()
+	if tree, err := files_service.GetTreeBySHA(ctx, ctx.Repo.Repository, ctx.Repo.GitRepo, sha, opts.Page, opts.PageSize, ctx.FormBool("recursive")); err != nil {
 		ctx.APIError(http.StatusBadRequest, err.Error())
 	} else {
 		ctx.SetTotalCountHeader(int64(tree.TotalCount))

--- a/routers/api/v1/repo/wiki.go
+++ b/routers/api/v1/repo/wiki.go
@@ -16,6 +16,7 @@ import (
 	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/modules/web"
+	"code.gitea.io/gitea/routers/api/v1/utils"
 	"code.gitea.io/gitea/services/context"
 	"code.gitea.io/gitea/services/convert"
 	notify_service "code.gitea.io/gitea/services/notify"
@@ -298,17 +299,9 @@ func ListWikiPages(ctx *context.APIContext) {
 		return
 	}
 
-	page := ctx.FormInt("page")
-	if page <= 1 {
-		page = 1
-	}
-	limit := ctx.FormInt("limit")
-	if limit <= 1 {
-		limit = setting.API.DefaultPagingNum
-	}
-
-	skip := (page - 1) * limit
-	maxNum := page * limit
+	opts := utils.GetListOptions(ctx)
+	skip, limit := opts.GetSkipTake()
+	maxNum := skip + limit
 
 	entries, err := commit.ListEntries()
 	if err != nil {

--- a/routers/api/v1/user/follower.go
+++ b/routers/api/v1/user/follower.go
@@ -88,7 +88,10 @@ func ListFollowers(ctx *context.APIContext) {
 }
 
 func listUserFollowing(ctx *context.APIContext, u *user_model.User) {
-	users, count, err := user_model.GetUserFollowing(ctx, u, ctx.Doer, utils.GetListOptions(ctx))
+	opts := utils.GetListOptions(ctx)
+	// GetUserFollowing allows pagination bypass
+	opts.SetDefaultValues()
+	users, count, err := user_model.GetUserFollowing(ctx, u, ctx.Doer, opts)
 	if err != nil {
 		ctx.APIErrorInternal(err)
 		return

--- a/routers/api/v1/user/user.go
+++ b/routers/api/v1/user/user.go
@@ -55,6 +55,8 @@ func Search(ctx *context.APIContext) {
 	//             "$ref": "#/definitions/User"
 
 	listOptions := utils.GetListOptions(ctx)
+	// SearchUsers allows pagination bypass
+	listOptions.SetDefaultValues()
 
 	uid := ctx.FormInt64("uid")
 	var users []*user_model.User

--- a/routers/api/v1/utils/page.go
+++ b/routers/api/v1/utils/page.go
@@ -11,8 +11,14 @@ import (
 
 // GetListOptions returns list options using the page and limit parameters
 func GetListOptions(ctx *context.APIContext) db.ListOptions {
+	limit := ctx.FormInt("limit")
+	if limit == 0 {
+		// Compatibility with foreign API clients that used "per_page" instead of "limit"
+		limit = ctx.FormInt("per_page")
+	}
+
 	return db.ListOptions{
 		Page:     ctx.FormInt("page"),
-		PageSize: convert.ToCorrectPageSize(ctx.FormInt("limit")),
+		PageSize: convert.ToCorrectPageSize(limit),
 	}
 }

--- a/services/pull/review.go
+++ b/services/pull/review.go
@@ -428,6 +428,7 @@ func DismissReview(ctx context.Context, reviewID, repoID int64, message string, 
 	}
 
 	if dismissPriors {
+		// missing db.ListOptionsAll
 		reviews, err := issues_model.FindReviews(ctx, issues_model.FindReviewOptions{
 			IssueID:    review.IssueID,
 			ReviewerID: review.ReviewerID,

--- a/tests/integration/api_issue_test.go
+++ b/tests/integration/api_issue_test.go
@@ -266,10 +266,10 @@ func TestAPIEditIssue(t *testing.T) {
 func TestAPISearchIssues(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
 
-	// as this API was used in the frontend, it uses UI page size
+	// as this API is no longer used in the frontend, it uses API page size
 	expectedIssueCount := 20 // from the fixtures
-	if expectedIssueCount > setting.UI.IssuePagingNum {
-		expectedIssueCount = setting.UI.IssuePagingNum
+	if expectedIssueCount > setting.API.MaxResponseItems {
+		expectedIssueCount = setting.API.MaxResponseItems
 	}
 
 	link, _ := url.Parse("/api/v1/repos/issues/search")
@@ -314,7 +314,8 @@ func TestAPISearchIssues(t *testing.T) {
 	resp = MakeRequest(t, req, http.StatusOK)
 	DecodeJSON(t, resp, &apiIssues)
 	assert.Equal(t, "22", resp.Header().Get("X-Total-Count"))
-	assert.Len(t, apiIssues, 20)
+	// 30 is default page size now
+	assert.Len(t, apiIssues, 22)
 
 	query.Add("limit", "10")
 	link.RawQuery = query.Encode()
@@ -370,10 +371,10 @@ func TestAPISearchIssues(t *testing.T) {
 func TestAPISearchIssuesWithLabels(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
 
-	// as this API was used in the frontend, it uses UI page size
+	// as this API is no longer used in the frontend, it uses API page size
 	expectedIssueCount := 20 // from the fixtures
-	if expectedIssueCount > setting.UI.IssuePagingNum {
-		expectedIssueCount = setting.UI.IssuePagingNum
+	if expectedIssueCount > setting.API.MaxResponseItems {
+		expectedIssueCount = setting.API.MaxResponseItems
 	}
 
 	link, _ := url.Parse("/api/v1/repos/issues/search")


### PR DESCRIPTION
* disallow bypassing configured limits in api
* allow per_page without documenting it
* allow limit for the only endpoint that were only allowing per_page (see https://github.com/go-gitea/gitea/issues/18082)

This is an paging inconsistency api review, please comment your opinion about the added code comments

* 	ctx.SetLinkHeader(int(totalNumOfBranches), listOptions.PageSize) missing for several api endpoints should I add them everywhere?

* do we want to accept per_page in api?
  * better compatibility with existing keda github_runner
  * Otherwise I am 100% required to create a new provider, since it does not use paging
  * well this would add 20 entries, otherwise someone needs to set maximum to 100 for full GH Compat

* GetListOptions replaced almost all custom paging parsing of the rest api

* Should callers that expect page=0 to bypass paging be updated to use Listall constant?