### PR TITLE
Retarget branches to next branch in chain, rather than defaultBranch

### DIFF
--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -643,10 +643,10 @@ func UpdateRef(ctx context.Context, pr *issues_model.PullRequest) (err error) {
 	return err
 }
 
-// retargetBranchPulls change target branch for all pull requests whose base branch is the branch
-// Both branch and targetBranch must be in the same repo (for security reasons)
-func retargetBranchPulls(ctx context.Context, doer *user_model.User, repoID int64, branch, targetBranch string) error {
-	prs, err := issues_model.GetUnmergedPullRequestsByBaseInfo(ctx, repoID, branch)
+// RetargetBranchPulls change target branch for all pull requests whose base branch is oldBranch
+// Both oldBranch and newTargetBranch must be in the same repo (for security reasons)
+func RetargetBranchPulls(ctx context.Context, doer *user_model.User, repoID int64, oldBranch, newTargetBranch string) error {
+	prs, err := issues_model.GetUnmergedPullRequestsByBaseInfo(ctx, repoID, oldBranch)
 	if err != nil {
 		return err
 	}
@@ -659,7 +659,7 @@ func retargetBranchPulls(ctx context.Context, doer *user_model.User, repoID int6
 	for _, pr := range prs {
 		if err = pr.Issue.LoadRepo(ctx); err != nil {
 			errs = append(errs, err)
-		} else if err = ChangeTargetBranch(ctx, pr, doer, targetBranch); err != nil &&
+		} else if err = ChangeTargetBranch(ctx, pr, doer, newTargetBranch); err != nil &&
 			!issues_model.IsErrIssueIsClosed(err) && !IsErrPullRequestHasMerged(err) &&
 			!issues_model.IsErrPullRequestAlreadyExists(err) {
 			errs = append(errs, err)
@@ -668,9 +668,10 @@ func retargetBranchPulls(ctx context.Context, doer *user_model.User, repoID int6
 	return errors.Join(errs...)
 }
 
-// AdjustPullsCausedByBranchDeleted close all the pull requests who's head branch is the branch
-// Or Close all the plls who's base branch is the branch if setting.Repository.PullRequest.RetargetChildrenOnMerge is false.
-// If it's true, Retarget all these pulls to the default branch.
+// AdjustPullsCausedByBranchDeleted close all the pull requests with the deleted branch as head
+// Retarget all PR's with the deleted branch as target to the default branch
+// We don't handle setting.Repository.PullRequest.RetargetChildrenOnMerge here,
+// because we would need the PR that was merged to determine which branch to redirect to
 func AdjustPullsCausedByBranchDeleted(ctx context.Context, doer *user_model.User, repo *repo_model.Repository, branch string) error {
 	// branch as head branch
 	prs, err := issues_model.GetUnmergedPullRequestsByHeadInfo(ctx, repo.ID, branch)
@@ -698,12 +699,7 @@ func AdjustPullsCausedByBranchDeleted(ctx context.Context, doer *user_model.User
 			}
 		}
 	}
-
-	if setting.Repository.PullRequest.RetargetChildrenOnMerge {
-		if err := retargetBranchPulls(ctx, doer, repo.ID, branch, repo.DefaultBranch); err != nil {
-			log.Error("retargetBranchPulls failed: %v", err)
-			errs = append(errs, err)
-		}
+	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}
 


### PR DESCRIPTION
If setting RETARGET_CHILDREN_ON_MERGE is true, we should retarget a PR that targets a branch we're merging to the target branch of the branch we're merging.

Previously, RETARGET_CHILDREN_ON_MERGE incorrectly retargeted all following PR's in a chain to the defaultBranch when merging a PR in the middle of a chain.

Fixes #35138

---

I've moved the RETARGET_CHILDREN_ON_MERGE behavior from `pull/AdjustPullsCausedByBranchDeleted()` to `branch/DeleteBranch()`, because we need to know which PR is being closed to retarget the child branch(es). In `pull/pull.go` we only know that a branch is being deleted, but not why.
I'm not very happy with the dependency, though. So if there's a cleaner option, I'd be happy to move this behavior back to `pull/pull.go`.
