### PR TITLE
Use LFS object size instead of blob size when viewing a LFS file

### DIFF
--- a/routers/web/repo/editor.go
+++ b/routers/web/repo/editor.go
@@ -295,14 +295,14 @@ func EditFile(ctx *context.Context) {
 		}
 		defer dataRc.Close()
 
-		ctx.Data["FileSize"] = fInfo.fileSize
+		ctx.Data["FileSize"] = fInfo.blobOrLfsSize
 
 		// Only some file types are editable online as text.
 		if fInfo.isLFSFile() {
 			ctx.Data["NotEditableReason"] = ctx.Tr("repo.editor.cannot_edit_lfs_files")
 		} else if !fInfo.st.IsRepresentableAsText() {
 			ctx.Data["NotEditableReason"] = ctx.Tr("repo.editor.cannot_edit_non_text_files")
-		} else if fInfo.fileSize >= setting.UI.MaxDisplayFileSize {
+		} else if fInfo.blobOrLfsSize >= setting.UI.MaxDisplayFileSize {
 			ctx.Data["NotEditableReason"] = ctx.Tr("repo.editor.cannot_edit_too_large_file")
 		}
 

--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -114,7 +114,7 @@ func getFileReader(ctx gocontext.Context, repoID int64, blob *git.Blob) (buf []b
 	}
 	buf = buf[:n]
 	fi.st = typesniffer.DetectContentType(buf)
-	fi.fileSize = blob.Size()
+	fi.fileSize = meta.Pointer.Size
 	fi.lfsMeta = &meta.Pointer
 	return buf, dataRc, fi, nil
 }

