### PR TITLE
Mock external service in hcaptcha TestCaptcha

### DIFF
--- a/modules/hcaptcha/hcaptcha.go
+++ b/modules/hcaptcha/hcaptcha.go
@@ -14,7 +14,7 @@ import (
 	"code.gitea.io/gitea/modules/setting"
 )
 
-const verifyURL = "https://hcaptcha.com/siteverify"
+const VerifyURL = "https://hcaptcha.com/siteverify"
 
 // Client is an hCaptcha client
 type Client struct {
@@ -93,7 +93,7 @@ func (c *Client) Verify(token string, opts PostOptions) (*Response, error) {
 	}
 
 	// Basically a copy of http.PostForm, but with a context
-	req, err := http.NewRequestWithContext(c.ctx, http.MethodPost, verifyURL, strings.NewReader(post.Encode()))
+	req, err := http.NewRequestWithContext(c.ctx, http.MethodPost, VerifyURL, strings.NewReader(post.Encode()))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/hcaptcha/hcaptcha.go
+++ b/modules/hcaptcha/hcaptcha.go
@@ -14,7 +14,7 @@ import (
 	"code.gitea.io/gitea/modules/setting"
 )
 
-const VerifyURL = "https://hcaptcha.com/siteverify"
+const verifyURL = "https://hcaptcha.com/siteverify"
 
 // Client is an hCaptcha client
 type Client struct {
@@ -93,7 +93,7 @@ func (c *Client) Verify(token string, opts PostOptions) (*Response, error) {
 	}
 
 	// Basically a copy of http.PostForm, but with a context
-	req, err := http.NewRequestWithContext(c.ctx, http.MethodPost, VerifyURL, strings.NewReader(post.Encode()))
+	req, err := http.NewRequestWithContext(c.ctx, http.MethodPost, verifyURL, strings.NewReader(post.Encode()))
 	if err != nil {
 		return nil, err
 	}

--- a/modules/hcaptcha/hcaptcha_test.go
+++ b/modules/hcaptcha/hcaptcha_test.go
@@ -36,13 +36,19 @@ func (mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
-	values, err := url.ParseQuery(string(body))
-	token := values.Get("response")
-	if token == dummyToken {
-		return &http.Response{Request: req, Body: io.NopCloser(strings.NewReader(`{"success":true,"credit":false,"hostname":"dummy-key-pass","challenge_ts":"2025-10-08T16:02:56.136Z"}`))}, nil
-	} else {
-		return &http.Response{Request: req, Body: io.NopCloser(strings.NewReader(`{"success":false,"error-codes":["invalid-input-response"]}`))}, nil
+	bodyValues, err := url.ParseQuery(string(body))
+	if err != nil {
+		return nil, err
 	}
+
+	var responseText string
+	if bodyValues.Get("response") == dummyToken {
+		responseText = `{"success":true,"credit":false,"hostname":"dummy-key-pass","challenge_ts":"2025-10-08T16:02:56.136Z"}`
+	} else {
+		responseText = `{"success":false,"error-codes":["invalid-input-response"]}`
+	}
+
+	return &http.Response{Request: req, Body: io.NopCloser(strings.NewReader(responseText))}, nil
 }
 
 func TestCaptcha(t *testing.T) {

--- a/modules/hcaptcha/hcaptcha_test.go
+++ b/modules/hcaptcha/hcaptcha_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 type mockTransport struct{}
 
 func (mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if req.URL.String() != VerifyURL {
+	if req.URL.String() != verifyURL {
 		return nil, errors.New("unsupported url")
 	}
 

--- a/modules/hcaptcha/hcaptcha_test.go
+++ b/modules/hcaptcha/hcaptcha_test.go
@@ -28,7 +28,7 @@ type mockTransport struct{}
 
 func (mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if req.URL.String() != VerifyURL {
-		return nil, errors.New("unsupported host")
+		return nil, errors.New("unsupported url")
 	}
 
 	body, err := io.ReadAll(req.Body)


### PR DESCRIPTION
The test calls out to a web service which may be down or unreachable as seen in the linked issue. It's better for tests to not have such external dependencies to make them absolutely stable.

Fixes: https://github.com/go-gitea/gitea/issues/35571