### PR TITLE
fix(issue): Replace stopwatch toggle with explicit start/stop actions

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1727,7 +1727,7 @@ issues.time_estimate_invalid = Time estimate format is invalid
 issues.start_tracking_history = started working %s
 issues.tracker_auto_close = Timer will be stopped automatically when this issue gets closed
 issues.stopwatch_already_stopped = The timer for this issue is already stopped
-issues.stopwatch_already_created = The timer for this issue is already created
+issues.stopwatch_already_created = The timer for this issue already exists
 issues.tracking_already_started = `You have already started time tracking on <a href="%s">another issue</a>!`
 issues.stop_tracking = Stop Timer
 issues.stop_tracking_history = worked for <b>%[1]s</b> %[2]s

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1726,7 +1726,8 @@ issues.remove_time_estimate_at = removed time estimate %s
 issues.time_estimate_invalid = Time estimate format is invalid
 issues.start_tracking_history = started working %s
 issues.tracker_auto_close = Timer will be stopped automatically when this issue gets closed
-issues.tracker_already_stopped = The timer for this issue is already stopped
+issues.stopwatch_already_stopped = The timer for this issue is already stopped
+issues.stopwatch_already_created = The timer for this issue is already created
 issues.tracking_already_started = `You have already started time tracking on <a href="%s">another issue</a>!`
 issues.stop_tracking = Stop Timer
 issues.stop_tracking_history = worked for <b>%[1]s</b> %[2]s

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1726,6 +1726,7 @@ issues.remove_time_estimate_at = removed time estimate %s
 issues.time_estimate_invalid = Time estimate format is invalid
 issues.start_tracking_history = started working %s
 issues.tracker_auto_close = Timer will be stopped automatically when this issue gets closed
+issues.tracker_already_stopped = The timer for this issue is already stopped
 issues.tracking_already_started = `You have already started time tracking on <a href="%s">another issue</a>!`
 issues.stop_tracking = Stop Timer
 issues.stop_tracking_history = worked for <b>%[1]s</b> %[2]s

--- a/routers/api/v1/repo/issue_stopwatch.go
+++ b/routers/api/v1/repo/issue_stopwatch.go
@@ -57,7 +57,7 @@ func StartIssueStopwatch(ctx *context.APIContext) {
 		ctx.APIErrorInternal(err)
 		return
 	} else if !ok {
-		ctx.APIError(http.StatusConflict, "annot start a stopwatch again if it already exists")
+		ctx.APIError(http.StatusConflict, "cannot start a stopwatch again if it already exists")
 		return
 	}
 

