### PR TITLE
Fix git diff hunk 0 based start line

### DIFF
--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -864,9 +864,9 @@ func parseHunks(ctx context.Context, curFile *DiffFile, maxLines, maxLineCharact
 			}
 			curSection.Lines = append(curSection.Lines, diffLine)
 			curSection.FileName = curFile.Name
-			// update line number.
-			leftLine = lineSectionInfo.LeftIdx
-			rightLine = lineSectionInfo.RightIdx
+			// update line number. leftLine and rightLine are 1-based indexes, 0 means 1
+			leftLine = max(lineSectionInfo.LeftIdx, 1)
+			rightLine = max(lineSectionInfo.RightIdx, 1)
 			continue
 		case '\\':
 			if maxLines > -1 && curFileLinesCount >= maxLines {


### PR DESCRIPTION
Fix #35040

The git diff hunk `@@ -1,1 +0,4 @@` is a 0 based one which should not exist. The hunk is generated by the function `CutDiffAroundLine` which should be fixed in that function.

Before:

<img width="1022" height="293" alt="Image" src="https://github.com/user-attachments/assets/3c11090d-d281-42b5-a22e-6a91c7ff724f" />

After:

<img width="658" height="263" alt="image" src="https://github.com/user-attachments/assets/cedae20a-f1c7-41f0-af6c-4e224ee9f69e" />
