### PR TITLE
Enable gocritic equalFold and autofix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,6 +46,8 @@ linters:
             - pkg: gitea.com/go-chi/cache
               desc: do not use the go-chi cache package, use gitea's cache system
     gocritic:
+      enabled-checks:
+        - equalFold
       disabled-checks:
         - ifElseChain
         - singleCaseSwitch # Every time this occurred in the code, there was no other way.

--- a/models/repo/language_stats.go
+++ b/models/repo/language_stats.go
@@ -166,7 +166,7 @@ func UpdateLanguageStats(ctx context.Context, repo *Repository, commitID string,
 		llang := strings.ToLower(lang)
 		for _, s := range oldstats {
 			// Update already existing language
-			if strings.ToLower(s.Language) == llang {
+			if strings.EqualFold(s.Language, llang) {
 				s.CommitID = commitID
 				s.IsPrimary = llang == topLang
 				s.Size = size

--- a/modules/markup/mdstripper/mdstripper.go
+++ b/modules/markup/mdstripper/mdstripper.go
@@ -92,7 +92,7 @@ func (r *stripRenderer) processAutoLink(w io.Writer, link []byte) {
 
 	// Note: we're not attempting to match the URL scheme (http/https)
 	host := strings.ToLower(u.Host)
-	if host != "" && host != strings.ToLower(r.localhost.Host) {
+	if host != "" && !strings.EqualFold(host, r.localhost.Host) {
 		// Process out of band
 		r.links = append(r.links, linkStr)
 		return

--- a/modules/packages/pub/metadata.go
+++ b/modules/packages/pub/metadata.go
@@ -88,7 +88,7 @@ func ParsePackage(r io.Reader) (*Package, error) {
 			if err != nil {
 				return nil, err
 			}
-		} else if strings.ToLower(hd.Name) == "readme.md" {
+		} else if strings.EqualFold(hd.Name, "readme.md") {
 			data, err := io.ReadAll(tr)
 			if err != nil {
 				return nil, err

--- a/modules/setting/actions.go
+++ b/modules/setting/actions.go
@@ -62,11 +62,11 @@ func (c logCompression) IsValid() bool {
 }
 
 func (c logCompression) IsNone() bool {
-	return strings.ToLower(string(c)) == "none"
+	return strings.EqualFold(string(c), "none")
 }
 
 func (c logCompression) IsZstd() bool {
-	return c == "" || strings.ToLower(string(c)) == "zstd"
+	return c == "" || strings.EqualFold(string(c), "zstd")
 }
 
 func loadActionsFrom(rootCfg ConfigProvider) error {

--- a/modules/util/slice.go
+++ b/modules/util/slice.go
@@ -13,7 +13,7 @@ import (
 func SliceContainsString(slice []string, target string, insensitive ...bool) bool {
 	if len(insensitive) != 0 && insensitive[0] {
 		target = strings.ToLower(target)
-		return slices.ContainsFunc(slice, func(t string) bool { return strings.ToLower(t) == target })
+		return slices.ContainsFunc(slice, func(t string) bool { return strings.EqualFold(t, target) })
 	}
 
 	return slices.Contains(slice, target)

--- a/modules/util/time_str.go
+++ b/modules/util/time_str.go
@@ -59,7 +59,7 @@ func TimeEstimateParse(timeStr string) (int64, error) {
 		unit := timeStr[match[4]:match[5]]
 		found := false
 		for _, u := range timeStrGlobalVars().units {
-			if strings.ToLower(unit) == u.name {
+			if strings.EqualFold(unit, u.name) {
 				total += amount * u.num
 				found = true
 				break

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -145,7 +145,7 @@ func repoAssignment() func(ctx *context.APIContext) {
 		)
 
 		// Check if the user is the same as the repository owner.
-		if ctx.IsSigned && ctx.Doer.LowerName == strings.ToLower(userName) {
+		if ctx.IsSigned && strings.EqualFold(ctx.Doer.LowerName, userName) {
 			owner = ctx.Doer
 		} else {
 			owner, err = user_model.GetUserByName(ctx, userName)

--- a/routers/api/v1/repo/collaborators.go
+++ b/routers/api/v1/repo/collaborators.go
@@ -276,7 +276,7 @@ func GetRepoPermissions(ctx *context.APIContext) {
 	//     "$ref": "#/responses/forbidden"
 
 	collaboratorUsername := ctx.PathParam("collaborator")
-	if !ctx.Doer.IsAdmin && ctx.Doer.LowerName != strings.ToLower(collaboratorUsername) && !ctx.IsUserRepoAdmin() {
+	if !ctx.Doer.IsAdmin && !strings.EqualFold(ctx.Doer.LowerName, collaboratorUsername) && !ctx.IsUserRepoAdmin() {
 		ctx.APIError(http.StatusForbidden, "Only admins can query all permissions, repo admins can query all repo permissions, collaborators can query only their own")
 		return
 	}

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -669,7 +669,7 @@ func updateBasicProperties(ctx *context.APIContext, opts api.EditRepoOption) err
 		newRepoName = *opts.Name
 	}
 	// Check if repository name has been changed and not just a case change
-	if repo.LowerName != strings.ToLower(newRepoName) {
+	if !strings.EqualFold(repo.LowerName, newRepoName) {
 		if err := repo_service.ChangeRepositoryName(ctx, ctx.Doer, repo, newRepoName); err != nil {
 			switch {
 			case repo_model.IsErrRepoAlreadyExist(err):

--- a/routers/web/auth/oauth2_provider.go
+++ b/routers/web/auth/oauth2_provider.go
@@ -109,7 +109,7 @@ func InfoOAuth(ctx *context.Context) {
 	var accessTokenScope auth.AccessTokenScope
 	if auHead := ctx.Req.Header.Get("Authorization"); auHead != "" {
 		auths := strings.Fields(auHead)
-		if len(auths) == 2 && (auths[0] == "token" || strings.ToLower(auths[0]) == "bearer") {
+		if len(auths) == 2 && (auths[0] == "token" || strings.EqualFold(auths[0], "bearer")) {
 			accessTokenScope, _ = auth_service.GetOAuthAccessTokenScopeAndUserID(ctx, auths[1])
 		}
 	}

--- a/routers/web/repo/editor.go
+++ b/routers/web/repo/editor.go
@@ -796,7 +796,7 @@ func cleanUploadFileName(name string) string {
 	name = util.PathJoinRel(name)
 	// Git disallows any filenames to have a .git directory in them.
 	for _, part := range strings.Split(name, "/") {
-		if strings.ToLower(part) == ".git" {
+		if strings.EqualFold(part, ".git") {
 			return ""
 		}
 	}

--- a/routers/web/repo/setting/setting.go
+++ b/routers/web/repo/setting/setting.go
@@ -165,7 +165,7 @@ func handleSettingsPostUpdate(ctx *context.Context) {
 
 	newRepoName := form.RepoName
 	// Check if repository name has been changed.
-	if repo.LowerName != strings.ToLower(newRepoName) {
+	if !strings.EqualFold(repo.LowerName, newRepoName) {
 		// Close the GitRepo if open
 		if ctx.Repo.GitRepo != nil {
 			ctx.Repo.GitRepo.Close()

--- a/services/auth/basic.go
+++ b/services/auth/basic.go
@@ -60,7 +60,7 @@ func (b *Basic) Verify(req *http.Request, w http.ResponseWriter, store DataStore
 	}
 
 	auths := strings.SplitN(baHead, " ", 2)
-	if len(auths) != 2 || (strings.ToLower(auths[0]) != "basic") {
+	if len(auths) != 2 || (!strings.EqualFold(auths[0], "basic")) {
 		return nil, nil
 	}
 

--- a/services/auth/oauth2.go
+++ b/services/auth/oauth2.go
@@ -98,7 +98,7 @@ func parseToken(req *http.Request) (string, bool) {
 	// check header token
 	if auHead := req.Header.Get("Authorization"); auHead != "" {
 		auths := strings.Fields(auHead)
-		if len(auths) == 2 && (auths[0] == "token" || strings.ToLower(auths[0]) == "bearer") {
+		if len(auths) == 2 && (auths[0] == "token" || strings.EqualFold(auths[0], "bearer")) {
 			return auths[1], true
 		}
 	}

--- a/services/auth/source/ldap/source_search.go
+++ b/services/auth/source/ldap/source_search.go
@@ -241,7 +241,7 @@ func (source *Source) listLdapGroupMemberships(l *ldap.Conn, uid string, applyGr
 }
 
 func (source *Source) getUserAttributeListedInGroup(entry *ldap.Entry) string {
-	if strings.ToLower(source.UserUID) == "dn" {
+	if strings.EqualFold(source.UserUID, "dn") {
 		return entry.DN
 	}
 

--- a/services/context/org.go
+++ b/services/context/org.go
@@ -208,7 +208,7 @@ func OrgAssignment(opts OrgAssignmentOptions) func(ctx *Context) {
 		if len(teamName) > 0 {
 			teamExists := false
 			for _, team := range ctx.Org.Teams {
-				if team.LowerName == strings.ToLower(teamName) {
+				if strings.EqualFold(team.LowerName, teamName) {
 					teamExists = true
 					ctx.Org.Team = team
 					ctx.Org.IsTeamMember = true

--- a/services/context/repo.go
+++ b/services/context/repo.go
@@ -392,7 +392,7 @@ func RepoAssignment(ctx *Context) {
 	}
 
 	// Check if the user is the same as the repository owner
-	if ctx.IsSigned && ctx.Doer.LowerName == strings.ToLower(userName) {
+	if ctx.IsSigned && strings.EqualFold(ctx.Doer.LowerName, userName) {
 		ctx.Repo.Owner = ctx.Doer
 	} else {
 		ctx.Repo.Owner, err = user_model.GetUserByName(ctx, userName)

--- a/services/context/user.go
+++ b/services/context/user.go
@@ -61,7 +61,7 @@ func UserAssignmentAPI() func(ctx *APIContext) {
 func userAssignment(ctx *Base, doer *user_model.User, errCb func(int, any)) (contextUser *user_model.User) {
 	username := ctx.PathParam("username")
 
-	if doer != nil && doer.LowerName == strings.ToLower(username) {
+	if doer != nil && strings.EqualFold(doer.LowerName, username) {
 		contextUser = doer
 	} else {
 		var err error

--- a/services/repository/files/file.go
+++ b/services/repository/files/file.go
@@ -140,7 +140,7 @@ func CleanUploadFileName(name string) string {
 	name = util.PathJoinRel(name)
 	// Git disallows any filenames to have a .git directory in them.
 	for _, part := range strings.Split(name, "/") {
-		if strings.ToLower(part) == ".git" {
+		if strings.EqualFold(part, ".git") {
 			return ""
 		}
 	}


### PR DESCRIPTION
Enable https://go-critic.com/overview.html#equalfold, which is marked experimental, so was not enabled by default and ran `make lint-go-fix`. Reasons why `strings.EqualFold` is preferred [here](https://docs.datadoghq.com/security/code_security/static_analysis/static_analysis_rules/go-best-practices/inefficient-string-comparison/).