### PR TITLE
wiki: reuse selectable style for wiki

### DIFF
--- a/templates/repo/wiki/pages.tmpl
+++ b/templates/repo/wiki/pages.tmpl
@@ -11,7 +11,7 @@
 			</span>
 		</h2>
 		{{if $.Permission.IsAdmin}}<div>{{ctx.Locale.Tr "repo.default_branch"}}: {{.Repository.DefaultWikiBranch}}</div>{{end}}
-		<table class="ui table wiki-pages-list">
+		<table class="ui table selectable wiki-pages-list">
 			<tbody>
 				{{range .Pages}}
 					<tr>

--- a/web_src/css/repo/wiki.css
+++ b/web_src/css/repo/wiki.css
@@ -1,7 +1,3 @@
-.repository.wiki .wiki-pages-list tr:hover {
-  background-color: var(--color-hover);
-}
-
 .repository.wiki .wiki-pages-list .wiki-git-entry {
   margin-left: 10px;
   display: none;


### PR DESCRIPTION
This patch amends https://github.com/go-gitea/gitea/pull/27507.

Since https://github.com/go-gitea/gitea/pull/35072, `selectable` css class can be used for providing hover effect for tables. This patch let the wiki page be able to make use of that css class, and we can safely remove the custom css for this purpose.

Behavior is not changed.

----

Side note: I made this patch locally months ago but completely forget to submit it as a PR :joy: