### PR TITLE
Make pull request and issue history more compact

### DIFF
--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -523,7 +523,7 @@ td .commit-summary {
 
 .repository.view.issue .comment-list .timeline-item,
 .repository.view.issue .comment-list .timeline-item-group {
-  padding: 16px 0;
+  padding: 8px 0;
 }
 
 .repository.view.issue .comment-list .timeline-item-group .timeline-item {
@@ -577,6 +577,11 @@ td .commit-summary {
   justify-content: center;
 }
 
+.repository.view.issue .comment-list .timeline-item.commits-list .badge {
+  margin-right: 0;
+  height: 28px;
+}
+
 .repository.view.issue .comment-list .timeline-item .badge .svg {
   width: 22px;
   height: 22px;
@@ -599,10 +604,6 @@ td .commit-summary {
 .repository.view.issue .comment-list .timeline-item.commits-list {
   padding-left: 15px;
   padding-top: 0;
-}
-
-.repository.view.issue .comment-list .timeline-item.commits-list .ui.avatar {
-  margin-right: 0.25em;
 }
 
 .repository.view.issue .comment-list .timeline-item.event > .commit-status-link {


### PR DESCRIPTION
Before, waste of space in multiple places:

<img width="962" alt="Screenshot 2025-06-02 at 23 11 08" src="https://github.com/user-attachments/assets/ecddf247-d690-434c-a865-9d5e6c690b7d" />

After, reduced spacing around history entries and inside commits list, also fixed unequal horizontal spacing inside commit badge.

<img width="946" alt="Screenshot 2025-06-02 at 23 10 45" src="https://github.com/user-attachments/assets/fe92f8e6-28af-4647-ac3a-1aced23d3b27" />

Also, here's a rendering of issue history events, it's more compact now at 8px padding:

<img width="565" alt="image" src="https://github.com/user-attachments/assets/cdbf7c0a-a9a2-4942-85fc-c388abb36e15" />
