### PR TITLE
Fix http auth header parsing

### DIFF
--- a/modules/auth/httpauth/httpauth.go
+++ b/modules/auth/httpauth/httpauth.go
@@ -1,0 +1,40 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package httpauth
+
+import (
+	"encoding/base64"
+	"strings"
+
+	"code.gitea.io/gitea/modules/util"
+)
+
+func ParseAuthorizationHeaderBasic(header string) (string, string, bool) {
+	parts := strings.Fields(header)
+	if len(parts) != 2 {
+		return "", "", false
+	}
+	if !util.AsciiEqualFold(parts[0], "basic") {
+		return "", "", false
+	}
+	s, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", "", false
+	}
+	if u, p, ok := strings.Cut(string(s), ":"); ok {
+		return u, p, true
+	}
+	return "", "", false
+}
+
+func ParseAuthorizationHeaderBearerToken(header string) (string, bool) {
+	parts := strings.Fields(header)
+	if len(parts) != 2 {
+		return "", false
+	}
+	if util.AsciiEqualFold(parts[0], "token") || util.AsciiEqualFold(parts[0], "bearer") {
+		return parts[1], true
+	}
+	return "", false
+}

--- a/modules/auth/httpauth/httpauth.go
+++ b/modules/auth/httpauth/httpauth.go
@@ -10,31 +10,38 @@ import (
 	"code.gitea.io/gitea/modules/util"
 )
 
