### PR TITLE
Use correct form field for allowed force push users in branch protection API

### DIFF
--- a/routers/api/v1/repo/branch.go
+++ b/routers/api/v1/repo/branch.go
@@ -897,7 +897,7 @@ func EditBranchProtection(ctx *context.APIContext) {
 	} else {
 		whitelistUsers = protectBranch.WhitelistUserIDs
 	}
-	if form.ForcePushAllowlistDeployKeys != nil {
+	if form.ForcePushAllowlistUsernames != nil {
 		forcePushAllowlistUsers, err = user_model.GetUserIDsByNames(ctx, form.ForcePushAllowlistUsernames, false)
 		if err != nil {
 			if user_model.IsErrUserNotExist(err) {


### PR DESCRIPTION
Test was wrong and preventing update of force push allow users list by the API

Resolves #35893 