### PR TITLE
Fix "Always expand running logs" behavior on subsequent updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
         "@typescript-eslint/parser": "8.35.1",
         "@vitejs/plugin-vue": "6.0.0",
         "@vitest/eslint-plugin": "1.3.4",
+        "@vue/test-utils": "2.4.6",
         "eslint": "8.57.0",
         "eslint-import-resolver-typescript": "4.4.4",
         "eslint-plugin-array-func": "4.0.0",
@@ -1583,6 +1584,13 @@
       "version": "1.0.44",
       "resolved": "https://registry.npmjs.org/@nolyfill/shared/-/shared-1.0.44.tgz",
       "integrity": "sha512-NI1zxDh4LYL7PYlKKCwojjuc5CEZslywrOTKBNyodjmWjRiZ4AlCMs3Gp+zDoPQPNkYCSQp/luNojHmJWWfCbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4062,6 +4070,17 @@
       "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
       "license": "MIT"
     },
+    "node_modules/@vue/test-utils": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.6.tgz",
+      "integrity": "sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-beautify": "^1.14.9",
+        "vue-component-type-helpers": "^2.0.0"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -4263,6 +4282,16 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -5269,6 +5298,24 @@
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
       "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
       "license": "MIT"
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/config-chain/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/core-js": {
       "version": "3.32.2",
@@ -6320,6 +6367,68 @@
         "codemirror": "^5.65.15",
         "codemirror-spell-checker": "1.1.2",
         "marked": "^4.1.0"
+      }
+    },
+    "node_modules/editorconfig": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
+      "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/editorconfig/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/editorconfig/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/minimatch": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -8598,6 +8707,132 @@
       "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
       "license": "MIT"
     },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-beautify/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-beautify/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/js-beautify/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-beautify/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-beautify/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-beautify/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-beautify/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/js-levenshtein-esm": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/js-levenshtein-esm/-/js-levenshtein-esm-2.0.0.tgz",
@@ -10253,6 +10488,22 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -11243,6 +11494,13 @@
       "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
       "dev": true,
       "license": "Unlicense"
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/proto-props": {
       "version": "2.0.0",
@@ -13875,6 +14133,13 @@
         "chart.js": "^4.1.1",
         "vue": "^3.0.0-0 || ^2.7.0"
       }