-func ParseAuthorizationHeaderBasic(header string) (string, string, bool) {
-	parts := strings.Fields(header)
-	if len(parts) != 2 {
-		return "", "", false
-	}
-	if !util.AsciiEqualFold(parts[0], "basic") {
-		return "", "", false
-	}
-	s, err := base64.StdEncoding.DecodeString(parts[1])
-	if err != nil {
-		return "", "", false
-	}
-	if u, p, ok := strings.Cut(string(s), ":"); ok {
-		return u, p, true
-	}
-	return "", "", false
+type BasicAuth struct {
+	Username, Password string
 }
 
-func ParseAuthorizationHeaderBearerToken(header string) (string, bool) {
+type BearerToken struct {
+	Token string
+}
+
+type ParsedAuthorizationHeader struct {
+	BasicAuth   *BasicAuth
+	BearerToken *BearerToken
+}
+
+func ParseAuthorizationHeader(header string) (ret ParsedAuthorizationHeader, _ bool) {
 	parts := strings.Fields(header)
 	if len(parts) != 2 {
-		return "", false
+		return ret, false
 	}
-	if util.AsciiEqualFold(parts[0], "token") || util.AsciiEqualFold(parts[0], "bearer") {
-		return parts[1], true
+	if util.AsciiEqualFold(parts[0], "basic") {
+		s, err := base64.StdEncoding.DecodeString(parts[1])
+		if err != nil {
+			return ret, false
+		}
+		u, p, ok := strings.Cut(string(s), ":")
+		if !ok {
+			return ret, false
+		}
+		ret.BasicAuth = &BasicAuth{Username: u, Password: p}
+		return ret, true
+	} else if util.AsciiEqualFold(parts[0], "token") || util.AsciiEqualFold(parts[0], "bearer") {
+		ret.BearerToken = &BearerToken{Token: parts[1]}
+		return ret, true
 	}
-	return "", false
+	return ret, false
 }

--- a/modules/auth/httpauth/httpauth_test.go
+++ b/modules/auth/httpauth/httpauth_test.go
@@ -1,0 +1,56 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package httpauth
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseAuthorizationHeader(t *testing.T) {
+	t.Run("Basic", func(t *testing.T) {
+		cases := []struct {
+			headerValue string
+			user, pass  string
+			ok          bool
+		}{
+			{"", "", "", false},
+			{"?", "", "", false},
+			{"foo", "", "", false},
+			{"Basic ?", "", "", false},
+			{"Basic " + base64.StdEncoding.EncodeToString([]byte("foo")), "", "", false},
+			{"Basic " + base64.StdEncoding.EncodeToString([]byte("foo:bar")), "foo", "bar", true},
+			{"basic " + base64.StdEncoding.EncodeToString([]byte("foo:bar")), "foo", "bar", true},
+		}
+		for _, c := range cases {
+			user, pass, ok := ParseAuthorizationHeaderBasic(c.headerValue)
+			assert.Equal(t, c.ok, ok, "header %q", c.headerValue)
+			assert.Equal(t, c.user, user, "header %q", c.headerValue)
+			assert.Equal(t, c.pass, pass, "header %q", c.headerValue)
+		}
+	})
+	t.Run("BearerToken", func(t *testing.T) {
+		cases := []struct {
+			headerValue string
+			expected    string
+			ok          bool
+		}{
+			{"", "", false},
+			{"?", "", false},
+			{"any value", "", false},
+			{"token value", "value", true},
+			{"Token value", "value", true},
+			{"bearer value", "value", true},
+			{"Bearer value", "value", true},
+			{"Bearer wrong value", "", false},
+		}
+		for _, c := range cases {
+			token, ok := ParseAuthorizationHeaderBearerToken(c.headerValue)
+			assert.Equal(t, c.ok, ok, "header %q", c.headerValue)
+			assert.Equal(t, c.expected, token, "header %q", c.headerValue)
+		}
+	})
+}

--- a/modules/base/tool.go
+++ b/modules/base/tool.go
@@ -8,13 +8,10 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/subtle"
-	"encoding/base64"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"hash"
 	"strconv"
-	"strings"
 	"time"
 
 	"code.gitea.io/gitea/modules/setting"
@@ -34,19 +31,6 @@ func EncodeSha256(str string) string {
 // It is DEPRECATED and will be removed in the future.
 func ShortSha(sha1 string) string {
 	return util.TruncateRunes(sha1, 10)
-}
-
-// BasicAuthDecode decode basic auth string
-func BasicAuthDecode(encoded string) (string, string, error) {
-	s, err := base64.StdEncoding.DecodeString(encoded)
-	if err != nil {
-		return "", "", err
-	}
-
-	if username, password, ok := strings.Cut(string(s), ":"); ok {
-		return username, password, nil
-	}
-	return "", "", errors.New("invalid basic authentication")
 }
 
 // VerifyTimeLimitCode verify time limit code

--- a/modules/base/tool_test.go
+++ b/modules/base/tool_test.go
@@ -26,25 +26,6 @@ func TestShortSha(t *testing.T) {
 	assert.Equal(t, "veryverylo", ShortSha("veryverylong"))
 }
 
-func TestBasicAuthDecode(t *testing.T) {
-	_, _, err := BasicAuthDecode("?")
-	assert.Equal(t, "illegal base64 data at input byte 0", err.Error())
-
-	user, pass, err := BasicAuthDecode("Zm9vOmJhcg==")
-	assert.NoError(t, err)
-	assert.Equal(t, "foo", user)
-	assert.Equal(t, "bar", pass)
-
-	_, _, err = BasicAuthDecode("aW52YWxpZA==")
-	assert.Error(t, err)
-
-	_, _, err = BasicAuthDecode("invalid")
-	assert.Error(t, err)
-
-	_, _, err = BasicAuthDecode("YWxpY2U=") // "alice", no colon
-	assert.Error(t, err)
-}
-
 func TestVerifyTimeLimitCode(t *testing.T) {
 	defer test.MockVariableValue(&setting.InstallLock, true)()
 	initGeneralSecret := func(secret string) {

--- a/modules/util/string.go
+++ b/modules/util/string.go
@@ -110,3 +110,24 @@ func SplitTrimSpace(input, sep string) []string {
 	}
 	return stringList
 }
+
+func asciiLower(b byte) byte {
+	if 'A' <= b && b <= 'Z' {
+		return b + ('a' - 'A')
+	}
+	return b
+}
+
+// AsciiEqualFold is from Golang https://cs.opensource.google/go/go/+/refs/tags/go1.24.4:src/net/http/internal/ascii/print.go
+// ASCII only. In most cases for protocols, we should only use this but not [strings.EqualFold]
+func AsciiEqualFold(s, t string) bool { //nolint:revive // PascalCase
+	if len(s) != len(t) {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if asciiLower(s[i]) != asciiLower(t[i]) {
+			return false
+		}
+	}
+	return true
+}

--- a/routers/web/auth/oauth2_provider.go
+++ b/routers/web/auth/oauth2_provider.go
@@ -4,18 +4,16 @@
 package auth
 
 import (
-	"errors"
 	"fmt"
 	"html"
 	"html/template"
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 
 	"code.gitea.io/gitea/models/auth"
 	user_model "code.gitea.io/gitea/models/user"
-	"code.gitea.io/gitea/modules/base"
+	"code.gitea.io/gitea/modules/auth/httpauth"
 	"code.gitea.io/gitea/modules/json"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
@@ -108,9 +106,8 @@ func InfoOAuth(ctx *context.Context) {
 
 	var accessTokenScope auth.AccessTokenScope
 	if auHead := ctx.Req.Header.Get("Authorization"); auHead != "" {
-		auths := strings.Fields(auHead)
-		if len(auths) == 2 && (auths[0] == "token" || strings.ToLower(auths[0]) == "bearer") {
-			accessTokenScope, _ = auth_service.GetOAuthAccessTokenScopeAndUserID(ctx, auths[1])
+		if headerAuthToken, ok := httpauth.ParseAuthorizationHeaderBearerToken(auHead); ok {
+			accessTokenScope, _ = auth_service.GetOAuthAccessTokenScopeAndUserID(ctx, headerAuthToken)
 		}
 	}
 
@@ -127,18 +124,11 @@ func InfoOAuth(ctx *context.Context) {
 	ctx.JSON(http.StatusOK, response)
 }
 
-func parseBasicAuth(ctx *context.Context) (username, password string, err error) {
-	authHeader := ctx.Req.Header.Get("Authorization")
-	if authType, authData, ok := strings.Cut(authHeader, " "); ok && strings.EqualFold(authType, "Basic") {
-		return base.BasicAuthDecode(authData)
-	}
-	return "", "", errors.New("invalid basic authentication")
-}
-
 // IntrospectOAuth introspects an oauth token
 func IntrospectOAuth(ctx *context.Context) {
 	clientIDValid := false
-	if clientID, clientSecret, err := parseBasicAuth(ctx); err == nil {
+	authHeader := ctx.Req.Header.Get("Authorization")
+	if clientID, clientSecret, ok := httpauth.ParseAuthorizationHeaderBasic(authHeader); ok {
 		app, err := auth.GetOAuth2ApplicationByClientID(ctx, clientID)
 		if err != nil && !auth.IsErrOauthClientIDInvalid(err) {
 			// this is likely a database error; log it and respond without details
@@ -465,10 +455,9 @@ func AccessTokenOAuth(ctx *context.Context) {
 	form := *web.GetForm(ctx).(*forms.AccessTokenForm)
 	// if there is no ClientID or ClientSecret in the request body, fill these fields by the Authorization header and ensure the provided field matches the Authorization header
 	if form.ClientID == "" || form.ClientSecret == "" {
-		authHeader := ctx.Req.Header.Get("Authorization")
-		if authType, authData, ok := strings.Cut(authHeader, " "); ok && strings.EqualFold(authType, "Basic") {
-			clientID, clientSecret, err := base.BasicAuthDecode(authData)
-			if err != nil {
+		if authHeader := ctx.Req.Header.Get("Authorization"); authHeader != "" {
+			clientID, clientSecret, ok := httpauth.ParseAuthorizationHeaderBasic(authHeader)
+			if !ok {
 				handleAccessTokenError(ctx, oauth2_provider.AccessTokenError{
 					ErrorCode:        oauth2_provider.AccessTokenErrorCodeInvalidRequest,
 					ErrorDescription: "cannot parse basic auth header",

--- a/services/auth/basic.go
+++ b/services/auth/basic.go
@@ -57,7 +57,11 @@ func (b *Basic) Verify(req *http.Request, w http.ResponseWriter, store DataStore
 	if authHeader == "" {
 		return nil, nil
 	}
-	uname, passwd, _ := httpauth.ParseAuthorizationHeaderBasic(authHeader)
+	parsed, ok := httpauth.ParseAuthorizationHeader(authHeader)
+	if !ok || parsed.BasicAuth == nil {
+		return nil, nil
+	}
+	uname, passwd := parsed.BasicAuth.Username, parsed.BasicAuth.Password
 
 	// Check if username or password is a token
 	isUsernameToken := len(passwd) == 0 || passwd == "x-oauth-basic"

--- a/services/auth/basic.go
+++ b/services/auth/basic.go
@@ -7,12 +7,11 @@ package auth
 import (
 	"errors"
 	"net/http"
-	"strings"
 
 	actions_model "code.gitea.io/gitea/models/actions"
 	auth_model "code.gitea.io/gitea/models/auth"
 	user_model "code.gitea.io/gitea/models/user"
-	"code.gitea.io/gitea/modules/base"
+	"code.gitea.io/gitea/modules/auth/httpauth"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/timeutil"
@@ -54,17 +53,11 @@ func (b *Basic) Verify(req *http.Request, w http.ResponseWriter, store DataStore
 		return nil, nil
 	}
 
-	baHead := req.Header.Get("Authorization")
-	if len(baHead) == 0 {
+	authHeader := req.Header.Get("Authorization")
+	if authHeader == "" {
 		return nil, nil
 	}
-
-	auths := strings.SplitN(baHead, " ", 2)
-	if len(auths) != 2 || (strings.ToLower(auths[0]) != "basic") {
-		return nil, nil
-	}
-
-	uname, passwd, _ := base.BasicAuthDecode(auths[1])
+	uname, passwd, _ := httpauth.ParseAuthorizationHeaderBasic(authHeader)
 
 	// Check if username or password is a token
 	isUsernameToken := len(passwd) == 0 || passwd == "x-oauth-basic"

--- a/services/auth/oauth2.go
+++ b/services/auth/oauth2.go
@@ -13,6 +13,7 @@ import (
 	actions_model "code.gitea.io/gitea/models/actions"
 	auth_model "code.gitea.io/gitea/models/auth"
 	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/auth/httpauth"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/timeutil"
@@ -97,10 +98,7 @@ func parseToken(req *http.Request) (string, bool) {
 
 	// check header token
 	if auHead := req.Header.Get("Authorization"); auHead != "" {
-		auths := strings.Fields(auHead)
-		if len(auths) == 2 && (auths[0] == "token" || strings.ToLower(auths[0]) == "bearer") {
-			return auths[1], true
-		}
+		return httpauth.ParseAuthorizationHeaderBearerToken(auHead)
 	}
 	return "", false
 }

--- a/services/auth/oauth2.go
+++ b/services/auth/oauth2.go
@@ -98,7 +98,10 @@ func parseToken(req *http.Request) (string, bool) {
 
 	// check header token
 	if auHead := req.Header.Get("Authorization"); auHead != "" {
-		return httpauth.ParseAuthorizationHeaderBearerToken(auHead)
+		parsed, ok := httpauth.ParseAuthorizationHeader(auHead)
+		if ok && parsed.BearerToken != nil {
+			return parsed.BearerToken.Token, true
+		}
 	}
 	return "", false
 }

--- a/services/lfs/server.go
+++ b/services/lfs/server.go
@@ -27,6 +27,7 @@ import (
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unit"
 	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/auth/httpauth"
 	"code.gitea.io/gitea/modules/json"
 	lfs_module "code.gitea.io/gitea/modules/lfs"
 	"code.gitea.io/gitea/modules/log"
@@ -594,19 +595,11 @@ func parseToken(ctx stdCtx.Context, authorization string, target *repo_model.Rep
 	if authorization == "" {
 		return nil, errors.New("no token")
 	}
-
-	parts := strings.SplitN(authorization, " ", 2)
-	if len(parts) != 2 {
-		return nil, errors.New("no token")
+	token, ok := httpauth.ParseAuthorizationHeaderBearerToken(authorization)
+	if !ok {
+		return nil, errors.New("token not found")
 	}
-	tokenSHA := parts[1]
-	switch strings.ToLower(parts[0]) {
-	case "bearer":
-		fallthrough
-	case "token":
-		return handleLFSToken(ctx, tokenSHA, target, mode)
-	}
-	return nil, errors.New("token not found")
+	return handleLFSToken(ctx, token, target, mode)
 }
 
 func requireAuth(ctx *context.Context) {

--- a/services/lfs/server.go
+++ b/services/lfs/server.go
@@ -595,11 +595,11 @@ func parseToken(ctx stdCtx.Context, authorization string, target *repo_model.Rep
 	if authorization == "" {
 		return nil, errors.New("no token")
 	}
-	token, ok := httpauth.ParseAuthorizationHeaderBearerToken(authorization)
-	if !ok {
+	parsed, ok := httpauth.ParseAuthorizationHeader(authorization)
+	if !ok || parsed.BearerToken == nil {
 		return nil, errors.New("token not found")
 	}
-	return handleLFSToken(ctx, token, target, mode)
+	return handleLFSToken(ctx, parsed.BearerToken.Token, target, mode)
 }
 
 func requireAuth(ctx *context.Context) {


### PR DESCRIPTION
Using `strings.EqualFold` is wrong in many cases.