### PR TITLE
Fix required contexts and commit status matching bug (#34815)

### DIFF
--- a/services/pull/commit_status.go
+++ b/services/pull/commit_status.go
@@ -35,14 +35,15 @@ func MergeRequiredContextsCommitStatus(commitStatuses []*git_model.CommitStatus,
 		}
 
 		for _, gp := range requiredContextsGlob {
-			var targetStatus structs.CommitStatusState
+			var targetStatuses []*git_model.CommitStatus
 			for _, commitStatus := range commitStatuses {
 				if gp.Match(commitStatus.Context) {
-					targetStatus = commitStatus.State
+					targetStatuses = append(targetStatuses, commitStatus)
 					matchedCount++
-					break
 				}
 			}
+
+			targetStatus := git_model.CalcCommitStatus(targetStatuses).State
 
 			// If required rule not match any action, then it is pending
 			if targetStatus == "" {

--- a/services/pull/commit_status_test.go
+++ b/services/pull/commit_status_test.go
@@ -33,6 +33,11 @@ func TestMergeRequiredContextsCommitStatus(t *testing.T) {
 		{
 			{Context: "Build 1", State: structs.CommitStatusSuccess},
 			{Context: "Build 2", State: structs.CommitStatusSuccess},
+			{Context: "Build 2t", State: structs.CommitStatusFailure},
+		},
+		{
+			{Context: "Build 1", State: structs.CommitStatusSuccess},
+			{Context: "Build 2", State: structs.CommitStatusSuccess},
 			{Context: "Build 2t", State: structs.CommitStatusSuccess},
 		},
 		{
@@ -45,6 +50,7 @@ func TestMergeRequiredContextsCommitStatus(t *testing.T) {
 		{"Build*"},
 		{"Build*", "Build 2t*"},
 		{"Build*", "Build 2t*"},
+		{"Build*"},
 		{"Build*", "Build 2t*", "Build 3*"},
 		{"Build*", "Build *", "Build 2t*", "Build 1*"},
 	}
@@ -52,6 +58,7 @@ func TestMergeRequiredContextsCommitStatus(t *testing.T) {
 	testCasesExpected := []structs.CommitStatusState{
 		structs.CommitStatusSuccess,
 		structs.CommitStatusPending,
+		structs.CommitStatusFailure,
 		structs.CommitStatusFailure,
 		structs.CommitStatusPending,
 		structs.CommitStatusSuccess,


### PR DESCRIPTION
Backport #34815

Fix #34504

Since one required context can match more than one commit statuses, we should not directly compare the lengths of `requiredCommitStatuses` and `requiredContexts`