--- a/routers/api/v1/repo/issue_stopwatch.go
+++ b/routers/api/v1/repo/issue_stopwatch.go
@@ -4,7 +4,6 @@
 package repo
 
 import (
-	"errors"
 	"net/http"
 
 	issues_model "code.gitea.io/gitea/models/issues"
@@ -49,13 +48,16 @@ func StartIssueStopwatch(ctx *context.APIContext) {
 	//   "409":
 	//     description: Cannot start a stopwatch again if it already exists
 
-	issue, err := prepareIssueStopwatch(ctx, false)
-	if err != nil {
+	issue := prepareIssueForStopwatch(ctx)
+	if ctx.Written() {
 		return
 	}
 
-	if err := issues_model.CreateIssueStopwatch(ctx, ctx.Doer, issue); err != nil {
+	if ok, err := issues_model.CreateIssueStopwatch(ctx, ctx.Doer, issue); err != nil {
 		ctx.APIErrorInternal(err)
+		return
+	} else if !ok {
+		ctx.APIError(http.StatusConflict, "annot start a stopwatch again if it already exists")
 		return
 	}
 
@@ -96,18 +98,20 @@ func StopIssueStopwatch(ctx *context.APIContext) {
 	//   "404":
 	//     "$ref": "#/responses/notFound"
 	//   "409":
-	//     description:  Cannot stop a non existent stopwatch
+	//     description:  Cannot stop a non-existent stopwatch
 
-	issue, err := prepareIssueStopwatch(ctx, true)
-	if err != nil {
+	issue := prepareIssueForStopwatch(ctx)
+	if ctx.Written() {
 		return
 	}
 
-	if err := issues_model.FinishIssueStopwatch(ctx, ctx.Doer, issue); err != nil {
+	if ok, err := issues_model.FinishIssueStopwatch(ctx, ctx.Doer, issue); err != nil {
 		ctx.APIErrorInternal(err)
 		return
+	} else if !ok {
+		ctx.APIError(http.StatusConflict, "cannot stop a non-existent stopwatch")
+		return
 	}
-
 	ctx.Status(http.StatusCreated)
 }
 
@@ -145,22 +149,25 @@ func DeleteIssueStopwatch(ctx *context.APIContext) {
 	//   "404":
 	//     "$ref": "#/responses/notFound"
 	//   "409":
-	//     description:  Cannot cancel a non existent stopwatch
+	//     description:  Cannot cancel a non-existent stopwatch
 
-	issue, err := prepareIssueStopwatch(ctx, true)
-	if err != nil {
+	issue := prepareIssueForStopwatch(ctx)
+	if ctx.Written() {
 		return
 	}
 
-	if err := issues_model.CancelStopwatch(ctx, ctx.Doer, issue); err != nil {
+	if ok, err := issues_model.CancelStopwatch(ctx, ctx.Doer, issue); err != nil {
 		ctx.APIErrorInternal(err)
+		return
+	} else if !ok {
+		ctx.APIError(http.StatusConflict, "cannot cancel a non-existent stopwatch")
 		return
 	}
 
 	ctx.Status(http.StatusNoContent)
 }
 
-func prepareIssueStopwatch(ctx *context.APIContext, shouldExist bool) (*issues_model.Issue, error) {
+func prepareIssueForStopwatch(ctx *context.APIContext) *issues_model.Issue {
 	issue, err := issues_model.GetIssueByIndex(ctx, ctx.Repo.Repository.ID, ctx.PathParamInt64("index"))
 	if err != nil {
 		if issues_model.IsErrIssueNotExist(err) {
@@ -168,32 +175,19 @@ func prepareIssueStopwatch(ctx *context.APIContext, shouldExist bool) (*issues_m
 		} else {
 			ctx.APIErrorInternal(err)
 		}
-
-		return nil, err
+		return nil
 	}
 
 	if !ctx.Repo.CanWriteIssuesOrPulls(issue.IsPull) {
 		ctx.Status(http.StatusForbidden)
-		return nil, errors.New("Unable to write to PRs")
+		return nil
 	}
 
 	if !ctx.Repo.CanUseTimetracker(ctx, issue, ctx.Doer) {
 		ctx.Status(http.StatusForbidden)
-		return nil, errors.New("Cannot use time tracker")
+		return nil
 	}
-
-	if issues_model.StopwatchExists(ctx, ctx.Doer.ID, issue.ID) != shouldExist {
-		if shouldExist {
-			ctx.APIError(http.StatusConflict, "cannot stop/cancel a non existent stopwatch")
-			err = errors.New("cannot stop/cancel a non existent stopwatch")
-		} else {
-			ctx.APIError(http.StatusConflict, "cannot start a stopwatch again if it already exists")
-			err = errors.New("cannot start a stopwatch again if it already exists")
-		}
-		return nil, err
-	}
-
-	return issue, nil
+	return issue
 }
 
 // GetStopwatches get all stopwatches

--- a/routers/web/repo/issue_stopwatch.go
+++ b/routers/web/repo/issue_stopwatch.go
@@ -22,13 +22,14 @@ func IssueStartStopwatch(c *context.Context) {
 		return
 	}
 
-	if err := issues_model.CreateIssueStopwatch(c, c.Doer, issue); err != nil {
+	if ok, err := issues_model.CreateIssueStopwatch(c, c.Doer, issue); err != nil {
 		c.ServerError("CreateIssueStopwatch", err)
 		return
+	} else if !ok {
+		c.Flash.Warning(c.Tr("repo.issues.stopwatch_already_created"))
+	} else {
+		c.Flash.Success(c.Tr("repo.issues.tracker_auto_close"))
 	}
-
-	c.Flash.Success(c.Tr("repo.issues.tracker_auto_close"))
-
 	c.JSONRedirect("")
 }
 
@@ -44,17 +45,12 @@ func IssueStopStopwatch(c *context.Context) {
 		return
 	}
 
-	wasRunning := issues_model.StopwatchExists(c, c.Doer.ID, issue.ID)
-
-	if wasRunning {
-		if err := issues_model.FinishIssueStopwatch(c, c.Doer, issue); err != nil {
-			c.ServerError("FinishIssueStopwatch", err)
-			return
-		}
-	} else {
-		c.Flash.Warning(c.Tr("repo.issues.tracker_already_stopped"))
+	if ok, err := issues_model.FinishIssueStopwatch(c, c.Doer, issue); err != nil {
+		c.ServerError("FinishIssueStopwatch", err)
+		return
+	} else if !ok {
+		c.Flash.Warning(c.Tr("repo.issues.stopwatch_already_stopped"))
 	}
-
 	c.JSONRedirect("")
 }
 
@@ -69,7 +65,7 @@ func CancelStopwatch(c *context.Context) {
 		return
 	}
 
-	if err := issues_model.CancelStopwatch(c, c.Doer, issue); err != nil {
+	if _, err := issues_model.CancelStopwatch(c, c.Doer, issue); err != nil {
 		c.ServerError("CancelStopwatch", err)
 		return
 	}

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -1258,13 +1258,8 @@ func CancelAutoMergePullRequest(ctx *context.Context) {
 }
 
 func stopTimerIfAvailable(ctx *context.Context, user *user_model.User, issue *issues_model.Issue) error {
-	if issues_model.StopwatchExists(ctx, user.ID, issue.ID) {
-		if err := issues_model.CreateOrStopIssueStopwatch(ctx, user, issue); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	_, err := issues_model.FinishIssueStopwatch(ctx, user, issue)
+	return err
 }
 
 func PullsNewRedirect(ctx *context.Context) {

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1253,7 +1253,8 @@ func registerWebRoutes(m *web.Router) {
 					m.Post("/add", web.Bind(forms.AddTimeManuallyForm{}), repo.AddTimeManually)
 					m.Post("/{timeid}/delete", repo.DeleteTime)
 					m.Group("/stopwatch", func() {
-						m.Post("/toggle", repo.IssueStopwatch)
+						m.Post("/start", repo.IssueStartStopwatch)
+						m.Post("/stop", repo.IssueStopStopwatch)
 						m.Post("/cancel", repo.CancelStopwatch)
 					})
 				})

--- a/services/issue/status.go
+++ b/services/issue/status.go
@@ -24,14 +24,14 @@ func CloseIssue(ctx context.Context, issue *issues_model.Issue, doer *user_model
 	comment, err := issues_model.CloseIssue(dbCtx, issue, doer)
 	if err != nil {
 		if issues_model.IsErrDependenciesLeft(err) {
-			if err := issues_model.FinishIssueStopwatchIfPossible(dbCtx, doer, issue); err != nil {
+			if _, err := issues_model.FinishIssueStopwatch(dbCtx, doer, issue); err != nil {
 				log.Error("Unable to stop stopwatch for issue[%d]#%d: %v", issue.ID, issue.Index, err)
 			}
 		}
 		return err
 	}
 
-	if err := issues_model.FinishIssueStopwatchIfPossible(dbCtx, doer, issue); err != nil {
+	if _, err := issues_model.FinishIssueStopwatch(dbCtx, doer, issue); err != nil {
 		return err
 	}
 

--- a/templates/base/head_navbar.tmpl
+++ b/templates/base/head_navbar.tmpl
@@ -197,7 +197,7 @@
 					<span class="stopwatch-issue">{{$activeStopwatch.RepoSlug}}#{{$activeStopwatch.IssueIndex}}</span>
 				</a>
 				<div class="tw-flex tw-gap-1">
-					<form class="stopwatch-commit form-fetch-action" method="post" action="{{$activeStopwatch.IssueLink}}/times/stopwatch/toggle">
+					<form class="stopwatch-commit form-fetch-action" method="post" action="{{$activeStopwatch.IssueLink}}/times/stopwatch/stop">
 						{{.CsrfTokenHtml}}
 						<button
 							type="submit"

--- a/templates/repo/issue/sidebar/stopwatch_timetracker.tmpl
+++ b/templates/repo/issue/sidebar/stopwatch_timetracker.tmpl
@@ -16,14 +16,14 @@
 					</a>
 					<div class="divider"></div>
 					{{if $.IsStopwatchRunning}}
-					<a class="item issue-stop-time link-action" data-url="{{.Issue.Link}}/times/stopwatch/toggle">
+					<a class="item issue-stop-time link-action" data-url="{{.Issue.Link}}/times/stopwatch/stop">
 						{{svg "octicon-stopwatch"}} {{ctx.Locale.Tr "repo.issues.timetracker_timer_stop"}}
 					</a>
 					<a class="item issue-cancel-time link-action" data-url="{{.Issue.Link}}/times/stopwatch/cancel">
 						{{svg "octicon-trash"}} {{ctx.Locale.Tr "repo.issues.timetracker_timer_discard"}}
 					</a>
 					{{else}}
-					<a class="item issue-start-time link-action" data-url="{{.Issue.Link}}/times/stopwatch/toggle">
+					<a class="item issue-start-time link-action" data-url="{{.Issue.Link}}/times/stopwatch/start">
 						{{svg "octicon-stopwatch"}} {{ctx.Locale.Tr "repo.issues.timetracker_timer_start"}}
 					</a>
 					<a class="item issue-add-time show-modal" data-modal="#issue-time-manually-add-modal">

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -11635,7 +11635,7 @@
             "$ref": "#/responses/notFound"
           },
           "409": {
-            "description": "Cannot cancel a non existent stopwatch"
+            "description": "Cannot cancel a non-existent stopwatch"
           }
         }
       }
@@ -11741,7 +11741,7 @@
             "$ref": "#/responses/notFound"
           },
           "409": {
-            "description": "Cannot stop a non existent stopwatch"
+            "description": "Cannot stop a non-existent stopwatch"
           }
         }
       }

--- a/tests/integration/timetracking_test.go
+++ b/tests/integration/timetracking_test.go
@@ -46,11 +46,12 @@ func testViewTimetrackingControls(t *testing.T, session *TestSession, user, repo
 	AssertHTMLElement(t, htmlDoc, ".issue-add-time", canTrackTime)
 
 	issueLink := path.Join(user, repo, "issues", issue)
-	req = NewRequestWithValues(t, "POST", path.Join(issueLink, "times", "stopwatch", "toggle"), map[string]string{
-		"_csrf": htmlDoc.GetCSRF(),
-	})
+
 	if canTrackTime {
-		session.MakeRequest(t, req, http.StatusOK)
+		reqStart := NewRequestWithValues(t, "POST", path.Join(issueLink, "times", "stopwatch", "start"), map[string]string{
+			"_csrf": htmlDoc.GetCSRF(),
+		})
+		session.MakeRequest(t, reqStart, http.StatusOK)
 
 		req = NewRequest(t, "GET", issueLink)
 		resp = session.MakeRequest(t, req, http.StatusOK)
@@ -65,10 +66,10 @@ func testViewTimetrackingControls(t *testing.T, session *TestSession, user, repo
 		// Sleep for 1 second to not get wrong order for stopping timer
 		time.Sleep(time.Second)
 
-		req = NewRequestWithValues(t, "POST", path.Join(issueLink, "times", "stopwatch", "toggle"), map[string]string{
+		reqStop := NewRequestWithValues(t, "POST", path.Join(issueLink, "times", "stopwatch", "stop"), map[string]string{
 			"_csrf": htmlDoc.GetCSRF(),
 		})
-		session.MakeRequest(t, req, http.StatusOK)
+		session.MakeRequest(t, reqStop, http.StatusOK)
 
 		req = NewRequest(t, "GET", issueLink)
 		resp = session.MakeRequest(t, req, http.StatusOK)
@@ -77,6 +78,9 @@ func testViewTimetrackingControls(t *testing.T, session *TestSession, user, repo
 		events = htmlDoc.doc.Find(".event > span.text")
 		assert.Contains(t, events.Last().Text(), "worked for ")
 	} else {
-		session.MakeRequest(t, req, http.StatusNotFound)
+		reqStart := NewRequestWithValues(t, "POST", path.Join(issueLink, "times", "stopwatch", "start"), map[string]string{
+			"_csrf": htmlDoc.GetCSRF(),
+		})
+		session.MakeRequest(t, reqStart, http.StatusNotFound)
 	}
 }

--- a/tests/integration/timetracking_test.go
+++ b/tests/integration/timetracking_test.go
@@ -46,11 +46,10 @@ func testViewTimetrackingControls(t *testing.T, session *TestSession, user, repo
 	AssertHTMLElement(t, htmlDoc, ".issue-add-time", canTrackTime)
 
 	issueLink := path.Join(user, repo, "issues", issue)
-
+	reqStart := NewRequestWithValues(t, "POST", path.Join(issueLink, "times", "stopwatch", "start"), map[string]string{
+		"_csrf": htmlDoc.GetCSRF(),
+	})
 	if canTrackTime {
-		reqStart := NewRequestWithValues(t, "POST", path.Join(issueLink, "times", "stopwatch", "start"), map[string]string{
-			"_csrf": htmlDoc.GetCSRF(),
-		})
 		session.MakeRequest(t, reqStart, http.StatusOK)
 
 		req = NewRequest(t, "GET", issueLink)
@@ -78,9 +77,6 @@ func testViewTimetrackingControls(t *testing.T, session *TestSession, user, repo
 		events = htmlDoc.doc.Find(".event > span.text")
 		assert.Contains(t, events.Last().Text(), "worked for ")
 	} else {
-		reqStart := NewRequestWithValues(t, "POST", path.Join(issueLink, "times", "stopwatch", "start"), map[string]string{
-			"_csrf": htmlDoc.GetCSRF(),
-		})
 		session.MakeRequest(t, reqStart, http.StatusNotFound)
 	}
 }

--- a/web_src/js/features/stopwatch.ts
+++ b/web_src/js/features/stopwatch.ts
@@ -134,7 +134,7 @@ function updateStopwatchData(data: any) {
     const {repo_owner_name, repo_name, issue_index, seconds} = watch;
     const issueUrl = `${appSubUrl}/${repo_owner_name}/${repo_name}/issues/${issue_index}`;
     document.querySelector('.stopwatch-link')?.setAttribute('href', issueUrl);
-    document.querySelector('.stopwatch-commit')?.setAttribute('action', `${issueUrl}/times/stopwatch/toggle`);
+    document.querySelector('.stopwatch-commit')?.setAttribute('action', `${issueUrl}/times/stopwatch/stop`);
     document.querySelector('.stopwatch-cancel')?.setAttribute('action', `${issueUrl}/times/stopwatch/cancel`);
     const stopwatchIssue = document.querySelector('.stopwatch-issue');
     if (stopwatchIssue) stopwatchIssue.textContent = `${repo_owner_name}/${repo_name}#${issue_index}`;


### PR DESCRIPTION
This PR fixes a state desynchronization bug with the issue stopwatch.

### Problem

The current stopwatch operates on a `toggle` mechanism. This leads to incorrect behavior when a user interacts with stopwatches for different issues across multiple browser tabs.

#### Steps to reproduce:
1. Open Issue A in Tab 1 and start the timer. The UI correctly shows a "Stop" button.
2. Open Issue B in Tab 2 and start the timer. The server correctly stops the timer for Issue A and starts it for Issue B.
3. Return to Tab 1. The UI still shows a "Stop" button for Issue A, even though its timer is already stopped on the server.
4. Clicking this "Stop" button sends a `toggle` request, which the server interprets as a "Start" command, causing the timer to start again unexpectedly.

### Solution

This PR resolves the issue by replacing the ambiguous `/toggle` endpoint with two explicit endpoints: `/start` and `/stop`.

- The "Start timer" button now exclusively calls the `/start` endpoint.
- The "Stop timer" button now exclusively calls the `/stop` endpoint.

This ensures the user's intent is clearly communicated to the server, eliminating the state inconsistency and fixing the bug.

#### Before (Bug in action)
![before](https://github.com/user-attachments/assets/75693b0d-e635-448c-9a5a-a685c608ae14)


#### After (Fix applied)

![after](https://github.com/user-attachments/assets/728e8af6-5767-458c-9849-a5a7c7db0343)