### PR TITLE
Upgrade devcontainer go version to 1.24.6

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,5 +38,7 @@
       "onAutoForward": "notify"
     }
   },
-  "postCreateCommand": "make deps"
+  // (Workaround to match go.mod version) -- Upgrades go version to 1.24.6, detects container architecture
+  "postCreateCommand": "ARCH=$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/') && curl -fsSL https://go.dev/dl/go1.24.6.linux-${ARCH}.tar.gz | sudo tar -C /usr/local -xz && make deps"
+  // "postCreateCommand": "make deps"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,10 @@
 {
   "name": "Gitea DevContainer",
   "image": "mcr.microsoft.com/devcontainers/go:1.24-bookworm",
+  "containerEnv": {
+    // override "local" from packaged version
+    "GOTOOLCHAIN": "auto"
+  },
   "features": {
     // installs nodejs into container
     "ghcr.io/devcontainers/features/node:1": {
@@ -32,13 +36,5 @@
       ]
     }
   },
-  "portsAttributes": {
-    "3000": {
-      "label": "Gitea Web",
-      "onAutoForward": "notify"
-    }
-  },
-  // (Workaround to match go.mod version) -- Upgrades go version to 1.24.6, detects container architecture
-  "postCreateCommand": "ARCH=$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/') && curl -fsSL https://go.dev/dl/go1.24.6.linux-${ARCH}.tar.gz | sudo tar -C /usr/local -xz && make deps"
-  // "postCreateCommand": "make deps"
+  "postCreateCommand": "make deps"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,5 +36,11 @@
       ]
     }
   },
+  "portsAttributes": {
+    "3000": {
+      "label": "Gitea Web",
+      "onAutoForward": "notify"
+    }
+  },
   "postCreateCommand": "make deps"
 }


### PR DESCRIPTION
Addresses go version mismatch when using the devcontainer as a result of [this commit](https://github.com/go-gitea/gitea/commit/793815adf7a694fa04c12bd3df3262e591f127ab) (bumps Go version from 1.24.5 to 1.24.6)

The current official devcontainer Go image used in this repository (`1.24-bookworm`) uses 1.24.5 and sets GOTOOLCHAIN to local. This PR overrides it to auto so that build commands automatically update to the correct version.