### PR TITLE
fix(webhook/discord): fixed username cannot be empty error

### DIFF
--- a/services/webhook/discord.go
+++ b/services/webhook/discord.go
@@ -57,7 +57,7 @@ type (
 	DiscordPayload struct {
 		Wait      bool           `json:"wait"`
 		Content   string         `json:"content"`
-		Username  string         `json:"username"`
+		Username  string         `json:"username,omitempty"`
 		AvatarURL string         `json:"avatar_url,omitempty"`
 		TTS       bool           `json:"tts"`
 		Embeds    []DiscordEmbed `json:"embeds"`


### PR DESCRIPTION
username field is not required by discord and used to override the default username. sending it as blank causes a 400 error. it should be omitted instead when it's not set.

Ref: https://discord.com/developers/docs/resources/webhook#execute-webhook-jsonform-params

Closes #35411