### PR TITLE
Add explicit permissions to all actions workflows

### DIFF
--- a/.github/workflows/cron-licenses.yml
+++ b/.github/workflows/cron-licenses.yml
@@ -9,6 +9,8 @@ jobs:
   cron-licenses:
     runs-on: ubuntu-latest
     if: github.repository == 'go-gitea/gitea'
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6

--- a/.github/workflows/cron-translations.yml
+++ b/.github/workflows/cron-translations.yml
@@ -9,6 +9,8 @@ jobs:
   crowdin-pull:
     runs-on: ubuntu-latest
     if: github.repository == 'go-gitea/gitea'
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v5
       - uses: crowdin/github-action@v1

--- a/.github/workflows/files-changed.yml
+++ b/.github/workflows/files-changed.yml
@@ -24,6 +24,8 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    permissions:
+      contents: read
     outputs:
       backend: ${{ steps.changes.outputs.backend }}
       frontend: ${{ steps.changes.outputs.frontend }}

--- a/.github/workflows/pull-compliance.yml
+++ b/.github/workflows/pull-compliance.yml
@@ -15,6 +15,8 @@ jobs:
     if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
@@ -30,6 +32,8 @@ jobs:
     if: needs.files-changed.outputs.templates == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v6
@@ -46,6 +50,8 @@ jobs:
     if: needs.files-changed.outputs.yaml == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v6
@@ -57,6 +63,8 @@ jobs:
     if: needs.files-changed.outputs.swagger == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
@@ -70,6 +78,8 @@ jobs:
     if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.frontend == 'true' || needs.files-changed.outputs.actions == 'true' || needs.files-changed.outputs.docs == 'true' || needs.files-changed.outputs.templates == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
@@ -82,6 +92,8 @@ jobs:
     if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
@@ -99,6 +111,8 @@ jobs:
     if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
@@ -114,6 +128,8 @@ jobs:
     if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
@@ -127,6 +143,8 @@ jobs:
     if: needs.files-changed.outputs.frontend == 'true' || needs.files-changed.outputs.actions == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
@@ -143,6 +161,8 @@ jobs:
     if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
@@ -175,6 +195,8 @@ jobs:
     if: needs.files-changed.outputs.docs == 'true' || needs.files-changed.outputs.actions == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
@@ -188,6 +210,8 @@ jobs:
     if: needs.files-changed.outputs.actions == 'true' || needs.files-changed.outputs.actions == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6

--- a/.github/workflows/pull-db-tests.yml
+++ b/.github/workflows/pull-db-tests.yml
@@ -15,6 +15,8 @@ jobs:
     if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     services:
       pgsql:
         image: postgres:14
@@ -65,6 +67,8 @@ jobs:
     if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
@@ -90,6 +94,8 @@ jobs:
     if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     services:
       elasticsearch:
         image: elasticsearch:7.5.0
@@ -152,6 +158,8 @@ jobs:
     if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     services:
       mysql:
         # the bitnami mysql image has more options than the official one, it's easier to customize
@@ -203,6 +211,8 @@ jobs:
     if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     services:
       mssql:
         image: mcr.microsoft.com/mssql/server:2019-latest

--- a/.github/workflows/pull-docker-dryrun.yml
+++ b/.github/workflows/pull-docker-dryrun.yml
@@ -15,6 +15,8 @@ jobs:
     if: needs.files-changed.outputs.docker == 'true' || needs.files-changed.outputs.actions == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -11,6 +11,8 @@ concurrency:
 jobs:
   nightly-binary:
     runs-on: namespace-profile-gitea-release-binary
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       # fetch all commits instead of only the last as some branches are long lived and could have many between versions
@@ -56,9 +58,11 @@ jobs:
       - name: upload binaries to s3
         run: |
           aws s3 sync dist/release s3://${{ secrets.AWS_S3_BUCKET }}/gitea/${{ steps.clean_name.outputs.branch }} --no-progress
+
   nightly-container:
     runs-on: namespace-profile-gitea-release-docker
     permissions:
+      contents: read
       packages: write # to publish to ghcr.io
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release-tag-rc.yml
+++ b/.github/workflows/release-tag-rc.yml
@@ -12,6 +12,8 @@ concurrency:
 jobs:
   binary:
     runs-on: namespace-profile-gitea-release-binary
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       # fetch all commits instead of only the last as some branches are long lived and could have many between versions
@@ -66,9 +68,11 @@ jobs:
           gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --draft --notes-from-tag dist/release/*
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+
   container:
     runs-on: namespace-profile-gitea-release-docker
     permissions:
+      contents: read
       packages: write # to publish to ghcr.io
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release-tag-version.yml
+++ b/.github/workflows/release-tag-version.yml
@@ -15,6 +15,7 @@ jobs:
   binary:
     runs-on: namespace-profile-gitea-release-binary
     permissions:
+      contents: read
       packages: write # to publish to ghcr.io
     steps:
       - uses: actions/checkout@v5
@@ -70,9 +71,11 @@ jobs:
           gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --notes-from-tag dist/release/*
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+
   container:
     runs-on: namespace-profile-gitea-release-docker
     permissions:
+      contents: read
       packages: write # to publish to ghcr.io
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Explicitely specify all workflow [`permissions`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions). This will fix [26 CodeQL alerts](https://github.com/go-gitea/gitea/security/code-scanning?query=permissions+is%3Aopen+branch%3Amain+).