### PR TITLE
Set `GOTOOLCHAIN=auto` in docker build containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 FROM docker.io/library/golang:1.25-alpine3.22 AS build-env
 
 ARG GOPROXY=direct
+ARG GOTOOLCHAIN=auto
 
 ARG GITEA_VERSION
 ARG TAGS="sqlite sqlite_unlock_notify"

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -3,6 +3,7 @@
 FROM docker.io/library/golang:1.25-alpine3.22 AS build-env
 
 ARG GOPROXY=direct
+ARG GOTOOLCHAIN=auto
 
 ARG GITEA_VERSION
 ARG TAGS="sqlite sqlite_unlock_notify"


### PR DESCRIPTION
In https://github.com/docker-library/golang/issues/472 it was decided to set `GOTOOLCHAIN=local` in these containers which inhibits go from downloading newer toolchains when the current one is older than the one defined in `go.mod`.

This should fix the nightly build errors from https://github.com/go-gitea/gitea/pull/35877.

From [docs](https://go.dev/doc/toolchain#download):

> When using GOTOOLCHAIN=auto or GOTOOLCHAIN=<name>+auto, the Go command downloads newer toolchains as needed