### PR TITLE
fix: spelling error in migrate-storage cmd utility

### DIFF
--- a/cmd/migrate_storage.go
+++ b/cmd/migrate_storage.go
@@ -36,7 +36,7 @@ var CmdMigrateStorage = &cli.Command{
 			Name:    "type",
 			Aliases: []string{"t"},
 			Value:   "",
-			Usage:   "Type of stored files to copy.  Allowed types: 'attachments', 'lfs', 'avatars', 'repo-avatars', 'repo-archivers', 'packages', 'actions-log', 'actions-artifacts",
+			Usage:   "Type of stored files to copy.  Allowed types: 'attachments', 'lfs', 'avatars', 'repo-avatars', 'repo-archivers', 'packages', 'actions-log', 'actions-artifacts'",
 		},
 		&cli.StringFlag{
 			Name:    "storage",


### PR DESCRIPTION
Added closing quote which looks to be forgotten