### PR TITLE
add more routes to the "expensive" list

### DIFF
--- a/routers/common/blockexpensive.go
+++ b/routers/common/blockexpensive.go
@@ -44,9 +44,11 @@ func isRoutePathExpensive(routePattern string) bool {
 		"/{username}/{reponame}/blame/",
 		"/{username}/{reponame}/commit/",
 		"/{username}/{reponame}/commits/",
+		"/{username}/{reponame}/compare/",
 		"/{username}/{reponame}/graph",
 		"/{username}/{reponame}/media/",
 		"/{username}/{reponame}/raw/",
+		"/{username}/{reponame}/rss/branch/",
 		"/{username}/{reponame}/src/",
 
 		// issue & PR related (no trailing slash)


### PR DESCRIPTION
My gitea server uses `REQUIRE_SIGNIN_VIEW = expensive`. These are some routes that were being hit by bots repeatedly in an apparent attempt to denial-of-service my gitea server. Both of them were triggering `git` invocations under the hood, so they really should be in the list of expensive routes. Adding them to the list helped in my situation, so I'm making a PR with these in case it helps others.