### PR TITLE
Fix the incorrect display of files encoded in Windows-1251 in the blame view.

### DIFF
--- a/routers/web/repo/blame.go
+++ b/routers/web/repo/blame.go
@@ -274,6 +274,7 @@ func renderBlame(ctx *context.Context, blameParts []*git.BlamePart, commitNames 
 			if i != len(lines)-1 {
 				line += "\n"
 			}
+			line = util.UnsafeBytesToString(charset.ToUTF8([]byte(line), charset.ConvertOpts{}))
 			line, lexerNameForLine := highlight.Code(path.Base(ctx.Repo.TreePath), language, line)
 
 			// set lexer name to the first detected lexer. this is certainly suboptimal and


### PR DESCRIPTION
Fix https://github.com/go-gitea/gitea/issues/35504#issuecomment-3649653437 as a quick patch