### PR TITLE
Enable gocheckcompilerdirectives linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - dupl
     - errcheck
     - forbidigo
+    - gocheckcompilerdirectives
     - gocritic
     - govet
     - ineffassign


### PR DESCRIPTION
Enable [`gocheckcompilerdirectives`](https://github.com/leighmcculloch/gocheckcompilerdirectives) to validate compiler directives, no current violation.