### PR TITLE
fix flaky mssql test

### DIFF
--- a/services/issue/comments.go
+++ b/services/issue/comments.go
@@ -162,6 +162,13 @@ func LoadCommentPushCommits(ctx context.Context, c *issues_model.Comment) (err e
 		return err
 	}
 
+	if err := c.LoadIssue(ctx); err != nil {
+		return err
+	}
+	if err := c.Issue.LoadRepo(ctx); err != nil {
+		return err
+	}
+
 	c.IsForcePush = data.IsForcePush
 
 	if c.IsForcePush {


### PR DESCRIPTION
In one of my other PRs I noticed that the mssql test was flaky (output here: https://github.com/go-gitea/gitea/actions/runs/18435115337/job/52527538242 ) and it was possible in rare-cases, due to timings, that the else branch below my code was triggered and c.Issue.Repo wasn't loaded causing a nil reference.