### PR TITLE
Add 'allow_maintainer_edit' API option for creating a pull request

### DIFF
--- a/modules/structs/pull.go
+++ b/modules/structs/pull.go
@@ -141,7 +141,7 @@ type CreatePullRequestOption struct {
 	// The list of team reviewer names
 	TeamReviewers []string `json:"team_reviewers"`
 	// Whether maintainers can edit the pull request
-	AllowMaintainerEdit bool `json:"allow_maintainer_edit"`
+	AllowMaintainerEdit *bool `json:"allow_maintainer_edit"`
 }
 
 // EditPullRequestOption options when modify pull request

--- a/modules/structs/pull.go
+++ b/modules/structs/pull.go
@@ -140,6 +140,8 @@ type CreatePullRequestOption struct {
 	Reviewers []string `json:"reviewers"`
 	// The list of team reviewer names
 	TeamReviewers []string `json:"team_reviewers"`
+	// Whether maintainers can edit the pull request
+	AllowMaintainerEdit bool `json:"allow_maintainer_edit"`
 }
 
 // EditPullRequestOption options when modify pull request

--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -25,6 +25,7 @@ import (
 	"code.gitea.io/gitea/modules/gitrepo"
 	"code.gitea.io/gitea/modules/graceful"
 	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/optional"
 	"code.gitea.io/gitea/modules/setting"
 	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/timeutil"
@@ -496,6 +497,11 @@ func CreatePullRequest(ctx *context.APIContext) {
 		deadlineUnix = timeutil.TimeStamp(form.Deadline.Unix())
 	}
 
+	unitPullRequest, err := ctx.Repo.Repository.GetUnit(ctx, unit.TypePullRequests)
+	if err != nil {
+		ctx.APIErrorInternal(err)
+	}
+
 	prIssue := &issues_model.Issue{
 		RepoID:       repo.ID,
 		Title:        form.Title,
@@ -516,6 +522,8 @@ func CreatePullRequest(ctx *context.APIContext) {
 		MergeBase:  compareResult.MergeBase,
 		Type:       issues_model.PullRequestGitea,
 	}
+
+	pr.AllowMaintainerEdit = optional.FromPtr(form.AllowMaintainerEdit).ValueOrDefault(unitPullRequest.PullRequestsConfig().DefaultAllowMaintainerEdit)
 
 	// Get all assignee IDs
 	assigneeIDs, err := issues_model.MakeIDsFromAPIAssigneesToAdd(ctx, form.Assignee, form.Assignees)
@@ -547,12 +555,11 @@ func CreatePullRequest(ctx *context.APIContext) {
 	}
 
 	prOpts := &pull_service.NewPullRequestOptions{
-		Repo:                repo,
-		Issue:               prIssue,
-		LabelIDs:            labelIDs,
-		PullRequest:         pr,
-		AssigneeIDs:         assigneeIDs,
-		AllowMaintainerEdit: form.AllowMaintainerEdit,
+		Repo:        repo,
+		Issue:       prIssue,
+		LabelIDs:    labelIDs,
+		PullRequest: pr,
+		AssigneeIDs: assigneeIDs,
 	}
 	prOpts.Reviewers, prOpts.TeamReviewers = parseReviewersByNames(ctx, form.Reviewers, form.TeamReviewers)
 	if ctx.Written() {

--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -547,11 +547,12 @@ func CreatePullRequest(ctx *context.APIContext) {
 	}
 
 	prOpts := &pull_service.NewPullRequestOptions{
-		Repo:        repo,
-		Issue:       prIssue,
-		LabelIDs:    labelIDs,
-		PullRequest: pr,
-		AssigneeIDs: assigneeIDs,
+		Repo:                repo,
+		Issue:               prIssue,
+		LabelIDs:            labelIDs,
+		PullRequest:         pr,
+		AssigneeIDs:         assigneeIDs,
+		AllowMaintainerEdit: form.AllowMaintainerEdit,
 	}
 	prOpts.Reviewers, prOpts.TeamReviewers = parseReviewersByNames(ctx, form.Reviewers, form.TeamReviewers)
 	if ctx.Written() {

--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -44,15 +44,16 @@ func getPullWorkingLockKey(prID int64) string {
 }
 
 type NewPullRequestOptions struct {
-	Repo            *repo_model.Repository
-	Issue           *issues_model.Issue
-	LabelIDs        []int64
-	AttachmentUUIDs []string
-	PullRequest     *issues_model.PullRequest
-	AssigneeIDs     []int64
-	Reviewers       []*user_model.User
-	TeamReviewers   []*organization.Team
-	ProjectID       int64
+	Repo                *repo_model.Repository
+	Issue               *issues_model.Issue
+	LabelIDs            []int64
+	AttachmentUUIDs     []string
+	PullRequest         *issues_model.PullRequest
+	AssigneeIDs         []int64
+	Reviewers           []*user_model.User
+	TeamReviewers       []*organization.Team
+	ProjectID           int64
+	AllowMaintainerEdit bool
 }
 
 // NewPullRequest creates new pull request with labels for repository.
@@ -129,6 +130,9 @@ func NewPullRequest(ctx context.Context, opts *NewPullRequestOptions) error {
 
 		pr.Issue = issue
 		issue.PullRequest = pr
+
+		pr.AllowMaintainerEdit = opts.AllowMaintainerEdit
+		issues_model.UpdateAllowEdits(ctx, pr)
 
 		if pr.Flow == issues_model.PullRequestFlowGithub {
 			err = PushToBaseRepo(ctx, pr)

--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -44,16 +44,15 @@ func getPullWorkingLockKey(prID int64) string {
 }
 
 type NewPullRequestOptions struct {
-	Repo                *repo_model.Repository
-	Issue               *issues_model.Issue
-	LabelIDs            []int64
-	AttachmentUUIDs     []string
-	PullRequest         *issues_model.PullRequest
-	AssigneeIDs         []int64
-	Reviewers           []*user_model.User
-	TeamReviewers       []*organization.Team
-	ProjectID           int64
-	AllowMaintainerEdit bool
+	Repo            *repo_model.Repository
+	Issue           *issues_model.Issue
+	LabelIDs        []int64
+	AttachmentUUIDs []string
+	PullRequest     *issues_model.PullRequest
+	AssigneeIDs     []int64
+	Reviewers       []*user_model.User
+	TeamReviewers   []*organization.Team
+	ProjectID       int64
 }
 
 // NewPullRequest creates new pull request with labels for repository.
@@ -130,9 +129,6 @@ func NewPullRequest(ctx context.Context, opts *NewPullRequestOptions) error {
 
 		pr.Issue = issue
 		issue.PullRequest = pr
-
-		pr.AllowMaintainerEdit = opts.AllowMaintainerEdit
-		issues_model.UpdateAllowEdits(ctx, pr)
 
 		if pr.Flow == issues_model.PullRequestFlowGithub {
 			err = PushToBaseRepo(ctx, pr)

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -23420,6 +23420,11 @@
       "description": "CreatePullRequestOption options when creating a pull request",
       "type": "object",
       "properties": {
+        "allow_maintainer_edit": {
+          "description": "Whether maintainers can edit the pull request",
+          "type": "boolean",
+          "x-go-name": "AllowMaintainerEdit"
+        },
         "assignee": {
           "description": "The primary assignee username",
           "type": "string",


### PR DESCRIPTION
WebUI has a checkbox for enabling maintainer edits you can check right away when creating a new pull request.
Also, it is possible to set `allow_maintainer_edit` in an existing pull request via API.
This change enables the option while creating a new pull request via API.