### PR TITLE
Add ff_only parameter to POST /repos/{owner}/{repo}/merge-upstream

### DIFF
--- a/modules/structs/repo_branch.go
+++ b/modules/structs/repo_branch.go
@@ -136,6 +136,7 @@ type UpdateBranchProtectionPriories struct {
 
 type MergeUpstreamRequest struct {
 	Branch string `json:"branch"`
+	FfOnly bool   `json:"ff_only"`
 }
 
 type MergeUpstreamResponse struct {

--- a/routers/api/v1/repo/branch.go
+++ b/routers/api/v1/repo/branch.go
@@ -1181,7 +1181,7 @@ func MergeUpstream(ctx *context.APIContext) {
 	//   "404":
 	//     "$ref": "#/responses/notFound"
 	form := web.GetForm(ctx).(*api.MergeUpstreamRequest)
-	mergeStyle, err := repo_service.MergeUpstream(ctx, ctx.Doer, ctx.Repo.Repository, form.Branch)
+	mergeStyle, err := repo_service.MergeUpstream(ctx, ctx.Doer, ctx.Repo.Repository, form.Branch, form.FfOnly)
 	if err != nil {
 		if errors.Is(err, util.ErrInvalidArgument) {
 			ctx.APIError(http.StatusBadRequest, err)

--- a/routers/web/repo/branch.go
+++ b/routers/web/repo/branch.go
@@ -258,7 +258,7 @@ func CreateBranch(ctx *context.Context) {
 
 func MergeUpstream(ctx *context.Context) {
 	branchName := ctx.FormString("branch")
-	_, err := repo_service.MergeUpstream(ctx, ctx.Doer, ctx.Repo.Repository, branchName)
+	_, err := repo_service.MergeUpstream(ctx, ctx.Doer, ctx.Repo.Repository, branchName, false)
 	if err != nil {
 		if errors.Is(err, util.ErrNotExist) {
 			ctx.JSONErrorNotFound()

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -24839,6 +24839,10 @@
         "branch": {
           "type": "string",
           "x-go-name": "Branch"
+        },
+        "ff_only": {
+          "type": "boolean",
+          "x-go-name": "FfOnly"
         }
       },
       "x-go-package": "code.gitea.io/gitea/modules/structs"


### PR DESCRIPTION
The merge-upstream route was so far performing any kind of merge, even those that would create merge commits and thus make your branch diverge from upstream, requiring manual intervention via the git cli to undo the damage.

With the new optional parameter ff_only, we can instruct gitea to error out, if a non-fast-forward merge would be performed.
