### PR TITLE
Fix bug when displaying git user avatar in commits list

### DIFF
--- a/templates/repo/commits_list.tmpl
+++ b/templates/repo/commits_list.tmpl
@@ -16,7 +16,7 @@
 					<td class="author">
 						<div class="tw-flex">
 							{{$userName := .Author.Name}}
-							{{if .User}}
+							{{if and .User (neq .User.ID 0)}} /* User with id == 0 is a fake user from git author */
 								{{if and .User.FullName DefaultShowFullName}}
 									{{$userName = .User.FullName}}
 								{{end}}

--- a/templates/repo/commits_list.tmpl
+++ b/templates/repo/commits_list.tmpl
@@ -16,7 +16,7 @@
 					<td class="author">
 						<div class="tw-flex">
 							{{$userName := .Author.Name}}
-							{{if and .User (neq .User.ID 0)}} /* User with id == 0 is a fake user from git author */
+							{{if and .User (gt .User.ID 0)}} /* User with id == 0 is a fake user from git author */
 								{{if and .User.FullName DefaultShowFullName}}
 									{{$userName = .User.FullName}}
 								{{end}}


### PR DESCRIPTION
A quick fix for #34991 

`ValidateCommitsWithEmails` will create a fake user for a git commit user with a related Gitea user. The UI should not display a link for such users.