### PR TITLE
Avoid dropdown resizing because of text

### DIFF
--- a/templates/shared/search/combo.tmpl
+++ b/templates/shared/search/combo.tmpl
@@ -10,7 +10,7 @@
 	{{template "shared/search/input" dict "Value" .Value "Disabled" .Disabled "Placeholder" .Placeholder}}
 	{{if .SearchModes}}
 	<div class="ui small dropdown selection {{if .Disabled}}disabled{{end}}" data-tooltip-content="{{ctx.Locale.Tr "search.type_tooltip"}}">
-		<div class="text"></div> {{svg "octicon-triangle-down" 14 "dropdown icon"}}
+		<div class="text">&nbsp;</div> {{svg "octicon-triangle-down" 14 "dropdown icon"}}
 		<input name="search_mode" type="hidden" value="
 			{{- if .SelectedSearchMode -}}
 				{{- .SelectedSearchMode -}}

--- a/templates/shared/search/combo.tmpl
+++ b/templates/shared/search/combo.tmpl
@@ -10,7 +10,7 @@
 	{{template "shared/search/input" dict "Value" .Value "Disabled" .Disabled "Placeholder" .Placeholder}}
 	{{if .SearchModes}}
 	<div class="ui small dropdown selection {{if .Disabled}}disabled{{end}}" data-tooltip-content="{{ctx.Locale.Tr "search.type_tooltip"}}">
-		<div class="text">&nbsp;</div> {{svg "octicon-triangle-down" 14 "dropdown icon"}}
+		<div class="text"></div> {{svg "octicon-triangle-down" 14 "dropdown icon"}}
 		<input name="search_mode" type="hidden" value="
 			{{- if .SelectedSearchMode -}}
 				{{- .SelectedSearchMode -}}

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -414,6 +414,10 @@ a.label,
   color: var(--color-text-light-2);
 }
 
+.ui.dropdown > .text {
+  min-height: 16px;
+}
+
 /* extend fomantic style '.ui.dropdown > .text > img' to include svg.img */
 .ui.dropdown > .text > .img {
   margin-left: 0;

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -415,7 +415,7 @@ a.label,
 }
 
 .ui.dropdown > .text {
-  min-height: 16px;
+  min-height: 16px; /* avoid resize on page load when text is empty */
 }
 
 /* extend fomantic style '.ui.dropdown > .text > img' to include svg.img */


### PR DESCRIPTION
Dropdown text is empty when rendering initially which causes the element to resize vertically when the text is set later via JS. Here seen on the global PR list:

![](https://github.com/user-attachments/assets/01165bd0-4b79-4ed9-8d73-62561d77f331)

Fix this by using a non-breaking space so the element will not resize when it receives the text.