### PR TITLE
Fix margin issue in markup paragraph rendering

### DIFF
--- a/web_src/css/markup/content.css
+++ b/web_src/css/markup/content.css
@@ -134,6 +134,11 @@
   margin-bottom: 16px;
 }
 
+/* override p:last-child from base.css */
+.markup p:last-child {
+  margin-bottom: 16px;
+}
+
 .markup hr {
   height: 4px;
   padding: 0;


### PR DESCRIPTION
The Fomantic-inherited `p:last-child` rule in base.css interferes with this markdown rendering:

```
1. a

2. a
```

Before (unequal margin):
<img width="143" alt="Screenshot 2025-06-04 at 14 09 07" src="https://github.com/user-attachments/assets/6d6ba5e0-0d84-42e0-a0e4-9e93a59c4d65" />

After (rendering matches GitHub):
<img width="181" alt="Screenshot 2025-06-04 at 14 09 14" src="https://github.com/user-attachments/assets/bb81e14e-bc9f-4d52-92d0-f7a17c63070e" />
