### PR TITLE
Don't use full-file highlight when there is a git diff textconv

### DIFF
--- a/modules/git/attribute/attribute.go
+++ b/modules/git/attribute/attribute.go
@@ -20,6 +20,7 @@ const (
 	GitlabLanguage        = "gitlab-language"
 	Lockable              = "lockable"
 	Filter                = "filter"
+	Diff                  = "diff"
 )
 
 var LinguistAttributes = []string{


### PR DESCRIPTION
Fix #35106
