### PR TITLE
Fix notification count positioning for variable-width elements

### DIFF
--- a/web_src/css/modules/navbar.css
+++ b/web_src/css/modules/navbar.css
@@ -129,8 +129,8 @@
   background: var(--color-primary);
   border: 2px solid var(--color-nav-bg);
   position: absolute;
-  left: 6px;
-  top: -9px;
+  left: calc(100% - 9px);
+  bottom: calc(100% - 9px);
   min-width: 17px;
   height: 17px;
   border-radius: 11px; /* (height + 2 * borderThickness) / 2 */


### PR DESCRIPTION
The notification count is currently positioned using top/left coordinates from its container's top/left corner. This works fine for fixed-size containers like the bell icon.

This PR changes the positioning to use bottom/left coordinates from the container's top/right corner instead. This improvement is needed when placing notification counts on text that can vary in size due to different languages or fonts.

The bell and stopwatch should look the same after this change.

---
*Sponsored by Kithara Software GmbH*