### PR TITLE
fix webAuthn insecure error view

### DIFF
--- a/web_src/js/features/user-auth-webauthn.ts
+++ b/web_src/js/features/user-auth-webauthn.ts
@@ -11,13 +11,8 @@ export async function initUserAuthWebAuthn() {
     return;
   }
 
-  // webauthn is only supported on secure contexts
-  if (!window.isSecureContext) {
-    if (elSignInPasskeyBtn) hideElem(elSignInPasskeyBtn);
-    return;
-  }
-
   if (!detectWebAuthnSupport()) {
+    if (elSignInPasskeyBtn) hideElem(elSignInPasskeyBtn);
     return;
   }
 


### PR DESCRIPTION
as you seen, in cureent status `initUserAuthWebAuthn` will prcheck `window.isSecureContext`, if not ok, will hide the `passkey` btton and return directly. I think it's not right, first, not show any error message looks not a good ui, and it's looks will make an empty container was show if the registion button was disabled also (maybe f-i-x #36115), then initUserAuthWebAuthn has `window.isSecureContext` check also which looks duplcate ref: 
https://github.com/go-gitea/gitea/blob/26602fd2070886a1e7e0545f11f5541a38396003/web_src/js/features/user-auth-webauthn.ts#L202-L206

so I'd like move hideElem(elSignInPasskeyBtn); to `detectWebAuthnSupport` failed routs to make it simple and show insecure error corectly.
![联想截图_20251215184757](https://github.com/user-attachments/assets/0eff43a0-18a6-4978-aa27-b4574fcf2601)
