### PR TITLE
Organizational branch protection

### DIFF
--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -395,6 +395,7 @@ func prepareMigrationTasks() []*migration {
 		newMigration(321, "Use LONGTEXT for some columns and fix review_state.updated_files column", v1_25.UseLongTextInSomeColumnsAndFixBugs),
 		newMigration(322, "Extend comment tree_path length limit", v1_25.ExtendCommentTreePathLength),
 		newMigration(323, "Add support for actions concurrency", v1_25.AddActionsConcurrency),
+		newMigration(324, "Add owner_id to protected_branch", v1_25.AddOwnerIDToProtectedBranch),
 	}
 	return preparedMigrations
 }

--- a/models/migrations/v1_25/v324.go
+++ b/models/migrations/v1_25/v324.go
@@ -1,0 +1,48 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v1_25
+
+import (
+	"code.gitea.io/gitea/modules/setting"
+
+	"xorm.io/xorm"
+)
+
+func AddOwnerIDToProtectedBranch(x *xorm.Engine) error {
+	type ProtectedBranch struct {
+		ID      int64 `xorm:"pk autoincr"`
+		RepoID  int64 `xorm:"INDEX DEFAULT 0"`
+		OwnerID int64 `xorm:"INDEX DEFAULT 0"`
+	}
+
+	if err := x.Sync(new(ProtectedBranch)); err != nil {
+		return err
+	}
+
+	db := x.NewSession()
+	defer db.Close()
+
+	if err := db.Begin(); err != nil {
+		return err
+	}
+
+	// Drop old unique index if it exists, ignoring errors if it doesn't.
+	if _, err := db.Exec("DROP INDEX `UQE_protected_branch_s`"); err != nil {
+		return err
+		//log.Warn("Could not drop index UQE_protected_branch_s: %v", err)
+	}
+
+	// These partial indexes might not be supported on all database versions, but they are the correct approach.
+	// We will assume modern database versions. The WHERE clause might need adjustment for MSSQL.
+	if !setting.Database.Type.IsMSSQL() {
+		if _, err := db.Exec("CREATE UNIQUE INDEX `UQE_protected_branch_repo_id_branch_name` ON `protected_branch` (`repo_id`, `branch_name`) WHERE `repo_id` != 0"); err != nil {
+			return err
+		}
+		if _, err := db.Exec("CREATE UNIQUE INDEX `UQE_protected_branch_owner_id_branch_name` ON `protected_branch` (`owner_id`, `branch_name`) WHERE `owner_id` != 0"); err != nil {
+			return err
+		}
+	}
+
+	return db.Commit()
+}

