### PR TITLE
Fix issue close timeline icon

### DIFF
--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -96,7 +96,7 @@
 			</div>
 		{{else if eq .Type 2}}
 			<div class="timeline-item event" id="{{.HashTag}}">
-				<span class="badge tw-bg-red tw-text-white">{{svg "octicon-circle-slash"}}</span>
+				<span class="badge tw-bg-red tw-text-white">{{svg "octicon-issue-closed"}}</span>
 				{{if not .OriginalAuthor}}
 					{{template "shared/user/avatarlink" dict "user" .Poster}}
 				{{end}}


### PR DESCRIPTION
Previously there was a icon mismatch between a issue's label and the timeline close event icon:

<img width="127" height="60" alt="Screenshot 2025-12-12 at 16 25 13" src="https://github.com/user-attachments/assets/04e46dd3-7122-495b-8119-696bb897df23" />

<img width="400" height="61" alt="Screenshot 2025-12-12 at 16 25 03" src="https://github.com/user-attachments/assets/6142cc19-73ac-4304-91b6-a8270ecec8b4" />

This fixes it and the icons match now:

<img width="398" height="60" alt="Screenshot 2025-12-12 at 16 25 20" src="https://github.com/user-attachments/assets/26aef3a4-522b-49f4-a11d-28c6d3915bcb" />
