### PR TITLE
Fix required contexts and commit status matching bug

### DIFF
--- a/services/pull/commit_status.go
+++ b/services/pull/commit_status.go
@@ -38,12 +38,17 @@ func MergeRequiredContextsCommitStatus(commitStatuses []*git_model.CommitStatus,
 	}
 
 	requiredCommitStatuses := make([]*git_model.CommitStatus, 0, len(commitStatuses))
+	allRequiredContextsMatched := true
 	for _, gp := range requiredContextsGlob {
+		requiredContextMatched := false
 		for _, commitStatus := range commitStatuses {
 			if gp.Match(commitStatus.Context) {
 				requiredCommitStatuses = append(requiredCommitStatuses, commitStatus)
-				break
+				requiredContextMatched = true
 			}
+		}
+		if !requiredContextMatched {
+			allRequiredContextsMatched = false
 		}
 	}
 	if len(requiredCommitStatuses) == 0 {
@@ -51,7 +56,7 @@ func MergeRequiredContextsCommitStatus(commitStatuses []*git_model.CommitStatus,
 	}
 
 	returnedStatus := git_model.CalcCommitStatus(requiredCommitStatuses).State
-	if len(requiredCommitStatuses) == len(requiredContexts) {
+	if allRequiredContextsMatched {
 		return returnedStatus
 	}
 

--- a/services/pull/commit_status.go
+++ b/services/pull/commit_status.go
@@ -47,9 +47,7 @@ func MergeRequiredContextsCommitStatus(commitStatuses []*git_model.CommitStatus,
 				requiredContextMatched = true
 			}
 		}
-		if !requiredContextMatched {
-			allRequiredContextsMatched = false
-		}
+		allRequiredContextsMatched = allRequiredContextsMatched && requiredContextMatched
 	}
 	if len(requiredCommitStatuses) == 0 {
 		return commitstatus.CommitStatusPending

--- a/services/pull/commit_status_test.go
+++ b/services/pull/commit_status_test.go
@@ -62,6 +62,15 @@ func TestMergeRequiredContextsCommitStatus(t *testing.T) {
 			commitStatuses: []*git_model.CommitStatus{
 				{Context: "Build 1", State: commitstatus.CommitStatusSuccess},
 				{Context: "Build 2", State: commitstatus.CommitStatusSuccess},
+				{Context: "Build 2t", State: commitstatus.CommitStatusFailure},
+			},
+			requiredContexts: []string{"Build*"},
+			expected:         commitstatus.CommitStatusFailure,
+		},
+		{
+			commitStatuses: []*git_model.CommitStatus{
+				{Context: "Build 1", State: commitstatus.CommitStatusSuccess},
+				{Context: "Build 2", State: commitstatus.CommitStatusSuccess},
 				{Context: "Build 2t", State: commitstatus.CommitStatusSuccess},
 			},
 			requiredContexts: []string{"Build*", "Build 2t*", "Build 3*"},


### PR DESCRIPTION
Fix #34504

Since one required context can match more than one commit statuses, we should not directly compare the lengths of `requiredCommitStatuses` and `requiredContexts`