### PR TITLE
Nix flake build static with sqlite support (#35149)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,17 @@ ifeq ($(HAS_GO), yes)
 	CGO_CFLAGS ?= $(shell $(GO) env CGO_CFLAGS) $(CGO_EXTRA_CFLAGS)
 endif
 
+CGO_ENABLED ?= 0
+ifneq (,$(findstring sqlite,$(TAGS))$(findstring pam,$(TAGS)))
+	CGO_ENABLED = 1
+endif
+
+STATIC ?=
+EXTLDFLAGS ?=
+ifneq ($(STATIC),)
+	EXTLDFLAGS = -extldflags "-static"
+endif
+
 ifeq ($(GOOS),windows)
 	IS_WINDOWS := yes
 else ifeq ($(patsubst Windows%,Windows,$(OS)),Windows)
@@ -740,7 +751,10 @@ security-check:
 	go run $(GOVULNCHECK_PACKAGE) -show color ./...
 
 $(EXECUTABLE): $(GO_SOURCES) $(TAGS_PREREQ)
-	CGO_CFLAGS="$(CGO_CFLAGS)" $(GO) build $(GOFLAGS) $(EXTRA_GOFLAGS) -tags '$(TAGS)' -ldflags '-s -w $(LDFLAGS)' -o $@
+ifneq ($(and $(STATIC),$(findstring pam,$(TAGS))),)
+  $(error pam support set via TAGS doesn't support static builds)
+endif
+	CGO_ENABLED="$(CGO_ENABLED)" CGO_CFLAGS="$(CGO_CFLAGS)" $(GO) build $(GOFLAGS) $(EXTRA_GOFLAGS) -tags '$(TAGS)' -ldflags '-s -w $(EXTLDFLAGS) $(LDFLAGS)' -o $@
 
 .PHONY: release
 release: frontend generate release-windows release-linux release-darwin release-freebsd release-copy release-compress vendor release-sources release-check

--- a/flake.nix
+++ b/flake.nix
@@ -11,33 +11,45 @@
         pkgs = nixpkgs.legacyPackages.${system};
       in
       {
-        devShells.default = pkgs.mkShell {
-          buildInputs = with pkgs; [
-            # generic
-            git
-            git-lfs
-            gnumake
-            gnused
-            gnutar
-            gzip
+        devShells.default =
+          with pkgs;
+          let
+            # only bump toolchain versions here
+            go = go_1_24;
+            nodejs = nodejs_24;
+            python3 = python312;
+          in
+          pkgs.mkShell {
+            buildInputs = [
+              # generic
+              git
+              git-lfs
+              gnumake
+              gnused
+              gnutar
+              gzip
 
-            # frontend
-            nodejs_22
+              # frontend
+              nodejs
 
-            # linting
-            python312
-            poetry
+              # linting
+              python3
+              poetry
 
-            # backend
-            go_1_24
-            gofumpt
-            sqlite
-          ];
-          shellHook = ''
-            export GO="${pkgs.go_1_24}/bin/go"
-            export GOROOT="${pkgs.go_1_24}/share/go"
-          '';
-        };
+              # backend
+              go
+              glibc.static
+              gofumpt
+              sqlite
+            ];
+            CFLAGS = "-I${glibc.static.dev}/include";
+            LDFLAGS = "-L ${glibc.static}/lib";
+            GO = "${go}/bin/go";
+            GOROOT = "${go}/share/go";
+
+            TAGS = "sqlite sqlite_unlock_notify";
+            STATIC = "true";
+          };
       }
     );
 }


### PR DESCRIPTION
Backport #35149

with `nix develop -c $SHELL` you can enter the dev environment. now with `make clean-all generate build -j1` you will get a static linked binary that has sqlite support

outside of an nix dev shell if you set `STATIC=true` you also will get a static binary
