### PR TITLE
chore: add hover background to table rows in admin pages

### DIFF
--- a/web_src/css/admin.css
+++ b/web_src/css/admin.css
@@ -43,6 +43,10 @@
   white-space: nowrap;
 }
 
+.admin .table>tbody>tr:hover {
+  background-color: var(--color-hover)!important;
+}
+
 .admin-responsive-columns {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
This is a small QoL change to make the admin easier to do their management job. This makes knowing which row is the correct row to operate easier by simply checking the hover background, especially when they have a wide screen.

Sample:

<img width="1713" height="173" alt="image" src="https://github.com/user-attachments/assets/3690c8d7-a1ad-4ad5-a41b-3a5e7c50e20d" />

The 2nd row is hovered, so before the admin clicks the "delete" button, they can know `Magical8bitPlug2` is the one that the "delete" operation will be applied to.



