### PR TITLE
make commit-graph write configurable

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -719,6 +719,8 @@ LEVEL = Info
 ;; To enable this for Git over SSH when using a OpenSSH server, add `AcceptEnv GIT_PROTOCOL` to your sshd_config file.
 ;ENABLE_AUTO_GIT_WIRE_PROTOCOL = true
 ;;
+;; Whether to write a commit graph on fetch and gc, only relevant if git version >= 2.18
+;;ENABLE_COMMIT_GRAPH_WRITE = true
 ;; Respond to pushes to a non-default branch with a URL for creating a Pull Request (if the repository has them enabled)
 ;PULL_REQUEST_PUSH_MESSAGE = true
 ;;

--- a/modules/git/config.go
+++ b/modules/git/config.go
@@ -50,7 +50,7 @@ func syncGitConfig() (err error) {
 		}
 	}
 
-	if DefaultFeatures().CheckVersionAtLeast("2.18") {
+	if (DefaultFeatures().CheckVersionAtLeast("2.18")) && (setting.Git.EnableCommitGraphWrite) {
 		if err := configSet("core.commitGraph", "true"); err != nil {
 			return err
 		}

--- a/modules/git/repo_commitgraph.go
+++ b/modules/git/repo_commitgraph.go
@@ -6,12 +6,14 @@ package git
 import (
 	"context"
 	"fmt"
+
+	"code.gitea.io/gitea/modules/setting"
 )
 
 // WriteCommitGraph write commit graph to speed up repo access
 // this requires git v2.18 to be installed
 func WriteCommitGraph(ctx context.Context, repoPath string) error {
-	if DefaultFeatures().CheckVersionAtLeast("2.18") {
+	if (DefaultFeatures().CheckVersionAtLeast("2.18")) && (setting.Git.EnableCommitGraphWrite) {
 		if _, _, err := NewCommand("commit-graph", "write").RunStdString(ctx, &RunOpts{Dir: repoPath}); err != nil {
 			return fmt.Errorf("unable to write commit-graph for '%s' : %w", repoPath, err)
 		}

--- a/modules/setting/git.go
+++ b/modules/setting/git.go
@@ -26,6 +26,7 @@ var Git = struct {
 	VerbosePushDelay          time.Duration
 	GCArgs                    []string `ini:"GC_ARGS" delim:" "`
 	EnableAutoGitWireProtocol bool
+	EnableCommitGraphWrite    bool
 	PullRequestPushMessage    bool
 	LargeObjectThreshold      int64
 	DisableCoreProtectNTFS    bool
@@ -49,6 +50,7 @@ var Git = struct {
 	VerbosePushDelay:          5 * time.Second,
 	GCArgs:                    []string{},
 	EnableAutoGitWireProtocol: true,
+	EnableCommitGraphWrite:    true,
 	PullRequestPushMessage:    true,
 	LargeObjectThreshold:      1024 * 1024,
 	DisablePartialClone:       false,


### PR DESCRIPTION
The following configuration key is exposed, defaulting to the current behavior (backwards-compatible):
```
[git]
  ENABLE_COMMIT_GRAPH_WRITE = true
```

Provides a workaround for intermittent mirror-sync failures in #33239 , as well as significant optimization to sync time for very large repositories.