### PR TITLE
Fix workflow run event status while rerunning a failed job

### DIFF
--- a/routers/web/repo/actions/view.go
+++ b/routers/web/repo/actions/view.go
@@ -432,6 +432,7 @@ func Rerun(ctx *context_module.Context) {
 		run.PreviousDuration = run.Duration()
 		run.Started = 0
 		run.Stopped = 0
+		run.Status = actions_model.StatusWaiting
 
 		vars, err := actions_model.GetVariablesOfRun(ctx, run)
 		if err != nil {

--- a/tests/integration/repo_webhook_test.go
+++ b/tests/integration/repo_webhook_test.go
@@ -1418,7 +1418,7 @@ jobs:
 	assert.Equal(t, "user2/repo1", webhookData.payloads[1].Repo.FullName)
 
 	// Call rerun ui api
-	// Only a web UI API exists for cancelling workflow runs, so use the UI endpoint.
+	// Only a web UI API exists for rerunning workflow runs, so use the UI endpoint.
 	rerunURL := fmt.Sprintf("/user2/repo1/actions/runs/%d/rerun", webhookData.payloads[0].WorkflowRun.RunNumber)
 	req = NewRequestWithValues(t, "POST", rerunURL, map[string]string{
 		"_csrf": GetUserCSRFToken(t, session),
@@ -1426,6 +1426,15 @@ jobs:
 	session.MakeRequest(t, req, http.StatusOK)
 
 	assert.Len(t, webhookData.payloads, 3)
+
+	// 5. Validate the third webhook payload
+	assert.Equal(t, "workflow_run", webhookData.triggeredEvent)
+	assert.Equal(t, "requested", webhookData.payloads[2].Action)
+	assert.Equal(t, "queued", webhookData.payloads[2].WorkflowRun.Status)
+	assert.Equal(t, repo1.DefaultBranch, webhookData.payloads[2].WorkflowRun.HeadBranch)
+	assert.Equal(t, commitID, webhookData.payloads[2].WorkflowRun.HeadSha)
+	assert.Equal(t, "repo1", webhookData.payloads[2].Repo.Name)
+	assert.Equal(t, "user2/repo1", webhookData.payloads[2].Repo.FullName)
 }
 
 func testWorkflowRunEventsOnCancellingAbandonedRun(t *testing.T, webhookData *workflowRunWebhook, allJobsAbandoned bool) {


### PR DESCRIPTION
The event reported a completion status instead of requested, therefore sent an email