### PR TITLE
Add toolchain directive to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module code.gitea.io/gitea
 
-go 1.25.4
+go 1.25.0
+
+toolchain go1.25.4
 
 // rfc5280 said: "The serial number is an integer assigned by the CA to each certificate."
 // But some CAs use negative serial number, just relax the check. related:


### PR DESCRIPTION
From [docs](https://go.dev/doc/toolchain#config):

> The go line declares the minimum required Go version for using the module or workspace. For compatibility reasons, if the go line is omitted from a go.mod file, the module is considered to have an implicit go 1.16 line, and if the go line is omitted from a go.work file, the workspace is considered to have an implicit go 1.18 line.

> The toolchain line declares a suggested toolchain to use with the module or workspace. As described in “[Go toolchain selection](https://go.dev/doc/toolchain#select)” below, the go command may run this specific toolchain when operating in that module or workspace if the default toolchain’s version is less than the suggested toolchain’s version. If the toolchain line is omitted, the module or workspace is considered to have an implicit toolchain goV line, where V is the Go version from the go line.

This is better than setting `go` to the latest version which may break builds when that go version is unavailable, for example with `GOTOOLCHAIN=local` in the official go docker images.