### PR TITLE
fix: improve english grammar and readability in locale_en-US.ini

### DIFF
--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -117,7 +117,7 @@ files = Files
 
 error = Error
 error404 = The page you are trying to reach either <strong>does not exist</strong> or <strong>you are not authorized</strong> to view it.
-error503 = The server was unable to complete your request. Please try again later.
+error503 = The server could not complete your request. Please try again later.
 go_back = Go Back
 invalid_data = Invalid data: %v
 
@@ -131,7 +131,7 @@ unpin = Unpin
 
 artifacts = Artifacts
 expired = Expired
-confirm_delete_artifact = Are you sure you want to delete the artifact '%s' ?
+confirm_delete_artifact = Are you sure you want to delete the artifact '%s'?
 
 archived = Archived
 
@@ -171,7 +171,7 @@ internal_error_skipped = Internal error occurred but is skipped: %s
 search = Search...
 type_tooltip = Search type
 fuzzy = Fuzzy
-fuzzy_tooltip = Include results that also match the search term closely
+fuzzy_tooltip = Include results that closely match the search term
 words = Words
 words_tooltip = Include only results that match the search term words
 regexp = Regexp
@@ -506,7 +506,7 @@ activate_email.text = Please click the following link to verify your email addre
 
 register_notify = Welcome to %s
 register_notify.title = %[1]s, welcome to %[2]s
-register_notify.text_1 = this is your registration confirmation email for %s!
+register_notify.text_1 = This is your registration confirmation email for %s!
 register_notify.text_2 = You can now login via username: %s.
 register_notify.text_3 = If this account has been created for you, please <a href="%s">set your password</a> first.
 
@@ -998,7 +998,7 @@ webauthn_alternative_tip = You may want to configure an additional authenticatio
 
 manage_account_links = Manage Linked Accounts
 manage_account_links_desc = These external accounts are linked to your Gitea account.
-account_links_not_available = There are currently no external accounts linked to your Gitea account.
+account_links_not_available = No external accounts are currently linked to your Gitea account.
 link_account = Link Account
 remove_account_link = Remove Linked Account
 remove_account_link_desc = Removing a linked account will revoke its access to your Gitea account. Continue?
@@ -1035,8 +1035,8 @@ new_repo_helper = A repository contains all project files, including revision hi
 owner = Owner
 owner_helper = Some organizations may not show up in the dropdown due to a maximum repository count limit.
 repo_name = Repository Name
-repo_name_profile_public_hint= .profile is a special repository that you can use to add README.md to your public organization profile, visible to anyone. Make sure it’s public and initialize it with a README in the profile directory to get started.
-repo_name_profile_private_hint = .profile-private is a special repository that you can use to add a README.md to your organization member profile, visible only to organization members. Make sure it’s private and initialize it with a README in the profile directory to get started.
+repo_name_profile_public_hint= .profile is a special repository that you can use to add README.md to your public organization profile, visible to anyone. Make sure it's public and initialize it with a README in the profile directory to get started.
+repo_name_profile_private_hint = .profile-private is a special repository that you can use to add a README.md to your organization member profile, visible only to organization members. Make sure it's private and initialize it with a README in the profile directory to get started.
 repo_name_helper = Good repository names use short, memorable and unique keywords. A repository named ".profile" or ".profile-private" could be used to add a README.md for the user/organization profile.
 repo_size = Repository Size
 template = Template
@@ -1058,7 +1058,7 @@ fork_branch = Branch to be cloned to the fork
 all_branches = All branches
 view_all_branches = View all branches
 view_all_tags = View all tags
-fork_no_valid_owners = This repository can not be forked because there are no valid owners.
+fork_no_valid_owners = This repository cannot be forked because there are no valid owners.
 fork.blocked_user = Cannot fork the repository because you are blocked by the repository owner.
 use_template = Use this template
 open_with_editor = Open with %s
@@ -1755,7 +1755,7 @@ issues.due_date_form = "yyyy-mm-dd"
 issues.due_date_form_add = "Add due date"
 issues.due_date_form_edit = "Edit"
 issues.due_date_form_remove = "Remove"
-issues.due_date_not_writer = "You need write access to this repository in order to update the due date of an issue."
+issues.due_date_not_writer = "You need write access to this repository to update the due date of an issue."
 issues.due_date_not_set = "No due date set."
 issues.due_date_added = "added the due date %s %s"
 issues.due_date_modified = "modified the due date from %[2]s to %[1]s %[3]s"
@@ -2123,7 +2123,7 @@ activity.title.releases_1 = %d Release
 activity.title.releases_n = %d Releases
 activity.title.releases_published_by = %s published by %s
 activity.published_release_label = Published
-activity.no_git_activity = There has not been any commit activity in this period.
+activity.no_git_activity = There has been no commit activity in this period.
 activity.git_stats_exclude_merges = Excluding merges,
 activity.git_stats_author_1 = %d author
 activity.git_stats_author_n = %d authors


### PR DESCRIPTION
#35015

## Changes Made
- **Grammar fixes**: `can not` → `cannot` 
- **Word order improvements**: `also match closely` → `closely match`
- **Simplified phrases**: `in order to` → `to`
- **Capitalization fixes**: Proper sentence case in email messages
- **Natural error messages**: `was unable to` → `could not`
- **Cleaner negative constructions**: `There has not been any` → `There has been no`
- **Punctuation fixes**: Removed extra spaces before punctuation

## Files Changed
- `options/locale/locale_en-US.ini` - 8 English improvements

## Testing
- [x] All changes are text-only improvements
- [x] No functional changes to application behavior
- [x] Verified changes maintain proper .ini file format
