### PR TITLE
Do not allow edit of due date for restricted users

### DIFF
--- a/modules/setting/restricted_user.go
+++ b/modules/setting/restricted_user.go
@@ -1,0 +1,14 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package setting
+
+var RestrictedUser = struct {
+	AllowEditDueDate bool
+}{}
+
+func loadRestrictedUserFrom(rootCfg ConfigProvider) {
+	sec := rootCfg.Section("restricted_user")
+
+	RestrictedUser.AllowEditDueDate = sec.Key("ALLOW_EDIT_DUE_DATE").MustBool(false)
+}

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -203,6 +203,7 @@ func LoadSettings() {
 
 	loadDBSetting(CfgProvider)
 	loadServiceFrom(CfgProvider)
+	loadRestrictedUserFrom(CfgProvider)
 	loadOAuth2ClientFrom(CfgProvider)
 	loadCacheFrom(CfgProvider)
 	loadSessionFrom(CfgProvider)

--- a/routers/api/v1/repo/issue.go
+++ b/routers/api/v1/repo/issue.go
@@ -845,6 +845,11 @@ func EditIssue(ctx *context.APIContext) {
 
 	// Update or remove the deadline, only if set and allowed
 	if (form.Deadline != nil || form.RemoveDeadline != nil) && canWrite {
+		if ctx.Doer.IsRestricted && !setting.RestrictedUser.AllowEditDueDate {
+			ctx.APIError(http.StatusForbidden, "restricted users cannot modify due dates")
+			return
+		}
+
 		var deadlineUnix timeutil.TimeStamp
 
 		if form.RemoveDeadline == nil || !*form.RemoveDeadline {

--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -24,6 +24,7 @@ import (
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/markup/markdown"
 	"code.gitea.io/gitea/modules/optional"
+	"code.gitea.io/gitea/modules/setting"
 	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/templates"
 	"code.gitea.io/gitea/modules/util"
@@ -394,6 +395,11 @@ func UpdateIssueDeadline(ctx *context.Context) {
 
 	if !ctx.Repo.CanWriteIssuesOrPulls(issue.IsPull) {
 		ctx.HTTPError(http.StatusForbidden, "", "Not repo writer")
+		return
+	}
+
+	if ctx.Doer.IsRestricted && !setting.RestrictedUser.AllowEditDueDate {
+		ctx.HTTPError(http.StatusForbidden, "", "restricted users cannot modify due dates")
 		return
 	}
 

--- a/routers/web/repo/issue_view.go
+++ b/routers/web/repo/issue_view.go
@@ -412,6 +412,7 @@ func ViewIssue(ctx *context.Context) {
 	ctx.Data["SignInLink"] = setting.AppSubURL + "/user/login?redirect_to=" + url.QueryEscape(ctx.Data["Link"].(string))
 	ctx.Data["IsIssuePoster"] = ctx.IsSigned && issue.IsPoster(ctx.Doer.ID)
 	ctx.Data["HasIssuesOrPullsWritePermission"] = ctx.Repo.CanWriteIssuesOrPulls(issue.IsPull)
+	ctx.Data["AllowEditDueDate"] = ctx.Repo.CanWriteIssuesOrPulls(issue.IsPull) && !(ctx.Doer.IsRestricted && !setting.RestrictedUser.AllowEditDueDate)
 	ctx.Data["HasProjectsWritePermission"] = ctx.Repo.CanWrite(unit.TypeProjects)
 	ctx.Data["IsRepoAdmin"] = ctx.IsSigned && (ctx.Repo.IsAdmin() || ctx.Doer.IsAdmin)
 	ctx.Data["LockReasons"] = setting.Repository.Issue.LockReasons

--- a/templates/repo/issue/sidebar/due_date.tmpl
+++ b/templates/repo/issue/sidebar/due_date.tmpl
@@ -7,7 +7,7 @@
 				{{svg "octicon-calendar"}} {{DateUtils.AbsoluteLong .Issue.DeadlineUnix}}
 			</div>
 			<div class="flex-text-block">
-				{{if and .HasIssuesOrPullsWritePermission (not .Repository.IsArchived)}}
+				{{if and .AllowEditDueDate (not .Repository.IsArchived)}}
 					<a class="issue-due-edit muted" data-tooltip-content="{{ctx.Locale.Tr "repo.issues.due_date_form_edit"}}">{{svg "octicon-pencil"}}</a>
 					<a class="issue-due-remove muted" data-tooltip-content="{{ctx.Locale.Tr "repo.issues.due_date_form_remove"}}">{{svg "octicon-trash"}}</a>
 				{{end}}
@@ -17,7 +17,7 @@
 		{{ctx.Locale.Tr "repo.issues.due_date_not_set"}}
 	{{end}}
 
-	{{if and .HasIssuesOrPullsWritePermission (not .Repository.IsArchived)}}
+	{{if and .AllowEditDueDate (not .Repository.IsArchived)}}
 		<form class="ui fluid action input issue-due-form form-fetch-action tw-mt-2 {{if .Issue.DeadlineUnix}}tw-hidden{{end}}"
 					method="post" action="{{AppSubUrl}}/{{PathEscape .Repository.Owner.Name}}/{{PathEscape .Repository.Name}}/issues/{{.Issue.Index}}/deadline"
 		>


### PR DESCRIPTION
### Summary

This PR introduces a new configuration section for restricted users, starting with a flag that controls whether restricted users are allowed to edit issue due dates.

### Motivation

To improve permission granularity, this PR introduces a dedicated `[restricted_user]` configuration section that can be extended with additional restrictions in the future. As a first step, restricted users are prevented from editing issue due dates unless explicitly enabled by the admin.

### Changes

- Added new module: `modules/setting/restricted_user.go`
  - Central place for all restricted-user-related options, designed for future extension.
- Added new config option:
  - `ALLOW_EDIT_DUE_DATE` (default: `false`)
- Enforced restriction in both API (`PATCH /repos/{owner}/{repo}/issues/{index}`) and web routes.
- Updated issue view and templates to hide due date form and edit/remove controls when not allowed.
 
### Configuration Example
```ini
[restricted_user]
ALLOW_EDIT_DUE_DATE = true
```

### Behavior

- **Default (false)**: Restricted users cannot set, change, or remove due dates.
  - API requests return `403 Forbidden`.
  - Web UI hides due date edit/remove controls.
- **True**: Restricted users can edit due dates if they otherwise have write permission.

### Impact / Compatibility

- Breaking change in default behavior:
  - Before: restricted users could edit due dates if they had write permission.
  - After: restricted users are blocked unless `ALLOW_EDIT_DUE_DATE = true` is explicitly set.
- No changes for unrestricted users.