--- a/models/migrations/v1_25/v324_test.go
+++ b/models/migrations/v1_25/v324_test.go
@@ -1,0 +1,106 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v1_25
+
+import (
+	"testing"
+
+	"code.gitea.io/gitea/models/migrations/base"
+	"code.gitea.io/gitea/modules/setting"
+
+	"github.com/stretchr/testify/assert"
+	"xorm.io/xorm"
+	"xorm.io/xorm/schemas"
+)
+
+func prepareOldProtectedBranch(t *testing.T) (*xorm.Engine, func()) {
+	type ProtectedBranch struct {
+		ID       int64  `xorm:"pk autoincr"`
+		RepoID   int64  `xorm:"UNIQUE(s)"`
+		RuleName string `xorm:"'branch_name' UNIQUE(s)"`
+	}
+
+	return base.PrepareTestEnv(t, 0, new(ProtectedBranch))
+}
+
+func Test_AddOwnerIDToProtectedBranch(t *testing.T) {
+	x, deferable := prepareOldProtectedBranch(t)
+	defer deferable()
+	if x == nil {
+		return
+	}
+
+	// The test fixtures will have already created the UQE_protected_branch_s index.
+	// We can run the migration.
+	assert.NoError(t, AddOwnerIDToProtectedBranch(x))
+
+	// Verify that the new column exists.
+	type ProtectedBranch struct {
+		ID       int64 `xorm:"pk autoincr"`
+		RepoID   int64 `xorm:"INDEX DEFAULT 0"`
+		OwnerID  int64 `xorm:"INDEX DEFAULT 0"`
+		RuleName string
+	}
+
+	has, err := x.Dialect().IsColumnExist(x.DB(), t.Context(), "protected_branch", "owner_id")
+	assert.NoError(t, err)
+	assert.True(t, has, "owner_id column should exist")
+
+	// Skip index check for unsupported DBs
+	if setting.Database.Type.IsMSSQL() || setting.Database.Type.IsSQLite3() {
+		t.Log("Skipping index check for unsupported database")
+		return
+	}
+
+	table, err := x.TableInfo("protected_branch")
+	assert.NoError(t, err)
+
+	// Check if the old index is gone
+	_, exist := table.Indexes["UQE_protected_branch_s"]
+	assert.False(t, exist, "old index UQE_protected_branch_s should not exist")
+
+	// Check if new indexes are created
+	idx, exist := table.Indexes["UQE_protected_branch_repo_id_branch_name"]
+	assert.True(t, exist, "new index UQE_protected_branch_repo_id_branch_name should exist")
+	if exist {
+		assert.Equal(t, schemas.UniqueType, idx.Type)
+		assert.ElementsMatch(t, []string{"repo_id", "branch_name"}, idx.Cols)
+	}
+
+	idx, exist = table.Indexes["UQE_protected_branch_owner_id_branch_name"]
+	assert.True(t, exist, "new index UQE_protected_branch_owner_id_branch_name should exist")
+	if exist {
+		assert.Equal(t, schemas.UniqueType, idx.Type)
+		assert.ElementsMatch(t, []string{"owner_id", "branch_name"}, idx.Cols)
+	}
+
+	// Test repo-level unique constraint
+	_, err = x.Insert(&ProtectedBranch{RepoID: 1, RuleName: "main"})
+	assert.NoError(t, err)
+	_, err = x.Insert(&ProtectedBranch{RepoID: 1, RuleName: "main"})
+	assert.Error(t, err, "should fail to insert duplicate repo-level rule")
+
+	// Test org-level unique constraint
+	_, err = x.Insert(&ProtectedBranch{OwnerID: 1, RuleName: "main"})
+	assert.NoError(t, err)
+	_, err = x.Insert(&ProtectedBranch{OwnerID: 1, RuleName: "main"})
+	assert.Error(t, err, "should fail to insert duplicate org-level rule")
+
+	// Test that repo-level and org-level rules with the same name don't conflict
+	_, err = x.Insert(&ProtectedBranch{RepoID: 2, RuleName: "develop"})
+	assert.NoError(t, err)
+	_, err = x.Insert(&ProtectedBranch{OwnerID: 2, RuleName: "develop"})
+	assert.NoError(t, err)
+
+	// Test that rules with repo_id=0 or owner_id=0 don't conflict with partial indexes
+	_, err = x.Insert(&ProtectedBranch{RepoID: 3, OwnerID: 0, RuleName: "feature-a"})
+	assert.NoError(t, err)
+	_, err = x.Insert(&ProtectedBranch{RepoID: 4, OwnerID: 0, RuleName: "feature-a"})
+	assert.NoError(t, err)
+
+	_, err = x.Insert(&ProtectedBranch{RepoID: 0, OwnerID: 3, RuleName: "feature-b"})
+	assert.NoError(t, err)
+	_, err = x.Insert(&ProtectedBranch{RepoID: 0, OwnerID: 4, RuleName: "feature-b"})
+	assert.NoError(t, err)
+}

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -1182,6 +1182,14 @@ func Routes() *web.Router {
 			// (repo scope)
 			m.Post("/migrate", reqToken(), bind(api.MigrateRepoOptions{}), repo.Migrate)
 
+			m.Group("/{org}", func() {
+				// FIXME: The swagger definition is wrong, it should be /orgs/{org}/branch_protections
+				m.Group("/branch_protections", func() {
+					m.Get("", repo.ListOrgBranchProtections)
+					m.Post("", bind(api.CreateBranchProtectionOption{}), repo.CreateOrgBranchProtection)
+				}, reqToken(), reqOrgOwnership())
+			}, orgAssignment(true), tokenRequiresScopes(auth_model.AccessTokenScopeCategoryRepository))
+
 			m.Group("/{username}/{reponame}", func() {
 				m.Get("/compare/*", reqRepoReader(unit.TypeCode), repo.CompareDiff)
 

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -1182,18 +1182,6 @@ func Routes() *web.Router {
 			// (repo scope)
 			m.Post("/migrate", reqToken(), bind(api.MigrateRepoOptions{}), repo.Migrate)
 
-			m.Group("/{org}", func() {
-				m.Group("/branch_protections", func() {
-					m.Get("", repo.ListOrgBranchProtections)
-					m.Post("", bind(api.CreateBranchProtectionOption{}), repo.CreateOrgBranchProtection)
-					m.Group("/{name}", func() {
-						m.Get("", repo.GetOrgBranchProtection)
-						m.Patch("", bind(api.EditBranchProtectionOption{}), repo.EditOrgBranchProtection)
-						m.Delete("", repo.DeleteOrgBranchProtection)
-					})
-				}, reqToken(), reqOrgOwnership())
-			}, orgAssignment(true), tokenRequiresScopes(auth_model.AccessTokenScopeCategoryRepository))
-
 			m.Group("/{username}/{reponame}", func() {
 				m.Get("/compare/*", reqRepoReader(unit.TypeCode), repo.CompareDiff)
 
@@ -1644,6 +1632,15 @@ func Routes() *web.Router {
 		m.Post("/orgs", tokenRequiresScopes(auth_model.AccessTokenScopeCategoryOrganization), reqToken(), bind(api.CreateOrgOption{}), org.Create)
 		m.Get("/orgs", org.GetAll, tokenRequiresScopes(auth_model.AccessTokenScopeCategoryOrganization))
 		m.Group("/orgs/{org}", func() {
+			m.Group("/branch_protections", func() {
+				m.Get("", repo.ListOrgBranchProtections)
+				m.Post("", bind(api.CreateBranchProtectionOption{}), repo.CreateOrgBranchProtection)
+				m.Group("/{name}", func() {
+					m.Get("", repo.GetOrgBranchProtection)
+					m.Patch("", bind(api.EditBranchProtectionOption{}), repo.EditOrgBranchProtection)
+					m.Delete("", repo.DeleteOrgBranchProtection)
+				})
+			}, reqToken(), reqOrgOwnership())
 			m.Combo("").Get(org.Get).
 				Patch(reqToken(), reqOrgOwnership(), bind(api.EditOrgOption{}), org.Edit).
 				Delete(reqToken(), reqOrgOwnership(), org.Delete)

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -1183,7 +1183,6 @@ func Routes() *web.Router {
 			m.Post("/migrate", reqToken(), bind(api.MigrateRepoOptions{}), repo.Migrate)
 
 			m.Group("/{org}", func() {
-				// FIXME: The swagger definition is wrong, it should be /orgs/{org}/branch_protections
 				m.Group("/branch_protections", func() {
 					m.Get("", repo.ListOrgBranchProtections)
 					m.Post("", bind(api.CreateBranchProtectionOption{}), repo.CreateOrgBranchProtection)

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -1187,6 +1187,11 @@ func Routes() *web.Router {
 				m.Group("/branch_protections", func() {
 					m.Get("", repo.ListOrgBranchProtections)
 					m.Post("", bind(api.CreateBranchProtectionOption{}), repo.CreateOrgBranchProtection)
+					m.Group("/{name}", func() {
+						m.Get("", repo.GetOrgBranchProtection)
+						m.Patch("", bind(api.EditBranchProtectionOption{}), repo.EditOrgBranchProtection)
+						m.Delete("", repo.DeleteOrgBranchProtection)
+					})
 				}, reqToken(), reqOrgOwnership())
 			}, orgAssignment(true), tokenRequiresScopes(auth_model.AccessTokenScopeCategoryRepository))
 

--- a/routers/api/v1/repo/branch.go
+++ b/routers/api/v1/repo/branch.go
@@ -460,15 +460,15 @@ func RenameBranch(ctx *context.APIContext) {
 
 // GetOrgBranchProtection gets a branch protection
 func GetOrgBranchProtection(ctx *context.APIContext) {
-	// swagger:operation GET /repos/{owner}/branch_protections/{name} repository repoGetBranchProtection
+	// swagger:operation GET /repos/{org}/branch_protections/{name} repository repoGetOrgBranchProtection
 	// ---
 	// summary: Get a specific branch protection for the repository
 	// produces:
 	// - application/json
 	// parameters:
-	// - name: owner
+	// - name: org
 	//   in: path
-	//   description: owner of the repo
+	//   description: organization
 	//   type: string
 	//   required: true
 	// - name: name
@@ -543,15 +543,15 @@ func GetBranchProtection(ctx *context.APIContext) {
 
 // ListOrgBranchProtections list branch protections for an organization
 func ListOrgBranchProtections(ctx *context.APIContext) {
-	// swagger:operation GET /repos/{owner}/branch_protections repository repoListBranchProtection
+	// swagger:operation GET /repos/{org}/branch_protections repository repoListOrgBranchProtection
 	// ---
 	// summary: List branch protections for a repository
 	// produces:
 	// - application/json
 	// parameters:
-	// - name: owner
+	// - name: org
 	//   in: path
-	//   description: owner of the repo
+	//   description: organization
 	//   type: string
 	//   required: true
 	// responses:
@@ -616,7 +616,7 @@ func ListBranchProtections(ctx *context.APIContext) {
 
 // CreateBranchProtection creates a branch protection for a repo
 func CreateOrgBranchProtection(ctx *context.APIContext) {
-	// swagger:operation POST /repos/{owner}/branch_protections repository repoCreateBranchProtection
+	// swagger:operation POST /repos/{org}/branch_protections repository repoCreateOrgBranchProtection
 	// ---
 	// summary: Create a branch protections for a repository
 	// consumes:
@@ -624,9 +624,9 @@ func CreateOrgBranchProtection(ctx *context.APIContext) {
 	// produces:
 	// - application/json
 	// parameters:
-	// - name: owner
+	// - name: organization
 	//   in: path
-	//   description: owner of the repo
+	//   description: organization
 	//   type: string
 	//   required: true
 	// - name: body
@@ -993,7 +993,7 @@ func CreateBranchProtection(ctx *context.APIContext) {
 
 // EditBranchProtection edits a branch protection for a repo
 func EditOrgBranchProtection(ctx *context.APIContext) {
-	// swagger:operation PATCH /repos/{owner}/branch_protections/{name} repository repoEditBranchProtection
+	// swagger:operation PATCH /repos/{org}/branch_protections/{name} repository repoEditOrgBranchProtection
 	// ---
 	// summary: Edit a branch protections for a repository. Only fields that are set will be changed
 	// consumes:
@@ -1001,9 +1001,9 @@ func EditOrgBranchProtection(ctx *context.APIContext) {
 	// produces:
 	// - application/json
 	// parameters:
-	// - name: owner
+	// - name: org
 	//   in: path
-	//   description: owner of the repo
+	//   description: organization
 	//   type: string
 	//   required: true
 	// - name: name
@@ -1608,15 +1608,15 @@ func EditBranchProtection(ctx *context.APIContext) {
 
 // DeleteOrgBranchProtection deletes a branch protection for a repo
 func DeleteOrgBranchProtection(ctx *context.APIContext) {
-	// swagger:operation DELETE /repos/{owner}/branch_protections/{name} repository repoDeleteBranchProtection
+	// swagger:operation DELETE /repos/{org}/branch_protections/{name} repository repoDeleteOrgBranchProtection
 	// ---
 	// summary: Delete a specific branch protection for the repository
 	// produces:
 	// - application/json
 	// parameters:
-	// - name: owner
+	// - name: org
 	//   in: path
-	//   description: owner of the repo
+	//   description: organizatio
 	//   type: string
 	//   required: true
 	// - name: name

--- a/routers/api/v1/repo/branch.go
+++ b/routers/api/v1/repo/branch.go
@@ -1616,7 +1616,7 @@ func DeleteOrgBranchProtection(ctx *context.APIContext) {
 	// parameters:
 	// - name: org
 	//   in: path
-	//   description: organizatio
+	//   description: organization
 	//   type: string
 	//   required: true
 	// - name: name

--- a/routers/api/v1/repo/branch.go
+++ b/routers/api/v1/repo/branch.go
@@ -460,9 +460,9 @@ func RenameBranch(ctx *context.APIContext) {
 
 // GetOrgBranchProtection gets a branch protection
 func GetOrgBranchProtection(ctx *context.APIContext) {
-	// swagger:operation GET /repos/{org}/branch_protections/{name} repository repoGetOrgBranchProtection
+	// swagger:operation GET /orgs/{org}/branch_protections/{name} organization orgGetBranchProtection
 	// ---
-	// summary: Get a specific branch protection for the repository
+	// summary: Get a specific branch protection for the organization
 	// produces:
 	// - application/json
 	// parameters:
@@ -543,9 +543,9 @@ func GetBranchProtection(ctx *context.APIContext) {
 
 // ListOrgBranchProtections list branch protections for an organization
 func ListOrgBranchProtections(ctx *context.APIContext) {
-	// swagger:operation GET /repos/{org}/branch_protections repository repoListOrgBranchProtection
+	// swagger:operation GET /orgs/{org}/branch_protections organization orgListBranchProtections
 	// ---
-	// summary: List branch protections for a repository
+	// summary: List branch protections for an organization
 	// produces:
 	// - application/json
 	// parameters:
@@ -616,15 +616,15 @@ func ListBranchProtections(ctx *context.APIContext) {
 
 // CreateBranchProtection creates a branch protection for a repo
 func CreateOrgBranchProtection(ctx *context.APIContext) {
-	// swagger:operation POST /repos/{org}/branch_protections repository repoCreateOrgBranchProtection
+	// swagger:operation POST /orgs/{org}/branch_protections organization orgCreateBranchProtection
 	// ---
-	// summary: Create a branch protections for a repository
+	// summary: Create a branch protection for an organization
 	// consumes:
 	// - application/json
 	// produces:
 	// - application/json
 	// parameters:
-	// - name: organization
+	// - name: org
 	//   in: path
 	//   description: organization
 	//   type: string
@@ -993,9 +993,9 @@ func CreateBranchProtection(ctx *context.APIContext) {
 
 // EditBranchProtection edits a branch protection for a repo
 func EditOrgBranchProtection(ctx *context.APIContext) {
-	// swagger:operation PATCH /repos/{org}/branch_protections/{name} repository repoEditOrgBranchProtection
+	// swagger:operation PATCH /orgs/{org}/branch_protections/{name} organization orgEditBranchProtection
 	// ---
-	// summary: Edit a branch protections for a repository. Only fields that are set will be changed
+	// summary: Edit a branch protection for an organization. Only fields that are set will be changed
 	// consumes:
 	// - application/json
 	// produces:
@@ -1608,9 +1608,9 @@ func EditBranchProtection(ctx *context.APIContext) {
 
 // DeleteOrgBranchProtection deletes a branch protection for a repo
 func DeleteOrgBranchProtection(ctx *context.APIContext) {
-	// swagger:operation DELETE /repos/{org}/branch_protections/{name} repository repoDeleteOrgBranchProtection
+	// swagger:operation DELETE /orgs/{org}/branch_protections/{name} organization orgDeleteBranchProtection
 	// ---
-	// summary: Delete a specific branch protection for the repository
+	// summary: Delete a specific branch protection for the organization
 	// produces:
 	// - application/json
 	// parameters:

--- a/services/pull/protected_branch.go
+++ b/services/pull/protected_branch.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	git_model "code.gitea.io/gitea/models/git"
+	"code.gitea.io/gitea/models/organization"
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/modules/gitrepo"
 )
@@ -14,32 +15,42 @@ import (
 func CreateOrUpdateProtectedBranch(ctx context.Context, repo *repo_model.Repository,
 	protectBranch *git_model.ProtectedBranch, whitelistOptions git_model.WhitelistOptions,
 ) error {
-	err := git_model.UpdateProtectBranch(ctx, repo, protectBranch, whitelistOptions)
+	var err error
+	if repo != nil {
+		err = git_model.UpdateProtectBranch(ctx, repo, protectBranch, whitelistOptions)
+	} else {
+		org, err := organization.GetOrgByID(ctx, protectBranch.OwnerID)
+		if err == nil {
+			err = git_model.UpdateOrgProtectBranch(ctx, org, protectBranch, whitelistOptions)
+		}
+	}
 	if err != nil {
 		return err
 	}
 
-	isPlainRule := !git_model.IsRuleNameSpecial(protectBranch.RuleName)
-	var isBranchExist bool
-	if isPlainRule {
-		// TODO: read the database directly to check if the branch exists
-		isBranchExist = gitrepo.IsBranchExist(ctx, repo, protectBranch.RuleName)
-	}
-
-	if isBranchExist {
-		if err := CheckPRsForBaseBranch(ctx, repo, protectBranch.RuleName); err != nil {
-			return err
+	if repo != nil {
+		isPlainRule := !git_model.IsRuleNameSpecial(protectBranch.RuleName)
+		var isBranchExist bool
+		if isPlainRule {
+			// TODO: read the database directly to check if the branch exists
+			isBranchExist = gitrepo.IsBranchExist(ctx, repo, protectBranch.RuleName)
 		}
-	} else {
-		if !isPlainRule {
-			// FIXME: since we only need to recheck files protected rules, we could improve this
-			matchedBranches, err := git_model.FindAllMatchedBranches(ctx, repo.ID, protectBranch.RuleName)
-			if err != nil {
+
+		if isBranchExist {
+			if err := CheckPRsForBaseBranch(ctx, repo, protectBranch.RuleName); err != nil {
 				return err
 			}
-			for _, branchName := range matchedBranches {
-				if err = CheckPRsForBaseBranch(ctx, repo, branchName); err != nil {
+		} else {
+			if !isPlainRule {
+				// FIXME: since we only need to recheck files protected rules, we could improve this
+				matchedBranches, err := git_model.FindAllMatchedBranches(ctx, repo.ID, protectBranch.RuleName)
+				if err != nil {
 					return err
+				}
+				for _, branchName := range matchedBranches {
+					if err = CheckPRsForBaseBranch(ctx, repo, branchName); err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -21,7 +21,7 @@
     },
     "version": "{{.SwaggerAppVer}}"
   },
-  "basePath": "/{{.SwaggerAppSubUrl}}/api/v1",
+  "basePath": "{{.SwaggerAppSubUrl}}/api/v1",
   "paths": {
     "/activitypub/user-id/{user-id}": {
       "get": {
@@ -2806,6 +2806,198 @@
         }
       }
     },
+    "/orgs/{org}/branch_protections": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "organization"
+        ],
+        "summary": "List branch protections for an organization",
+        "operationId": "orgListBranchProtections",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "organization",
+            "name": "org",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/BranchProtectionList"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "organization"
+        ],
+        "summary": "Create a branch protection for an organization",
+        "operationId": "orgCreateBranchProtection",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "organization",
+            "name": "org",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/CreateBranchProtectionOption"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "$ref": "#/responses/BranchProtection"
+          },
+          "403": {
+            "$ref": "#/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/responses/notFound"
+          },
+          "422": {
+            "$ref": "#/responses/validationError"
+          },
+          "423": {
+            "$ref": "#/responses/repoArchivedError"
+          }
+        }
+      }
+    },
+    "/orgs/{org}/branch_protections/{name}": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "organization"
+        ],
+        "summary": "Get a specific branch protection for the organization",
+        "operationId": "orgGetBranchProtection",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "organization",
+            "name": "org",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "name of protected branch",
+            "name": "name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/BranchProtection"
+          },
+          "404": {
+            "$ref": "#/responses/notFound"
+          }
+        }
+      },
+      "delete": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "organization"
+        ],
+        "summary": "Delete a specific branch protection for the organization",
+        "operationId": "orgDeleteBranchProtection",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "organization",
+            "name": "org",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "name of protected branch",
+            "name": "name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "$ref": "#/responses/empty"
+          },
+          "404": {
+            "$ref": "#/responses/notFound"
+          }
+        }
+      },
+      "patch": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "organization"
+        ],
+        "summary": "Edit a branch protection for an organization. Only fields that are set will be changed",
+        "operationId": "orgEditBranchProtection",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "organization",
+            "name": "org",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "name of protected branch",
+            "name": "name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/EditBranchProtectionOption"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/BranchProtection"
+          },
+          "404": {
+            "$ref": "#/responses/notFound"
+          },
+          "422": {
+            "$ref": "#/responses/validationError"
+          },
+          "423": {
+            "$ref": "#/responses/repoArchivedError"
+          }
+        }
+      }
+    },
     "/orgs/{org}/hooks": {
       "get": {
         "produces": [
@@ -4447,198 +4639,6 @@
           },
           "422": {
             "$ref": "#/responses/validationError"
-          }
-        }
-      }
-    },
-    "/repos/{org}/branch_protections": {
-      "get": {
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "repository"
-        ],
-        "summary": "List branch protections for a repository",
-        "operationId": "repoListOrgBranchProtection",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "organization",
-            "name": "org",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/BranchProtectionList"
-          }
-        }
-      },
-      "post": {
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "repository"
-        ],
-        "summary": "Create a branch protections for a repository",
-        "operationId": "repoCreateOrgBranchProtection",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "organization",
-            "name": "organization",
-            "in": "path",
-            "required": true
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/CreateBranchProtectionOption"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "$ref": "#/responses/BranchProtection"
-          },
-          "403": {
-            "$ref": "#/responses/forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/notFound"
-          },
-          "422": {
-            "$ref": "#/responses/validationError"
-          },
-          "423": {
-            "$ref": "#/responses/repoArchivedError"
-          }
-        }
-      }
-    },
-    "/repos/{org}/branch_protections/{name}": {
-      "get": {
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "repository"
-        ],
-        "summary": "Get a specific branch protection for the repository",
-        "operationId": "repoGetOrgBranchProtection",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "organization",
-            "name": "org",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "name of protected branch",
-            "name": "name",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/BranchProtection"
-          },
-          "404": {
-            "$ref": "#/responses/notFound"
-          }
-        }
-      },
-      "delete": {
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "repository"
-        ],
-        "summary": "Delete a specific branch protection for the repository",
-        "operationId": "repoDeleteOrgBranchProtection",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "organizatio",
-            "name": "org",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "name of protected branch",
-            "name": "name",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "204": {
-            "$ref": "#/responses/empty"
-          },
-          "404": {
-            "$ref": "#/responses/notFound"
-          }
-        }
-      },
-      "patch": {
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "repository"
-        ],
-        "summary": "Edit a branch protections for a repository. Only fields that are set will be changed",
-        "operationId": "repoEditOrgBranchProtection",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "organization",
-            "name": "org",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "description": "name of protected branch",
-            "name": "name",
-            "in": "path",
-            "required": true
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/EditBranchProtectionOption"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/BranchProtection"
-          },
-          "404": {
-            "$ref": "#/responses/notFound"
-          },
-          "422": {
-            "$ref": "#/responses/validationError"
-          },
-          "423": {
-            "$ref": "#/responses/repoArchivedError"
           }
         }
       }

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -4451,6 +4451,198 @@
         }
       }
     },
+    "/repos/{org}/branch_protections": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "repository"
+        ],
+        "summary": "List branch protections for a repository",
+        "operationId": "repoListOrgBranchProtection",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "organization",
+            "name": "org",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/BranchProtectionList"
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "repository"
+        ],
+        "summary": "Create a branch protections for a repository",
+        "operationId": "repoCreateOrgBranchProtection",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "organization",
+            "name": "organization",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/CreateBranchProtectionOption"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "$ref": "#/responses/BranchProtection"
+          },
+          "403": {
+            "$ref": "#/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/responses/notFound"
+          },
+          "422": {
+            "$ref": "#/responses/validationError"
+          },
+          "423": {
+            "$ref": "#/responses/repoArchivedError"
+          }
+        }
+      }
+    },
+    "/repos/{org}/branch_protections/{name}": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "repository"
+        ],
+        "summary": "Get a specific branch protection for the repository",
+        "operationId": "repoGetOrgBranchProtection",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "organization",
+            "name": "org",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "name of protected branch",
+            "name": "name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/BranchProtection"
+          },
+          "404": {
+            "$ref": "#/responses/notFound"
+          }
+        }
+      },
+      "delete": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "repository"
+        ],
+        "summary": "Delete a specific branch protection for the repository",
+        "operationId": "repoDeleteOrgBranchProtection",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "organizatio",
+            "name": "org",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "name of protected branch",
+            "name": "name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "$ref": "#/responses/empty"
+          },
+          "404": {
+            "$ref": "#/responses/notFound"
+          }
+        }
+      },
+      "patch": {
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "repository"
+        ],
+        "summary": "Edit a branch protections for a repository. Only fields that are set will be changed",
+        "operationId": "repoEditOrgBranchProtection",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "organization",
+            "name": "org",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "name of protected branch",
+            "name": "name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/EditBranchProtectionOption"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/BranchProtection"
+          },
+          "404": {
+            "$ref": "#/responses/notFound"
+          },
+          "422": {
+            "$ref": "#/responses/validationError"
+          },
+          "423": {
+            "$ref": "#/responses/repoArchivedError"
+          }
+        }
+      }
+    },
     "/repos/{owner}/{repo}": {
       "get": {
         "produces": [

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -21,7 +21,7 @@
     },
     "version": "{{.SwaggerAppVer}}"
   },
-  "basePath": "{{.SwaggerAppSubUrl}}/api/v1",
+  "basePath": "/{{.SwaggerAppSubUrl}}/api/v1",
   "paths": {
     "/activitypub/user-id/{user-id}": {
       "get": {


### PR DESCRIPTION
In organizations with a large number of repositories, managing branch protection rules on a per-repository basis is not scalable and can lead to security inconsistencies. This pull request introduces organization-level branch protection rules to address this, allowing administrators to define rules that apply to all repositories within an organization.

To enhance security and ensure consistent policy enforcement, organization-level rules are designed to take precedence over repository-level rules. When determining the effective protection for a branch, the system will first look for a matching rule at the organization level. If one is found, it is applied. If not, it falls back to checking for repository-specific rules.

This change includes:

- Database schema modifications to the protected_branch table to support both owner_id and repo_id, with partial unique indexes to ensure rule name uniqueness at both levels.
- New API endpoints under /orgs/{org}/branch_protections for creating, reading, updating, and deleting organization-level branch protection rules.
- Updated logic to prioritize organization-level rules over repository-level rules during branch protection checks.

As I am not deeply familiar with the Gitea codebase and am relatively new to Go, I would greatly appreciate a thorough community review of these changes.