### PR TITLE
Make "update file" API can create a new file when SHA is not set

### DIFF
--- a/modules/structs/repo_file.go
+++ b/modules/structs/repo_file.go
@@ -24,13 +24,6 @@ type FileOptions struct {
 	Signoff bool `json:"signoff"`
 }
 
-type FileOptionsWithSHA struct {
-	FileOptions
-	// the blob ID (SHA) for the file that already exists, it is required for changing existing files
-	// required: true
-	SHA string `json:"sha" binding:"Required"`
-}
-
 func (f *FileOptions) GetFileOptions() *FileOptions {
 	return f
 }
@@ -41,7 +34,7 @@ type FileOptionsInterface interface {
 
 var _ FileOptionsInterface = (*FileOptions)(nil)
 
-// CreateFileOptions options for creating files
+// CreateFileOptions options for creating a file
 // Note: `author` and `committer` are optional (if only one is given, it will be used for the other, otherwise the authenticated user will be used)
 type CreateFileOptions struct {
 	FileOptions
@@ -50,16 +43,21 @@ type CreateFileOptions struct {
 	ContentBase64 string `json:"content"`
 }
 
-// DeleteFileOptions options for deleting files (used for other File structs below)
+// DeleteFileOptions options for deleting a file
 // Note: `author` and `committer` are optional (if only one is given, it will be used for the other, otherwise the authenticated user will be used)
 type DeleteFileOptions struct {
-	FileOptionsWithSHA
+	FileOptions
+	// the blob ID (SHA) for the file to delete
+	// required: true
+	SHA string `json:"sha" binding:"Required"`
 }
 
-// UpdateFileOptions options for updating files
+// UpdateFileOptions options for updating or creating a file
 // Note: `author` and `committer` are optional (if only one is given, it will be used for the other, otherwise the authenticated user will be used)
 type UpdateFileOptions struct {
-	FileOptionsWithSHA
+	FileOptions
+	// the blob ID (SHA) for the file that already exists to update, or leave it empty to create a new file
+	SHA string `json:"sha"`
 	// content must be base64 encoded
 	// required: true
 	ContentBase64 string `json:"content"`

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -7634,7 +7634,7 @@
         "tags": [
           "repository"
         ],
-        "summary": "Update a file in a repository",
+        "summary": "Update a file in a repository if SHA is set, or create the file if SHA is not set",
         "operationId": "repoUpdateFile",
         "parameters": [
           {
@@ -7669,6 +7669,9 @@
         ],
         "responses": {
           "200": {
+            "$ref": "#/responses/FileResponse"
+          },
+          "201": {
             "$ref": "#/responses/FileResponse"
           },
           "403": {
@@ -22886,7 +22889,7 @@
       "x-go-package": "code.gitea.io/gitea/modules/structs"
     },
     "CreateFileOptions": {
-      "description": "CreateFileOptions options for creating files\nNote: `author` and `committer` are optional (if only one is given, it will be used for the other, otherwise the authenticated user will be used)",
+      "description": "CreateFileOptions options for creating a file\nNote: `author` and `committer` are optional (if only one is given, it will be used for the other, otherwise the authenticated user will be used)",
       "type": "object",
       "required": [
         "content"
@@ -23904,7 +23907,7 @@
       "x-go-package": "code.gitea.io/gitea/modules/structs"
     },
     "DeleteFileOptions": {
-      "description": "DeleteFileOptions options for deleting files (used for other File structs below)\nNote: `author` and `committer` are optional (if only one is given, it will be used for the other, otherwise the authenticated user will be used)",
+      "description": "DeleteFileOptions options for deleting a file\nNote: `author` and `committer` are optional (if only one is given, it will be used for the other, otherwise the authenticated user will be used)",
       "type": "object",
       "required": [
         "sha"
@@ -23940,7 +23943,7 @@
           "x-go-name": "NewBranchName"
         },
         "sha": {
-          "description": "the blob ID (SHA) for the file that already exists, it is required for changing existing files",
+          "description": "the blob ID (SHA) for the file to delete",
           "type": "string",
           "x-go-name": "SHA"
         },
@@ -28700,10 +28703,9 @@
       "x-go-package": "code.gitea.io/gitea/modules/structs"
     },
     "UpdateFileOptions": {
-      "description": "UpdateFileOptions options for updating files\nNote: `author` and `committer` are optional (if only one is given, it will be used for the other, otherwise the authenticated user will be used)",
+      "description": "UpdateFileOptions options for updating or creating a file\nNote: `author` and `committer` are optional (if only one is given, it will be used for the other, otherwise the authenticated user will be used)",
       "type": "object",
       "required": [
-        "sha",
         "content"
       ],
       "properties": {
@@ -28747,7 +28749,7 @@
           "x-go-name": "NewBranchName"
         },
         "sha": {
-          "description": "the blob ID (SHA) for the file that already exists, it is required for changing existing files",
+          "description": "the blob ID (SHA) for the file that already exists to update, or leave it empty to create a new file",
           "type": "string",
           "x-go-name": "SHA"
         },

--- a/tests/integration/api_repo_file_delete_test.go
+++ b/tests/integration/api_repo_file_delete_test.go
@@ -20,21 +20,19 @@ import (
 
 func getDeleteFileOptions() *api.DeleteFileOptions {
 	return &api.DeleteFileOptions{
-		FileOptionsWithSHA: api.FileOptionsWithSHA{
-			FileOptions: api.FileOptions{
-				BranchName:    "master",
-				NewBranchName: "master",
-				Message:       "Removing the file new/file.txt",
-				Author: api.Identity{
-					Name:  "John Doe",
-					Email: "johndoe@example.com",
-				},
-				Committer: api.Identity{
-					Name:  "Jane Doe",
-					Email: "janedoe@example.com",
-				},
+		SHA: "103ff9234cefeee5ec5361d22b49fbb04d385885",
+		FileOptions: api.FileOptions{
+			BranchName:    "master",
+			NewBranchName: "master",
+			Message:       "Removing the file new/file.txt",
+			Author: api.Identity{
+				Name:  "John Doe",
+				Email: "johndoe@example.com",
 			},
-			SHA: "103ff9234cefeee5ec5361d22b49fbb04d385885",
+			Committer: api.Identity{
+				Name:  "Jane Doe",
+				Email: "janedoe@example.com",
+			},
 		},
 	}
 }


### PR DESCRIPTION
Fix #19008, use GitHub's behavior (empty SHA to create a new file)