### PR TITLE
Create public folder relative to GITEA_CUSTOM in Docker setup

### DIFF
--- a/docker/root/etc/s6/gitea/setup
+++ b/docker/root/etc/s6/gitea/setup
@@ -59,6 +59,9 @@ fi
 # Replace app.ini settings with env variables in the form GITEA__SECTION_NAME__KEY_NAME
 environment-to-ini --config ${GITEA_CUSTOM}/conf/app.ini
 
+# Create public folder so the user knows where things such as robots.txt should go
+mkdir -p ${GITEA_CUSTOM}/public
+
 # only chown if current owner is not already the gitea ${USER}. No recursive check to save time
 if ! [[ $(ls -ld /data/gitea | awk '{print $3}') = ${USER} ]]; then chown -R ${USER}:git /data/gitea; fi
 if ! [[ $(ls -ld /app/gitea  | awk '{print $3}') = ${USER} ]]; then chown -R ${USER}:git /app/gitea;  fi

--- a/docker/rootless/usr/local/bin/docker-setup.sh
+++ b/docker/rootless/usr/local/bin/docker-setup.sh
@@ -49,3 +49,6 @@ fi
 
 # Replace app.ini settings with env variables in the form GITEA__SECTION_NAME__KEY_NAME
 environment-to-ini --config ${GITEA_APP_INI}
+
+# Create public folder so the user knows where things such as robots.txt should go
+mkdir -p ${GITEA_CUSTOM}/public


### PR DESCRIPTION
It may not be apparent where a custom robots.txt or such should go in the absence of a 'custom' or 'public' folder.