### PR TITLE
Don't create default column when viewing project columns

### DIFF
--- a/services/projects/issue.go
+++ b/services/projects/issue.go
@@ -100,12 +100,7 @@ func LoadIssuesFromProject(ctx context.Context, project *project_model.Project, 
 		return nil, err
 	}
 
-	defaultColumn, err := project.MustDefaultColumn(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	issueColumnMap, err := issues_model.LoadProjectIssueColumnMap(ctx, project.ID, defaultColumn.ID)
+	issueColumnMap, err := issues_model.LoadProjectIssueColumnMap(ctx, project.ID, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +108,7 @@ func LoadIssuesFromProject(ctx context.Context, project *project_model.Project, 
 	results := make(map[int64]issues_model.IssueList)
 	for _, issue := range issueList {
 		projectColumnID, ok := issueColumnMap[issue.ID]
-		if !ok {
+		if !ok || projectColumnID == 0 {
 			continue
 		}
 		if _, ok := results[projectColumnID]; !ok {


### PR DESCRIPTION
When viewing a project column, if there is no column, a default column will be created but not display in the UI. When refresh the page, the column will be displayed. It seems uncomfortable for me.

This PR will not create default column when viewing project columns. Now the default column will only be created when adding an issue to an empty project(there is no any column).

----

Please review with whitespaces ignored. https://github.com/go-gitea/gitea/pull/34878/files?diff=unified&w=1