### PR TITLE
Add healthcheck to Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,9 @@ LABEL maintainer="maintainers@gitea.io"
 
 EXPOSE 22 3000
 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+  CMD curl -f http://localhost:3000/api/healthz || exit 1
+
 RUN apk --no-cache add \
     bash \
     ca-certificates \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ LABEL maintainer="maintainers@gitea.io"
 
 EXPOSE 22 3000
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+HEALTHCHECK --interval=2m --timeout=10s --start-period=2m --retries=3 \
   CMD curl -f http://localhost:3000/api/healthz || exit 1
 
 RUN apk --no-cache add \

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -44,6 +44,9 @@ LABEL maintainer="maintainers@gitea.io"
 
 EXPOSE 2222 3000
 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+  CMD curl -f http://localhost:3000/api/healthz || exit 1
+
 RUN apk --no-cache add \
     bash \
     ca-certificates \

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -44,7 +44,7 @@ LABEL maintainer="maintainers@gitea.io"
 
 EXPOSE 2222 3000
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+HEALTHCHECK --interval=2m --timeout=10s --start-period=2m --retries=3 \
   CMD curl -f http://localhost:3000/api/healthz || exit 1
 
 RUN apk --no-cache add \


### PR DESCRIPTION
Add HEALTHCHECK instructions to both Dockerfile and Dockerfile.rootless using the existing /api/healthz endpoint to monitor service health.

The healthcheck is configured with 30s interval, 10s timeout, 30s start period, and 3 retries before marking unhealthy.