### PR TITLE
Fix GitHub release assets URL validation

### DIFF
--- a/services/migrations/github.go
+++ b/services/migrations/github.go
@@ -354,7 +354,8 @@ func (g *GithubDownloaderV3) convertGithubRelease(ctx context.Context, rel *gith
 
 				// Prevent open redirect
 				if !hasBaseURL(redirectURL, g.baseURL) &&
-					!hasBaseURL(redirectURL, "https://objects.githubusercontent.com/") {
+					!hasBaseURL(redirectURL, "https://objects.githubusercontent.com/") &&
+					!hasBaseURL(redirectURL, "https://release-assets.githubusercontent.com/") {
 					WarnAndNotice("Unexpected AssetURL for assetID[%d] in %s: %s", asset.GetID(), g, redirectURL)
 
 					return io.NopCloser(strings.NewReader(redirectURL)), nil


### PR DESCRIPTION
GitHub changed where the attachments on releases are stored, which means repo migrations with releases now fail because the redirect URLs don't match the base URL validation. We need to update the base URL check to check for the `release-assets` subdomain as well.