### PR TITLE
docs: fix typo in pull request merge warning message text

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1969,7 +1969,7 @@ pulls.cmd_instruction_checkout_title = Checkout
 pulls.cmd_instruction_checkout_desc = From your project repository, check out a new branch and test the changes.
 pulls.cmd_instruction_merge_title = Merge
 pulls.cmd_instruction_merge_desc = Merge the changes and update on Gitea.
-pulls.cmd_instruction_merge_warning = Warning: This operation can not merge pull request because "autodetect manual merge" was not enable
+pulls.cmd_instruction_merge_warning = Warning: This operation cannot merge pull request because "autodetect manual merge" is not enabled.
 pulls.clear_merge_message = Clear merge message
 pulls.clear_merge_message_hint = Clearing the merge message will only remove the commit message content and keep generated git trailers such as "Co-Authored-By …".
 


### PR DESCRIPTION
### Description

This PR fixes two typos in the pull request merge command warning message.

- "can not" → "cannot"
- "was not enable" → "is not enabled."

### File Updated
- `options/locale/locale_en-US.ini` (line 1972)

### Related Discussion
https://github.com/go-gitea/gitea/issues/34893