+    },
+    "node_modules/vue-component-type-helpers": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.2.12.tgz",
+      "integrity": "sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vue-eslint-parser": {
       "version": "10.2.0",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@typescript-eslint/parser": "8.35.1",
     "@vitejs/plugin-vue": "6.0.0",
     "@vitest/eslint-plugin": "1.3.4",
+    "@vue/test-utils": "2.4.6",
     "eslint": "8.57.0",
     "eslint-import-resolver-typescript": "4.4.4",
     "eslint-plugin-array-func": "4.0.0",

--- a/web_src/js/components/RepoActionView.autoExpand.test.ts
+++ b/web_src/js/components/RepoActionView.autoExpand.test.ts
@@ -1,0 +1,192 @@
+import {test, expect, beforeEach, afterEach, vi} from 'vitest';
+import {mount} from '@vue/test-utils';
+import RepoActionView from './RepoActionView.vue';
+
+/**
+ * Focused tests for RepoActionView auto-expand functionality.
+ *
+ * This test suite specifically targets the "Always expand running logs" setting.
+ */
+
+// Helper function to create default props
+function createDefaultProps() {
+  return {
+    runIndex: '1',
+    jobIndex: '0',
+    actionsURL: '/test/actions',
+    locale: {
+      status: {},
+      approve: 'Approve',
+      cancel: 'Cancel',
+      rerun_all: 'Rerun all',
+      scheduled: 'Scheduled',
+      commit: 'Commit',
+      pushedBy: 'pushed by',
+      logsAlwaysAutoScroll: 'Always auto scroll logs',
+      logsAlwaysExpandRunning: 'Always expand running logs',
+      showLogSeconds: 'Show seconds',
+      showTimeStamps: 'Show timestamps',
+      showFullScreen: 'Show full screen',
+      downloadLogs: 'Download logs',
+      artifactsTitle: 'Artifacts',
+      artifactExpired: 'Expired',
+      confirmDeleteArtifact: 'Confirm delete artifact: %s',
+      rerun: 'Rerun',
+    },
+  };
+}
+
+// Helper function to create mock API response
+function createMockApiResponse(steps: any[] = [], runStatus = 'running') {
+  return {
+    artifacts: [] as any[],
+    state: {
+      run: {
+        link: '',
+        title: '',
+        titleHTML: '',
+        status: runStatus,
+        canCancel: false,
+        canApprove: false,
+        canRerun: false,
+        canDeleteArtifact: false,
+        done: false,
+        workflowID: '',
+        workflowLink: '',
+        isSchedule: false,
+        jobs: [] as any[],
+        commit: {
+          localeCommit: '',
+          localePushedBy: '',
+          shortSHA: '',
+          link: '',
+          pusher: {displayName: '', link: ''},
+          branch: {name: '', link: '', isDeleted: false},
+        },
+      },
+      currentJob: {
+        title: 'Test Job',
+        detail: 'Test job detail',
+        steps,
+      },
+    },
+    logs: {stepsLog: [] as any[]},
+  };
+}
+
+// Helper function to setup auto-expand localStorage
+function enableAutoExpand() {
+  localStorage.setItem('actions-view-options', JSON.stringify({
+    autoScroll: true,
+    expandRunning: true,
+  }));
+}
+
+beforeEach(() => {
+  // Setup window.config for CSRF token which is needed by fetch.ts
+  (globalThis as any).window = globalThis.window || {};
+  globalThis.window.config = globalThis.window.config || {};
+  globalThis.window.config.csrfToken = 'test-csrf-token';
+
+  // Default mock - needed because unmocked `loadJobData` is called when component is mounted
+  globalThis.fetch = vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(createMockApiResponse()),
+    } as Response),
+  );
+});
+
+afterEach(() => {
+  localStorage.removeItem('actions-view-options');
+});
+
+test('auto expand works on subsequent loads', async () => {
+  enableAutoExpand();
+
+  const wrapper = mount(RepoActionView, {props: createDefaultProps()});
+  await wrapper.vm.$nextTick();
+
+  // Stop the interval timer
+  if (wrapper.vm.intervalID) {
+    clearInterval(wrapper.vm.intervalID);
+    wrapper.vm.intervalID = null;
+  }
+
+  // Create mock fetch function
+  const mockResponse = createMockApiResponse([
+    {summary: 'Step 1', duration: '1s', status: 'running'},
+  ]);
+  const mockFetchJobData = vi.fn().mockResolvedValue(mockResponse);
+
+  // Reset component state to ensure isFirstLoad = true
+  wrapper.vm.run.status = '' as any;
+  wrapper.vm.currentJob.steps = [];
+  wrapper.vm.currentJobStepsStates = [];
+  wrapper.vm.loadingAbortController = null;
+
+  // Call the real loadJob method with our mock fetch function
+  await wrapper.vm.loadJob(mockFetchJobData);
+
+  // First load should work - step should be auto-expanded
+  expect(wrapper.vm.run.status).toBe('running');
+  expect(wrapper.vm.currentJobStepsStates.length).toBe(1);
+  expect(wrapper.vm.currentJobStepsStates[0].expanded).toBe(true);
+
+  // manually collapse the step
+  wrapper.vm.currentJobStepsStates[0].expanded = false;
+
+  // Clear abort controller and call loadJob again (isFirstLoad will now be false)
+  wrapper.vm.loadingAbortController = null;
+  await wrapper.vm.loadJob(mockFetchJobData);
+
+  // The step should auto-expand on subsequent loads
+  expect(wrapper.vm.currentJobStepsStates[0].expanded).toBe(true);
+
+  wrapper.unmount();
+});
+
+test('auto expand works when step becomes running', async () => {
+  enableAutoExpand();
+
+  const wrapper = mount(RepoActionView, {props: createDefaultProps()});
+  await wrapper.vm.$nextTick();
+
+  // Stop the interval timer
+  if (wrapper.vm.intervalID) {
+    clearInterval(wrapper.vm.intervalID);
+    wrapper.vm.intervalID = null;
+  }
+
+  // Create mock fetch function that returns different responses on each call
+  let callCount = 0;
+  const mockFetchJobData = vi.fn().mockImplementation(async () => {
+    callCount++;
+    const stepStatus = callCount === 1 ? 'waiting' : 'running';
+
+    return createMockApiResponse([
+      {summary: 'Step 1', duration: '1s', status: stepStatus},
+      {summary: 'Step 2', duration: '0s', status: 'waiting'},
+    ]);
+  });
+
+  // Reset component state
+  wrapper.vm.run.status = 'unknown' as any;
+  wrapper.vm.currentJob.steps = [];
+  wrapper.vm.currentJobStepsStates = [];
+  wrapper.vm.loadingAbortController = null;
+
+  // First load - step is waiting (using real component loadJob logic)
+  await wrapper.vm.loadJob(mockFetchJobData);
+  expect(wrapper.vm.currentJobStepsStates.length).toBe(2);
+  expect(wrapper.vm.currentJobStepsStates[0].expanded).toBe(false); // Not expanded because step is waiting
+
+  // Clear abort controller and do second load - step becomes running, should auto-expand
+  wrapper.vm.loadingAbortController = null;
+  await wrapper.vm.loadJob(mockFetchJobData);
+
+  // The step transitioned to running and should auto-expand even when isFirstLoad = false
+  expect(wrapper.vm.currentJobStepsStates[0].expanded).toBe(true);
+
+  wrapper.unmount();
+});


