### PR TITLE
Closed milestones with no issues now show as 100% completed

### DIFF
--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -398,6 +398,7 @@ func prepareMigrationTasks() []*migration {
 		// Gitea 1.25.0 ends at migration ID number 322 (database version 323)
 
 		newMigration(323, "Add support for actions concurrency", v1_26.AddActionsConcurrency),
+		newMigration(324, "Fix closed milestone completeness for milestones with no issues", v1_26.FixClosedMilestoneCompleteness),
 	}
 	return preparedMigrations
 }

--- a/models/migrations/v1_26/v324.go
+++ b/models/migrations/v1_26/v324.go
@@ -1,0 +1,24 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v1_26
+
+import (
+	"fmt"
+
+	"xorm.io/xorm"
+)
+
+func FixClosedMilestoneCompleteness(x *xorm.Engine) error {
+	// Update all milestones to recalculate completeness with the new logic:
+	// - Closed milestones with 0 issues should show 100%
+	// - All other milestones should calculate based on closed/total ratio
+	_, err := x.Exec("UPDATE `milestone` SET completeness=(CASE WHEN is_closed = ? AND num_issues = 0 THEN 100 ELSE 100*num_closed_issues/(CASE WHEN num_issues > 0 THEN num_issues ELSE 1 END) END)",
+		true,
+	)
+	if err != nil {
+		return fmt.Errorf("error updating milestone completeness: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Closed milestones with 0 issues currently display as having 0% completion. This makes sense if the milestone is still open, but if the milestone is closed it seems like that it should show 100% completeness instead.

Before:
<img width="1708" height="252" alt="image" src="https://github.com/user-attachments/assets/0b58c78f-0609-44ee-8d58-bd67534c6164" />
After:
<img width="1716" height="263" alt="image" src="https://github.com/user-attachments/assets/3fb0044f-d76c-4888-9d60-640f2ca5fec6" />
