### PR TITLE
Vertically center date in file view latest commit

### DIFF
--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -17,7 +17,7 @@
 			{{template "repo/latest_commit" .}}
 			{{if .LatestCommit}}
 				{{if .LatestCommit.Committer}}
-					<div class="text grey age">
+					<div class="text grey age flex-text-block">
 						{{DateUtils.TimeSince .LatestCommit.Committer.When}}
 					</div>
 				{{end}}


### PR DESCRIPTION
This text in file view latest commit was slightly off-center:

<img width="266" height="83" alt="Screenshot 2025-09-10 at 17 06 30" src="https://github.com/user-attachments/assets/965d6909-b8b7-4927-b960-e18fc8a2b326" />

Fixed it by adding this class:

<img width="388" height="91" alt="image" src="https://github.com/user-attachments/assets/b9320767-8678-4f8f-9f13-9484790b39ca" />
