### PR TITLE
correct migration tab name

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1229,7 +1229,7 @@ migrate.migrating_issues = Migrating Issues
 migrate.migrating_pulls = Migrating Pull Requests
 migrate.cancel_migrating_title = Cancel Migration
 migrate.cancel_migrating_confirm = Do you want to cancel this migration?
-migrating_status = Migration status
+migration_status = Migration status
 
 mirror_from = mirror of
 forked_from = forked from

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1229,7 +1229,7 @@ migrate.migrating_issues = Migrating Issues
 migrate.migrating_pulls = Migrating Pull Requests
 migrate.cancel_migrating_title = Cancel Migration
 migrate.cancel_migrating_confirm = Do you want to cancel this migration?
-migrating_status = Migrating status
+migrating_status = Migration status
 
 mirror_from = mirror of
 forked_from = forked from

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -230,7 +230,7 @@
 				<div class="overflow-menu-items">
 					{{if(and .Repository.IsBeingCreated (.Permission.CanRead ctx.Consts.RepoUnitTypeCode))}}
 					<a class="{{if not .PageIsRepoSettings}}active {{end}}item" href="{{.RepoLink}}">
-						{{svg "octicon-clock"}} {{ctx.Locale.Tr "repo.migrating_status"}}
+						{{svg "octicon-clock"}} {{ctx.Locale.Tr "repo.migration_status"}}
 					</a>
 					{{end}}
 


### PR DESCRIPTION
Previous version reads like we're migrating some kind of status instead of what it is - status of the migration.