### PR TITLE
Add inline diff in repos/pulls/files api

### DIFF
--- a/modules/structs/pull.go
+++ b/modules/structs/pull.go
@@ -188,4 +188,6 @@ type ChangedFile struct {
 	ContentsURL string `json:"contents_url,omitempty"`
 	// The raw URL to download the file
 	RawURL string `json:"raw_url,omitempty"`
+	// The patch text for the file changes
+	Patch string `json:"patch,omitempty"`
 }

--- a/services/convert/convert.go
+++ b/services/convert/convert.go
@@ -812,6 +812,7 @@ func ToChangedFile(f *gitdiff.DiffFile, repo *repo_model.Repository, commit stri
 		HTMLURL:          fmt.Sprint(repo.HTMLURL(), "/src/commit/", commit, "/", util.PathEscapeSegments(f.GetDiffFileName())),
 		ContentsURL:      fmt.Sprint(repo.APIURL(), "/contents/", util.PathEscapeSegments(f.GetDiffFileName()), "?ref=", commit),
 		RawURL:           fmt.Sprint(repo.HTMLURL(), "/raw/commit/", commit, "/", util.PathEscapeSegments(f.GetDiffFileName())),
+		Patch:            gitdiff.RenderUnifiedDiff(f),
 	}
 
 	return file

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -22121,6 +22121,11 @@
           "type": "string",
           "x-go-name": "HTMLURL"
         },
+        "patch": {
+          "description": "The patch text for the file changes",
+          "type": "string",
+          "x-go-name": "Patch"
+        },
         "previous_filename": {
           "description": "The previous filename if the file was renamed",
           "type": "string",

--- a/tests/integration/api_pull_test.go
+++ b/tests/integration/api_pull_test.go
@@ -80,6 +80,7 @@ func TestAPIViewPulls(t *testing.T) {
 					assert.Equal(t, 1, files[0].Changes)
 					assert.Equal(t, 0, files[0].Deletions)
 					assert.Equal(t, "added", files[0].Status)
+					assert.Equal(t, gitdiff.RenderUnifiedDiff(patch.Files[0]), files[0].Patch)
 				}
 			}))
 	}


### PR DESCRIPTION
Add the inline diff on a per file basis to be compatible with GitHub

Example:

```
curl http://localhost:3000/api/v1/repos/cedstrom/test/pulls/1/files?token=[redacted]
```

```
[
    {
        "filename": ".gitignore",
        "status": "added",
        "additions": 2,
        "deletions": 0,
        "changes": 2,
        "html_url": "http://localhost:3000/cedstrom/test/src/commit/ce2c53223388eaaa026c25156b807e30acc05a56/.gitignore",
        "contents_url": "http://localhost:3000/api/v1/repos/cedstrom/test/contents/.gitignore?ref=ce2c53223388eaaa026c25156b807e30acc05a56",
        "raw_url": "http://localhost:3000/cedstrom/test/raw/commit/ce2c53223388eaaa026c25156b807e30acc05a56/.gitignore",
        "patch": "diff --git a/.gitignore b/.gitignore\n--- a/.gitignore\n+++ b/.gitignore\n@@ -0,1 +1,2 @@\n @@ -0,0 +1,2 @@\n++.env\n++.env.local\n\n"
    },
    {
        "filename": "README.md",
        "status": "changed",
        "additions": 1,
        "deletions": 0,
        "changes": 1,
        "html_url": "http://localhost:3000/cedstrom/test/src/commit/ce2c53223388eaaa026c25156b807e30acc05a56/README.md",
        "contents_url": "http://localhost:3000/api/v1/repos/cedstrom/test/contents/README.md?ref=ce2c53223388eaaa026c25156b807e30acc05a56",
        "raw_url": "http://localhost:3000/cedstrom/test/raw/commit/ce2c53223388eaaa026c25156b807e30acc05a56/README.md",
        "patch": "diff --git a/README.md b/README.md\n--- a/README.md\n+++ b/README.md\n@@ -1,2 +1,3 @@\n @@ -1,2 +1,3 @@\n  # test\n  \n++This is my first PR.\n\n"
    }
]
```