### PR TITLE
Disable dependabot automatic labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 
 updates:
   - package-ecosystem: github-actions
+    labels: []
     directory: /
     schedule:
       interval: daily


### PR DESCRIPTION
Disable dependabot's [automatic labels](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#labels--), we have `actions/labeler` to do this job. After this is merged, I will delete the labels `dependencies` and `github_actions` that dependabot had created.