### PR TITLE
Change admin indicator to icon-only

### DIFF
--- a/templates/base/head_navbar.tmpl
+++ b/templates/base/head_navbar.tmpl
@@ -130,8 +130,7 @@
 					<span class="only-mobile">{{.SignedUser.Name}}</span>
 					<span class="not-mobile">{{svg "octicon-triangle-down"}}</span>
 				</span>
-				{{/* do not localize it, here it needs the fixed length (width) to make UI comfortable */}}
-				{{if .IsAdmin}}<span class="navbar-profile-admin">admin</span>{{end}}
+				{{if .IsAdmin}}<span class="navbar-profile-admin" title="{{ctx.Locale.Tr "repo.settings.collaboration.admin"}}">{{svg "octicon-server" 11}}</span>{{end}}
 				<div class="menu user-menu">
 					<div class="header">
 						{{ctx.Locale.Tr "signed_in_as"}} <strong>{{.SignedUser.Name}}</strong>

--- a/templates/base/head_navbar.tmpl
+++ b/templates/base/head_navbar.tmpl
@@ -130,7 +130,7 @@
 					<span class="only-mobile">{{.SignedUser.Name}}</span>
 					<span class="not-mobile">{{svg "octicon-triangle-down"}}</span>
 				</span>
-				{{if .IsAdmin}}<span class="navbar-profile-admin" title="{{ctx.Locale.Tr "repo.settings.collaboration.admin"}}">{{svg "octicon-server" 11}}</span>{{end}}
+				{{if .IsAdmin}}<span class="navbar-profile-admin">{{svg "octicon-server" 11}}</span>{{end}}
 				<div class="menu user-menu">
 					<div class="header">
 						{{ctx.Locale.Tr "signed_in_as"}} <strong>{{.SignedUser.Name}}</strong>

--- a/web_src/css/modules/navbar.css
+++ b/web_src/css/modules/navbar.css
@@ -101,17 +101,22 @@
   }
 }
 
+#navbar .ui.dropdown.active .navbar-profile-admin {
+  background: var(--color-nav-hover-bg);
+  border-color: var(--color-nav-hover-bg);
+}
+
 #navbar .ui.dropdown .navbar-profile-admin {
   display: block;
   position: absolute;
-  font-size: 9px;
-  font-weight: var(--font-weight-bold);
-  color: var(--color-nav-bg);
-  background: var(--color-primary);
-  padding: 2px 3px;
+  color: var(--color-text);
+  background: var(--color-nav-bg);
+  border: 1px solid var(--color-nav-bg);
+  padding: 2px;
   border-radius: 10px;
-  top: -1px;
-  left: 18px;
+  top: -0.75px;
+  left: 28px;
+  line-height: 0;
 }
 
 #navbar a.item:hover .notification_count,

--- a/web_src/css/modules/navbar.css
+++ b/web_src/css/modules/navbar.css
@@ -114,7 +114,7 @@
   border: 1px solid var(--color-nav-bg);
   padding: 2px;
   border-radius: 10px;
-  top: -0.75px;
+  top: -0.5px;
   left: 28px;
   line-height: 0;
 }


### PR DESCRIPTION
Change admin indicator in navbar to icon only, which looks better imho, and the icon is the same as "Site Administration" in this menu, which is exactly what the admin role gives access to. User can hover over the icon to get a native `title` tooltip which localized text.

<img width="93" alt="Screenshot 2025-06-02 at 19 02 17" src="https://github.com/user-attachments/assets/b1f18a14-0920-447c-ad2c-ba6534cf7e9d" />

Works with any avatar and is now aligned to the notifications and stopwatch dots:

<img width="263" alt="Screenshot 2025-06-02 at 19 07 37" src="https://github.com/user-attachments/assets/956404c4-5820-41a9-8bc4-19a3bb107a50" />

(Before there was slight misalignment):

<img width="296" alt="Screenshot 2025-06-02 at 19 01 29" src="https://github.com/user-attachments/assets/ce2b86dc-cc3f-4e77-83a5-9def7e4282ed" />

Active state:

<img width="121" alt="Screenshot 2025-06-02 at 19 08 56" src="https://github.com/user-attachments/assets/f351aee8-6849-43b0-851f-7ef2ab7bac9e" />

