### PR TITLE
Fix code tag style problem and LFS view bug

### DIFF
--- a/routers/web/repo/setting/lfs.go
+++ b/routers/web/repo/setting/lfs.go
@@ -270,8 +270,7 @@ func LFSFileGet(ctx *context.Context) {
 	// FIXME: there is no IsPlainText set, but template uses it
 	ctx.Data["IsTextFile"] = st.IsText()
 	ctx.Data["FileSize"] = meta.Size
-	// FIXME: the last field is the URL-base64-encoded filename, it should not be "direct"
-	ctx.Data["RawFileLink"] = fmt.Sprintf("%s%s/%s.git/info/lfs/objects/%s/%s", setting.AppURL, url.PathEscape(ctx.Repo.Repository.OwnerName), url.PathEscape(ctx.Repo.Repository.Name), url.PathEscape(meta.Oid), "direct")
+	ctx.Data["RawFileLink"] = fmt.Sprintf("%s/%s/%s.git/info/lfs/objects/%s", setting.AppSubURL, url.PathEscape(ctx.Repo.Repository.OwnerName), url.PathEscape(ctx.Repo.Repository.Name), url.PathEscape(meta.Oid))
 	switch {
 	case st.IsRepresentableAsText():
 		if meta.Size >= setting.UI.MaxDisplayFileSize {

--- a/templates/admin/config.tmpl
+++ b/templates/admin/config.tmpl
@@ -252,9 +252,9 @@
 				{{end}}
 				{{if .CacheConn}}
 					<dt>{{ctx.Locale.Tr "admin.config.cache_conn"}}</dt>
-					<dd><code>{{.CacheConn}}</code></dd>
+					<dd>{{.CacheConn}}</dd>
 					<dt>{{ctx.Locale.Tr "admin.config.cache_item_ttl"}}</dt>
-					<dd><code>{{.CacheItemTTL}}</code></dd>
+					<dd>{{.CacheItemTTL}}</dd>
 				{{end}}
 				<div class="divider"></div>
 				<dt class="tw-py-1 tw-flex tw-items-center">{{ctx.Locale.Tr "admin.config.cache_test"}}</dt>
@@ -275,7 +275,7 @@
 				<dt>{{ctx.Locale.Tr "admin.config.session_provider"}}</dt>
 				<dd>{{.SessionConfig.Provider}}</dd>
 				<dt>{{ctx.Locale.Tr "admin.config.provider_config"}}</dt>
-				<dd><code>{{if .SessionConfig.ProviderConfig}}{{.SessionConfig.ProviderConfig}}{{else}}-{{end}}</code></dd>
+				<dd>{{if .SessionConfig.ProviderConfig}}{{.SessionConfig.ProviderConfig}}{{else}}-{{end}}</dd>
 				<dt>{{ctx.Locale.Tr "admin.config.cookie_name"}}</dt>
 				<dd>{{.SessionConfig.CookieName}}</dd>
 				<dt>{{ctx.Locale.Tr "admin.config.gc_interval_time"}}</dt>
@@ -301,7 +301,7 @@
 				<dt>{{ctx.Locale.Tr "admin.config.git_max_diff_files"}}</dt>
 				<dd>{{.Git.MaxGitDiffFiles}}</dd>
 				<dt>{{ctx.Locale.Tr "admin.config.git_gc_args"}}</dt>
-				<dd><code>{{.Git.GCArgs}}</code></dd>
+				<dd>{{.Git.GCArgs}}</dd>
 
 				<div class="divider"></div>
 
@@ -330,7 +330,7 @@
 
 				{{if .Loggers.access.IsEnabled}}
 					<dt>{{ctx.Locale.Tr "admin.config.access_log_template"}}</dt>
-					<dd><code>{{$.AccessLogTemplate}}</code></dd>
+					<dd>{{$.AccessLogTemplate}}</dd>
 				{{end}}
 
 				{{range $loggerName, $loggerDetail := .Loggers}}

--- a/templates/admin/stacktrace-row.tmpl
+++ b/templates/admin/stacktrace-row.tmpl
@@ -46,8 +46,8 @@
 								<div class="item tw-flex tw-items-center">
 									<span class="icon tw-mr-4">{{svg "octicon-dot-fill" 16}}</span>
 									<div class="content tw-flex-1">
-										<div class="header"><code>{{.Function}}</code></div>
-										<div class="description"><code>{{.File}}:{{.Line}}</code></div>
+										<div class="header">{{.Function}}</div>
+										<div class="description">{{.File}}:{{.Line}}</div>
 									</div>
 								</div>
 							{{end}}

--- a/templates/base/alert_details.tmpl
+++ b/templates/base/alert_details.tmpl
@@ -2,7 +2,7 @@
 {{if .Details}}
 <details>
 	<summary>{{.Summary}}</summary>
-	<code>{{.Details | SanitizeHTML}}</code>
+	{{.Details | SanitizeHTML}}
 </details>
 {{else}}
 <div>

--- a/templates/projects/view.tmpl
+++ b/templates/projects/view.tmpl
@@ -65,7 +65,9 @@
 	</div>
 
 	<div class="ui container project-description">
-		{{$.Project.RenderedContent}}
+		<div class="render-content markup">
+			{{$.Project.RenderedContent}}
+		</div>
 		<div class="divider"></div>
 	</div>
 

--- a/templates/repo/settings/lfs_file.tmpl
+++ b/templates/repo/settings/lfs_file.tmpl
@@ -39,7 +39,7 @@
 							<tbody>
 								<tr>
 									<td class="lines-num">{{.LineNums}}</td>
-									<td class="lines-code"><pre><code class="{{.HighlightClass}}"><ol>{{.FileContent}}</ol></code></pre></td>
+									<td class="lines-code"><pre>{{.FileContent}}</pre></td>
 								</tr>
 							</tbody>
 						</table>

--- a/templates/repo/settings/webhook/history.tmpl
+++ b/templates/repo/settings/webhook/history.tmpl
@@ -68,7 +68,7 @@
 {{range $key, $val := .RequestInfo.Headers}}<strong>{{$key}}:</strong> {{$val}}
 {{end}}</pre>
 								<h5>{{ctx.Locale.Tr "repo.settings.webhook.payload"}}</h5>
-								<pre class="webhook-info"><code class="json">{{or .RequestInfo.Body .PayloadContent}}</code></pre>
+								<pre class="webhook-info">{{or .RequestInfo.Body .PayloadContent}}</pre>
 							{{else}}
 								-
 							{{end}}
@@ -79,7 +79,7 @@
 								<pre class="webhook-info">{{range $key, $val := .ResponseInfo.Headers}}<strong>{{$key}}:</strong> {{$val}}
 {{end}}</pre>
 								<h5>{{ctx.Locale.Tr "repo.settings.webhook.body"}}</h5>
-								<pre class="webhook-info"><code>{{.ResponseInfo.Body}}</code></pre>
+								<pre class="webhook-info">{{.ResponseInfo.Body}}</pre>
 							{{else}}
 								-
 							{{end}}

--- a/templates/user/settings/keys_gpg.tmpl
+++ b/templates/user/settings/keys_gpg.tmpl
@@ -22,7 +22,7 @@
 					<input readonly="" value="{{.TokenToSign}}">
 					<div class="help">
 						<p>{{ctx.Locale.Tr "settings.gpg_token_help"}}</p>
-						<p><code>{{printf `echo "%s" | gpg -a --default-key %s --detach-sig` .TokenToSign .PaddedKeyID}}</code></p>
+						<p>{{printf `echo "%s" | gpg -a --default-key %s --detach-sig` .TokenToSign .PaddedKeyID}}</p>
 					</div>
 				</div>
 				<div class="field">
@@ -90,7 +90,7 @@
 							<input readonly="" value="{{$.TokenToSign}}">
 							<div class="help">
 								<p>{{ctx.Locale.Tr "settings.gpg_token_help"}}</p>
-								<p><code>{{printf `echo "%s" | gpg -a --default-key %s --detach-sig` $.TokenToSign .PaddedKeyID}}</code></p>
+								<p>{{printf `echo "%s" | gpg -a --default-key %s --detach-sig` $.TokenToSign .PaddedKeyID}}</p>
 							</div>
 							<br>
 						</div>

--- a/templates/user/settings/keys_gpg.tmpl
+++ b/templates/user/settings/keys_gpg.tmpl
@@ -21,8 +21,8 @@
 					<label for="token">{{ctx.Locale.Tr "settings.gpg_token"}}</label>
 					<input readonly="" value="{{.TokenToSign}}">
 					<div class="help">
-						<p>{{ctx.Locale.Tr "settings.gpg_token_help"}}</p>
-						<p>{{printf `echo "%s" | gpg -a --default-key %s --detach-sig` .TokenToSign .PaddedKeyID}}</p>
+						{{ctx.Locale.Tr "settings.gpg_token_help"}}
+						<pre class="command-block">{{printf `echo "%s" | gpg -a --default-key %s --detach-sig` .TokenToSign .PaddedKeyID}}</pre>
 					</div>
 				</div>
 				<div class="field">
@@ -89,8 +89,8 @@
 							<label for="token">{{ctx.Locale.Tr "settings.gpg_token"}}</label>
 							<input readonly="" value="{{$.TokenToSign}}">
 							<div class="help">
-								<p>{{ctx.Locale.Tr "settings.gpg_token_help"}}</p>
-								<p>{{printf `echo "%s" | gpg -a --default-key %s --detach-sig` $.TokenToSign .PaddedKeyID}}</p>
+								{{ctx.Locale.Tr "settings.gpg_token_help"}}
+								<pre class="command-block">{{printf `echo "%s" | gpg -a --default-key %s --detach-sig` $.TokenToSign .PaddedKeyID}}</pre>
 							</div>
 							<br>
 						</div>

--- a/templates/user/settings/keys_ssh.tmpl
+++ b/templates/user/settings/keys_ssh.tmpl
@@ -78,15 +78,15 @@
 							<input readonly="" value="{{$.TokenToSign}}">
 							<div class="help">
 								<p>{{ctx.Locale.Tr "settings.ssh_token_help"}}</p>
-								<p><code>echo -n '{{$.TokenToSign}}' | ssh-keygen -Y sign -n gitea -f /path_to_PrivateKey_or_RelatedPublicKey</code></p>
+								<p>echo -n '{{$.TokenToSign}}' | ssh-keygen -Y sign -n gitea -f /path_to_PrivateKey_or_RelatedPublicKey</p>
 								<details>
 									<summary>Windows PowerShell</summary>
-									<p><code>cmd /c "&lt;NUL set /p=`"{{$.TokenToSign}}`"| ssh-keygen -Y sign -n gitea -f /path_to_PrivateKey_or_RelatedPublicKey"</code></p>
+									<p>cmd /c "&lt;NUL set /p=`"{{$.TokenToSign}}`"| ssh-keygen -Y sign -n gitea -f /path_to_PrivateKey_or_RelatedPublicKey"</p>
 								</details>
 								<br>
 								<details>
 									<summary>Windows CMD</summary>
-									<p><code>set /p={{$.TokenToSign}}| ssh-keygen -Y sign -n gitea -f /path_to_PrivateKey_or_RelatedPublicKey</code></p>
+									<p>set /p={{$.TokenToSign}}| ssh-keygen -Y sign -n gitea -f /path_to_PrivateKey_or_RelatedPublicKey</p>
 								</details>
 							</div>
 							<br>

--- a/templates/user/settings/keys_ssh.tmpl
+++ b/templates/user/settings/keys_ssh.tmpl
@@ -77,16 +77,15 @@
 							<label for="token">{{ctx.Locale.Tr "settings.ssh_token"}}</label>
 							<input readonly="" value="{{$.TokenToSign}}">
 							<div class="help">
-								<p>{{ctx.Locale.Tr "settings.ssh_token_help"}}</p>
-								<p>echo -n '{{$.TokenToSign}}' | ssh-keygen -Y sign -n gitea -f /path_to_PrivateKey_or_RelatedPublicKey</p>
+								{{ctx.Locale.Tr "settings.ssh_token_help"}}
+								<pre class="command-block">echo -n '{{$.TokenToSign}}' | ssh-keygen -Y sign -n gitea -f /path_to_PrivateKey_or_RelatedPublicKey</pre>
 								<details>
 									<summary>Windows PowerShell</summary>
-									<p>cmd /c "&lt;NUL set /p=`"{{$.TokenToSign}}`"| ssh-keygen -Y sign -n gitea -f /path_to_PrivateKey_or_RelatedPublicKey"</p>
+									<pre class="command-block">cmd /c "&lt;NUL set /p=`"{{$.TokenToSign}}`"| ssh-keygen -Y sign -n gitea -f /path_to_PrivateKey_or_RelatedPublicKey"</pre>
 								</details>
-								<br>
 								<details>
 									<summary>Windows CMD</summary>
-									<p>set /p={{$.TokenToSign}}| ssh-keygen -Y sign -n gitea -f /path_to_PrivateKey_or_RelatedPublicKey</p>
+									<pre class="command-block">set /p={{$.TokenToSign}}| ssh-keygen -Y sign -n gitea -f /path_to_PrivateKey_or_RelatedPublicKey</pre>
 								</details>
 							</div>
 							<br>

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -101,13 +101,6 @@ samp,
   font-size: 0.95em; /* compensate for monospace fonts being usually slightly larger */
 }
 
-code {
-  padding: 1px 4px;
-  border-radius: var(--border-radius);
-  background-color: var(--color-label-bg);
-  color: var(--color-label-text);
-}
-
 b,
 strong,
 h1,
@@ -302,6 +295,13 @@ a.label,
 .ui.cards a.card,
 .issue-keyword a {
   text-decoration-line: none !important;
+}
+
+.help code {
+  padding: 1px 4px;
+  border-radius: var(--border-radius);
+  background-color: var(--color-label-bg);
+  color: var(--color-label-text);
 }
 
 .ui.search > .results {

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -101,6 +101,15 @@ samp,
   font-size: 0.95em; /* compensate for monospace fonts being usually slightly larger */
 }
 
+/* there are many <code> blocks in non-markup(.markup code) / non-code-diff(code.code-inner) containers (for example: translation strings, etc),
+so we need to make <code> have default global styles, ".markup code" has its own styles and doesn't conflict, but `.code-inner` is special.
+TODO: in the future, we should use `div` instead of `code` for `.code-inner` because it is a container for highlighted code line */
+code:not(.code-inner) {
+  padding: 1px 4px;
+  border-radius: var(--border-radius);
+  background-color: var(--color-label-bg);
+}
+
 b,
 strong,
 h1,
@@ -295,13 +304,6 @@ a.label,
 .ui.cards a.card,
 .issue-keyword a {
   text-decoration-line: none !important;
-}
-
-.help code {
-  padding: 1px 4px;
-  border-radius: var(--border-radius);
-  background-color: var(--color-label-bg);
-  color: var(--color-label-text);
 }
 
 .ui.search > .results {

--- a/web_src/css/form.css
+++ b/web_src/css/form.css
@@ -228,6 +228,12 @@ textarea:focus,
   color: var(--color-text-light-1);
 }
 
+.form .help pre.command-block {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  margin: 0.25em 0 0.25em 1em;
+}
+
 .m-captcha-style {
   width: 100%;
   height: 5em;


### PR DESCRIPTION
#35567

Limit the style of the code to the help information and avoid applying it to the code preview

<img width="548" height="447" alt="image" src="https://github.com/user-attachments/assets/de8a95db-5e05-4c63-bae9-631679eab522" />
