### PR TITLE
Bump `actions/labeler` to v6

### DIFF
--- a/.github/workflows/pull-labeler.yml
+++ b/.github/workflows/pull-labeler.yml
@@ -15,6 +15,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
           sync-labels: true


### PR DESCRIPTION
https://github.com/actions/labeler/releases/tag/v6.0.0