### PR TITLE
Update gopls to 0.20.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ XGO_PACKAGE ?= src.techknowlogick.com/xgo@latest
 GO_LICENSES_PACKAGE ?= github.com/google/go-licenses@v1
 GOVULNCHECK_PACKAGE ?= golang.org/x/vuln/cmd/govulncheck@v1
 ACTIONLINT_PACKAGE ?= github.com/rhysd/actionlint/cmd/actionlint@v1
-GOPLS_PACKAGE ?= golang.org/x/tools/gopls@v0.19.1
-GOPLS_MODERNIZE_PACKAGE ?= golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@v0.19.1
+GOPLS_PACKAGE ?= golang.org/x/tools/gopls@v0.20.0
+GOPLS_MODERNIZE_PACKAGE ?= golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@v0.20.0
 
 DOCKER_IMAGE ?= gitea/gitea
 DOCKER_TAG ?= latest


### PR DESCRIPTION
Ran `make lint-go-gopls fix` and it did not find any new issues or introduce any changes.

Release notes: https://go.dev/gopls/release/v0.20.0