### PR TITLE
Add filtering functionality for team repositories

### DIFF
--- a/models/repo/org_repo.go
+++ b/models/repo/org_repo.go
@@ -178,3 +178,14 @@ func (env *accessibleReposEnv) AddKeyword(keyword string) {
 func (env *accessibleReposEnv) SetSort(orderBy db.SearchOrderBy) {
 	env.orderBy = orderBy
 }
+
+// Add a new function to filter repositories by a search term
+func GetFilteredTeamRepositories(teamID int64, searchTerm string) ([]*Repository, error) {
+	// Query to fetch repositories with filtering
+	repos := make([]*Repository, 0, 10)
+	sess := x.Where("team_id = ?", teamID)
+	if searchTerm != "" {
+		sess = sess.And("name LIKE ?", "%"+searchTerm+"%")
+	}
+	return repos, sess.Find(&repos)
+}

--- a/routers/web/org/teams.go
+++ b/routers/web/org/teams.go
@@ -416,15 +416,16 @@ func TeamRepositories(ctx *context.Context) {
 	ctx.Data["PageIsOrgTeams"] = true
 	ctx.Data["PageIsOrgTeamRepos"] = true
 
-	repos, err := repo_model.GetTeamRepositories(ctx, &repo_model.SearchTeamRepoOptions{
-		TeamID: ctx.Org.Team.ID,
-	})
+	searchTerm := ctx.FormTrim("q") // Get the search term from the query parameter
+	repos, err := repo_model.GetFilteredTeamRepositories(ctx.Org.Team.ID, searchTerm)
 	if err != nil {
-		ctx.ServerError("GetTeamRepositories", err)
+		ctx.ServerError("GetFilteredTeamRepositories", err)
 		return
 	}
+
 	ctx.Data["Units"] = unit_model.Units
 	ctx.Data["TeamRepos"] = repos
+	ctx.Data["SearchTerm"] = searchTerm // Pass the search term back to the template
 	ctx.HTML(http.StatusOK, tplTeamRepositories)
 }
 


### PR DESCRIPTION
This PR introduces the ability to filter repositories within a team project in Gitea. 

### Changes:
- Added a new function `GetFilteredTeamRepositories` in `models/repo/org_repo.go` to filter repositories by a search term.
- Updated the `TeamRepositories` handler in `routers/web/org/teams.go` to accept a search parameter (`q`) and use the filtering function.
- Passed the search term back to the template for better user experience.

### Problem Solved:
Large organizations often have dozens or hundreds of repositories assigned to teams. This feature allows users to quickly narrow down results, improving navigation efficiency.

### Testing:
- Ensure the search parameter (`q`) filters repositories correctly.
- Verify that the feature does not break existing functionality.