### PR TITLE
Replace `setup-python` with `setup-uv`

### DIFF
--- a/.github/workflows/pull-compliance.yml
+++ b/.github/workflows/pull-compliance.yml
@@ -32,15 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v6
+      - run: uv python install 3.12
       - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: npm
           cache-dependency-path: package-lock.json
-      - run: pip install uv
       - run: make deps-py
       - run: make deps-frontend
       - run: make lint-templates
@@ -51,10 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - run: pip install uv
+      - uses: astral-sh/setup-uv@v6
+      - run: uv python install 3.12
       - run: make deps-py
       - run: make lint-yaml
 


### PR DESCRIPTION
Use [`setup-uv`](https://github.com/astral-sh/setup-uv) to install both uv and python, replacing the previous pip usage.