### PR TITLE
mailer: pass request context to generateAdditionalHeadersForIssue

### DIFF
--- a/services/mailer/mail_issue_common.go
+++ b/services/mailer/mail_issue_common.go
@@ -203,7 +203,7 @@ func composeIssueCommentMessages(ctx context.Context, comment *mailComment, lang
 		msg.SetHeader("References", references...)
 		msg.SetHeader("List-Unsubscribe", listUnsubscribe...)
 
-		for key, value := range generateAdditionalHeadersForIssue(comment, actType, recipient) {
+		for key, value := range generateAdditionalHeadersForIssue(ctx, comment, actType, recipient) {
 			msg.SetHeader(key, value)
 		}
 
@@ -303,17 +303,17 @@ func generateMessageIDForIssue(issue *issues_model.Issue, comment *issues_model.
 	return fmt.Sprintf("<%s/%s/%d%s@%s>", issue.Repo.FullName(), path, issue.Index, extra, setting.Domain)
 }
 
-func generateAdditionalHeadersForIssue(ctx *mailComment, reason string, recipient *user_model.User) map[string]string {
-	repo := ctx.Issue.Repo
+func generateAdditionalHeadersForIssue(ctx context.Context, comment *mailComment, reason string, recipient *user_model.User) map[string]string {
+	repo := comment.Issue.Repo
 
-	issueID := strconv.FormatInt(ctx.Issue.Index, 10)
+	issueID := strconv.FormatInt(comment.Issue.Index, 10)
 	headers := generateMetadataHeaders(repo)
 
-	maps.Copy(headers, generateSenderRecipientHeaders(ctx.Doer, recipient))
+	maps.Copy(headers, generateSenderRecipientHeaders(comment.Doer, recipient))
 	maps.Copy(headers, generateReasonHeaders(reason))
 
 	headers["X-Gitea-Issue-ID"] = issueID
-	headers["X-Gitea-Issue-Link"] = ctx.Issue.HTMLURL(context.TODO()) // FIXME: use proper context
+	headers["X-Gitea-Issue-Link"] = comment.Issue.HTMLURL(ctx)
 	headers["X-GitLab-Issue-IID"] = issueID
 
 	return headers

--- a/services/mailer/mail_test.go
+++ b/services/mailer/mail_test.go
@@ -304,7 +304,7 @@ func TestGenerateAdditionalHeadersForIssue(t *testing.T) {
 	comment := &mailComment{Issue: issue, Doer: doer}
 	recipient := &user_model.User{Name: "test", Email: "test@gitea.com"}
 
-	headers := generateAdditionalHeadersForIssue(comment, "dummy-reason", recipient)
+	headers := generateAdditionalHeadersForIssue(t.Context(), comment, "dummy-reason", recipient)
 
 	expected := map[string]string{
 		"List-ID":                   "user2/repo1 <repo1.user2.localhost>",


### PR DESCRIPTION
Fixes #36273

Use the caller-provided context when building X-Gitea-Issue-Link, instead of `context.TODO()`.

## Changes

- Add `ctx context.Context` parameter to `generateAdditionalHeadersForIssue`
- Rename misleading `ctx` parameter (was `*mailComment`) to `comment` for clarity
- Update test to use `t.Context()`