### PR TITLE
Fix various permission & login related bugs

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -774,7 +774,7 @@ func apiAuth(authMethod auth.Method) func(*context.APIContext) {
 	return func(ctx *context.APIContext) {
 		ar, err := common.AuthShared(ctx.Base, nil, authMethod)
 		if err != nil {
-			ctx.APIError(http.StatusUnauthorized, err)
+			ctx.APIError(http.StatusUnauthorized, "invalid username or password")
 			return
 		}
 		ctx.Doer = ar.Doer

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -81,6 +81,7 @@ import (
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 	api "code.gitea.io/gitea/modules/structs"
+	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/modules/web"
 	"code.gitea.io/gitea/routers/api/v1/activitypub"
 	"code.gitea.io/gitea/routers/api/v1/admin"
@@ -774,7 +775,9 @@ func apiAuth(authMethod auth.Method) func(*context.APIContext) {
 	return func(ctx *context.APIContext) {
 		ar, err := common.AuthShared(ctx.Base, nil, authMethod)
 		if err != nil {
-			ctx.APIError(http.StatusUnauthorized, "invalid username or password")
+			msg, ok := auth.ErrAsUserAuthMessage(err)
+			msg = util.Iif(ok, msg, "invalid username, password or token")
+			ctx.APIError(http.StatusUnauthorized, msg)
 			return
 		}
 		ctx.Doer = ar.Doer

--- a/routers/api/v1/repo/issue_dependency.go
+++ b/routers/api/v1/repo/issue_dependency.go
@@ -201,7 +201,7 @@ func CreateIssueDependency(ctx *context.APIContext) {
 		return
 	}
 
-	dependencyPerm := getPermissionForRepo(ctx, target.Repo)
+	dependencyPerm := getPermissionForRepo(ctx, dependency.Repo)
 	if ctx.Written() {
 		return
 	}
@@ -262,7 +262,7 @@ func RemoveIssueDependency(ctx *context.APIContext) {
 		return
 	}
 
-	dependencyPerm := getPermissionForRepo(ctx, target.Repo)
+	dependencyPerm := getPermissionForRepo(ctx, dependency.Repo)
 	if ctx.Written() {
 		return
 	}

--- a/routers/api/v1/repo/release_tags.go
+++ b/routers/api/v1/repo/release_tags.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	repo_model "code.gitea.io/gitea/models/repo"
+	unit_model "code.gitea.io/gitea/models/unit"
 	"code.gitea.io/gitea/services/context"
 	"code.gitea.io/gitea/services/convert"
 	release_service "code.gitea.io/gitea/services/release"
@@ -56,6 +57,13 @@ func GetReleaseByTag(ctx *context.APIContext) {
 	if release.IsTag {
 		ctx.APIErrorNotFound()
 		return
+	}
+
+	if release.IsDraft { // only the users with write access can see draft releases
+		if !ctx.IsSigned || !ctx.Repo.CanWrite(unit_model.TypeReleases) {
+			ctx.APIErrorNotFound()
+			return
+		}
 	}
 
 	if err = release.LoadAttributes(ctx); err != nil {

--- a/routers/web/repo/githttp.go
+++ b/routers/web/repo/githttp.go
@@ -146,7 +146,13 @@ func httpBase(ctx *context.Context) *serviceHandler {
 		// rely on the results of Contexter
 		if !ctx.IsSigned {
 			// TODO: support digit auth - which would be Authorization header with digit
-			ctx.Resp.Header().Set("WWW-Authenticate", `Basic realm="Gitea"`)
+			if setting.OAuth2.Enabled {
+				// `Basic realm="Gitea"` tells the GCM to use builtin OAuth2 application: https://github.com/git-ecosystem/git-credential-manager/pull/1442
+				ctx.Resp.Header().Set("WWW-Authenticate", `Basic realm="Gitea"`)
+			} else {
+				// If OAuth2 is disabled, then use another realm to avoid GCM OAuth2 attempt
+				ctx.Resp.Header().Set("WWW-Authenticate", `Basic realm="Gitea (Basic Auth)"`)
+			}
 			ctx.HTTPError(http.StatusUnauthorized)
 			return nil
 		}

--- a/routers/web/repo/issue_content_history.go
+++ b/routers/web/repo/issue_content_history.go
@@ -206,12 +206,11 @@ func SoftDeleteContentHistory(ctx *context.Context) {
 		ctx.NotFound(issues_model.ErrCommentNotExist{})
 		return
 	}
+	if history.CommentID != commentID {
+		ctx.NotFound(issues_model.ErrCommentNotExist{})
+		return
+	}
 	if commentID != 0 {
-		if history.CommentID != commentID {
-			ctx.NotFound(issues_model.ErrCommentNotExist{})
-			return
-		}
-
 		if comment, err = issues_model.GetCommentByID(ctx, commentID); err != nil {
 			log.Error("can not get comment for issue content history %v. err=%v", historyID, err)
 			return

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -119,7 +119,7 @@ func webAuth(authMethod auth_service.Method) func(*context.Context) {
 		ar, err := common.AuthShared(ctx.Base, ctx.Session, authMethod)
 		if err != nil {
 			log.Error("Failed to verify user: %v", err)
-			ctx.HTTPError(http.StatusUnauthorized, "invalid username or password")
+			ctx.HTTPError(http.StatusUnauthorized, "Failed to authenticate user")
 			return
 		}
 		ctx.Doer = ar.Doer

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -119,7 +119,7 @@ func webAuth(authMethod auth_service.Method) func(*context.Context) {
 		ar, err := common.AuthShared(ctx.Base, ctx.Session, authMethod)
 		if err != nil {
 			log.Error("Failed to verify user: %v", err)
-			ctx.HTTPError(http.StatusUnauthorized, "Failed to authenticate user")
+			ctx.HTTPError(http.StatusUnauthorized, "invalid username or password")
 			return
 		}
 		ctx.Doer = ar.Doer

--- a/services/auth/auth.go
+++ b/services/auth/auth.go
@@ -5,6 +5,7 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -39,6 +40,20 @@ var globalVars = sync.OnceValue(func() *globalVarsStruct {
 		feedRefPathRe:        regexp.MustCompile(`^/[-.\w]+/[-.\w]+/(rss|atom)/`),     // "/owner/repo/rss/branch/..."
 	}
 })
+
+type ErrUserAuthMessage string
+
+func (e ErrUserAuthMessage) Error() string {
+	return string(e)
+}
+
+func ErrAsUserAuthMessage(err error) (string, bool) {
+	var msg ErrUserAuthMessage
+	if errors.As(err, &msg) {
+		return msg.Error(), true
+	}
+	return "", false
+}
 
 // Init should be called exactly once when the application starts to allow plugins
 // to allocate necessary resources

--- a/services/auth/basic.go
+++ b/services/auth/basic.go
@@ -5,7 +5,6 @@
 package auth
 
 import (
-	"errors"
 	"net/http"
 
 	actions_model "code.gitea.io/gitea/models/actions"
@@ -146,7 +145,7 @@ func (b *Basic) Verify(req *http.Request, w http.ResponseWriter, store DataStore
 			return nil, err
 		}
 		if hasWebAuthn {
-			return nil, errors.New("basic authorization is not allowed while WebAuthn enrolled")
+			return nil, ErrUserAuthMessage("basic authorization is not allowed while WebAuthn enrolled")
 		}
 
 		if err := validateTOTP(req, u); err != nil {

--- a/services/convert/convert.go
+++ b/services/convert/convert.go
@@ -542,8 +542,9 @@ func ToVerification(ctx context.Context, c *git.Commit) *api.PayloadCommitVerifi
 	}
 	if verif.SigningUser != nil {
 		commitVerification.Signer = &api.PayloadUser{
-			Name:  verif.SigningUser.Name,
-			Email: verif.SigningUser.Email,
+			UserName: verif.SigningUser.Name,
+			Name:     verif.SigningUser.DisplayName(),
+			Email:    verif.SigningEmail, // Use the email from the signature, not from the user profile
 		}
 	}
 	return commitVerification

--- a/services/pull/merge.go
+++ b/services/pull/merge.go
@@ -547,11 +547,15 @@ var escapedSymbols = regexp.MustCompile(`([*[?! \\])`)
 
 // IsUserAllowedToMerge check if user is allowed to merge PR with given permissions and branch protections
 func IsUserAllowedToMerge(ctx context.Context, pr *issues_model.PullRequest, p access_model.Permission, user *user_model.User) (bool, error) {
+	return isUserAllowedToMergeInRepoBranch(ctx, pr.BaseRepoID, pr.BaseBranch, p, user)
+}
+
+func isUserAllowedToMergeInRepoBranch(ctx context.Context, repoID int64, branch string, p access_model.Permission, user *user_model.User) (bool, error) {
 	if user == nil {
 		return false, nil
 	}
 
-	pb, err := git_model.GetFirstMatchProtectedBranchRule(ctx, pr.BaseRepoID, pr.BaseBranch)
+	pb, err := git_model.GetFirstMatchProtectedBranchRule(ctx, repoID, branch)
 	if err != nil {
 		return false, err
 	}

--- a/services/pull/update.go
+++ b/services/pull/update.go
@@ -101,11 +101,11 @@ func Update(ctx context.Context, pr *issues_model.PullRequest, doer *user_model.
 }
 
 // IsUserAllowedToUpdate check if user is allowed to update PR with given permissions and branch protections
+// update PR means send new commits to PR head branch from base branch
 func IsUserAllowedToUpdate(ctx context.Context, pull *issues_model.PullRequest, user *user_model.User) (mergeAllowed, rebaseAllowed bool, err error) {
 	if pull.Flow == issues_model.PullRequestFlowAGit {
 		return false, false, nil
 	}
-
 	if user == nil {
 		return false, false, nil
 	}
@@ -121,60 +121,54 @@ func IsUserAllowedToUpdate(ctx context.Context, pull *issues_model.PullRequest, 
 		return false, false, err
 	}
 
-	pr := &issues_model.PullRequest{
-		HeadRepoID: pull.BaseRepoID,
-		HeadRepo:   pull.BaseRepo,
-		BaseRepoID: pull.HeadRepoID,
-		BaseRepo:   pull.HeadRepo,
-		HeadBranch: pull.BaseBranch,
-		BaseBranch: pull.HeadBranch,
+	// 1. check base repository's AllowRebaseUpdate configuration
+	// it is a config in base repo but controls the head (fork) repo's "Update" behavior
+	prBaseUnit, err := pull.BaseRepo.GetUnit(ctx, unit.TypePullRequests)
+	if repo_model.IsErrUnitTypeNotExist(err) {
+		return false, false, nil // the PR unit is disabled in base repo
+	} else if err != nil {
+		return false, false, fmt.Errorf("get base repo unit: %v", err)
+	} else {
+		rebaseAllowed = prBaseUnit.PullRequestsConfig().AllowRebaseUpdate
 	}
 
-	pb, err := git_model.GetFirstMatchProtectedBranchRule(ctx, pr.BaseRepoID, pr.BaseBranch)
-	if err != nil {
-		return false, false, err
-	}
-
-	if err := pr.LoadBaseRepo(ctx); err != nil {
-		return false, false, err
-	}
-	prUnit, err := pr.BaseRepo.GetUnit(ctx, unit.TypePullRequests)
-	if err != nil {
-		if repo_model.IsErrUnitTypeNotExist(err) {
-			return false, false, nil
+	// 2. check head branch protection whether rebase is allowed, if pb not found then rebase depends on the above setting
+	{
+		pb, err := git_model.GetFirstMatchProtectedBranchRule(ctx, pull.HeadRepoID, pull.HeadBranch)
+		if err != nil {
+			return false, false, err
 		}
-		log.Error("pr.BaseRepo.GetUnit(unit.TypePullRequests): %v", err)
-		return false, false, err
-	}
-
-	rebaseAllowed = prUnit.PullRequestsConfig().AllowRebaseUpdate
-
-	// If branch protected, disable rebase unless user is whitelisted to force push (which extends regular push)
-	if pb != nil {
-		pb.Repo = pull.BaseRepo
-		if !pb.CanUserForcePush(ctx, user) {
-			rebaseAllowed = false
+		// If branch protected, disable rebase unless user is whitelisted to force push (which extends regular push)
+		if pb != nil {
+			pb.Repo = pull.HeadRepo
+			rebaseAllowed = rebaseAllowed && pb.CanUserForcePush(ctx, user)
 		}
 	}
 
+	// 3. check whether user has write access to head branch
 	baseRepoPerm, err := access_model.GetUserRepoPermission(ctx, pull.BaseRepo, user)
 	if err != nil {
 		return false, false, err
 	}
 
-	mergeAllowed, err = IsUserAllowedToMerge(ctx, pr, headRepoPerm, user)
+	mergeAllowed, err = isUserAllowedToMergeInRepoBranch(ctx, pull.HeadRepoID, pull.HeadBranch, headRepoPerm, user)
 	if err != nil {
 		return false, false, err
 	}
 
+	// 4. if the pull creator allows maintainer to edit, it means the write permissions of the head branch has been
+	// granted to the user with write permission of the base repository
 	if pull.AllowMaintainerEdit {
-		mergeAllowedMaintainer, err := IsUserAllowedToMerge(ctx, pr, baseRepoPerm, user)
+		mergeAllowedMaintainer, err := isUserAllowedToMergeInRepoBranch(ctx, pull.BaseRepoID, pull.BaseBranch, baseRepoPerm, user)
 		if err != nil {
 			return false, false, err
 		}
 
 		mergeAllowed = mergeAllowed || mergeAllowedMaintainer
 	}
+
+	// if merge is not allowed, rebase is also not allowed
+	rebaseAllowed = rebaseAllowed && mergeAllowed
 
 	return mergeAllowed, rebaseAllowed, nil
 }

--- a/services/pull/update.go
+++ b/services/pull/update.go
@@ -123,12 +123,13 @@ func IsUserAllowedToUpdate(ctx context.Context, pull *issues_model.PullRequest, 
 
 	// 1. check base repository's AllowRebaseUpdate configuration
 	// it is a config in base repo but controls the head (fork) repo's "Update" behavior
-	prBaseUnit, err := pull.BaseRepo.GetUnit(ctx, unit.TypePullRequests)
-	if repo_model.IsErrUnitTypeNotExist(err) {
-		return false, false, nil // the PR unit is disabled in base repo
-	} else if err != nil {
-		return false, false, fmt.Errorf("get base repo unit: %v", err)
-	} else {
+	{
+		prBaseUnit, err := pull.BaseRepo.GetUnit(ctx, unit.TypePullRequests)
+		if repo_model.IsErrUnitTypeNotExist(err) {
+			return false, false, nil // the PR unit is disabled in base repo
+		} else if err != nil {
+			return false, false, fmt.Errorf("get base repo unit: %v", err)
+		}
 		rebaseAllowed = prBaseUnit.PullRequestsConfig().AllowRebaseUpdate
 	}
 

--- a/services/release/release.go
+++ b/services/release/release.go
@@ -361,7 +361,7 @@ func DeleteReleaseByID(ctx context.Context, repo *repo_model.Repository, rel *re
 		if err != nil {
 			return fmt.Errorf("GetProtectedTags: %w", err)
 		}
-		isAllowed, err := git_model.IsUserAllowedToControlTag(ctx, protectedTags, rel.TagName, rel.PublisherID)
+		isAllowed, err := git_model.IsUserAllowedToControlTag(ctx, protectedTags, rel.TagName, doer.ID)
 		if err != nil {
 			return err
 		}

--- a/tests/integration/api_auth_test.go
+++ b/tests/integration/api_auth_test.go
@@ -1,0 +1,28 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package integration
+
+import (
+	"net/http"
+	"testing"
+
+	"code.gitea.io/gitea/tests"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAPIAuth(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	req := NewRequestf(t, "GET", "/api/v1/user").AddBasicAuth("user2")
+	MakeRequest(t, req, http.StatusOK)
+
+	req = NewRequestf(t, "GET", "/api/v1/user").AddBasicAuth("user2", "wrong-password")
+	resp := MakeRequest(t, req, http.StatusUnauthorized)
+	assert.Contains(t, resp.Body.String(), `{"message":"invalid username or password"`)
+
+	req = NewRequestf(t, "GET", "/api/v1/user").AddBasicAuth("user-not-exist")
+	resp = MakeRequest(t, req, http.StatusUnauthorized)
+	assert.Contains(t, resp.Body.String(), `{"message":"invalid username or password"`)
+}

--- a/tests/integration/api_auth_test.go
+++ b/tests/integration/api_auth_test.go
@@ -20,9 +20,13 @@ func TestAPIAuth(t *testing.T) {
 
 	req = NewRequestf(t, "GET", "/api/v1/user").AddBasicAuth("user2", "wrong-password")
 	resp := MakeRequest(t, req, http.StatusUnauthorized)
-	assert.Contains(t, resp.Body.String(), `{"message":"invalid username or password"`)
+	assert.Contains(t, resp.Body.String(), `{"message":"invalid username, password or token"`)
 
 	req = NewRequestf(t, "GET", "/api/v1/user").AddBasicAuth("user-not-exist")
 	resp = MakeRequest(t, req, http.StatusUnauthorized)
-	assert.Contains(t, resp.Body.String(), `{"message":"invalid username or password"`)
+	assert.Contains(t, resp.Body.String(), `{"message":"invalid username, password or token"`)
+
+	req = NewRequestf(t, "GET", "/api/v1/users/user2/repos").AddTokenAuth("Bearer wrong_token")
+	resp = MakeRequest(t, req, http.StatusUnauthorized)
+	assert.Contains(t, resp.Body.String(), `{"message":"invalid username, password or token"`)
 }

--- a/tests/integration/api_issue_dependency_test.go
+++ b/tests/integration/api_issue_dependency_test.go
@@ -1,0 +1,152 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	auth_model "code.gitea.io/gitea/models/auth"
+	"code.gitea.io/gitea/models/db"
+	issues_model "code.gitea.io/gitea/models/issues"
+	"code.gitea.io/gitea/models/perm"
+	access_model "code.gitea.io/gitea/models/perm/access"
+	repo_model "code.gitea.io/gitea/models/repo"
+	"code.gitea.io/gitea/models/unit"
+	"code.gitea.io/gitea/models/unittest"
+	user_model "code.gitea.io/gitea/models/user"
+	api "code.gitea.io/gitea/modules/structs"
+	repo_service "code.gitea.io/gitea/services/repository"
+	"code.gitea.io/gitea/tests"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func enableRepoDependencies(t *testing.T, repoID int64) {
+	t.Helper()
+
+	repoUnit := unittest.AssertExistsAndLoadBean(t, &repo_model.RepoUnit{RepoID: repoID, Type: unit.TypeIssues})
+	repoUnit.IssuesConfig().EnableDependencies = true
+	assert.NoError(t, repo_model.UpdateRepoUnit(t.Context(), repoUnit))
+}
+
+func TestAPICreateIssueDependencyCrossRepoPermission(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	targetRepo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+	targetIssue := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{RepoID: targetRepo.ID, Index: 1})
+	dependencyRepo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 3})
+	assert.True(t, dependencyRepo.IsPrivate)
+	dependencyIssue := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{RepoID: dependencyRepo.ID, Index: 1})
+
+	enableRepoDependencies(t, targetIssue.RepoID)
+	enableRepoDependencies(t, dependencyRepo.ID)
+
+	// remove user 40 access from target repository
+	_, err := db.DeleteByID[access_model.Access](t.Context(), 30)
+	assert.NoError(t, err)
+
+	url := fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/dependencies", "user2", "repo1", targetIssue.Index)
+	dependencyMeta := &api.IssueMeta{
+		Owner: "org3",
+		Name:  "repo3",
+		Index: dependencyIssue.Index,
+	}
+
+	user40 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 40})
+	// user40 has no access to both target issue and dependency issue
+	writerToken := getUserToken(t, "user40", auth_model.AccessTokenScopeWriteIssue)
+	req := NewRequestWithJSON(t, "POST", url, dependencyMeta).
+		AddTokenAuth(writerToken)
+	MakeRequest(t, req, http.StatusNotFound)
+	unittest.AssertNotExistsBean(t, &issues_model.IssueDependency{
+		IssueID:      targetIssue.ID,
+		DependencyID: dependencyIssue.ID,
+	})
+
+	// add user40 as a collaborator to dependency repository with read permission
+	assert.NoError(t, repo_service.AddOrUpdateCollaborator(t.Context(), dependencyRepo, user40, perm.AccessModeRead))
+
+	// try again after getting read permission to dependency repository
+	req = NewRequestWithJSON(t, "POST", url, dependencyMeta).
+		AddTokenAuth(writerToken)
+	MakeRequest(t, req, http.StatusNotFound)
+	unittest.AssertNotExistsBean(t, &issues_model.IssueDependency{
+		IssueID:      targetIssue.ID,
+		DependencyID: dependencyIssue.ID,
+	})
+
+	// add user40 as a collaborator to target repository with write permission
+	assert.NoError(t, repo_service.AddOrUpdateCollaborator(t.Context(), targetRepo, user40, perm.AccessModeWrite))
+
+	req = NewRequestWithJSON(t, "POST", url, dependencyMeta).
+		AddTokenAuth(writerToken)
+	MakeRequest(t, req, http.StatusCreated)
+	unittest.AssertExistsAndLoadBean(t, &issues_model.IssueDependency{
+		IssueID:      targetIssue.ID,
+		DependencyID: dependencyIssue.ID,
+	})
+}
+
+func TestAPIDeleteIssueDependencyCrossRepoPermission(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	targetRepo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+	targetIssue := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{RepoID: targetRepo.ID, Index: 1})
+	dependencyRepo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 3})
+	assert.True(t, dependencyRepo.IsPrivate)
+	dependencyIssue := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{RepoID: dependencyRepo.ID, Index: 1})
+
+	enableRepoDependencies(t, targetIssue.RepoID)
+	enableRepoDependencies(t, dependencyRepo.ID)
+
+	user1 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 1})
+	assert.NoError(t, issues_model.CreateIssueDependency(t.Context(), user1, targetIssue, dependencyIssue))
+
+	// remove user 40 access from target repository
+	_, err := db.DeleteByID[access_model.Access](t.Context(), 30)
+	assert.NoError(t, err)
+
+	url := fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/dependencies", "user2", "repo1", targetIssue.Index)
+	dependencyMeta := &api.IssueMeta{
+		Owner: "org3",
+		Name:  "repo3",
+		Index: dependencyIssue.Index,
+	}
+
+	user40 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 40})
+	// user40 has no access to both target issue and dependency issue
+	writerToken := getUserToken(t, "user40", auth_model.AccessTokenScopeWriteIssue)
+	req := NewRequestWithJSON(t, "DELETE", url, dependencyMeta).
+		AddTokenAuth(writerToken)
+	MakeRequest(t, req, http.StatusNotFound)
+	unittest.AssertExistsAndLoadBean(t, &issues_model.IssueDependency{
+		IssueID:      targetIssue.ID,
+		DependencyID: dependencyIssue.ID,
+	})
+
+	// add user40 as a collaborator to dependency repository with read permission
+	assert.NoError(t, repo_service.AddOrUpdateCollaborator(t.Context(), dependencyRepo, user40, perm.AccessModeRead))
+
+	// try again after getting read permission to dependency repository
+	req = NewRequestWithJSON(t, "DELETE", url, dependencyMeta).
+		AddTokenAuth(writerToken)
+	MakeRequest(t, req, http.StatusNotFound)
+	unittest.AssertExistsAndLoadBean(t, &issues_model.IssueDependency{
+		IssueID:      targetIssue.ID,
+		DependencyID: dependencyIssue.ID,
+	})
+
+	// add user40 as a collaborator to target repository with write permission
+	assert.NoError(t, repo_service.AddOrUpdateCollaborator(t.Context(), targetRepo, user40, perm.AccessModeWrite))
+
+	req = NewRequestWithJSON(t, "DELETE", url, dependencyMeta).
+		AddTokenAuth(writerToken)
+	MakeRequest(t, req, http.StatusCreated)
+	unittest.AssertNotExistsBean(t, &issues_model.IssueDependency{
+		IssueID:      targetIssue.ID,
+		DependencyID: dependencyIssue.ID,
+	})
+}

--- a/tests/integration/api_repo_test.go
+++ b/tests/integration/api_repo_test.go
@@ -41,17 +41,6 @@ func TestAPIUserReposNotLogin(t *testing.T) {
 	}
 }
 
-func TestAPIUserReposWithWrongToken(t *testing.T) {
-	defer tests.PrepareTestEnv(t)()
-	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
-	wrongToken := "Bearer " + "wrong_token"
-	req := NewRequestf(t, "GET", "/api/v1/users/%s/repos", user.Name).
-		AddTokenAuth(wrongToken)
-	resp := MakeRequest(t, req, http.StatusUnauthorized)
-
-	assert.Contains(t, resp.Body.String(), "user does not exist")
-}
-
 func TestAPISearchRepo(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
 	const keyword = "test"

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -271,8 +271,8 @@ type RequestWrapper struct {
 	*http.Request
 }
 
-func (req *RequestWrapper) AddBasicAuth(username string) *RequestWrapper {
-	req.Request.SetBasicAuth(username, userPassword)
+func (req *RequestWrapper) AddBasicAuth(username string, password ...string) *RequestWrapper {
+	req.Request.SetBasicAuth(username, util.OptionalArg(password, userPassword))
 	return req
 }
 


### PR DESCRIPTION
Permission & protection check:

- Fix Delete Release permission check
- Fix Update Pull Request with rebase branch protection check
- Fix Issue Dependency permission check
- Fix Delete Comment History ID check

Information leaking:

- Show unified message for non-existing user and invalid password
    - Fix #35984
- Don't expose release draft to non-writer users.
- Make API returns signature's email address instead of the user profile's.

Auth & Login:

- Avoid GCM OAuth2 attempt when OAuth2 is disabled
    - Fix #35510 