### PR TITLE
Adjust notification icon vertical alignment in navbar

### DIFF
--- a/web_src/css/modules/navbar.css
+++ b/web_src/css/modules/navbar.css
@@ -15,6 +15,14 @@
   min-height: 49px; /* +1px border-bottom */
 }
 
+.navbar-right .tw-relative .octicon-bell {
+  margin-top: 2px;
+}
+
+.navbar-left .tw-relative .octicon-bell {
+  margin-top: 1.5px;
+}
+
 .navbar-left > .item,
 .navbar-right > .item,
 .navbar-mobile-right > .item {


### PR DESCRIPTION
Fix slight vertical misalignment of the notification icon in the navbar

# Comparation

## Desktop

Before adjustment:
<img width="267" height="60" alt="c8ba915b82096a4b5a669af42d5cca96" src="https://github.com/user-attachments/assets/48d7ff31-752c-47ea-8d5d-89f89749d560" />

After adjustment:
<img width="269" height="62" alt="56364ee9907c54df77efd7681ba56582" src="https://github.com/user-attachments/assets/57fd2fac-bd52-463b-959e-3a9fa4df575f" />


## Mobile

Before adjustment:
<img width="224" height="69" alt="a31cc613733cbe1b387cff76f3f83873" src="https://github.com/user-attachments/assets/13f55c80-87bf-40a0-85f3-dde7aac70302" />

After adjustment:
<img width="229" height="69" alt="ca08a53303b146759818399b82d8317d" src="https://github.com/user-attachments/assets/6df66ade-98bd-45ef-9837-16ece279cfee" />


