### PR TITLE
add `/.pnpm-store` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ cpu.out
 /yarn.lock
 /yarn-error.log
 /npm-debug.log*
+/.pnpm-store
 /public/assets/js
 /public/assets/css
 /public/assets/fonts


### PR DESCRIPTION
add `/.pnpm-store` to .gitignore to not drive git diff crazy with 10k+ changes after .pnpm-store update, introduced by #35274
