### PR TITLE
Update go toolchain to 1.25.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module code.gitea.io/gitea
 
 go 1.25.0
 
-toolchain go1.25.4
+toolchain go1.25.5
 
 // rfc5280 said: "The serial number is an integer assigned by the CA to each certificate."
 // But some CAs use negative serial number, just relax the check. related:


### PR DESCRIPTION
Fixes: https://pkg.go.dev/vuln/GO-2025-4155