### PR TITLE
add openssh-keygen to rootless image

### DIFF
--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -52,6 +52,7 @@ RUN apk --no-cache add \
     git \
     curl \
     gnupg \
+    openssh-keygen \
     && rm -rf /var/cache/apk/*
 
 RUN addgroup \


### PR DESCRIPTION
add openssh-keygen to rootless image for ssh signing

partially closes: https://github.com/go-gitea/gitea/issues/33783
dependency of: https://github.com/go-gitea/gitea/pull/34341

---