### PR TITLE
fix: prevent 100% width radio buttons

### DIFF
--- a/web_src/css/modules/form.css
+++ b/web_src/css/modules/form.css
@@ -33,7 +33,7 @@
 }
 
 .ui.form textarea,
-.ui.form input {
+.ui.form input:not([type="checkbox"], [type="radio"]) {
   width: 100%;
   vertical-align: top;
 }


### PR DESCRIPTION
as part of [Remove fomantic form module](https://github.com/go-gitea/gitea/commit/eddf8759926911c465b249de5f6d68c052a539e0#diff-c34b74004deb63fb4f8a8549ef9d822b9839db0b69ae2c0cdacc05ce3d5d5682) radio buttons get caught in crossfire and recieve `width: 100%` this is particularly noticeable on the `user/settings/applications` page which has many radio buttons.

This continues using an opt out `input:not([type="checkbox"], [type="radio"])` to prevent this.