### PR TITLE
Add mount cache for docker building

### DIFF
--- a/.github/workflows/pull-docker-dryrun.yml
+++ b/.github/workflows/pull-docker-dryrun.yml
@@ -16,24 +16,43 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
+      - name: Get cleaned branch name
+        id: clean_name
+        run: |
+          # if main then say nightly otherwise cleanup name
+          if [ "${{ github.base_ref }}" = "refs/heads/main" ]; then
+            echo "branch=nightly" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          REF_NAME=$(echo "${{ github.base_ref }}" | sed -e 's/refs\/heads\///' -e 's/refs\/tags\///' -e 's/release\/v//')
+          echo "branch=${REF_NAME}-nightly" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@v3
       - uses: docker/build-push-action@v5
         with:
           push: false
           tags: gitea/gitea:linux-amd64
-          cache-from: type=registry,ref=gitea/gitea:buildcache-pr-amd64
-          cache-to: type=registry,ref=gitea/gitea:buildcache-pr-amd64,mode=max
+          platforms: linux/amd64,linux/arm64,linux/riscv64
+          cache-from: type=registry,ref=gitea/gitea:buildcache-${{ steps.clean_name.outputs.branch }}
 
   rootless:
     if: needs.files-changed.outputs.docker == 'true' || needs.files-changed.outputs.actions == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
+      - name: Get cleaned branch name
+        id: clean_name
+        run: |
+          # if main then say nightly otherwise cleanup name
+          if [ "${{ github.base_ref }}" = "refs/heads/main" ]; then
+            echo "branch=nightly" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          REF_NAME=$(echo "${{ github.base_ref }}" | sed -e 's/refs\/heads\///' -e 's/refs\/tags\///' -e 's/release\/v//')
+          echo "branch=${REF_NAME}-nightly" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@v3
       - uses: docker/build-push-action@v5
         with:
           push: false
           file: Dockerfile.rootless
           tags: gitea/gitea:linux-amd64
-          cache-from: type=registry,ref=gitea/gitea:buildcache-pr-amd64-rootless
-          cache-to: type=registry,ref=gitea/gitea:buildcache-pr-amd64-rootless,mode=max
+          cache-from: type=registry,ref=gitea/gitea:buildcache-${{ steps.clean_name.outputs.branch }}-rootless

--- a/.github/workflows/pull-docker-dryrun.yml
+++ b/.github/workflows/pull-docker-dryrun.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           push: false
           tags: gitea/gitea:linux-amd64
+          cache-from: type=registry,ref=gitea/gitea:buildcache-pr-amd64
+          cache-to: type=registry,ref=gitea/gitea:buildcache-pr-amd64,mode=max
 
   rootless:
     if: needs.files-changed.outputs.docker == 'true' || needs.files-changed.outputs.actions == 'true'
@@ -33,3 +35,5 @@ jobs:
           push: false
           file: Dockerfile.rootless
           tags: gitea/gitea:linux-amd64
+          cache-from: type=registry,ref=gitea/gitea:buildcache-pr-amd64-rootless
+          cache-to: type=registry,ref=gitea/gitea:buildcache-pr-amd64-rootless,mode=max

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -104,6 +104,8 @@ jobs:
           tags: |-
             gitea/gitea:${{ steps.clean_name.outputs.branch }}
             ghcr.io/go-gitea/gitea:${{ steps.clean_name.outputs.branch }}
+          cache-from: type=registry,ref=gitea/gitea:buildcache-${{ steps.clean_name.outputs.branch }}
+          cache-to: type=registry,ref=gitea/gitea:buildcache-${{ steps.clean_name.outputs.branch }},mode=max
   nightly-docker-rootless:
     runs-on: namespace-profile-gitea-release-docker
     permissions:
@@ -152,3 +154,5 @@ jobs:
           tags: |-
             gitea/gitea:${{ steps.clean_name.outputs.branch }}-rootless
             ghcr.io/go-gitea/gitea:${{ steps.clean_name.outputs.branch }}-rootless
+          cache-from: type=registry,ref=gitea/gitea:buildcache-${{ steps.clean_name.outputs.branch }}-rootless
+          cache-to: type=registry,ref=gitea/gitea:buildcache-${{ steps.clean_name.outputs.branch }}-rootless,mode=max

--- a/.github/workflows/release-tag-rc.yml
+++ b/.github/workflows/release-tag-rc.yml
@@ -100,6 +100,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get cleaned branch name
+        id: clean_name
+        run: |
+          REF_NAME=$(echo "${{ github.ref }}" | sed -e 's/refs\/heads\///' -e 's/refs\/tags\/v//' -e 's/release\/v//')
+          echo "Cleaned name is ${REF_NAME}"
+          echo "branch=${REF_NAME}" >> "$GITHUB_OUTPUT"
       - name: build rootful docker image
         uses: docker/build-push-action@v5
         with:
@@ -144,6 +150,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get cleaned branch name
+        id: clean_name
+        run: |
+          REF_NAME=$(echo "${{ github.ref }}" | sed -e 's/refs\/heads\///' -e 's/refs\/tags\/v//' -e 's/release\/v//')
+          echo "Cleaned name is ${REF_NAME}"
+          echo "branch=${REF_NAME}" >> "$GITHUB_OUTPUT"
       - name: build rootless docker image
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/release-tag-rc.yml
+++ b/.github/workflows/release-tag-rc.yml
@@ -108,6 +108,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=gitea/gitea:buildcache-${{ steps.clean_name.outputs.branch }}
   docker-rootless:
     runs-on: namespace-profile-gitea-release-docker
     permissions:
