### PR TITLE
Fix oauth2 sync error

### DIFF
--- a/services/auth/source/oauth2/source_sync.go
+++ b/services/auth/source/oauth2/source_sync.go
@@ -47,7 +47,7 @@ func (source *Source) Sync(ctx context.Context, updateExisting bool) error {
 }
 
 func (source *Source) refresh(ctx context.Context, provider goth.Provider, u *user_model.ExternalLoginUser) error {
-	log.Trace("Syncing login_source_id=%d external_id=%s expiration=%s", u.LoginSourceID, u.ExternalID, u.ExpiresAt)
+	log.Trace("Syncing login_source_id=%d external_id=%s user_id=%s expiration=%s", u.LoginSourceID, u.ExternalID, u.UserID, u.ExpiresAt)
 
 	shouldDisable := false
 
@@ -62,7 +62,7 @@ func (source *Source) refresh(ctx context.Context, provider goth.Provider, u *us
 	}
 
 	user := &user_model.User{
-		LoginName:   u.ExternalID,
+		ID:          u.UserID,
 		LoginType:   auth.OAuth2,
 		LoginSource: u.LoginSourceID,
 	}


### PR DESCRIPTION
We identified an issue with OAuth2 synchronization. The following logs indicate the problem:

> Nov 06 01:05:45 ecs-gitea gitea[629433]: 2025/11/06 01:05:45 .../oauth2/source_sync.go:50:(*Source).refresh() [T] Syncing login_source_id=1 external_id=00u1wwyot5yExxxxxd8 expiration=2025-11-05 16:55:33 +0800 CST
Nov 06 01:05:45 ecs-gitea gitea[629433]: 2025/11/06 01:05:45 .../oauth2/source_sync.go:80:(*Source).refresh() [I] SyncExternalUsers[Okta] disabling user 0

The logs show that the gitea correctly identified the user with external ID 00u1wwyot5yExxxxxd8 for deactivation. However, the action was incorrectly applied to user ID 0 instead.

So, we'd better to use ID to identify a user, not LoginName. For Okta, the ExternalID is Okta User ObjectID, LoginName!= ExternalID.

#31572 