### PR TITLE
Add start time on perf trace because it seems some steps haven't been recorded.

### DIFF
--- a/modules/gtprof/trace_builtin.go
+++ b/modules/gtprof/trace_builtin.go
@@ -40,7 +40,7 @@ func (t *traceBuiltinSpan) toString(out *strings.Builder, indent int) {
 	if t.ts.endTime.IsZero() {
 		out.WriteString(" duration: (not ended)")
 	} else {
-		fmt.Fprintf(out, " duration=%.4fs", t.ts.endTime.Sub(t.ts.startTime).Seconds())
+		fmt.Fprintf(out, " start=%s duration=%.4fs", t.ts.startTime.Format("2006-01-02 15:04:05"), t.ts.endTime.Sub(t.ts.startTime).Seconds())
 	}
 	for _, a := range t.ts.attributes {
 		out.WriteString(" ")


### PR DESCRIPTION
The new trace log looks like
```
http start=2025-08-14 15:03:04 duration=0.6978s http.route=/
  http.func start=2025-08-14 15:03:04 duration=0.6978s func=common.ForwardedHeadersHandler.ForwardedHeaders
    http.func start=2025-08-14 15:03:04 duration=0.6978s func=routing.(*requestRecordsManager).handler-fm
      http.func start=2025-08-14 15:03:04 duration=0.6978s func=gzhttp.NewWrapper
        http.func start=2025-08-14 15:03:04 duration=0.6975s func=session.Sessioner
          http.func start=2025-08-14 15:03:04 duration=0.6973s func=context.Contexter
```