### PR TITLE
Tweak placement of diff file menu

### DIFF
--- a/web_src/js/features/repo-diff.ts
+++ b/web_src/js/features/repo-diff.ts
@@ -138,7 +138,14 @@ function initDiffHeaderPopup() {
     btn.setAttribute('data-header-popup-initialized', '');
     const popup = btn.nextElementSibling;
     if (!popup?.matches('.tippy-target')) throw new Error('Popup element not found');
-    createTippy(btn, {content: popup, theme: 'menu', placement: 'bottom', trigger: 'click', interactive: true, hideOnClick: true});
+    createTippy(btn, {
+      content: popup,
+      theme: 'menu',
+      placement: 'bottom-end',
+      trigger: 'click',
+      interactive: true,
+      hideOnClick: true,
+    });
   }
 }
 


### PR DESCRIPTION
Small tweak for better visual placement. Before:

<img width="175" alt="Screenshot 2025-07-08 at 18 16 51" src="https://github.com/user-attachments/assets/766cfc82-1382-4aaa-8e99-c254665a0480" />

After:

<img width="134" alt="Screenshot 2025-07-08 at 18 16 34" src="https://github.com/user-attachments/assets/2653dfcc-29be-4922-a4de-3257db7b66fd" />

Placement matches the "..." button above.