### PR TITLE
Remove mermaid margin workaround

### DIFF
--- a/web_src/js/markup/mermaid.ts
+++ b/web_src/js/markup/mermaid.ts
@@ -6,11 +6,9 @@ import {html, htmlRaw} from '../utils/html.ts';
 
 const {mermaidMaxSourceCharacters} = window.config;
 
-// margin removal is for https://github.com/mermaid-js/mermaid/issues/4907
 const iframeCss = `:root {color-scheme: normal}
 body {margin: 0; padding: 0; overflow: hidden}
-#mermaid {display: block; margin: 0 auto}
-blockquote, dd, dl, figure, h1, h2, h3, h4, h5, h6, hr, p, pre {margin: 0}`;
+#mermaid {display: block; margin: 0 auto}`;
 
 export async function initMarkupCodeMermaid(elMarkup: HTMLElement): Promise<void> {
   // .markup code.language-mermaid


### PR DESCRIPTION
https://github.com/mermaid-js/mermaid/issues/4907 was fixed with mermaid v11, so we no longer need to ship this workaround. The test case works as expected:

<img width="244" height="58" alt="image" src="https://github.com/user-attachments/assets/439616e9-4883-47fb-bf18-21ca86cb5da6" />
