### PR TITLE
Instance signing rule `pubkey` should allow all public keys, not just GPG

### DIFF
--- a/services/asymkey/sign.go
+++ b/services/asymkey/sign.go
@@ -75,7 +75,7 @@ func userHasPubkeys(ctx context.Context, u *user_model.User) (bool, error) {
 		IncludeSubKeys: true,
 	})
 	if err != nil {
-		return nil, err
+		return false, err
 	}
 	if len(gpgKeys) > 0 {
 		return true, nil
@@ -86,7 +86,7 @@ func userHasPubkeys(ctx context.Context, u *user_model.User) (bool, error) {
 		NotKeytype: asymkey_model.KeyTypePrincipal,
 	})
 	if err != nil {
-		return nil, err
+		return false, err
 	}
 	if len(sshKeys) > 0 {
 		return true, nil

--- a/services/asymkey/sign_test.go
+++ b/services/asymkey/sign_test.go
@@ -6,11 +6,14 @@ package asymkey
 import (
 	"testing"
 
+	"code.gitea.io/gitea/models/unittest"
+	
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestUserHasPubkeys(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
 	test := func(t *testing.T, userID int64, expectedHasGPG, expectedHasSSH bool) {
 		ctx := t.Context()
 		hasGPG, err := userHasPubkeysGPG(ctx, userID)

--- a/services/asymkey/sign_test.go
+++ b/services/asymkey/sign_test.go
@@ -1,0 +1,39 @@
+// Copyright 2019 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package asymkey
+
+import (
+	"testing"
+
+	"code.gitea.io/gitea/models/unittest"
+
+	user_model "code.gitea.io/gitea/models/user"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserHasPubkeys(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("AllowUserWithGPGKey", func(t *testing.T) {
+		user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 36}) // user has GPG key
+		hasKeys, err := userHasPubkeys(ctx, user)
+		assert.NoError(t, err)
+		assert.True(t, hasKeys)
+	})
+
+	t.Run("AllowUserWithSSHKey", func(t *testing.T) {
+		user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2}) // user has SSH key
+		hasKeys, err := userHasPubkeys(ctx, user)
+		assert.NoError(t, err)
+		assert.True(t, hasKeys)
+	})
+
+	t.Run("DenyUserWithNoKeys", func(t *testing.T) {
+		user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 1})
+		hasKeys, err := userHasPubkeys(ctx, user)
+		assert.NoError(t, err)
+		assert.False(t, hasKeys)
+	})
+}

--- a/services/asymkey/sign_test.go
+++ b/services/asymkey/sign_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"code.gitea.io/gitea/models/unittest"
-	
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/services/asymkey/sign_test.go
+++ b/services/asymkey/sign_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"code.gitea.io/gitea/models/unittest"
-
 	user_model "code.gitea.io/gitea/models/user"
 
 	"github.com/stretchr/testify/assert"

--- a/services/asymkey/sign_test.go
+++ b/services/asymkey/sign_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Gitea Authors. All rights reserved.
+// Copyright 2025 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
 package asymkey
@@ -6,33 +6,31 @@ package asymkey
 import (
 	"testing"
 
-	"code.gitea.io/gitea/models/unittest"
-	user_model "code.gitea.io/gitea/models/user"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUserHasPubkeys(t *testing.T) {
-	ctx := t.Context()
+	test := func(t *testing.T, userID int64, expectedHasGPG, expectedHasSSH bool) {
+		ctx := t.Context()
+		hasGPG, err := userHasPubkeysGPG(ctx, userID)
+		require.NoError(t, err)
+		hasSSH, err := userHasPubkeysSSH(ctx, userID)
+		require.NoError(t, err)
+		hasPubkeys, err := userHasPubkeys(ctx, userID)
+		require.NoError(t, err)
+		assert.Equal(t, expectedHasGPG, hasGPG)
+		assert.Equal(t, expectedHasSSH, hasSSH)
+		assert.Equal(t, expectedHasGPG || expectedHasSSH, hasPubkeys)
+	}
 
 	t.Run("AllowUserWithGPGKey", func(t *testing.T) {
-		user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 36}) // user has GPG key
-		hasKeys, err := userHasPubkeys(ctx, user)
-		assert.NoError(t, err)
-		assert.True(t, hasKeys)
+		test(t, 36, true, false) // has gpg
 	})
-
 	t.Run("AllowUserWithSSHKey", func(t *testing.T) {
-		user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2}) // user has SSH key
-		hasKeys, err := userHasPubkeys(ctx, user)
-		assert.NoError(t, err)
-		assert.True(t, hasKeys)
+		test(t, 2, false, true) // has ssh
 	})
-
 	t.Run("DenyUserWithNoKeys", func(t *testing.T) {
-		user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 1})
-		hasKeys, err := userHasPubkeys(ctx, user)
-		assert.NoError(t, err)
-		assert.False(t, hasKeys)
+		test(t, 1, false, false) // no pubkey
 	})
 }


### PR DESCRIPTION
Instance signing rule `pubkey` is described as "Only sign if the user has a public key", however if the user only has SSH public keys, this check will fail, as it only checks for GPG keys.

Changed the `pubkey` checks to call a helper `userHasPubkeys` which sequentially checks for GPG, then SSH keys.

Related #34341