### PR TITLE
UI: add hover background to table rows in user and repo admin page

### DIFF
--- a/templates/admin/repo/list.tmpl
+++ b/templates/admin/repo/list.tmpl
@@ -10,7 +10,7 @@
 			{{template "shared/repo/search" .}}
 		</div>
 		<div class="ui attached table segment">
-			<table class="ui very basic striped table unstackable">
+			<table class="ui very basic striped table selectable unstackable">
 				<thead>
 					<tr>
 						<th data-sortt-asc="oldest" data-sortt-desc="newest">ID{{SortArrow "oldest" "newest" $.SortType false}}</th>

--- a/templates/admin/user/list.tmpl
+++ b/templates/admin/user/list.tmpl
@@ -56,7 +56,7 @@
 			</form>
 		</div>
 		<div class="ui attached table segment">
-			<table class="ui very basic striped table unstackable">
+			<table class="ui very basic striped selectable table unstackable">
 				<thead>
 					<tr>
 						<th data-sortt-asc="oldest" data-sortt-desc="newest">ID{{SortArrow "oldest" "newest" .SortType false}}</th>

--- a/web_src/css/modules/table.css
+++ b/web_src/css/modules/table.css
@@ -167,6 +167,11 @@
   text-overflow: ellipsis;
 }
 
+.ui.selectable.table > tbody > tr:hover,
+.ui.table tbody tr td.selectable:hover {
+  background: var(--color-hover);
+}
+
 .ui.attached.table {
   top: 0;
   bottom: 0;
@@ -288,6 +293,9 @@
 }
 .ui.basic.striped.table > tbody > tr:nth-child(2n) {
   background: var(--color-light);
+}
+.ui.basic.striped.selectable.table > tbody > tr:nth-child(2n):hover {
+  background: var(--color-hover);
 }
 
 .ui[class*="very basic"].table {


### PR DESCRIPTION
This is a small QoL change to make the admin easier to do their management job. This makes knowing which row is the correct row to operate easier by simply checking the hover background, especially when they have a wide screen.

Sample:

<img width="1713" height="173" alt="image" src="https://github.com/user-attachments/assets/3690c8d7-a1ad-4ad5-a41b-3a5e7c50e20d" />

The 2nd row is hovered, so before the admin clicks the "delete" button, they can know `Magical8bitPlug2` is the one that the "delete" operation will be applied to.

This patch only added the hover background (`selectable`) to the repo admin and user admin list page. Other tables can be added later.

Note: I'm not sure if my `table.css` change is sane, feel free to modify this PR directly if needed/preferred)
