### PR TITLE
Fix some trivial problems (#36336)

### DIFF
--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -39,3 +39,17 @@ func TestPktLine(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("0007a\nb"), w.Bytes())
 }
+
+func TestParseGitHookCommitRefLine(t *testing.T) {
+	oldCommitID, newCommitID, refName, ok := parseGitHookCommitRefLine("a b c")
+	assert.True(t, ok)
+	assert.Equal(t, "a", oldCommitID)
+	assert.Equal(t, "b", newCommitID)
+	assert.Equal(t, "c", string(refName))
+
+	_, _, _, ok = parseGitHookCommitRefLine("a\tb\tc")
+	assert.False(t, ok)
+
+	_, _, _, ok = parseGitHookCommitRefLine("a b")
+	assert.False(t, ok)
+}

--- a/services/actions/commit_status.go
+++ b/services/actions/commit_status.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"strings"
 
 	actions_model "code.gitea.io/gitea/models/actions"
 	"code.gitea.io/gitea/models/db"
@@ -91,6 +92,7 @@ func createCommitStatus(ctx context.Context, job *actions_model.ActionRunJob) er
 		runName = wfs[0].Name
 	}
 	ctxname := fmt.Sprintf("%s / %s (%s)", runName, job.Name, event)
+	ctxname = strings.TrimSpace(ctxname) // git_model.NewCommitStatus also trims spaces
 	state := toCommitStatus(job.Status)
 	if statuses, err := git_model.GetLatestCommitStatus(ctx, repo.ID, sha, db.ListOptionsAll); err == nil {
 		for _, v := range statuses {


### PR DESCRIPTION
Partially backport #36336

1. correctly parse git protocol's "OldCommit NewCommit RefName" line, it should be explicitly split by space
2. trim space for the "commit status context name" to follow the same behavior of git_model.NewCommitStatus

