### PR TITLE
nix dev shell add zip

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,7 @@
                 gnused
                 gnutar
                 gzip
+                zip
 
                 # frontend
                 nodejs


### PR DESCRIPTION
as zip is needed in our makefile and not installed on nixos by default