### PR TITLE
Update gofumpt, add go.mod ignore directive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ XGO_VERSION := go-1.25.x
 
 AIR_PACKAGE ?= github.com/air-verse/air@v1
 EDITORCONFIG_CHECKER_PACKAGE ?= github.com/editorconfig-checker/editorconfig-checker/v3/cmd/editorconfig-checker@v3
-GOFUMPT_PACKAGE ?= mvdan.cc/gofumpt@v0.8.0
+GOFUMPT_PACKAGE ?= mvdan.cc/gofumpt@v0.9.1
 GOLANGCI_LINT_PACKAGE ?= github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0
 GXZ_PACKAGE ?= github.com/ulikunitz/xz/cmd/gxz@v0.5.15
 MISSPELL_PACKAGE ?= github.com/golangci/misspell/cmd/misspell@v0.7.0

--- a/build/code-batch-process.go
+++ b/build/code-batch-process.go
@@ -181,7 +181,7 @@ func parseArgs() (mainOptions map[string]string, subCmd string, subArgs []string
 			break
 		}
 	}
-	return
+	return mainOptions, subCmd, subArgs
 }
 
 func showUsage() {

--- a/go.mod
+++ b/go.mod
@@ -289,7 +289,7 @@ require (
 
 ignore (
 	./node_modules
-	./venv
+	./.venv
 )
 
 replace github.com/jaytaylor/html2text => github.com/Necoro/html2text v0.0.0-20250804200300-7bf1ce1c7347

--- a/go.mod
+++ b/go.mod
@@ -287,6 +287,11 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
+ignore (
+  ./node_modules
+  ./venv
+)
+
 replace github.com/jaytaylor/html2text => github.com/Necoro/html2text v0.0.0-20250804200300-7bf1ce1c7347
 
 replace github.com/hashicorp/go-version => github.com/6543/go-version v1.3.1

--- a/go.mod
+++ b/go.mod
@@ -288,8 +288,8 @@ require (
 )
 
 ignore (
-  ./node_modules
-  ./venv
+	./node_modules
+	./venv
 )
 
 replace github.com/jaytaylor/html2text => github.com/Necoro/html2text v0.0.0-20250804200300-7bf1ce1c7347

--- a/go.mod
+++ b/go.mod
@@ -288,8 +288,8 @@ require (
 )
 
 ignore (
-	./node_modules
 	./.venv
+	./node_modules
 )
 
 replace github.com/jaytaylor/html2text => github.com/Necoro/html2text v0.0.0-20250804200300-7bf1ce1c7347


### PR DESCRIPTION
gofumpt now [supports](https://github.com/mvdan/gofumpt/releases/tag/v0.9.0) the [ignore](https://tip.golang.org/ref/mod#go-mod-file-ignore) directive added in go 1.25, make use of it which speeds up `make fmt` by around 30%. Likely this also has similar speed gains in other go-related commands which use the `./...` pattern.

The change in `build/code-batch-process.go` was introduced by `gofumpt` because of this change:

> A new rule is introduced to "clothe" naked returns for the sake of clarity. While there is nothing wrong with naming results in function signatures, using lone return statements can be confusing to the reader.