### PR TITLE
Add object pool interface and refactor related code

### DIFF
--- a/modules/git/batch_reader.go
+++ b/modules/git/batch_reader.go
@@ -10,27 +10,6 @@ import (
 	"code.gitea.io/gitea/modules/git/catfile"
 )
 
-// ReadBatchLine reads the header line from cat-file --batch while preserving the traditional return signature.
-func ReadBatchLine(rd *bufio.Reader) (sha []byte, typ string, size int64, err error) {
-	sha, typ, size, err = catfile.ReadBatchLine(rd)
-	return sha, typ, size, convertCatfileError(err, sha)
-}
-
-// ReadTagObjectID reads a tag object ID hash from a cat-file --batch stream, throwing away the rest of the stream.
-func ReadTagObjectID(rd *bufio.Reader, size int64) (string, error) {
-	return catfile.ReadTagObjectID(rd, size)
-}
-
-// ReadTreeID reads a tree ID from a cat-file --batch stream, throwing away the rest of the stream.
-func ReadTreeID(rd *bufio.Reader, size int64) (string, error) {
-	return catfile.ReadTreeID(rd, size)
-}
-
-// BinToHex converts a binary hash into a hex encoded one.
-func BinToHex(objectFormat ObjectFormat, sha, out []byte) []byte {
-	return catfile.BinToHex(objectFormat, sha, out)
-}
-
 // ParseCatFileTreeLine reads an entry from a tree in a cat-file --batch stream.
 func ParseCatFileTreeLine(objectFormat ObjectFormat, rd *bufio.Reader, modeBuf, fnameBuf, shaBuf []byte) (mode, fname, sha []byte, n int, err error) {
 	mode, fname, sha, n, err = catfile.ParseCatFileTreeLine(objectFormat, rd, modeBuf, fnameBuf, shaBuf)

--- a/modules/git/catfile/object_pool.go
+++ b/modules/git/catfile/object_pool.go
@@ -5,7 +5,6 @@ package catfile
 
 import (
 	"bufio"
-	"context"
 )
 
 type ObjectInfo struct {
@@ -15,16 +14,11 @@ type ObjectInfo struct {
 }
 
 type ObjectInfoPool interface {
-	ObjectInfo(ctx context.Context, sha string) (*ObjectInfo, error)
+	ObjectInfo(refName string) (*ObjectInfo, error)
 	Close()
 }
 
-type Object struct {
-	ObjectInfo
-	Reader *bufio.Reader
-}
-
 type ObjectPool interface {
-	Object(ctx context.Context, sha string) (*Object, error)
+	Object(refName string) (*ObjectInfo, *bufio.Reader, error)
 	Close()
 }

--- a/modules/git/catfile/object_pool.go
+++ b/modules/git/catfile/object_pool.go
@@ -1,0 +1,30 @@
+// Copyright 2024 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package catfile
+
+import (
+	"bufio"
+	"context"
+)
+
+type ObjectInfo struct {
+	ID   string
+	Type string
+	Size int64
+}
+
+type ObjectInfoPool interface {
+	ObjectInfo(ctx context.Context, sha string) (*ObjectInfo, error)
+	Close()
+}
+
+type Object struct {
+	ObjectInfo
+	Reader *bufio.Reader
+}
+
+type ObjectPool interface {
+	Object(ctx context.Context, sha string) (*Object, error)
+	Close()
+}

--- a/modules/git/catfile/object_pool_cmd.go
+++ b/modules/git/catfile/object_pool_cmd.go
@@ -28,7 +28,7 @@ func NewObjectInfoPool(ctx context.Context, repoPath string) (ObjectInfoPool, er
 	return &check, nil
 }
 
-func (b *batchCheck) ObjectInfo(ctx context.Context, refName string) (*ObjectInfo, error) {
+func (b *batchCheck) ObjectInfo(refName string) (*ObjectInfo, error) {
 	_, err := b.writer.Write([]byte(refName + "\n"))
 	if err != nil {
 		return nil, err
@@ -74,22 +74,21 @@ func NewObjectPool(ctx context.Context, repoPath string) (ObjectPool, error) {
 	return &batch, nil
 }
 
-func (b *batch) Object(ctx context.Context, refName string) (*Object, error) {
+func (b *batch) Object(refName string) (*ObjectInfo, *bufio.Reader, error) {
 	_, err := b.writer.Write([]byte(refName + "\n"))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	var obj Object
+	var obj ObjectInfo
 	var oid []byte
 	oid, obj.Type, obj.Size, err = ReadBatchLine(b.reader)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	obj.ID = string(oid)
-	obj.Reader = b.reader
 
-	return &obj, nil
+	return &obj, b.reader, nil
 }
 
 func (b *batch) Close() {

--- a/modules/git/catfile/object_pool_cmd.go
+++ b/modules/git/catfile/object_pool_cmd.go
@@ -1,0 +1,102 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package catfile
+
+import (
+	"bufio"
+	"context"
+)
+
+// batchCheck represents an active `git cat-file --batch-check` invocation
+// paired with the pipes that feed/read from it. Call Close to release resources.
+type batchCheck struct {
+	cancel context.CancelFunc
+	reader *bufio.Reader
+	writer WriteCloserError
+}
+
+// NewBatchCheck creates a cat-file --batch-check process for the provided repository path.
+// The returned Batch must be closed once the caller has finished with it.
+func NewObjectInfoPool(ctx context.Context, repoPath string) (ObjectInfoPool, error) {
+	if err := EnsureValidGitRepository(ctx, repoPath); err != nil {
+		return nil, err
+	}
+
+	var check batchCheck
+	check.writer, check.reader, check.cancel = catFileBatchCheck(ctx, repoPath)
+	return &check, nil
+}
+
+func (b *batchCheck) ObjectInfo(ctx context.Context, refName string) (*ObjectInfo, error) {
+	_, err := b.writer.Write([]byte(refName + "\n"))
+	if err != nil {
+		return nil, err
+	}
+
+	var objInfo ObjectInfo
+	var oid []byte
+	oid, objInfo.Type, objInfo.Size, err = ReadBatchLine(b.reader)
+	if err != nil {
+		return nil, err
+	}
+	objInfo.ID = string(oid)
+	return &objInfo, nil
+}
+
+// Close stops the underlying git cat-file process and releases held resources.
+func (b *batchCheck) Close() {
+	if b.cancel != nil {
+		b.cancel()
+	}
+	if b.writer != nil {
+		_ = b.writer.Close()
+	}
+}
+
+// batch represents an active `git cat-file --batch` invocation
+// paired with the pipes that feed/read from it. Call Close to release resources.
+type batch struct {
+	cancel context.CancelFunc
+	reader *bufio.Reader
+	writer WriteCloserError
+}
+
+// NewBatch creates a new cat-file --batch process for the provided repository path.
+// The returned Batch must be closed once the caller has finished with it.
+func NewObjectPool(ctx context.Context, repoPath string) (ObjectPool, error) {
+	if err := EnsureValidGitRepository(ctx, repoPath); err != nil {
+		return nil, err
+	}
+
+	var batch batch
+	batch.writer, batch.reader, batch.cancel = catFileBatch(ctx, repoPath)
+	return &batch, nil
+}
+
+func (b *batch) Object(ctx context.Context, refName string) (*Object, error) {
+	_, err := b.writer.Write([]byte(refName + "\n"))
+	if err != nil {
+		return nil, err
+	}
+
+	var obj Object
+	var oid []byte
+	oid, obj.Type, obj.Size, err = ReadBatchLine(b.reader)
+	if err != nil {
+		return nil, err
+	}
+	obj.ID = string(oid)
+	obj.Reader = b.reader
+
+	return &obj, nil
+}
+
+func (b *batch) Close() {
+	if b.cancel != nil {
+		b.cancel()
+	}
+	if b.writer != nil {
+		_ = b.writer.Close()
+	}
+}

--- a/modules/git/pipeline/lfs_nogogit.go
+++ b/modules/git/pipeline/lfs_nogogit.go
@@ -83,7 +83,7 @@ func FindLFSFile(repo *git.Repository, objectID git.ObjectID) ([]*LFSResult, err
 			switch object.Type {
 			case "tag":
 				// This shouldn't happen but if it does well just get the commit and try again
-				id, err := git.ReadTagObjectID(batchReader, object.Size)
+				id, err := catfile.ReadTagObjectID(batchReader, object.Size)
 				if err != nil {
 					return nil, err
 				}
@@ -120,7 +120,7 @@ func FindLFSFile(repo *git.Repository, objectID git.ObjectID) ([]*LFSResult, err
 						resultsMap[curCommit.ID.String()+":"+curPath+string(fname)] = &result
 					} else if string(mode) == git.EntryModeTree.String() {
 						hexObjectID := make([]byte, objectID.Type().FullLength())
-						git.BinToHex(objectID.Type(), binObjectID, hexObjectID)
+						catfile.BinToHex(objectID.Type(), binObjectID, hexObjectID)
 						trees = append(trees, hexObjectID)
 						paths = append(paths, curPath+string(fname)+"/")
 					}

--- a/modules/git/repo_base_nogogit.go
+++ b/modules/git/repo_base_nogogit.go
@@ -24,10 +24,10 @@ type Repository struct {
 	tagCache *ObjectCache[*Tag]
 
 	batchInUse bool
-	batch      catfile.Batch
+	batch      catfile.ObjectPool
 
 	checkInUse bool
-	check      catfile.Batch
+	check      catfile.ObjectInfoPool
 
 	Ctx             context.Context
 	LastCommitCache *LastCommitCache
@@ -57,10 +57,10 @@ func OpenRepository(ctx context.Context, repoPath string) (*Repository, error) {
 }
 
 // CatFileBatch obtains a CatFileBatch for this repository
-func (repo *Repository) CatFileBatch(ctx context.Context) (catfile.Batch, func(), error) {
+func (repo *Repository) CatFileBatch(ctx context.Context) (catfile.ObjectPool, func(), error) {
 	if repo.batch == nil {
 		var err error
-		repo.batch, err = catfile.NewBatch(ctx, repo.Path)
+		repo.batch, err = catfile.NewObjectPool(ctx, repo.Path)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -74,7 +74,7 @@ func (repo *Repository) CatFileBatch(ctx context.Context) (catfile.Batch, func()
 	}
 
 	log.Debug("Opening temporary cat file batch for: %s", repo.Path)
-	tempBatch, err := catfile.NewBatch(ctx, repo.Path)
+	tempBatch, err := catfile.NewObjectPool(ctx, repo.Path)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -82,10 +82,10 @@ func (repo *Repository) CatFileBatch(ctx context.Context) (catfile.Batch, func()
 }
 
 // CatFileBatchCheck obtains a CatFileBatchCheck for this repository
-func (repo *Repository) CatFileBatchCheck(ctx context.Context) (catfile.Batch, func(), error) {
+func (repo *Repository) CatFileBatchCheck(ctx context.Context) (catfile.ObjectInfoPool, func(), error) {
 	if repo.check == nil {
 		var err error
-		repo.check, err = catfile.NewBatchCheck(ctx, repo.Path)
+		repo.check, err = catfile.NewObjectInfoPool(ctx, repo.Path)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -99,7 +99,7 @@ func (repo *Repository) CatFileBatchCheck(ctx context.Context) (catfile.Batch, f
 	}
 
 	log.Debug("Opening temporary cat file batch-check for: %s", repo.Path)
-	tempBatchCheck, err := catfile.NewBatchCheck(ctx, repo.Path)
+	tempBatchCheck, err := catfile.NewObjectInfoPool(ctx, repo.Path)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/modules/git/repo_branch_nogogit.go
+++ b/modules/git/repo_branch_nogogit.go
@@ -28,7 +28,7 @@ func (repo *Repository) IsObjectExist(name string) bool {
 		return false
 	}
 	defer cancel()
-	objInfo, err := objInfoPool.ObjectInfo(repo.Ctx, name)
+	objInfo, err := objInfoPool.ObjectInfo(name)
 	if err != nil {
 		log.Debug("Error writing to ObjectInfo %v", err)
 		return false
@@ -49,7 +49,7 @@ func (repo *Repository) IsReferenceExist(name string) bool {
 	}
 	defer cancel()
 
-	_, err = objInfoPool.ObjectInfo(repo.Ctx, name)
+	_, err = objInfoPool.ObjectInfo(name)
 	return err == nil
 }
 

--- a/modules/git/repo_commit_nogogit.go
+++ b/modules/git/repo_commit_nogogit.go
@@ -43,9 +43,9 @@ func (repo *Repository) GetRefCommitID(name string) (string, error) {
 	}
 	defer cancel()
 
-	objInfo, err := objInfoPool.ObjectInfo(repo.Ctx, name)
+	objInfo, err := objInfoPool.ObjectInfo(name)
 	if err != nil {
-		if IsErrNotExist(err) {
+		if catfile.IsErrObjectNotFound(err) {
 			return "", ErrNotExist{name, ""}
 		}
 		return "", err
@@ -77,15 +77,13 @@ func (repo *Repository) getCommit(id ObjectID) (*Commit, error) {
 }
 
 func (repo *Repository) getCommitFromBatchReader(objectPool catfile.ObjectPool, id ObjectID) (*Commit, error) {
-	object, err := objectPool.Object(repo.Ctx, id.String())
+	object, rd, err := objectPool.Object(id.String())
 	if err != nil {
-		if errors.Is(err, io.EOF) || IsErrNotExist(err) {
+		if errors.Is(err, io.EOF) || catfile.IsErrObjectNotFound(err) {
 			return nil, ErrNotExist{ID: id.String()}
 		}
 		return nil, err
 	}
-
-	rd := object.Reader
 
 	switch object.Type {
 	case "missing":
@@ -153,9 +151,9 @@ func (repo *Repository) ConvertToGitID(commitID string) (ObjectID, error) {
 	}
 	defer cancel()
 
-	objInfo, err := objInfoPool.ObjectInfo(repo.Ctx, commitID)
+	objInfo, err := objInfoPool.ObjectInfo(commitID)
 	if err != nil {
-		if IsErrNotExist(err) {
+		if catfile.IsErrObjectNotFound(err) {
 			return nil, ErrNotExist{commitID, ""}
 		}
 		return nil, err

--- a/modules/git/repo_tree_nogogit.go
+++ b/modules/git/repo_tree_nogogit.go
@@ -7,6 +7,8 @@ package git
 
 import (
 	"io"
+
+	"code.gitea.io/gitea/modules/git/catfile"
 )
 
 func (repo *Repository) getTree(id ObjectID) (*Tree, error) {
@@ -16,12 +18,15 @@ func (repo *Repository) getTree(id ObjectID) (*Tree, error) {
 	}
 	defer cancel()
 
-	object, err := objectPool.Object(repo.Ctx, id.String())
+	object, rd, err := objectPool.Object(id.String())
 	if err != nil {
+		if catfile.IsErrObjectNotFound(err) {
+			return nil, ErrNotExist{
+				ID: id.String(),
+			}
+		}
 		return nil, err
 	}
-
-	rd := object.Reader
 
 	switch object.Type {
 	case "tag":

--- a/modules/git/tree_entry_nogogit.go
+++ b/modules/git/tree_entry_nogogit.go
@@ -21,7 +21,7 @@ func (te *TreeEntry) Size() int64 {
 		return 0
 	}
 	defer cancel()
-	objInfo, err := objInfoPool.ObjectInfo(te.ptree.repo.Ctx, te.ID.String())
+	objInfo, err := objInfoPool.ObjectInfo(te.ID.String())
 	if err != nil {
 		log.Debug("error whilst reading size for %s in %s. Error: %v", te.ID.String(), te.ptree.repo.Path, err)
 		return 0

--- a/modules/git/tree_entry_nogogit.go
+++ b/modules/git/tree_entry_nogogit.go
@@ -15,23 +15,18 @@ func (te *TreeEntry) Size() int64 {
 		return te.size
 	}
 
-	batch, cancel, err := te.ptree.repo.CatFileBatchCheck(te.ptree.repo.Ctx)
+	objInfoPool, cancel, err := te.ptree.repo.CatFileBatchCheck(te.ptree.repo.Ctx)
 	if err != nil {
 		log.Debug("error whilst reading size for %s in %s. Error: %v", te.ID.String(), te.ptree.repo.Path, err)
 		return 0
 	}
 	defer cancel()
-	_, err = batch.Writer().Write([]byte(te.ID.String() + "\n"))
+	objInfo, err := objInfoPool.ObjectInfo(te.ptree.repo.Ctx, te.ID.String())
 	if err != nil {
 		log.Debug("error whilst reading size for %s in %s. Error: %v", te.ID.String(), te.ptree.repo.Path, err)
 		return 0
 	}
-	_, _, te.size, err = ReadBatchLine(batch.Reader())
-	if err != nil {
-		log.Debug("error whilst reading size for %s in %s. Error: %v", te.ID.String(), te.ptree.repo.Path, err)
-		return 0
-	}
-
+	te.size = objInfo.Size
 	te.sized = true
 	return te.size
 }

--- a/modules/git/tree_nogogit.go
+++ b/modules/git/tree_nogogit.go
@@ -45,7 +45,7 @@ func (t *Tree) ListEntries() (Entries, error) {
 		}
 
 		if object.Type == "commit" {
-			treeID, err := ReadTreeID(rd, object.Size)
+			treeID, err := catfile.ReadTreeID(rd, object.Size)
 			if err != nil && err != io.EOF {
 				return nil, err
 			}

--- a/modules/gitrepo/cat_file.go
+++ b/modules/gitrepo/cat_file.go
@@ -9,6 +9,6 @@ import (
 	"code.gitea.io/gitea/modules/git/catfile"
 )
 
-func NewBatch(ctx context.Context, repo Repository) (catfile.Batch, error) {
-	return catfile.NewBatch(ctx, repoPath(repo))
+func NewObjectPool(ctx context.Context, repo Repository) (catfile.ObjectPool, error) {
+	return catfile.NewObjectPool(ctx, repoPath(repo))
 }

--- a/modules/indexer/code/bleve/bleve.go
+++ b/modules/indexer/code/bleve/bleve.go
@@ -14,6 +14,7 @@ import (
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/modules/analyze"
 	"code.gitea.io/gitea/modules/charset"
+	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/git/catfile"
 	"code.gitea.io/gitea/modules/git/gitcmd"
 	"code.gitea.io/gitea/modules/gitrepo"
@@ -176,12 +177,15 @@ func (b *Indexer) addUpdate(ctx context.Context, objectPool catfile.ObjectPool, 
 		return b.addDelete(update.Filename, repo, batch)
 	}
 
-	object, err := objectPool.Object(ctx, update.BlobSha)
+	object, batchReader, err := objectPool.Object(update.BlobSha)
 	if err != nil {
+		if catfile.IsErrObjectNotFound(err) {
+			return git.ErrNotExist{ID: update.BlobSha}
+		}
 		return err
 	}
 
-	batchReader := object.Reader
+	size = object.Size
 
 	fileContents, err := io.ReadAll(io.LimitReader(batchReader, size))
 	if err != nil {

--- a/modules/indexer/code/bleve/bleve.go
+++ b/modules/indexer/code/bleve/bleve.go
@@ -14,7 +14,6 @@ import (
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/modules/analyze"
 	"code.gitea.io/gitea/modules/charset"
-	"code.gitea.io/gitea/modules/git"
 	"code.gitea.io/gitea/modules/git/catfile"
 	"code.gitea.io/gitea/modules/git/gitcmd"
 	"code.gitea.io/gitea/modules/gitrepo"
@@ -151,7 +150,7 @@ func NewIndexer(indexDir string) *Indexer {
 	}
 }
 
-func (b *Indexer) addUpdate(ctx context.Context, catfileBatch catfile.Batch, commitSha string,
+func (b *Indexer) addUpdate(ctx context.Context, objectPool catfile.ObjectPool, commitSha string,
 	update internal.FileUpdate, repo *repo_model.Repository, batch *inner_bleve.FlushingBatch,
 ) error {
 	// Ignore vendored files in code search
@@ -177,15 +176,12 @@ func (b *Indexer) addUpdate(ctx context.Context, catfileBatch catfile.Batch, com
 		return b.addDelete(update.Filename, repo, batch)
 	}
 
-	if _, err := catfileBatch.Writer().Write([]byte(update.BlobSha + "\n")); err != nil {
-		return err
-	}
-
-	batchReader := catfileBatch.Reader()
-	_, _, size, err = git.ReadBatchLine(batchReader)
+	object, err := objectPool.Object(ctx, update.BlobSha)
 	if err != nil {
 		return err
 	}
+
+	batchReader := object.Reader
 
 	fileContents, err := io.ReadAll(io.LimitReader(batchReader, size))
 	if err != nil {
@@ -219,18 +215,18 @@ func (b *Indexer) addDelete(filename string, repo *repo_model.Repository, batch 
 func (b *Indexer) Index(ctx context.Context, repo *repo_model.Repository, sha string, changes *internal.RepoChanges) error {
 	batch := inner_bleve.NewFlushingBatch(b.inner.Indexer, maxBatchSize)
 	if len(changes.Updates) > 0 {
-		catfileBatch, err := gitrepo.NewBatch(ctx, repo)
+		objectPool, err := gitrepo.NewObjectPool(ctx, repo)
 		if err != nil {
 			return err
 		}
-		defer catfileBatch.Close()
+		defer objectPool.Close()
 
 		for _, update := range changes.Updates {
-			if err := b.addUpdate(ctx, catfileBatch, sha, update, repo, batch); err != nil {
+			if err := b.addUpdate(ctx, objectPool, sha, update, repo, batch); err != nil {
 				return err
 			}
 		}
-		catfileBatch.Close()
+		objectPool.Close()
 	}
 	for _, filename := range changes.RemovedFilenames {
 		if err := b.addDelete(filename, repo, batch); err != nil {


### PR DESCRIPTION
Replace the `Batch` interface with the new `ObjectInfoPool` and `ObjectPool` interfaces. This avoids exposing the `writer` and limits access to a read-only interface for Git object content. In addition, this abstraction makes it possible to support alternative implementations, such as a go-git–based `ObjectPool` or a remote `ObjectPool`, in the future.