### PR TITLE
Make OAuth2 issuer configurable

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -567,7 +567,9 @@ ENABLED = true
 ;; Alternative location to specify OAuth2 authentication secret. You cannot specify both this and JWT_SECRET, and must pick one
 ;JWT_SECRET_URI = file:/etc/gitea/oauth2_jwt_secret
 ;;
-;; The "issuer" claim identifies the principal that issued the JWT. Default to ROOT_URL without the last slash.
+;; The "issuer" claim identifies the principal that issued the JWT.
+;; Gitea 1.25 makes it default to "ROOT_URL without the last slash" to follow the standard.
+;; If you have old logins from before 1.25, you may want to set it to the old (non-standard) value "ROOT_URL with the last slash".
 ;JWT_CLAIM_ISSUER =
 ;;
 ;; Lifetime of an OAuth2 access token in seconds

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -567,6 +567,9 @@ ENABLED = true
 ;; Alternative location to specify OAuth2 authentication secret. You cannot specify both this and JWT_SECRET, and must pick one
 ;JWT_SECRET_URI = file:/etc/gitea/oauth2_jwt_secret
 ;;
+;; The "issuer" claim identifies the principal that issued the JWT. Default to ROOT_URL without the last slash.
+;JWT_CLAIM_ISSUER =
+;;
 ;; Lifetime of an OAuth2 access token in seconds
 ;ACCESS_TOKEN_EXPIRATION_TIME = 3600
 ;;

--- a/modules/setting/oauth2.go
+++ b/modules/setting/oauth2.go
@@ -96,6 +96,7 @@ var OAuth2 = struct {
 	InvalidateRefreshTokens    bool
 	JWTSigningAlgorithm        string `ini:"JWT_SIGNING_ALGORITHM"`
 	JWTSigningPrivateKeyFile   string `ini:"JWT_SIGNING_PRIVATE_KEY_FILE"`
+	JWTClaimIssuer             string `ini:"JWT_CLAIM_ISSUER"`
 	MaxTokenLength             int
 	DefaultApplications        []string
 }{

--- a/services/oauth2_provider/access_token.go
+++ b/services/oauth2_provider/access_token.go
@@ -112,8 +112,12 @@ func NewJwtRegisteredClaimsFromUser(clientID string, grantUserID int64, exp *jwt
 	// to retrieve the configuration information. This MUST also be identical to the "iss" Claim value in ID Tokens issued from this Issuer.
 	// * https://accounts.google.com/.well-known/openid-configuration
 	// * https://github.com/login/oauth/.well-known/openid-configuration
+	issuer := setting.OAuth2.JWTClaimIssuer
+	if issuer == "" {
+		issuer = strings.TrimSuffix(setting.AppURL, "/")
+	}
 	return jwt.RegisteredClaims{
-		Issuer:    strings.TrimSuffix(setting.AppURL, "/"),
+		Issuer:    issuer,
 		Audience:  []string{clientID},
 		Subject:   strconv.FormatInt(grantUserID, 10),
 		ExpiresAt: exp,


### PR DESCRIPTION
The new (correct) behavior breaks the old (incorrect) logins.

Add a config option to support legacy "issuer".

Fix #35830