### PR TITLE
Add logging functions to govet printf analyzer

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,6 +49,17 @@ linters:
       disabled-checks:
         - ifElseChain
         - singleCaseSwitch # Every time this occurred in the code, there was no other way.
+    govet:
+      settings:
+        printf:
+          funcs:
+            - (code.gitea.io/gitea/modules/log).Error
+            - (code.gitea.io/gitea/modules/log).Trace
+            - (code.gitea.io/gitea/modules/log).Debug
+            - (code.gitea.io/gitea/modules/log).Info
+            - (code.gitea.io/gitea/modules/log).Warn
+            - (code.gitea.io/gitea/modules/log).Error
+            - (code.gitea.io/gitea/modules/log).Critical
     revive:
       severity: error
       rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,7 +53,6 @@ linters:
       settings:
         printf:
           funcs:
-            - (code.gitea.io/gitea/modules/log).Error
             - (code.gitea.io/gitea/modules/log).Trace
             - (code.gitea.io/gitea/modules/log).Debug
             - (code.gitea.io/gitea/modules/log).Info


### PR DESCRIPTION
In theory, this should make those logging functions recognized by govet printf analyzer and it should raise lint errors for cases like mismatched arguments like https://github.com/go-gitea/gitea/pull/34810. From `go tool vet help printf`:

```
The check applies to calls of the formatting functions such as
[fmt.Printf] and [fmt.Sprintf], as well as any detected wrappers of
those functions such as [log.Printf]. It reports a variety of
mistakes such as syntax errors in the format string and mismatches
(of number and type) between the verbs and their arguments.
```

Currently, this does not seem to work locally, therefor draft.