### PR TITLE
fix: Missing repo name in push mirror system message

### DIFF
--- a/services/mirror/mirror_push.go
+++ b/services/mirror/mirror_push.go
@@ -92,7 +92,10 @@ func SyncPushMirror(ctx context.Context, mirrorID int64) bool {
 		return false
 	}
 
-	_ = m.GetRepository(ctx)
+	if m.GetRepository(ctx) == nil {
+		log.Error("PushMirror[%d] repository does not exist", m.ID)
+		return false
+	}
 
 	m.LastError = ""
 


### PR DESCRIPTION
## Summary
This PR fixes #36211

## Changes
- Added proper nil check for GetRepository() in SyncPushMirror function
- Prevents nil pointer dereference when constructing process description
- Ensures repository names are properly displayed in system messages

When a push mirror's repository no longer exists, the previous code ignored the return value of GetRepository(), which could lead to nil pointer access when constructing the process description at line 102. This resulted in empty repository names in system messages.

This fix checks if GetRepository() returns nil and exits early with an error log, preventing the use of nil repository fields.

---
Generated with Claude Code