### PR TITLE
Fix the response format for `actions/workflows`. (#35009)

### DIFF
--- a/routers/api/v1/swagger/action.go
+++ b/routers/api/v1/swagger/action.go
@@ -44,5 +44,5 @@ type swaggerResponseActionWorkflow struct {
 // swagger:response ActionWorkflowList
 type swaggerResponseActionWorkflowList struct {
 	// in:body
-	Body []api.ActionWorkflow `json:"body"`
+	Body api.ActionWorkflowResponse `json:"body"`
 }

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -20327,6 +20327,25 @@
       },
       "x-go-package": "code.gitea.io/gitea/modules/structs"
     },
+    "ActionWorkflowResponse": {
+      "description": "ActionWorkflowResponse returns a ActionWorkflow",
+      "type": "object",
+      "properties": {
+        "total_count": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "TotalCount"
+        },
+        "workflows": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ActionWorkflow"
+          },
+          "x-go-name": "Workflows"
+        }
+      },
+      "x-go-package": "code.gitea.io/gitea/modules/structs"
+    },
     "ActionWorkflowRun": {
       "description": "ActionWorkflowRun represents a WorkflowRun",
       "type": "object",
@@ -27464,10 +27483,7 @@
     "ActionWorkflowList": {
       "description": "ActionWorkflowList",
       "schema": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/ActionWorkflow"
-        }
+        "$ref": "#/definitions/ActionWorkflowResponse"
       }
     },
     "ActivityFeedsList": {


### PR DESCRIPTION
Backport #35009

This PR fixes the response format for the OpenAPI Spec of `ActionsListRepositoryWorkflows`.
It was specified in the OpenAPI spec as returning a `[]*ActionWorkflow`, but it actually should return a `api.ActionWorkflowResponse`.

The test already expects an `api.ActionWorkflowResponse` like expected.
