### PR TITLE
Only hide dropzone when no files have been uploaded

### DIFF
--- a/web_src/js/features/repo-issue.ts
+++ b/web_src/js/features/repo-issue.ts
@@ -545,10 +545,8 @@ function initIssueTemplateCommentEditors(commentForm: HTMLFormElement) {
       queryElems(commentForm, '.combo-editor-dropzone .form-field-dropzone', (dropzoneContainer) => {
         const dropzoneEl = dropzoneContainer.closest<HTMLElement>('.combo-editor-dropzone').querySelector<HTMLElement>('.dropzone');
         const dzInstance = dropzoneEl?.dropzone;
-
-        if (dzInstance && dzInstance.files.length === 0) {
-          hideElem(dropzoneContainer);
-        }
+        const hasUploadedFiles = Boolean(dzInstance?.files.length);
+        toggleElem(dropzoneContainer, hasUploadedFiles);
       });
 
       // activate this markdown editor

--- a/web_src/js/features/repo-issue.ts
+++ b/web_src/js/features/repo-issue.ts
@@ -544,7 +544,7 @@ function initIssueTemplateCommentEditors(commentForm: HTMLFormElement) {
       hideElem(commentForm.querySelectorAll('.combo-editor-dropzone .combo-markdown-editor'));
       queryElems(commentForm, '.combo-editor-dropzone .form-field-dropzone', (dropzoneContainer) => {
         // if "form-field-dropzone" exists, then "dropzone" must also exist
-        const dropzone = dropzoneContainer.querySelector('.dropzone').dropzone;
+        const dropzone = dropzoneContainer.querySelector<HTMLElement>('.dropzone').dropzone;
         const hasUploadedFiles = dropzone.files.length !== 0;
         toggleElem(dropzoneContainer, hasUploadedFiles);
       });

--- a/web_src/js/features/repo-issue.ts
+++ b/web_src/js/features/repo-issue.ts
@@ -543,9 +543,9 @@ function initIssueTemplateCommentEditors(commentForm: HTMLFormElement) {
       showElem(commentForm.querySelectorAll('.combo-editor-dropzone .form-field-real'));
       hideElem(commentForm.querySelectorAll('.combo-editor-dropzone .combo-markdown-editor'));
       queryElems(commentForm, '.combo-editor-dropzone .form-field-dropzone', (dropzoneContainer) => {
-        const dropzoneEl = dropzoneContainer.closest<HTMLElement>('.combo-editor-dropzone').querySelector<HTMLElement>('.dropzone');
-        const dzInstance = dropzoneEl?.dropzone;
-        const hasUploadedFiles = Boolean(dzInstance?.files.length);
+        // if "form-field-dropzone" exists, then "dropzone" must also exist
+        const dropzone = dropzoneContainer.querySelector('.dropzone').dropzone;
+        const hasUploadedFiles = dropzone.files.length !== 0;
         toggleElem(dropzoneContainer, hasUploadedFiles);
       });
 

--- a/web_src/js/features/repo-issue.ts
+++ b/web_src/js/features/repo-issue.ts
@@ -542,7 +542,11 @@ function initIssueTemplateCommentEditors(commentForm: HTMLFormElement) {
       // deactivate all markdown editors
       showElem(commentForm.querySelectorAll('.combo-editor-dropzone .form-field-real'));
       hideElem(commentForm.querySelectorAll('.combo-editor-dropzone .combo-markdown-editor'));
-      hideElem(commentForm.querySelectorAll('.combo-editor-dropzone .form-field-dropzone'));
+      queryElems(commentForm, '.combo-editor-dropzone .form-field-dropzone', (dropzoneContainer) => {
+        const dropzone = dropzoneContainer.closest('.combo-editor-dropzone')?.querySelector('.dropzone');
+        const hasUploadedFiles = dropzone?.querySelector('.dz-preview') !== null;
+        if (!hasUploadedFiles) hideElem(dropzoneContainer);
+      });
 
       // activate this markdown editor
       hideElem(fieldTextarea);

--- a/web_src/js/features/repo-issue.ts
+++ b/web_src/js/features/repo-issue.ts
@@ -543,9 +543,12 @@ function initIssueTemplateCommentEditors(commentForm: HTMLFormElement) {
       showElem(commentForm.querySelectorAll('.combo-editor-dropzone .form-field-real'));
       hideElem(commentForm.querySelectorAll('.combo-editor-dropzone .combo-markdown-editor'));
       queryElems(commentForm, '.combo-editor-dropzone .form-field-dropzone', (dropzoneContainer) => {
-        const dropzone = dropzoneContainer.closest('.combo-editor-dropzone')?.querySelector('.dropzone');
-        const hasUploadedFiles = dropzone?.querySelector('.dz-preview') !== null;
-        if (!hasUploadedFiles) hideElem(dropzoneContainer);
+        const dropzoneEl = dropzoneContainer.closest<HTMLElement>('.combo-editor-dropzone')?.querySelector<HTMLElement>('.dropzone');
+        const dzInstance = dropzoneEl?.dropzone;
+
+        if (dzInstance && dzInstance.files.length === 0) {
+          hideElem(dropzoneContainer);
+        }
       });
 
       // activate this markdown editor

--- a/web_src/js/features/repo-issue.ts
+++ b/web_src/js/features/repo-issue.ts
@@ -543,7 +543,7 @@ function initIssueTemplateCommentEditors(commentForm: HTMLFormElement) {
       showElem(commentForm.querySelectorAll('.combo-editor-dropzone .form-field-real'));
       hideElem(commentForm.querySelectorAll('.combo-editor-dropzone .combo-markdown-editor'));
       queryElems(commentForm, '.combo-editor-dropzone .form-field-dropzone', (dropzoneContainer) => {
-        const dropzoneEl = dropzoneContainer.closest<HTMLElement>('.combo-editor-dropzone')?.querySelector<HTMLElement>('.dropzone');
+        const dropzoneEl = dropzoneContainer.closest<HTMLElement>('.combo-editor-dropzone').querySelector<HTMLElement>('.dropzone');
         const dzInstance = dropzoneEl?.dropzone;
 
         if (dzInstance && dzInstance.files.length === 0) {


### PR DESCRIPTION
Instead of always hiding the dropzone when it's not active:
- hide it when when there are no uploaded files and it becomes inactive 
- don't hide it when there are uploaded files

Fixes #35125 
