### PR TITLE
ignore .worktrees as a "special folder"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ prime/
 /AGENT.md
 /CLAUDE.md
 /llms.txt
+
+# Ignore worktrees when working on multiple branches
+.worktrees/


### PR DESCRIPTION
following the approach from nixpkgs that ignore the .worktrees folder, we could also do the same, this would allow worktrees to be worked on in the same folder as the primary branch.

ref: https://github.com/NixOS/nixpkgs/commit/b6420c7bca86997ad66218dcf4fb902efc7ac4f6