### PR TITLE
Enable `bodyclose` linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
   default: none
   enable:
     - bidichk
+    - bodyclose
     - depguard
     - dupl
     - errcheck

--- a/modules/indexer/issues/elasticsearch/elasticsearch_test.go
+++ b/modules/indexer/issues/elasticsearch/elasticsearch_test.go
@@ -30,7 +30,11 @@ func TestElasticsearchIndexer(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		resp, err := http.Get(url)
-		return err == nil && resp.StatusCode == http.StatusOK
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
 	}, time.Minute, time.Second, "Expected elasticsearch to be up")
 
 	indexer := NewIndexer(url, fmt.Sprintf("test_elasticsearch_indexer_%d", time.Now().Unix()))

--- a/modules/indexer/issues/meilisearch/meilisearch_test.go
+++ b/modules/indexer/issues/meilisearch/meilisearch_test.go
@@ -36,7 +36,11 @@ func TestMeilisearchIndexer(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		resp, err := http.Get(url)
-		return err == nil && resp.StatusCode == http.StatusOK
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
 	}, time.Minute, time.Second, "Expected meilisearch to be up")
 
 	indexer := NewIndexer(url, key, fmt.Sprintf("test_meilisearch_indexer_%d", time.Now().Unix()))

--- a/services/migrations/dump.go
+++ b/services/migrations/dump.go
@@ -306,14 +306,15 @@ func (g *RepositoryDumper) CreateReleases(_ context.Context, releases ...*base.R
 						if err != nil {
 							return err
 						}
+						defer rc.Close()
 					} else {
 						resp, err := http.Get(*asset.DownloadURL)
 						if err != nil {
 							return err
 						}
+						defer resp.Body.Close()
 						rc = resp.Body
 					}
-					defer rc.Close()
 
 					fw, err := os.Create(attachPath)
 					if err != nil {

--- a/services/migrations/gitea_downloader_test.go
+++ b/services/migrations/gitea_downloader_test.go
@@ -27,6 +27,7 @@ func TestGiteaDownloadRepo(t *testing.T) {
 	if err != nil || resp.StatusCode != http.StatusOK {
 		t.Skipf("Can't reach https://gitea.com, skipping %s", t.Name())
 	}
+	defer resp.Body.Close()
 	ctx := t.Context()
 	downloader, err := NewGiteaDownloader(ctx, "https://gitea.com", "gitea/test_repo", "", "", giteaToken)
 	require.NoError(t, err, "NewGiteaDownloader error occur")

--- a/services/migrations/gitlab_test.go
+++ b/services/migrations/gitlab_test.go
@@ -30,6 +30,7 @@ func TestGitlabDownloadRepo(t *testing.T) {
 	if err != nil || resp.StatusCode != http.StatusOK {
 		t.Skipf("Can't access test repo, skipping %s", t.Name())
 	}
+	defer resp.Body.Close()
 	ctx := t.Context()
 	downloader, err := NewGitlabDownloader(ctx, "https://gitlab.com", "gitea/test_repo", gitlabPersonalAccessToken)
 	if err != nil {

--- a/services/migrations/gogs_test.go
+++ b/services/migrations/gogs_test.go
@@ -27,6 +27,7 @@ func TestGogsDownloadRepo(t *testing.T) {
 		t.Skipf("visit test repo failed, ignored")
 		return
 	}
+	defer resp.Body.Close()
 	ctx := t.Context()
 	downloader := NewGogsDownloader(ctx, "https://try.gogs.io", "", "", gogsPersonalAccessToken, "lunnytest", "TESTREPO")
 	repo, err := downloader.GetRepoInfo(ctx)

--- a/services/migrations/onedev_test.go
+++ b/services/migrations/onedev_test.go
@@ -19,6 +19,7 @@ func TestOneDevDownloadRepo(t *testing.T) {
 	if err != nil || resp.StatusCode != http.StatusOK {
 		t.Skipf("Can't access test repo, skipping %s", t.Name())
 	}
+	defer resp.Body.Close()
 
 	u, _ := url.Parse("https://code.onedev.io")
 	ctx := t.Context()

--- a/tests/integration/api_activitypub_person_test.go
+++ b/tests/integration/api_activitypub_person_test.go
@@ -78,6 +78,7 @@ func TestActivityPubPerson(t *testing.T) {
 
 		// Signed request succeeds
 		resp, err := c.Post([]byte{}, user2inboxurl)
+		defer resp.Body.Close()
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 

--- a/tests/integration/api_packages_generic_test.go
+++ b/tests/integration/api_packages_generic_test.go
@@ -163,6 +163,7 @@ func TestPackageGeneric(t *testing.T) {
 
 			resp2, err := (&http.Client{}).Get(location)
 			assert.NoError(t, err)
+			defer resp2.Body.Close()
 			assert.Equal(t, http.StatusOK, resp2.StatusCode, location)
 
 			body, err := io.ReadAll(resp2.Body)


### PR DESCRIPTION
Enabe [`bodyclose`](https://golangci-lint.run/docs/linters/configuration/#bodyclose). The only issue in non-test code (`services/migrations/dump.go`) was a false-positive and I think there are a number of undetected cases, but I guess it's still better than not having it.