### PR TITLE
Upgrade htmx to 2.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "esbuild-loader": "4.3.0",
         "escape-goat": "4.0.0",
         "fast-glob": "3.3.3",
-        "htmx.org": "2.0.5",
+        "htmx.org": "2.0.6",
         "idiomorph": "0.7.3",
         "jquery": "3.7.1",
         "katex": "0.16.22",
@@ -8233,9 +8233,9 @@
       }
     },
     "node_modules/htmx.org": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.5.tgz",
-      "integrity": "sha512-ocgvtHCShWFW0DvSV1NbJC7Y5EzUMy2eo5zeWvGj2Ac4LOr7sv9YKg4jzCZJdXN21fXACmCViwKSy+cm6i2dWQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.6.tgz",
+      "integrity": "sha512-7ythjYneGSk3yCHgtCnQeaoF+D+o7U2LF37WU3O0JYv3gTZSicdEFiI/Ai/NJyC5ZpYJWMpUb11OC5Lr6AfAqA==",
       "license": "0BSD"
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "esbuild-loader": "4.3.0",
     "escape-goat": "4.0.0",
     "fast-glob": "3.3.3",
-    "htmx.org": "2.0.5",
+    "htmx.org": "2.0.6",
     "idiomorph": "0.7.3",
     "jquery": "3.7.1",
     "katex": "0.16.22",


### PR DESCRIPTION
Release notes: https://github.com/bigskysoftware/htmx/releases/tag/v2.0.6

Tested Star, Watch, and the admin dashboard page. All functionality remains unchanged.