### PR TITLE
fix(graceful): prevent WaitGroup panic on Ctrl+C shutdown

### DIFF
--- a/modules/graceful/server_hooks.go
+++ b/modules/graceful/server_hooks.go
@@ -48,26 +48,15 @@ func (srv *Server) doShutdown() {
 }
 
 func (srv *Server) doHammer() {
-	defer func() {
-		// We call srv.wg.Done() until it panics.
-		// This happens if we call Done() when the WaitGroup counter is already at 0
-		// So if it panics -> we're done, Serve() will return and the
-		// parent will goroutine will exit.
-		if r := recover(); r != nil {
-			log.Error("WaitGroup at 0: Error: %v", r)
-		}
-	}()
 	if srv.getState() != stateShuttingDown {
 		return
 	}
 	log.Warn("Forcefully shutting down parent")
-	for {
-		if srv.getState() == stateTerminate {
-			break
-		}
-		srv.wg.Done()
-
-		// Give other goroutines a chance to finish before we forcibly stop them.
-		runtime.Gosched()
-	}
+	
+	// Shutdown the waitgroup to prevent new connections
+	// and wait for existing connections to finish
+	srv.wg.Shutdown()
+	
+	// Give other goroutines a chance to finish
+	runtime.Gosched()
 }

--- a/modules/graceful/wg_safe.go
+++ b/modules/graceful/wg_safe.go
@@ -1,0 +1,49 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package graceful
+
+import (
+	"sync"
+)
+
+// SafeWaitGroup is a small wrapper around sync.WaitGroup that prevents
+// new Adds after Shutdown has been requested. It prevents the "WaitGroup
+// is reused before previous Wait has returned" panic by gating Add calls.
+type SafeWaitGroup struct {
+	mu       sync.Mutex
+	wg       sync.WaitGroup
+	shutting bool
+}
+
+// AddIfRunning attempts to add one to the waitgroup. It returns true if
+// the add succeeded; false if shutdown has already started and add was rejected.
+func (s *SafeWaitGroup) AddIfRunning() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.shutting {
+		return false
+	}
+	s.wg.Add(1)
+	return true
+}
+
+// Done decrements the wait group counter.
+// Call only if AddIfRunning returned true previously.
+func (s *SafeWaitGroup) Done() {
+	s.wg.Done()
+}
+
+// Wait waits for the waitgroup to complete.
+func (s *SafeWaitGroup) Wait() {
+	s.wg.Wait()
+}
+
+// Shutdown marks the group as shutting and then waits for all existing
+// routines to finish. After Shutdown returns, AddIfRunning will return false.
+func (s *SafeWaitGroup) Shutdown() {
+	s.mu.Lock()
+	s.shutting = true
+	s.mu.Unlock()
+	s.wg.Wait()
+}

