### PR TITLE
Remove wrong code

### DIFF
--- a/web_src/js/features/pull-view-file.ts
+++ b/web_src/js/features/pull-view-file.ts
@@ -20,14 +20,6 @@ function refreshViewedFilesSummary() {
     .replace('%[2]d', prReview.numberOfFiles);
 }
 
-// Explicitly recounts how many files the user has currently reviewed by counting the number of checked "viewed" checkboxes
-// Additionally, the viewed files summary will be updated if it exists
-export function countAndUpdateViewedFiles() {
-  // The number of files is constant, but the number of viewed files can change because files can be loaded dynamically
-  prReview.numberOfViewedFiles = document.querySelectorAll(`${viewedCheckboxSelector} > input[type=checkbox][checked]`).length;
-  refreshViewedFilesSummary();
-}
-
 // Initializes a listener for all children of the given html element
 // (for example 'document' in the most basic case)
 // to watch for changes of viewed-file checkboxes

--- a/web_src/js/features/repo-diff.ts
+++ b/web_src/js/features/repo-diff.ts
@@ -2,7 +2,7 @@ import {initRepoIssueContentHistory} from './repo-issue-content.ts';
 import {initDiffFileTree} from './repo-diff-filetree.ts';
 import {initDiffCommitSelect} from './repo-diff-commitselect.ts';
 import {validateTextareaNonEmpty} from './comp/ComboMarkdownEditor.ts';
-import {initViewedCheckboxListenerFor, countAndUpdateViewedFiles, initExpandAndCollapseFilesButton} from './pull-view-file.ts';
+import {initViewedCheckboxListenerFor, initExpandAndCollapseFilesButton} from './pull-view-file.ts';
 import {initImageDiff} from './imagediff.ts';
 import {showErrorToast} from '../modules/toast.ts';
 import {submitEventSubmitter, queryElemSiblings, hideElem, showElem, animateOnce, addDelegatedEventListener, createElementFromHTML, queryElems} from '../utils/dom.ts';
@@ -152,7 +152,6 @@ function onShowMoreFiles() {
   // TODO: replace these calls with the "observer.ts" methods
   initRepoIssueContentHistory();
   initViewedCheckboxListenerFor();
-  countAndUpdateViewedFiles();
   initImageDiff();
   initDiffHeaderPopup();
 }


### PR DESCRIPTION
Follow #35821
Fix https://github.com/go-gitea/gitea/pull/35844#issuecomment-3483521045

The reviewed file numbers and progress have been set from backend so that we don't need to update the numbers when clicking `load more`.