### PR TITLE
Bump minimum go version to 1.25.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module code.gitea.io/gitea
 
-go 1.25.1
+go 1.25.3
 
 // rfc5280 said: "The serial number is an integer assigned by the CA to each certificate."
 // But some CAs use negative serial number, just relax the check. related:


### PR DESCRIPTION
Should fix all the govulncheck issues seen in https://github.com/go-gitea/gitea/pull/35787.