### PR TITLE
Fix file-tree ui error when adding files to repo without commits

### DIFF
--- a/web_src/js/components/ViewFileTreeStore.ts
+++ b/web_src/js/components/ViewFileTreeStore.ts
@@ -20,7 +20,7 @@ export function createViewFileTreeStore(props: {repoLink: string, treePath: stri
     selectedItem: props.treePath,
 
     async loadChildren(treePath: string, subPath: string = '') {
-      // there are no files if no commits were made yet
+      // there is no git ref if no commits were made yet (an empty repo)
       if (!props.currentRefNameSubURL) return null;
 
       const response = await GET(`${props.repoLink}/tree-view/${props.currentRefNameSubURL}/${pathEscapeSegments(treePath)}?sub_path=${encodeURIComponent(subPath)}`);

--- a/web_src/js/components/ViewFileTreeStore.ts
+++ b/web_src/js/components/ViewFileTreeStore.ts
@@ -20,6 +20,9 @@ export function createViewFileTreeStore(props: {repoLink: string, treePath: stri
     selectedItem: props.treePath,
 
     async loadChildren(treePath: string, subPath: string = '') {
+      // there are no files if no commits were made yet
+      if (!props.currentRefNameSubURL) return null;
+
       const response = await GET(`${props.repoLink}/tree-view/${props.currentRefNameSubURL}/${pathEscapeSegments(treePath)}?sub_path=${encodeURIComponent(subPath)}`);
       const json = await response.json();
       const poolSvgs = [];


### PR DESCRIPTION
When visiting the new file & upload file pages on a repo that has no commits, the request for file-tree files fails.

---

<img width="1173" height="728" alt="Screenshot_20260106_175938" src="https://github.com/user-attachments/assets/69e0ee0d-24af-4f5f-be7e-d64c03b5a5cb" />
<img width="349" height="95" alt="image" src="https://github.com/user-attachments/assets/6e0b5252-95f2-4094-8d11-e0c5262f525b" />
