### PR TITLE
Refactor file-view toggle button visibility logic

### DIFF
--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -36,12 +36,12 @@
 		</div>
 		<div class="file-header-right file-actions flex-text-block tw-flex-wrap">
 			{{/* this componment is also controlled by frontend plugin renders */}}
-			<div class="ui compact icon buttons file-view-toggle-buttons {{Iif .HasSourceRenderedToggle "" "tw-hidden"}}">
-				{{if .IsRepresentableAsText}}
-				<a href="?display=source" class="ui mini basic button file-view-toggle-source {{if .IsDisplayingSource}}active{{end}}" data-tooltip-content="{{ctx.Locale.Tr "repo.file_view_source"}}">{{svg "octicon-code" 15}}</a>
-				{{end}}
-				<a href="?display=rendered" class="ui mini basic button file-view-toggle-rendered {{if not .IsDisplayingSource}}active{{end}}" data-tooltip-content="{{ctx.Locale.Tr "repo.file_view_rendered"}}">{{svg "octicon-file" 15}}</a>
-			</div>
+			{{if and .HasSourceRenderedToggle .IsRepresentableAsText}}
+				<div class="ui compact icon buttons file-view-toggle-buttons">
+					<a href="?display=source" class="ui mini basic button file-view-toggle-source {{if .IsDisplayingSource}}active{{end}}" data-tooltip-content="{{ctx.Locale.Tr "repo.file_view_source"}}">{{svg "octicon-code" 15}}</a>
+					<a href="?display=rendered" class="ui mini basic button file-view-toggle-rendered {{if not .IsDisplayingSource}}active{{end}}" data-tooltip-content="{{ctx.Locale.Tr "repo.file_view_rendered"}}">{{svg "octicon-file" 15}}</a>
+				</div>
+			{{end}}
 			{{if not .ReadmeInList}}
 				<div class="ui buttons tw-mr-1">
 					<a class="ui mini basic button" href="{{$.RawFileLink}}">{{ctx.Locale.Tr "repo.file_raw"}}</a>

--- a/web_src/js/features/file-view.ts
+++ b/web_src/js/features/file-view.ts
@@ -2,7 +2,7 @@ import type {FileRenderPlugin} from '../render/plugin.ts';
 import {newRenderPlugin3DViewer} from '../render/plugins/3d-viewer.ts';
 import {newRenderPluginPdfViewer} from '../render/plugins/pdf-viewer.ts';
 import {registerGlobalInitFunc} from '../modules/observer.ts';
-import {createElementFromHTML, showElem, toggleClass} from '../utils/dom.ts';
+import {createElementFromHTML, toggleClass} from '../utils/dom.ts';
 import {html} from '../utils/html.ts';
 import {basename} from '../utils.ts';
 
@@ -19,11 +19,10 @@ function findFileRenderPlugin(filename: string, mimeType: string): FileRenderPlu
 
 function showRenderRawFileButton(elFileView: HTMLElement, renderContainer: HTMLElement | null): void {
   const toggleButtons = elFileView.querySelector('.file-view-toggle-buttons');
-  showElem(toggleButtons);
+  if (!toggleButtons) return;
   const displayingRendered = Boolean(renderContainer);
   toggleClass(toggleButtons.querySelectorAll('.file-view-toggle-source'), 'active', !displayingRendered); // it may not exist
   toggleClass(toggleButtons.querySelector('.file-view-toggle-rendered'), 'active', displayingRendered);
-  // TODO: if there is only one button, hide it?
 }
 
 async function renderRawFileToContainer(container: HTMLElement, rawFileLink: string, mimeType: string) {


### PR DESCRIPTION
Move the visibility control of file-view-toggle-buttons to the backend template.
Frontend now only updates button state if the group exists.
This avoids UI flicker and keeps logic clear.