### PR TITLE
Fix modal + form abuse

### DIFF
--- a/web_src/js/features/comp/LabelEdit.ts
+++ b/web_src/js/features/comp/LabelEdit.ts
@@ -72,6 +72,7 @@ export function initCompLabelEdit(pageSelector: string) {
           return false;
         }
         submitFormFetchAction(form);
+        return false;
       },
     }).modal('show');
   };


### PR DESCRIPTION
See the comment. And due to the abuse, there is a regression: when the modal is hidden, the form will be reset and it can't submit.

This PR fixes all problems: keep the modal with form open, and add "loading" indicator.