### PR TITLE
Fix removing some packages will result dirty data

### DIFF
--- a/routers/api/packages/chef/chef.go
+++ b/routers/api/packages/chef/chef.go
@@ -21,6 +21,7 @@ import (
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/routers/api/packages/helper"
+	"code.gitea.io/gitea/routers/common"
 	"code.gitea.io/gitea/services/context"
 	packages_service "code.gitea.io/gitea/services/packages"
 )
@@ -357,7 +358,7 @@ func DeletePackageVersion(ctx *context.Context) {
 	packageName := ctx.PathParam("name")
 	packageVersion := ctx.PathParam("version")
 
-	err := packages_service.RemovePackageVersionByNameAndVersion(
+	err := common.RemovePackageVersionByNameAndVersion(
 		ctx,
 		ctx.Doer,
 		&packages_service.PackageInfo{
@@ -393,7 +394,7 @@ func DeletePackage(ctx *context.Context) {
 	}
 
 	for _, pv := range pvs {
-		if err := packages_service.RemovePackageVersion(ctx, ctx.Doer, pv); err != nil {
+		if err := common.RemovePackageVersion(ctx, ctx.Doer, pv); err != nil {
 			apiError(ctx, http.StatusInternalServerError, err)
 			return
 		}

--- a/routers/api/packages/generic/generic.go
+++ b/routers/api/packages/generic/generic.go
@@ -14,6 +14,7 @@ import (
 	"code.gitea.io/gitea/modules/log"
 	packages_module "code.gitea.io/gitea/modules/packages"
 	"code.gitea.io/gitea/routers/api/packages/helper"
+	"code.gitea.io/gitea/routers/common"
 	"code.gitea.io/gitea/services/context"
 	packages_service "code.gitea.io/gitea/services/packages"
 )
@@ -144,7 +145,7 @@ func UploadPackage(ctx *context.Context) {
 
 // DeletePackage deletes the specific generic package.
 func DeletePackage(ctx *context.Context) {
-	err := packages_service.RemovePackageVersionByNameAndVersion(
+	err := common.RemovePackageVersionByNameAndVersion(
 		ctx,
 		ctx.Doer,
 		&packages_service.PackageInfo{
@@ -197,7 +198,7 @@ func DeletePackageFile(ctx *context.Context) {
 	}
 
 	if len(pfs) == 1 {
-		if err := packages_service.RemovePackageVersion(ctx, ctx.Doer, pv); err != nil {
+		if err := common.RemovePackageVersion(ctx, ctx.Doer, pv); err != nil {
 			apiError(ctx, http.StatusInternalServerError, err)
 			return
 		}

--- a/routers/api/packages/npm/npm.go
+++ b/routers/api/packages/npm/npm.go
@@ -23,6 +23,7 @@ import (
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/routers/api/packages/helper"
+	"code.gitea.io/gitea/routers/common"
 	"code.gitea.io/gitea/services/context"
 	packages_service "code.gitea.io/gitea/services/packages"
 
@@ -256,7 +257,7 @@ func DeletePackageVersion(ctx *context.Context) {
 	packageName := packageNameFromParams(ctx)
 	packageVersion := ctx.PathParam("version")
 
-	err := packages_service.RemovePackageVersionByNameAndVersion(
+	err := common.RemovePackageVersionByNameAndVersion(
 		ctx,
 		ctx.Doer,
 		&packages_service.PackageInfo{
@@ -294,7 +295,7 @@ func DeletePackage(ctx *context.Context) {
 	}
 
 	for _, pv := range pvs {
-		if err := packages_service.RemovePackageVersion(ctx, ctx.Doer, pv); err != nil {
+		if err := common.RemovePackageVersion(ctx, ctx.Doer, pv); err != nil {
 			apiError(ctx, http.StatusInternalServerError, err)
 			return
 		}

--- a/routers/api/packages/nuget/nuget.go
+++ b/routers/api/packages/nuget/nuget.go
@@ -24,6 +24,7 @@ import (
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/routers/api/packages/helper"
+	"code.gitea.io/gitea/routers/common"
 	"code.gitea.io/gitea/services/context"
 	packages_service "code.gitea.io/gitea/services/packages"
 )
@@ -688,7 +689,7 @@ func DeletePackage(ctx *context.Context) {
 	packageName := ctx.PathParam("id")
 	packageVersion := ctx.PathParam("version")
 
-	err := packages_service.RemovePackageVersionByNameAndVersion(
+	err := common.RemovePackageVersionByNameAndVersion(
 		ctx,
 		ctx.Doer,
 		&packages_service.PackageInfo{

--- a/routers/api/packages/rubygems/rubygems.go
+++ b/routers/api/packages/rubygems/rubygems.go
@@ -19,6 +19,7 @@ import (
 	rubygems_module "code.gitea.io/gitea/modules/packages/rubygems"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/routers/api/packages/helper"
+	"code.gitea.io/gitea/routers/common"
 	"code.gitea.io/gitea/services/context"
 	packages_service "code.gitea.io/gitea/services/packages"
 )
@@ -277,7 +278,7 @@ func DeletePackage(ctx *context.Context) {
 	packageName := ctx.FormString("gem_name")
 	packageVersion := ctx.FormString("version")
 
-	err := packages_service.RemovePackageVersionByNameAndVersion(
+	err := common.RemovePackageVersionByNameAndVersion(
 		ctx,
 		ctx.Doer,
 		&packages_service.PackageInfo{

--- a/routers/api/v1/packages/package.go
+++ b/routers/api/v1/packages/package.go
@@ -13,6 +13,7 @@ import (
 	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/routers/api/v1/utils"
+	"code.gitea.io/gitea/routers/common"
 	"code.gitea.io/gitea/services/context"
 	"code.gitea.io/gitea/services/convert"
 	packages_service "code.gitea.io/gitea/services/packages"
@@ -148,7 +149,7 @@ func DeletePackage(ctx *context.APIContext) {
 	//   "404":
 	//     "$ref": "#/responses/notFound"
 
-	err := packages_service.RemovePackageVersion(ctx, ctx.Doer, ctx.Package.Descriptor.Version)
+	err := common.RemovePackageVersion(ctx, ctx.Doer, ctx.Package.Descriptor.Version)
 	if err != nil {
 		ctx.APIErrorInternal(err)
 		return

--- a/routers/common/package.go
+++ b/routers/common/package.go
@@ -1,0 +1,45 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package common
+
+import (
+	"context"
+
+	packages_model "code.gitea.io/gitea/models/packages"
+	user_model "code.gitea.io/gitea/models/user"
+	packages_service "code.gitea.io/gitea/services/packages"
+	alpine_service "code.gitea.io/gitea/services/packages/alpine"
+	cargo_service "code.gitea.io/gitea/services/packages/cargo"
+	debian_service "code.gitea.io/gitea/services/packages/debian"
+	rpm_service "code.gitea.io/gitea/services/packages/rpm"
+)
+
+// RemovePackageVersionByNameAndVersion deletes a package version and all associated files
+func RemovePackageVersionByNameAndVersion(ctx context.Context, doer *user_model.User, pvi *packages_service.PackageInfo) error {
+	pv, err := packages_model.GetVersionByNameAndVersion(ctx, pvi.Owner.ID, pvi.PackageType, pvi.Name, pvi.Version)
+	if err != nil {
+		return err
+	}
+
+	return RemovePackageVersion(ctx, doer, pv)
+}
+
+func RemovePackageVersion(ctx context.Context, doer *user_model.User, pv *packages_model.PackageVersion) error {
+	pd, err := packages_model.GetPackageDescriptor(ctx, pv)
+	if err != nil {
+		return err
+	}
+	switch pd.Package.Type {
+	case packages_model.TypeAlpine:
+		return alpine_service.RemovePackageVersion(ctx, doer, pv)
+	case packages_model.TypeCargo:
+		return cargo_service.RemovePackageVersion(ctx, doer, pv)
+	case packages_model.TypeDebian:
+		return debian_service.RemovePackageVersion(ctx, doer, pv)
+	case packages_model.TypeRpm:
+		return rpm_service.RemovePackageVersion(ctx, doer, pv)
+	default:
+		return packages_service.RemovePackageVersion(ctx, doer, pv)
+	}
+}

--- a/routers/web/admin/packages.go
+++ b/routers/web/admin/packages.go
@@ -13,8 +13,8 @@ import (
 	"code.gitea.io/gitea/modules/optional"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/templates"
+	"code.gitea.io/gitea/routers/common"
 	"code.gitea.io/gitea/services/context"
-	packages_service "code.gitea.io/gitea/services/packages"
 	packages_cleanup_service "code.gitea.io/gitea/services/packages/cleanup"
 )
 
@@ -91,7 +91,7 @@ func DeletePackageVersion(ctx *context.Context) {
 		return
 	}
 
-	if err := packages_service.RemovePackageVersion(ctx, ctx.Doer, pv); err != nil {
+	if err := common.RemovePackageVersion(ctx, ctx.Doer, pv); err != nil {
 		ctx.ServerError("RemovePackageVersion", err)
 		return
 	}

--- a/routers/web/user/package.go
+++ b/routers/web/user/package.go
@@ -27,6 +27,7 @@ import (
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/modules/web"
 	packages_helper "code.gitea.io/gitea/routers/api/packages/helper"
+	"code.gitea.io/gitea/routers/common"
 	shared_user "code.gitea.io/gitea/routers/web/shared/user"
 	"code.gitea.io/gitea/services/context"
 	"code.gitea.io/gitea/services/forms"
@@ -457,7 +458,7 @@ func PackageSettingsPost(ctx *context.Context) {
 		ctx.Redirect(ctx.Link)
 		return
 	case "delete":
-		err := packages_service.RemovePackageVersion(ctx, ctx.Doer, ctx.Package.Descriptor.Version)
+		err := common.RemovePackageVersion(ctx, ctx.Doer, ctx.Package.Descriptor.Version)
 		if err != nil {
 			log.Error("Error deleting package: %v", err)
 			ctx.Flash.Error(ctx.Tr("packages.settings.delete.error"))

--- a/services/packages/alpine/update.go
+++ b/services/packages/alpine/update.go
@@ -1,0 +1,37 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package alpine
+
+import (
+	"context"
+	"fmt"
+
+	"code.gitea.io/gitea/models/db"
+	packages_model "code.gitea.io/gitea/models/packages"
+	user_model "code.gitea.io/gitea/models/user"
+	notify_service "code.gitea.io/gitea/services/notify"
+	packages_service "code.gitea.io/gitea/services/packages"
+)
+
+func RemovePackageVersion(ctx context.Context, doer *user_model.User, pv *packages_model.PackageVersion) error {
+	pd, err := packages_model.GetPackageDescriptor(ctx, pv)
+	if err != nil {
+		return err
+	}
+
+	if err := db.WithTx(ctx, func(ctx context.Context) error {
+		if err := packages_service.DeletePackageVersionAndReferences(ctx, pv); err != nil {
+			return err
+		}
+		if err := BuildAllRepositoryFiles(ctx, pd.Owner.ID); err != nil {
+			return fmt.Errorf("alpine.BuildAllRepositoryFiles failed: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	notify_service.PackageDelete(ctx, doer, pd)
+	return nil
+}

--- a/services/packages/cargo/update.go
+++ b/services/packages/cargo/update.go
@@ -1,0 +1,37 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package cargo
+
+import (
+	"context"
+	"fmt"
+
+	"code.gitea.io/gitea/models/db"
+	packages_model "code.gitea.io/gitea/models/packages"
+	user_model "code.gitea.io/gitea/models/user"
+	notify_service "code.gitea.io/gitea/services/notify"
+	packages_service "code.gitea.io/gitea/services/packages"
+)
+
+func RemovePackageVersion(ctx context.Context, doer *user_model.User, pv *packages_model.PackageVersion) error {
+	pd, err := packages_model.GetPackageDescriptor(ctx, pv)
+	if err != nil {
+		return err
+	}
+
+	if err := db.WithTx(ctx, func(ctx context.Context) error {
+		if err := packages_service.DeletePackageVersionAndReferences(ctx, pv); err != nil {
+			return err
+		}
+		if err := UpdatePackageIndexIfExists(ctx, doer, pd.Owner, pd.Package.ID); err != nil {
+			return fmt.Errorf("alpine.BuildAllRepositoryFiles failed: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	notify_service.PackageDelete(ctx, doer, pd)
+	return nil
+}

--- a/services/packages/debian/update.go
+++ b/services/packages/debian/update.go
@@ -1,0 +1,37 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package debian
+
+import (
+	"context"
+	"fmt"
+
+	"code.gitea.io/gitea/models/db"
+	packages_model "code.gitea.io/gitea/models/packages"
+	user_model "code.gitea.io/gitea/models/user"
+	notify_service "code.gitea.io/gitea/services/notify"
+	packages_service "code.gitea.io/gitea/services/packages"
+)
+
+func RemovePackageVersion(ctx context.Context, doer *user_model.User, pv *packages_model.PackageVersion) error {
+	pd, err := packages_model.GetPackageDescriptor(ctx, pv)
+	if err != nil {
+		return err
+	}
+
+	if err := db.WithTx(ctx, func(ctx context.Context) error {
+		if err := packages_service.DeletePackageVersionAndReferences(ctx, pv); err != nil {
+			return err
+		}
+		if err := BuildAllRepositoryFiles(ctx, pd.Owner.ID); err != nil {
+			return fmt.Errorf("alpine.BuildAllRepositoryFiles failed: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	notify_service.PackageDelete(ctx, doer, pd)
+	return nil
+}

--- a/services/packages/packages.go
+++ b/services/packages/packages.go
@@ -456,16 +456,6 @@ func GetOrCreateInternalPackageVersion(ctx context.Context, ownerID int64, packa
 	})
 }
 
-// RemovePackageVersionByNameAndVersion deletes a package version and all associated files
-func RemovePackageVersionByNameAndVersion(ctx context.Context, doer *user_model.User, pvi *PackageInfo) error {
-	pv, err := packages_model.GetVersionByNameAndVersion(ctx, pvi.Owner.ID, pvi.PackageType, pvi.Name, pvi.Version)
-	if err != nil {
-		return err
-	}
-
-	return RemovePackageVersion(ctx, doer, pv)
-}
-
 // RemovePackageVersion deletes the package version and all associated files
 func RemovePackageVersion(ctx context.Context, doer *user_model.User, pv *packages_model.PackageVersion) error {
 	dbCtx, committer, err := db.TxContext(ctx)

--- a/services/packages/rpm/update.go
+++ b/services/packages/rpm/update.go
@@ -1,0 +1,37 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package rpm
+
+import (
+	"context"
+	"fmt"
+
+	"code.gitea.io/gitea/models/db"
+	packages_model "code.gitea.io/gitea/models/packages"
+	user_model "code.gitea.io/gitea/models/user"
+	notify_service "code.gitea.io/gitea/services/notify"
+	packages_service "code.gitea.io/gitea/services/packages"
+)
+
+func RemovePackageVersion(ctx context.Context, doer *user_model.User, pv *packages_model.PackageVersion) error {
+	pd, err := packages_model.GetPackageDescriptor(ctx, pv)
+	if err != nil {
+		return err
+	}
+
+	if err := db.WithTx(ctx, func(ctx context.Context) error {
+		if err := packages_service.DeletePackageVersionAndReferences(ctx, pv); err != nil {
+			return err
+		}
+		if err := BuildAllRepositoryFiles(ctx, pd.Owner.ID); err != nil {
+			return fmt.Errorf("alpine.BuildAllRepositoryFiles failed: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	notify_service.PackageDelete(ctx, doer, pd)
+	return nil
+}


### PR DESCRIPTION
Fix #32830 

Inspired by #22810 and replace it.

When deleting alphe, cargo, debian, rpm packages, some extra actions should be taken which was missed. It will result in dirty data and inconsistent. This PR fix it. To avoid recycle dependencies, this is a quick patch. Like https://github.com/go-gitea/gitea/pull/22810#issuecomment-1421117309 said, this might need a new design for such more packages types.