### PR DESCRIPTION
## Summary

Fixes the "Always expand running logs" setting behavior so that it properly auto-expands running log steps on subsequent job updates, not just on the initial page load.

## Problem

Currently, the "Always expand running logs" setting only works when the Actions page is first loaded (`isFirstLoad = true`). If a a running step is collapsed, or if a step transitions from "waiting" to "running" status during subsequent job updates, the logs do not auto-expand even though the setting is enabled.

## Solution

Modified `RepoActionView.vue` to:
1. Check for running steps and auto-expand them on all job updates when the setting is enabled
2. Handle step status transitions (e.g., waiting → running) by expanding logs when steps become running
3. Preserve existing behavior for initial page loads

## Test Coverage

Added basic tests (`RepoActionView.autoExpand.test.ts`) to reproduce buggy behavior. This was challenging because of how the Vue component is currently written - introduced a (hopefully) minor refactoring to simplify mocking the `loadJobData` function by optionally allowing injection of it. Also removed a check of the `abortController` that I think is unnecessary - `if (this.loadingAbortController !== abortController) return` -- this was really making the testing difficult and I'm not 100% sure what was going on behind the scenes to make it so, but according to the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/AbortController), this line shouldn't be necessary - the line to read from the response, `await resp.json()` will fail with an AbortError if the request was aborted at any point before the response is read. There's already try/catch handling of the AbortError further down, so this should still be handled. Apologies if I'm parsing this wrong, it just seems impossible to get a component test past this line otherwise ☹️.

## Changes Made

- `web_src/js/components/RepoActionView.vue`: Enhanced the `loadJob` method to handle auto-expansion on all updates
- `web_src/js/components/RepoActionView.autoExpand.test.ts`: Added focused tests for the auto-expand functionality
- `package.json` / `package-lock.json`: Added `@vue/test-utils` dependency for testing

p.s. _interestingly_ when I was testing this "live", I found that with the auto-expand behavior working, the current auto-scroll logs (see https://github.com/go-gitea/gitea/pull/34957) worked better ... until it got to a long step that was updating a lot ... then it broke again, so I think #34957 is still needed.
