### PR TITLE
Increase gap on latest commit

### DIFF
--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -141,7 +141,7 @@ td .commit-summary {
   align-items: center;
   overflow: hidden;
   text-overflow: ellipsis;
-  gap: 0.25em;
+  gap: .5rem;
 }
 
 @media (max-width: 767.98px) {

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -141,7 +141,7 @@ td .commit-summary {
   align-items: center;
   overflow: hidden;
   text-overflow: ellipsis;
-  gap: .5rem;
+  gap: 0.5em;
 }
 
 @media (max-width: 767.98px) {


### PR DESCRIPTION
Before:

<img width="964" height="101" alt="Screenshot 2025-07-17 at 02 31 05" src="https://github.com/user-attachments/assets/e02181f3-f730-40bb-8cfa-ecfea4ed4aec" />

After:

<img width="967" height="104" alt="Screenshot 2025-07-17 at 02 42 13" src="https://github.com/user-attachments/assets/7ca7b9a8-1f59-4dc0-9bb0-c72346fd792a" />


