### PR TITLE
Filter gitea-specific variables when running tests

### DIFF
--- a/.github/workflows/pull-db-tests.yml
+++ b/.github/workflows/pull-db-tests.yml
@@ -146,6 +146,9 @@ jobs:
       - name: unit-tests
         run: make unit-test-coverage test-check
         env:
+          GITEA_ROOT: foo
+          GITEA_CONF: bar
+          GITEA_CUSTOM: baz
           TAGS: bindata
           RACE_ENABLED: true
           GITHUB_READ_TOKEN: ${{ secrets.GITHUB_READ_TOKEN }}

--- a/models/unittest/fixtures_test.go
+++ b/models/unittest/fixtures_test.go
@@ -10,6 +10,7 @@ import (
 	"code.gitea.io/gitea/models/unittest"
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/test"
+	"code.gitea.io/gitea/tests/env"
 
 	"github.com/stretchr/testify/require"
 	"xorm.io/xorm"
@@ -111,4 +112,9 @@ func BenchmarkFixturesLoader(b *testing.B) {
 			require.NoError(b, loaderVendor.Load())
 		}
 	})
+}
+
+func TestMain(m *testing.M) {
+	env.Filter([]string{"GITEA_TEST_", "GITEA_UNIT_TESTS_"}, []string{"GITEA_"})
+	m.Run()
 }