--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -60,9 +60,9 @@ const (
 )
 
 type fileInfo struct {
-	fileSize int64
-	lfsMeta  *lfs.Pointer
-	st       typesniffer.SniffedType
+	blobOrLfsSize int64
+	lfsMeta       *lfs.Pointer
+	st            typesniffer.SniffedType
 }
 
 func (fi *fileInfo) isLFSFile() bool {
@@ -81,7 +81,7 @@ func getFileReader(ctx gocontext.Context, repoID int64, blob *git.Blob) (buf []b
 	n, _ := util.ReadAtMost(dataRc, buf)
 	buf = buf[:n]
 
-	fi = &fileInfo{fileSize: blob.Size(), st: typesniffer.DetectContentType(buf)}
+	fi = &fileInfo{blobOrLfsSize: blob.Size(), st: typesniffer.DetectContentType(buf)}
 
 	// FIXME: what happens when README file is an image?
 	if !fi.st.IsText() || !setting.LFS.StartServer {
@@ -114,7 +114,7 @@ func getFileReader(ctx gocontext.Context, repoID int64, blob *git.Blob) (buf []b
 	}
 	buf = buf[:n]
 	fi.st = typesniffer.DetectContentType(buf)
-	fi.fileSize = meta.Pointer.Size
+	fi.blobOrLfsSize = meta.Pointer.Size
 	fi.lfsMeta = &meta.Pointer
 	return buf, dataRc, fi, nil
 }

--- a/routers/web/repo/view_file.go
+++ b/routers/web/repo/view_file.go
@@ -226,7 +226,7 @@ func prepareFileView(ctx *context.Context, entry *git.TreeEntry) {
 	}
 
 	ctx.Data["IsLFSFile"] = fInfo.isLFSFile()
-	ctx.Data["FileSize"] = fInfo.fileSize
+	ctx.Data["FileSize"] = fInfo.blobOrLfsSize
 	ctx.Data["IsRepresentableAsText"] = fInfo.st.IsRepresentableAsText()
 	ctx.Data["IsExecutable"] = entry.IsExecutable()
 	ctx.Data["CanCopyContent"] = fInfo.st.IsRepresentableAsText() || fInfo.st.IsImage()
@@ -243,7 +243,7 @@ func prepareFileView(ctx *context.Context, entry *git.TreeEntry) {
 
 	utf8Reader := charset.ToUTF8WithFallbackReader(io.MultiReader(bytes.NewReader(buf), dataRc), charset.ConvertOpts{})
 	switch {
-	case fInfo.fileSize >= setting.UI.MaxDisplayFileSize:
+	case fInfo.blobOrLfsSize >= setting.UI.MaxDisplayFileSize:
 		ctx.Data["IsFileTooLarge"] = true
 	case handleFileViewRenderMarkup(ctx, entry.Name(), fInfo.st, buf, utf8Reader):
 		// it also sets ctx.Data["FileContent"] and more

--- a/routers/web/repo/view_readme.go
+++ b/routers/web/repo/view_readme.go
@@ -170,7 +170,7 @@ func prepareToRenderReadmeFile(ctx *context.Context, subfolder string, readmeFil
 
 	ctx.Data["FileIsText"] = fInfo.st.IsText()
 	ctx.Data["FileTreePath"] = readmeFullPath
-	ctx.Data["FileSize"] = fInfo.fileSize
+	ctx.Data["FileSize"] = fInfo.blobOrLfsSize
 	ctx.Data["IsLFSFile"] = fInfo.isLFSFile()
 
 	if fInfo.isLFSFile() {
@@ -182,7 +182,7 @@ func prepareToRenderReadmeFile(ctx *context.Context, subfolder string, readmeFil
 		return
 	}
 
-	if fInfo.fileSize >= setting.UI.MaxDisplayFileSize {
+	if fInfo.blobOrLfsSize >= setting.UI.MaxDisplayFileSize {
 		// Pretend that this is a normal text file to display 'This file is too large to be shown'
 		ctx.Data["IsFileTooLarge"] = true
 		return

--- a/templates/repo/file_info.tmpl
+++ b/templates/repo/file_info.tmpl
@@ -11,11 +11,11 @@
 	{{end}}
 	{{if ne .FileSize nil}}
 		<div class="file-info-entry">
-			{{FileSize .FileSize}}{{if .IsLFSFile}}<span class="ui label">LFS</span>{{end}}
+			<span class="file-info-size">{{FileSize .FileSize}}</span>{{if .IsLFSFile}}<span class="ui label">LFS</span>{{end}}
 		</div>
 	{{end}}
 	{{if .LFSLock}}
-		<div class="file-info-entry ui" data-tooltip-content="{{.LFSLockHint}}">
+		<div class="file-info-entry" data-tooltip-content="{{.LFSLockHint}}">
 			{{svg "octicon-lock" 16 "tw-mr-1"}}
 			<a href="{{.LFSLockOwnerHomeLink}}">{{.LFSLockOwner}}</a>
 		</div>

--- a/tests/integration/lfs_view_test.go
+++ b/tests/integration/lfs_view_test.go
@@ -72,6 +72,8 @@ func TestLFSRender(t *testing.T) {
 
 		fileInfo := doc.Find("div.file-info-entry").First().Text()
 		assert.Contains(t, fileInfo, "LFS")
+		fileSize := doc.Find("div.file-info-entry > .file-info-size").Text()
+		assert.Equal(t, "2.0 KiB", fileSize)
 
 		// find new file view container
 		fileViewContainer := doc.Find("[data-global-init=initRepoFileView]")

--- a/tests/integration/repo_test.go
+++ b/tests/integration/repo_test.go
@@ -257,10 +257,12 @@ func testViewFileInRepo(t *testing.T) {
 	description := htmlDoc.doc.Find(".repo-description")
 	repoTopics := htmlDoc.doc.Find("#repo-topics")
 	repoSummary := htmlDoc.doc.Find(".repository-summary")
+	fileSize := htmlDoc.Find("div.file-info-entry > .file-info-size").Text()
 
 	assert.Equal(t, 0, description.Length())
 	assert.Equal(t, 0, repoTopics.Length())
 	assert.Equal(t, 0, repoSummary.Length())
+	assert.Equal(t, "30 B", fileSize)
 }
 
 // TestBlameFileInRepo repo description, topics and summary should not be displayed when running blame on a file

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -1582,6 +1582,7 @@ tbody.commit-list {
   display: flex;
   align-items: center;
   width: max-content;
+  gap: 0.25em;
 }
 
 .file-info-entry + .file-info-entry {


### PR DESCRIPTION
shows the main LFS filesize instead of the pointer filesize when viewing a file
