### PR TITLE
Fix panic in blame view when a file has only a single commit

### DIFF
--- a/routers/web/repo/blame.go
+++ b/routers/web/repo/blame.go
@@ -271,7 +271,7 @@ func renderBlame(ctx *context.Context, blameParts []*gitrepo.BlamePart, commitNa
 	unsafeLines := highlight.UnsafeSplitHighlightedLines(highlighted)
 	for i, br := range rows {
 		var line template.HTML
-		if i < len(rows) {
+		if i < len(unsafeLines) {
 			line = template.HTML(util.UnsafeBytesToString(unsafeLines[i]))
 		}
 		br.EscapeStatus, br.Code = charset.EscapeControlHTML(line, ctx.Locale)


### PR DESCRIPTION
This PR fixes a panic in the repository blame view that occurs when rendering files
whose blame history consists of only a single commit.

In this case, the number of rendered blame rows can exceed the number of
highlighted lines returned by the syntax highlighter. The existing bounds check
incorrectly used `len(rows)`, which may be greater than `len(unsafeLines)`,
leading to an out-of-range access on `unsafeLines` and a runtime panic.

The fix changes the bounds check to use `len(unsafeLines)` instead, ensuring we
never index past the available highlighted lines.

This issue is reproducible with files that:
- were introduced in exactly one commit, and
- are accessed via the blame view (e.g. `/blame/commit/<sha>/file`).

The change is minimal, safe, and does not affect normal blame rendering.

---

Example error:

```
2025/12/22 02:35:31 HTTPRequest [W] router: failed    GET /actions/deb-changelog-action/blame/commit/1239d674128fe38b284802f4e97c70068116fd52/CHANGELOG.md for XXX.XXX.XXX.XXX:0, panic in 34.8ms @ repo/blame.go:44(repo.RefBlame), err=runtime error: index out of range [61] with length 61
2025/12/22 02:35:31 routers/common/errpage.go:25:RenderPanicErrorPage() [E] PANIC: runtime error: index out of range [61] with length 61
/usr/local/go/src/runtime/panic.go:783 (0x4860b1)
/go/src/code.gitea.io/gitea/modules/web/routing/logger_manager.go:116 (0x19b8a84)
/usr/local/go/src/runtime/panic.go:783 (0x4860b1)
/usr/local/go/src/runtime/panic.go:115 (0x44a1b3)
/go/src/code.gitea.io/gitea/routers/web/repo/blame.go:275 (0x2aaa01a)
/go/src/code.gitea.io/gitea/routers/web/repo/blame.go:97 (0x2aa8a08)
[...]
```

Introduced with PR #36157