@@ -152,3 +153,4 @@ jobs:
           file: Dockerfile.rootless
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=gitea/gitea:buildcache-${{ steps.clean_name.outputs.branch }}-rootless

--- a/.github/workflows/release-tag-version.yml
+++ b/.github/workflows/release-tag-version.yml
@@ -116,6 +116,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=gitea/gitea:buildcache-${{ steps.clean_name.outputs.branch }}
   docker-rootless:
     runs-on: namespace-profile-gitea-release-docker
     steps:
@@ -163,3 +164,4 @@ jobs:
           file: Dockerfile.rootless
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=gitea/gitea:buildcache-${{ steps.clean_name.outputs.branch }}-rootless

--- a/.github/workflows/release-tag-version.yml
+++ b/.github/workflows/release-tag-version.yml
@@ -108,6 +108,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get cleaned branch name
+        id: clean_name
+        run: |
+          REF_NAME=$(echo "${{ github.ref }}" | sed -e 's/refs\/heads\///' -e 's/refs\/tags\/v//' -e 's/release\/v//')
+          echo "Cleaned name is ${REF_NAME}"
+          echo "branch=${REF_NAME}" >> "$GITHUB_OUTPUT"
       - name: build rootful docker image
         uses: docker/build-push-action@v5
         with:
@@ -155,6 +161,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get cleaned branch name
+        id: clean_name
+        run: |
+          REF_NAME=$(echo "${{ github.ref }}" | sed -e 's/refs\/heads\///' -e 's/refs\/tags\/v//' -e 's/release\/v//')
+          echo "Cleaned name is ${REF_NAME}"
+          echo "branch=${REF_NAME}" >> "$GITHUB_OUTPUT"
       - name: build rootless docker image
         uses: docker/build-push-action@v5
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,12 @@ ARG TAGS="sqlite sqlite_unlock_notify"
 ENV TAGS="bindata timetzdata $TAGS"
 ARG CGO_EXTRA_CFLAGS
 
+ARG GOCACHE
+ENV GOCACHE=${GOCACHE:-/root/.cache/go-build}
+
+ARG GOMODCACHE
+ENV GOMODCACHE=${GOMODCACHE:-/go/pkg/mod}
+
 # Build deps
 RUN apk --no-cache add \
     build-base \
@@ -23,10 +29,17 @@ WORKDIR ${GOPATH}/src/code.gitea.io/gitea
 
 # Checkout version if set
 RUN if [ -n "${GITEA_VERSION}" ]; then git checkout "${GITEA_VERSION}"; fi \
- && make clean-all build
+  && make clean-all
+
+RUN --mount=type=cache,target=/root/.npm \
+  --mount=type=cache,target=/go/pkg/mod/ \
+  --mount=type=cache,target="/root/.cache/go-build" \
+  make build
 
 # Begin env-to-ini build
-RUN go build contrib/environment-to-ini/environment-to-ini.go
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+  --mount=type=cache,target="/root/.cache/go-build" \
+  go build contrib/environment-to-ini/environment-to-ini.go
 
 # Copy local files
 COPY docker/root /tmp/local

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -9,6 +9,12 @@ ARG TAGS="sqlite sqlite_unlock_notify"
 ENV TAGS="bindata timetzdata $TAGS"
 ARG CGO_EXTRA_CFLAGS
 
+ARG GOCACHE
+ENV GOCACHE=${GOCACHE:-/root/.cache/go-build}
+
+ARG GOMODCACHE
+ENV GOMODCACHE=${GOMODCACHE:-/go/pkg/mod}
+
 #Build deps
 RUN apk --no-cache add \
     build-base \
@@ -23,10 +29,17 @@ WORKDIR ${GOPATH}/src/code.gitea.io/gitea
 
 # Checkout version if set
 RUN if [ -n "${GITEA_VERSION}" ]; then git checkout "${GITEA_VERSION}"; fi \
- && make clean-all build
+ && make clean-all
+
+RUN --mount=type=cache,target=/root/.npm \
+  --mount=type=cache,target=/go/pkg/mod/ \
+  --mount=type=cache,target="/root/.cache/go-build" \
+  make build
 
 # Begin env-to-ini build
-RUN go build contrib/environment-to-ini/environment-to-ini.go
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+  --mount=type=cache,target="/root/.cache/go-build" \
+  go build contrib/environment-to-ini/environment-to-ini.go
 
 # Copy local files
 COPY docker/rootless /tmp/local


### PR DESCRIPTION
This PR use cache mounts feature of docker to accelerate the docker image build process.
ref: https://docs.docker.com/build/cache/optimize/#use-cache-mounts

Run docker build locally it will take about `242.8s` and now it's `16s` after cached.

TODO:

- [x] Add shared cache in CI/CD 
```
    cache-from: type=registry,ref=gitea/gitea:buildcache-v1.24
    cache-to: type=registry,ref=gitea/gitea:buildcache-v1.24,mode=max
```