### PR TITLE
Fix pull description code label background

### DIFF
--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -387,6 +387,7 @@ td .commit-summary {
 
 .repository.view.issue .pull-desc code {
   color: var(--color-primary);
+  background: transparent;
 }
 
 .repository.view.issue .pull-desc a[data-clipboard-text] {


### PR DESCRIPTION
Fix visual regression from https://github.com/go-gitea/gitea/pull/35567:

Before:

<img width="612" height="33" alt="image" src="https://github.com/user-attachments/assets/aee4017c-b8b9-4ac2-9809-9d3eb3fda56c" />

After:

<img width="613" height="32" alt="image" src="https://github.com/user-attachments/assets/ee6624da-b417-4e3b-8773-88c77c2cd672" />
