### PR TITLE
Fix some trivial problems

### DIFF
--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -39,3 +39,17 @@ func TestPktLine(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("0007a\nb"), w.Bytes())
 }
+
+func TestParseGitHookCommitRefLine(t *testing.T) {
+	oldCommitID, newCommitID, refName, ok := parseGitHookCommitRefLine("a b c")
+	assert.True(t, ok)
+	assert.Equal(t, "a", oldCommitID)
+	assert.Equal(t, "b", newCommitID)
+	assert.Equal(t, "c", string(refName))
+
+	_, _, _, ok = parseGitHookCommitRefLine("a\tb\tc")
+	assert.False(t, ok)
+
+	_, _, _, ok = parseGitHookCommitRefLine("a b")
+	assert.False(t, ok)
+}

--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -500,6 +500,7 @@ func CreatePullRequest(ctx *context.APIContext) {
 	unitPullRequest, err := ctx.Repo.Repository.GetUnit(ctx, unit.TypePullRequests)
 	if err != nil {
 		ctx.APIErrorInternal(err)
+		return
 	}
 
 	prIssue := &issues_model.Issue{

--- a/routers/web/user/home.go
+++ b/routers/web/user/home.go
@@ -660,6 +660,8 @@ func ShowSSHKeys(ctx *context.Context) {
 	}
 
 	var buf bytes.Buffer
+	// "authorized_keys" file format: "#" followed by comment line per key
+	buf.WriteString("# Gitea isn't a key server. The keys are exported as the user uploaded and might not have been fully verified.\n")
 	for i := range keys {
 		buf.WriteString(keys[i].OmitEmail())
 		buf.WriteString("\n")
@@ -695,6 +697,8 @@ func ShowGPGKeys(ctx *context.Context) {
 	var buf bytes.Buffer
 
 	headers := make(map[string]string)
+	// https://www.rfc-editor.org/rfc/rfc4880
+	headers["Comment"] = "Gitea isn't a key server. The keys are exported as the user uploaded and might not have been fully verified."
 	if len(failedEntitiesID) > 0 { // If some key need re-import to be exported
 		headers["Note"] = "The keys with the following IDs couldn't be exported and need to be reuploaded " + strings.Join(failedEntitiesID, ", ")
 	} else if len(entities) == 0 {

--- a/services/actions/commit_status.go
+++ b/services/actions/commit_status.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"path"
 	"strconv"
+	"strings"
 
 	actions_model "code.gitea.io/gitea/models/actions"
 	"code.gitea.io/gitea/models/db"
@@ -129,6 +130,7 @@ func createCommitStatus(ctx context.Context, repo *repo_model.Repository, event,
 		runName = wfs[0].Name
 	}
 	ctxName := fmt.Sprintf("%s / %s (%s)", runName, job.Name, event)
+	ctxName = strings.TrimSpace(ctxName) // git_model.NewCommitStatus also trims spaces
 	state := toCommitStatus(job.Status)
 	if statuses, err := git_model.GetLatestCommitStatus(ctx, repo.ID, commitID, db.ListOptionsAll); err == nil {
 		for _, v := range statuses {


### PR DESCRIPTION
1. correctly parse git protocol's "OldCommit NewCommit RefName" line, it should be explicitly split by space
2. add missing "return" in CreatePullRequest
3. add comments for "/user.keys" and "/user.gpg" outputs
4. trim space for the "commit status context name" to follow the same behavior of git_model.NewCommitStatus