--- a/models/unittest/testdb.go
+++ b/models/unittest/testdb.go
@@ -23,6 +23,7 @@ import (
 	"code.gitea.io/gitea/modules/tempdir"
 	"code.gitea.io/gitea/modules/test"
 	"code.gitea.io/gitea/modules/util"
+	"code.gitea.io/gitea/tests/env"
 
 	"github.com/stretchr/testify/assert"
 	"xorm.io/xorm"
@@ -73,6 +74,7 @@ type TestOptions struct {
 // MainTest a reusable TestMain(..) function for unit tests that need to use a
 // test database. Creates the test database, and sets necessary settings.
 func MainTest(m *testing.M, testOptsArg ...*TestOptions) {
+	env.Filter([]string{"GITEA_TEST_", "GITEA_UNIT_TESTS_"}, []string{"GITEA_"})
 	testOpts := util.OptionalArg(testOptsArg, &TestOptions{})
 	giteaRoot = test.SetupGiteaRoot()
 	setting.CustomPath = filepath.Join(giteaRoot, "custom")

--- a/modules/git/attribute/main_test.go
+++ b/modules/git/attribute/main_test.go
@@ -11,6 +11,7 @@ import (
 	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/util"
+	"code.gitea.io/gitea/tests/env"
 )
 
 func testRun(m *testing.M) error {
@@ -33,6 +34,7 @@ func testRun(m *testing.M) error {
 }
 
 func TestMain(m *testing.M) {
+	env.Filter([]string{"GITEA_TEST_", "GITEA_UNIT_TESTS_"}, []string{"GITEA_"})
 	if err := testRun(m); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Test failed: %v", err)
 		os.Exit(1)

--- a/modules/git/git_test.go
+++ b/modules/git/git_test.go
@@ -10,6 +10,7 @@ import (
 
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/tempdir"
+	"code.gitea.io/gitea/tests/env"
 
 	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
@@ -36,6 +37,7 @@ func testRun(m *testing.M) error {
 }
 
 func TestMain(m *testing.M) {
+	env.Filter([]string{"GITEA_TEST_", "GITEA_UNIT_TESTS_"}, []string{"GITEA_"})
 	if err := testRun(m); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Test failed: %v", err)
 		os.Exit(1)

--- a/modules/git/gitcmd/command_test.go
+++ b/modules/git/gitcmd/command_test.go
@@ -10,11 +10,13 @@ import (
 
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/tempdir"
+	"code.gitea.io/gitea/tests/env"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
+	env.Filter([]string{"GITEA_TEST_", "GITEA_UNIT_TESTS_"}, []string{"GITEA_"})
 	gitHomePath, cleanup, err := tempdir.OsTempDir("gitea-test").MkdirTempRandom("git-home")
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "unable to create temp dir: %v", err)

--- a/modules/git/languagestats/main_test.go
+++ b/modules/git/languagestats/main_test.go
@@ -11,6 +11,7 @@ import (
 	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/util"
+	"code.gitea.io/gitea/tests/env"
 )
 
 func testRun(m *testing.M) error {
@@ -33,6 +34,7 @@ func testRun(m *testing.M) error {
 }
 
 func TestMain(m *testing.M) {
+	env.Filter([]string{"GITEA_TEST_", "GITEA_UNIT_TESTS_"}, []string{"GITEA_"})
 	if err := testRun(m); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Test failed: %v", err)
 		os.Exit(1)

--- a/modules/gitrepo/main_test.go
+++ b/modules/gitrepo/main_test.go
@@ -12,9 +12,11 @@ import (
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/tempdir"
 	"code.gitea.io/gitea/modules/test"
+	"code.gitea.io/gitea/tests/env"
 )
 
 func TestMain(m *testing.M) {
+	env.Filter([]string{"GITEA_TEST_", "GITEA_UNIT_TESTS_"}, []string{"GITEA_"})
 	gitHomePath, cleanup, err := tempdir.OsTempDir("gitea-test").MkdirTempRandom("git-home")
 	if err != nil {
 		log.Fatal("Unable to create temp dir: %v", err)

--- a/modules/markup/main_test.go
+++ b/modules/markup/main_test.go
@@ -9,9 +9,11 @@ import (
 
 	"code.gitea.io/gitea/modules/markup"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/tests/env"
 )
 
 func TestMain(m *testing.M) {
+	env.Filter([]string{"GITEA_TEST_", "GITEA_UNIT_TESTS_"}, []string{"GITEA_"})
 	setting.IsInTesting = true
 	markup.RenderBehaviorForTesting.DisableAdditionalAttributes = true
 	os.Exit(m.Run())

--- a/modules/markup/markdown/main_test.go
+++ b/modules/markup/markdown/main_test.go
@@ -9,9 +9,11 @@ import (
 
 	"code.gitea.io/gitea/modules/markup"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/tests/env"
 )
 
 func TestMain(m *testing.M) {
+	env.Filter([]string{"GITEA_TEST_", "GITEA_UNIT_TESTS_"}, []string{"GITEA_"})
 	setting.IsInTesting = true
 	markup.RenderBehaviorForTesting.DisableAdditionalAttributes = true
 	os.Exit(m.Run())

--- a/modules/markup/orgmode/orgmode_test.go
+++ b/modules/markup/orgmode/orgmode_test.go
@@ -11,11 +11,13 @@ import (
 	"code.gitea.io/gitea/modules/markup"
 	"code.gitea.io/gitea/modules/markup/orgmode"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/tests/env"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
+	env.Filter([]string{"GITEA_TEST_", "GITEA_UNIT_TESTS_"}, []string{"GITEA_"})
 	setting.AppURL = "http://localhost:3000/"
 	setting.IsInTesting = true
 	os.Exit(m.Run())

--- a/modules/templates/util_render_test.go
+++ b/modules/templates/util_render_test.go
@@ -18,6 +18,7 @@ import (
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/test"
 	"code.gitea.io/gitea/modules/translation"
+	"code.gitea.io/gitea/tests/env"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -48,6 +49,7 @@ mail@domain.com
 }
 
 func TestMain(m *testing.M) {
+	env.Filter([]string{"GITEA_TEST_", "GITEA_UNIT_TESTS_"}, []string{"GITEA_"})
 	setting.Markdown.RenderOptionsComment.ShortIssuePattern = true
 	markup.Init(&markup.RenderHelperFuncs{
 		IsUsernameMentionable: func(ctx context.Context, username string) bool {

--- a/modules/timeutil/since_test.go
+++ b/modules/timeutil/since_test.go
@@ -11,6 +11,7 @@ import (
 
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/translation"
+	"code.gitea.io/gitea/tests/env"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -26,6 +27,7 @@ const (
 )
 
 func TestMain(m *testing.M) {
+	env.Filter([]string{"GITEA_TEST_", "GITEA_UNIT_TESTS_"}, []string{"GITEA_"})
 	setting.StaticRootPath = "../../"
 	setting.Names = []string{"english"}
 	setting.Langs = []string{"en-US"}

--- a/tests/env/filter.go
+++ b/tests/env/filter.go
@@ -1,0 +1,31 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package env
+
+import (
+	"os"
+	"strings"
+)
+
+func Filter(include, exclude []string) {
+	env := os.Environ()
+	for _, v := range env {
+		included := false
+		for _, i := range include {
+			if strings.HasPrefix(v, i) {
+				included = true
+				break
+			}
+		}
+		if !included {
+			for _, e := range exclude {
+				if strings.HasPrefix(v, e) {
+					parts := strings.SplitN(v, "=", 2)
+					os.Unsetenv(parts[0])
+					break
+				}
+			}
+		}
+	}
+}

--- a/tests/env/filter_test.go
+++ b/tests/env/filter_test.go
@@ -1,0 +1,39 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package env
+
+import (
+	"os"
+	"testing"
+)
+
+func TestFilter(t *testing.T) {
+	t.Setenv("GITEA_FOO", "bar")
+	t.Setenv("FOO", "bar")
+	Filter([]string{}, []string{"GITEA_"})
+	if os.Getenv("GITEA_FOO") != "" {
+		t.FailNow()
+	}
+	if os.Getenv("FOO") != "bar" {
+		t.FailNow()
+	}
+
+	t.Setenv("GITEA_TEST_FOO", "bar")
+	t.Setenv("GITEA_BAR", "foo")
+	t.Setenv("GITEA_BAR_BAZ", "foo")
+	t.Setenv("GITEA_BAZ", "huz")
+	Filter([]string{"GITEA_TEST_", "GITEA_BAR="}, []string{"GITEA_"})
+	if os.Getenv("GITEA_BAR") != "foo" {
+		t.Fail()
+	}
+	if os.Getenv("GITEA_TEST_FOO") != "bar" {
+		t.Fail()
+	}
+	if os.Getenv("GITEA_BAZ") != "" {
+		t.Fail()
+	}
+	if os.Getenv("GITEA_BAR_BAZ") != "" {
+		t.Fail()
+	}
+}

--- a/tests/test_utils.go
+++ b/tests/test_utils.go
@@ -22,12 +22,15 @@ import (
 	"code.gitea.io/gitea/modules/testlogger"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/routers"
+	"code.gitea.io/gitea/tests/env"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func InitTest(requireGitea bool) {
 	testlogger.Init()
+
+	env.Filter([]string{"GITEA_TEST_", "GITEA_UNIT_TESTS_", "GITEA_ROOT=", "GITEA_CONF="}, []string{"GITEA_"})
 
 	giteaRoot := test.SetupGiteaRoot()
 


### PR DESCRIPTION
The test code expects that GITEA_CUSTOM is not set. While there is no reason to set this variable some misguided packagers set it globally in /etc/profile rather than in the service definition.

Fixes: go-gitea/gitea#36042