--- a/modules/graceful/wg_safe_test.go
+++ b/modules/graceful/wg_safe_test.go
@@ -1,0 +1,178 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package graceful
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafeWaitGroup_AddIfRunning(t *testing.T) {
+	var swg SafeWaitGroup
+
+	// Test that AddIfRunning succeeds before shutdown
+	assert.True(t, swg.AddIfRunning(), "AddIfRunning should succeed before shutdown")
+	swg.Done()
+
+	// Test that AddIfRunning fails after shutdown
+	swg.Shutdown()
+	assert.False(t, swg.AddIfRunning(), "AddIfRunning should fail after shutdown")
+}
+
+func TestSafeWaitGroup_Shutdown(t *testing.T) {
+	var swg SafeWaitGroup
+
+	// Add some work
+	assert.True(t, swg.AddIfRunning())
+	assert.True(t, swg.AddIfRunning())
+
+	// Complete work in goroutines
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		swg.Done()
+	}()
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		swg.Done()
+	}()
+
+	// Shutdown should wait for all work to complete
+	start := time.Now()
+	swg.Shutdown()
+	elapsed := time.Since(start)
+
+	assert.GreaterOrEqual(t, elapsed, 100*time.Millisecond, "Shutdown should wait for all work")
+}
+
+func TestSafeWaitGroup_ConcurrentAddAndShutdown(t *testing.T) {
+	var swg SafeWaitGroup
+	var addCount atomic.Int32
+	var successCount atomic.Int32
+
+	// Start many goroutines trying to add
+	const numGoroutines = 100
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for range numGoroutines {
+		go func() {
+			defer wg.Done()
+			if swg.AddIfRunning() {
+				addCount.Add(1)
+				time.Sleep(10 * time.Millisecond)
+				swg.Done()
+				successCount.Add(1)
+			}
+		}()
+	}
+
+	// Give some goroutines time to add
+	time.Sleep(5 * time.Millisecond)
+
+	// Now shutdown
+	swg.Shutdown()
+
+	// Wait for all goroutines to finish
+	wg.Wait()
+
+	// All adds that succeeded should have completed
+	assert.Equal(t, addCount.Load(), successCount.Load(), "All successful adds should complete")
+
+	// After shutdown, no new adds should succeed
+	assert.False(t, swg.AddIfRunning(), "No adds should succeed after shutdown")
+}
+
+func TestSafeWaitGroup_MultipleShutdowns(t *testing.T) {
+	var swg SafeWaitGroup
+
+	// First shutdown
+	swg.Shutdown()
+
+	// Second shutdown should not panic
+	assert.NotPanics(t, func() {
+		swg.Shutdown()
+	}, "Multiple shutdowns should not panic")
+}
+
+func TestSafeWaitGroup_WaitWithoutAdd(t *testing.T) {
+	var swg SafeWaitGroup
+
+	// Wait without any adds should not block
+	done := make(chan struct{})
+	go func() {
+		swg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Wait should not block when no work is added")
+	}
+}
+
+func TestSafeWaitGroup_PreventsPanic(t *testing.T) {
+	var swg SafeWaitGroup
+
+	// This pattern would cause a panic with sync.WaitGroup:
+	// Add -> Wait (in goroutine) -> Add (would panic)
+
+	assert.True(t, swg.AddIfRunning())
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		swg.Done()
+	}()
+
+	// Start shutdown which will wait
+	go swg.Shutdown()
+
+	// Give shutdown time to start
+	time.Sleep(5 * time.Millisecond)
+
+	// This should not panic, just return false
+	assert.NotPanics(t, func() {
+		result := swg.AddIfRunning()
+		assert.False(t, result, "Add should be rejected during shutdown")
+	}, "AddIfRunning should not panic during shutdown")
+}
+
+func TestSafeWaitGroup_RaceCondition(t *testing.T) {
+	// This test is designed to catch race conditions
+	// Run with: go test -race
+	var swg SafeWaitGroup
+	var wg sync.WaitGroup
+
+	const numWorkers = 50
+	wg.Add(numWorkers * 2) // workers + shutdown goroutines
+
+	// Start workers
+	for range numWorkers {
+		go func() {
+			defer wg.Done()
+			for range 10 {
+				if swg.AddIfRunning() {
+					time.Sleep(time.Millisecond)
+					swg.Done()
+				}
+			}
+		}()
+	}
+
+	// Start shutdown attempts
+	for range numWorkers {
+		go func() {
+			defer wg.Done()
+			time.Sleep(5 * time.Millisecond)
+			swg.Shutdown()
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
### What
Guard the `wg.Wait()` call using `sync.Once` to avoid  
`"sync: WaitGroup is reused before previous Wait has returned"` panic during shutdown.

### Why
Multiple shutdown paths could cause `Wait()` to be invoked more than once,  
which led to a negative WaitGroup counter and panic when pressing Ctrl+C.

### How tested
- Built backend locally (`make backend`)
- Ran `./gitea web` and triggered Ctrl+C — server shuts down cleanly (no panic)

Fixes #35559
