### PR TITLE
Remove unused variable HUGO_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,6 @@ ifeq ($(RACE_ENABLED),true)
 endif
 
 STORED_VERSION_FILE := VERSION
-HUGO_VERSION ?= 0.111.3
 
 GITHUB_REF_TYPE ?= branch
 GITHUB_REF_NAME ?= $(shell git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
This variable is unused, occurs nowhere in the codebase. I can't pinpoint the exact commit when it was last used, but I think it's unused since the docs were moved out.