### PR TITLE
Allow disabling auto cancellation of duplicate workflow runs

### DIFF
--- a/models/actions/run.go
+++ b/models/actions/run.go
@@ -209,6 +209,11 @@ func updateRepoRunsNumbers(ctx context.Context, repo *repo_model.Repository) err
 // CancelPreviousJobs cancels all previous jobs of the same repository, reference, workflow, and event.
 // It's useful when a new run is triggered, and all previous runs needn't be continued anymore.
 func CancelPreviousJobs(ctx context.Context, repoID int64, ref, workflowID string, event webhook_module.HookEventType) ([]*ActionRunJob, error) {
+	// Do not do cancellation if disabled in settings
+	if !setting.Actions.EnableAutoCancellation {
+		return nil, nil
+	}
+
 	// Find all runs in the specified repository, reference, and workflow with non-final status
 	runs, total, err := db.FindAndCount[ActionRun](ctx, FindRunOptions{
 		RepoID:       repoID,

--- a/modules/setting/actions.go
+++ b/modules/setting/actions.go
@@ -14,21 +14,23 @@ import (
 // Actions settings
 var (
 	Actions = struct {
-		Enabled               bool
-		LogStorage            *Storage          // how the created logs should be stored
-		LogRetentionDays      int64             `ini:"LOG_RETENTION_DAYS"`
-		LogCompression        logCompression    `ini:"LOG_COMPRESSION"`
-		ArtifactStorage       *Storage          // how the created artifacts should be stored
-		ArtifactRetentionDays int64             `ini:"ARTIFACT_RETENTION_DAYS"`
-		DefaultActionsURL     defaultActionsURL `ini:"DEFAULT_ACTIONS_URL"`
-		ZombieTaskTimeout     time.Duration     `ini:"ZOMBIE_TASK_TIMEOUT"`
-		EndlessTaskTimeout    time.Duration     `ini:"ENDLESS_TASK_TIMEOUT"`
-		AbandonedJobTimeout   time.Duration     `ini:"ABANDONED_JOB_TIMEOUT"`
-		SkipWorkflowStrings   []string          `ini:"SKIP_WORKFLOW_STRINGS"`
+		Enabled                bool
+		LogStorage             *Storage          // how the created logs should be stored
+		LogRetentionDays       int64             `ini:"LOG_RETENTION_DAYS"`
+		LogCompression         logCompression    `ini:"LOG_COMPRESSION"`
+		ArtifactStorage        *Storage          // how the created artifacts should be stored
+		ArtifactRetentionDays  int64             `ini:"ARTIFACT_RETENTION_DAYS"`
+		DefaultActionsURL      defaultActionsURL `ini:"DEFAULT_ACTIONS_URL"`
+		ZombieTaskTimeout      time.Duration     `ini:"ZOMBIE_TASK_TIMEOUT"`
+		EndlessTaskTimeout     time.Duration     `ini:"ENDLESS_TASK_TIMEOUT"`
+		AbandonedJobTimeout    time.Duration     `ini:"ABANDONED_JOB_TIMEOUT"`
+		SkipWorkflowStrings    []string          `ini:"SKIP_WORKFLOW_STRINGS"`
+		EnableAutoCancellation bool              `ini:"ENABLE_AUTO_CANCELLATION"`
 	}{
-		Enabled:             true,
-		DefaultActionsURL:   defaultActionsURLGitHub,
-		SkipWorkflowStrings: []string{"[skip ci]", "[ci skip]", "[no ci]", "[skip actions]", "[actions skip]"},
+		Enabled:                true,
+		DefaultActionsURL:      defaultActionsURLGitHub,
+		SkipWorkflowStrings:    []string{"[skip ci]", "[ci skip]", "[no ci]", "[skip actions]", "[actions skip]"},
+		EnableAutoCancellation: true,
 	}
 )
 


### PR DESCRIPTION
As https://github.com/go-gitea/gitea/pull/32751 is currently blocked, and https://github.com/go-gitea/gitea/issues/32662 / https://github.com/go-gitea/gitea/issues/33260 reported issues caused by the auto cancellation, a configuration item should be added to disable the auto cancellation feature.

This PR should be easier to merge than https://github.com/go-gitea/gitea/pull/32751 , while also addressing concerns on auto cancellation (temporarily).