### PR TITLE
Allow empty commit when merging pull request with squash style (#35989)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,6 +25,10 @@ insert_final_newline = false
 [templates/user/auth/oidc_wellknown.tmpl]
 indent_style = space
 
+[templates/shared/actions/runner_badge_*.tmpl]
+# editconfig lint requires these XML-like files to have charset defined, but the files don't have.
+charset = unset
+
 [Makefile]
 indent_style = tab
 

--- a/services/pull/merge_squash.go
+++ b/services/pull/merge_squash.go
@@ -71,7 +71,8 @@ func doMergeStyleSquash(ctx *mergeContext, message string) error {
 	}
 	cmdCommit := gitcmd.NewCommand("commit").
 		AddOptionFormat("--author='%s <%s>'", sig.Name, sig.Email).
-		AddOptionFormat("--message=%s", message)
+		AddOptionFormat("--message=%s", message).
+		AddArguments("--allow-empty")
 	if ctx.signKey == nil {
 		cmdCommit.AddArguments("--no-gpg-sign")
 	} else {

--- a/tests/integration/pull_merge_test.go
+++ b/tests/integration/pull_merge_test.go
@@ -1110,3 +1110,35 @@ func TestPullNonMergeForAdminWithBranchProtection(t *testing.T) {
 		session.MakeRequest(t, mergeReq, http.StatusMethodNotAllowed)
 	})
 }
+
+func TestPullSquashMergeEmpty(t *testing.T) {
+	onGiteaRun(t, func(t *testing.T, u *url.URL) {
+		session := loginUser(t, "user1")
+		testEditFileToNewBranch(t, session, "user2", "repo1", "master", "pr-squash-empty", "README.md", "Hello, World (Edited)\n")
+		resp := testPullCreate(t, session, "user2", "repo1", false, "master", "pr-squash-empty", "This is a pull title")
+
+		elem := strings.Split(test.RedirectURL(resp), "/")
+		assert.Equal(t, "pulls", elem[3])
+
+		httpContext := NewAPITestContext(t, "user2", "repo1", auth_model.AccessTokenScopeWriteRepository)
+		dstPath := t.TempDir()
+
+		u.Path = httpContext.GitPath()
+		u.User = url.UserPassword("user2", userPassword)
+
+		t.Run("Clone", doGitClone(dstPath, u))
+		doGitCheckoutBranch(dstPath, "-b", "pr-squash-empty", "remotes/origin/pr-squash-empty")(t)
+		doGitCheckoutBranch(dstPath, "master")(t)
+		_, _, err := gitcmd.NewCommand("cherry-pick").AddArguments("pr-squash-empty").
+			WithDir(dstPath).
+			RunStdString(t.Context())
+		assert.NoError(t, err)
+
+		doGitPushTestRepository(dstPath)(t)
+
+		testPullMerge(t, session, elem[1], elem[2], elem[4], MergeOptions{
+			Style:        repo_model.MergeStyleSquash,
+			DeleteBranch: false,
+		})
+	})
+}

--- a/tests/integration/pull_merge_test.go
+++ b/tests/integration/pull_merge_test.go
@@ -1130,15 +1130,13 @@ func TestPullSquashMergeEmpty(t *testing.T) {
 		doGitCheckoutBranch(dstPath, "-b", "pr-squash-empty", "remotes/origin/pr-squash-empty")(t)
 		doGitCheckoutBranch(dstPath, "master")(t)
 		_, _, err := gitcmd.NewCommand("cherry-pick").AddArguments("pr-squash-empty").
-			WithDir(dstPath).
-			RunStdString(t.Context())
+			RunStdString(t.Context(), &gitcmd.RunOpts{
+				Dir: dstPath,
+			})
 		assert.NoError(t, err)
 
 		doGitPushTestRepository(dstPath)(t)
 
-		testPullMerge(t, session, elem[1], elem[2], elem[4], MergeOptions{
-			Style:        repo_model.MergeStyleSquash,
-			DeleteBranch: false,
-		})
+		testPullMerge(t, session, elem[1], elem[2], elem[4], repo_model.MergeStyleSquash, false)
 	})
 }


### PR DESCRIPTION
Before this PR, when merging an empty PR with squash style will result in 500.
Backport #35989 
