### PR TITLE
Indicate when only optional checks failed

### DIFF
--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -1847,7 +1847,7 @@
   "repo.pulls.status_checking": "Some checks are pending",
   "repo.pulls.status_checks_success": "All checks were successful",
   "repo.pulls.status_checks_warning": "Some checks reported warnings",
-  "repo.pulls.status_checks_failure": "Some checks failed",
+  "repo.pulls.status_checks_failure_required": "Some required checks failed",
   "repo.pulls.status_checks_failure_optional": "Some optional checks failed",
   "repo.pulls.status_checks_error": "Some checks reported errors",
   "repo.pulls.status_checks_requested": "Required",

--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -1848,6 +1848,7 @@
   "repo.pulls.status_checks_success": "All checks were successful",
   "repo.pulls.status_checks_warning": "Some checks reported warnings",
   "repo.pulls.status_checks_failure": "Some checks failed",
+  "repo.pulls.status_checks_failure_optional": "Some optional checks failed",
   "repo.pulls.status_checks_error": "Some checks reported errors",
   "repo.pulls.status_checks_requested": "Required",
   "repo.pulls.status_checks_details": "Details",

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -23,6 +23,7 @@ import (
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unit"
 	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/commitstatus"
 	"code.gitea.io/gitea/modules/emoji"
 	"code.gitea.io/gitea/modules/fileicon"
 	"code.gitea.io/gitea/modules/git"
@@ -35,6 +36,7 @@ import (
 	"code.gitea.io/gitea/modules/optional"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/templates"
+	"code.gitea.io/gitea/modules/translation"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/modules/web"
 	"code.gitea.io/gitea/routers/utils"
@@ -315,12 +317,31 @@ func prepareMergedViewPullInfo(ctx *context.Context, issue *issues_model.Issue) 
 }
 
 type pullCommitStatusCheckData struct {
-	MissingRequiredChecks    []string          // list of missing required checks
-	IsContextRequired        func(string) bool // function to check whether a context is required
-	RequireApprovalRunCount  int               // number of workflow runs that require approval
-	CanApprove               bool              // whether the user can approve workflow runs
-	ApproveLink              string            // link to approve all checks
-	OnlyOptionalChecksFailed bool              // whether only optional checks failed
+	MissingRequiredChecks   []string          // list of missing required checks
+	IsContextRequired       func(string) bool // function to check whether a context is required
+	RequireApprovalRunCount int               // number of workflow runs that require approval
+	CanApprove              bool              // whether the user can approve workflow runs
+	ApproveLink             string            // link to approve all checks
+	RequiredChecksState     commitstatus.CommitStatusState
+	LatestCommitStatus      *git_model.CommitStatus
+}
+
+func (d *pullCommitStatusCheckData) CommitStatusCheckPrompt(locale translation.Locale) string {
+	if d.RequiredChecksState.IsPending() || len(d.MissingRequiredChecks) > 0 {
+		return locale.TrString("repo.pulls.status_checking")
+	} else if d.RequiredChecksState.IsSuccess() {
+		if d.LatestCommitStatus != nil && d.LatestCommitStatus.State.IsFailure() {
+			return locale.TrString("repo.pulls.status_checks_failure_optional")
+		}
+		return locale.TrString("repo.pulls.status_checks_success")
+	} else if d.RequiredChecksState.IsWarning() {
+		return locale.TrString("repo.pulls.status_checks_warning")
+	} else if d.RequiredChecksState.IsFailure() {
+		return locale.TrString("repo.pulls.status_checks_failure_required")
+	} else if d.RequiredChecksState.IsError() {
+		return locale.TrString("repo.pulls.status_checks_error")
+	}
+	return locale.TrString("repo.pulls.status_checking")
 }
 
 // prepareViewPullInfo show meta information for a pull request preview page
@@ -361,6 +382,8 @@ func prepareViewPullInfo(ctx *context.Context, issue *issues_model.Issue) *git_s
 		defer baseGitRepo.Close()
 	}
 
+	statusCheckData := &pullCommitStatusCheckData{}
+
 	if exist, _ := git_model.IsBranchExist(ctx, pull.BaseRepo.ID, pull.BaseBranch); !exist {
 		ctx.Data["BaseBranchNotExist"] = true
 		ctx.Data["IsPullRequestBroken"] = true
@@ -381,9 +404,10 @@ func prepareViewPullInfo(ctx *context.Context, issue *issues_model.Issue) *git_s
 			git_model.CommitStatusesHideActionsURL(ctx, commitStatuses)
 		}
 
+		statusCheckData.LatestCommitStatus = git_model.CalcCommitStatus(commitStatuses)
 		if len(commitStatuses) > 0 {
 			ctx.Data["LatestCommitStatuses"] = commitStatuses
-			ctx.Data["LatestCommitStatus"] = git_model.CalcCommitStatus(commitStatuses)
+			ctx.Data["LatestCommitStatus"] = statusCheckData.LatestCommitStatus
 		}
 
 		compareInfo, err := git_service.GetCompareInfo(ctx, pull.BaseRepo, pull.BaseRepo, baseGitRepo,
@@ -468,10 +492,8 @@ func prepareViewPullInfo(ctx *context.Context, issue *issues_model.Issue) *git_s
 		return nil
 	}
 
-	statusCheckData := &pullCommitStatusCheckData{
-		ApproveLink: fmt.Sprintf("%s/actions/approve-all-checks?commit_id=%s", repo.Link(), sha),
-	}
 	ctx.Data["StatusCheckData"] = statusCheckData
+	statusCheckData.ApproveLink = fmt.Sprintf("%s/actions/approve-all-checks?commit_id=%s", repo.Link(), sha)
 
 	commitStatuses, err := git_model.GetLatestCommitStatus(ctx, repo.ID, sha, db.ListOptionsAll)
 	if err != nil {
@@ -496,9 +518,10 @@ func prepareViewPullInfo(ctx *context.Context, issue *issues_model.Issue) *git_s
 		statusCheckData.CanApprove = ctx.Repo.CanWrite(unit.TypeActions)
 	}
 
+	statusCheckData.LatestCommitStatus = git_model.CalcCommitStatus(commitStatuses)
 	if len(commitStatuses) > 0 {
 		ctx.Data["LatestCommitStatuses"] = commitStatuses
-		ctx.Data["LatestCommitStatus"] = git_model.CalcCommitStatus(commitStatuses)
+		ctx.Data["LatestCommitStatus"] = statusCheckData.LatestCommitStatus
 	}
 
 	if pb != nil && pb.EnableStatusCheck {
@@ -535,14 +558,7 @@ func prepareViewPullInfo(ctx *context.Context, issue *issues_model.Issue) *git_s
 			}
 			return false
 		}
-		requiredStatusCheckState := pull_service.MergeRequiredContextsCommitStatus(commitStatuses, pb.StatusCheckContexts)
-		ctx.Data["RequiredStatusCheckState"] = requiredStatusCheckState
-
-		if overallStatus := ctx.Data["LatestCommitStatus"]; overallStatus != nil {
-			if combined := overallStatus.(*git_model.CommitStatus); combined.State.IsFailure() && requiredStatusCheckState.IsSuccess() {
-				statusCheckData.OnlyOptionalChecksFailed = true
-			}
-		}
+		statusCheckData.RequiredChecksState = pull_service.MergeRequiredContextsCommitStatus(commitStatuses, pb.StatusCheckContexts)
 	}
 
 	ctx.Data["HeadBranchMovedOn"] = headBranchSha != sha

--- a/templates/repo/issue/view_content/pull_merge_box.tmpl
+++ b/templates/repo/issue/view_content/pull_merge_box.tmpl
@@ -8,6 +8,8 @@
 		data-pull-link="{{.Issue.Link}}"
 	{{end}}
 >
+	{{$statusCheckData := .StatusCheckData}}
+	{{$requiredStatusCheckState := $statusCheckData.RequiredChecksState}}
 	<div class="timeline-avatar text {{if .Issue.PullRequest.HasMerged}}purple
 	{{- else if .Issue.IsClosed}}grey
 	{{- else if .IsPullWorkInProgress}}grey
@@ -18,8 +20,8 @@
 	{{- else if .IsBlockedByOfficialReviewRequests}}red
 	{{- else if .IsBlockedByOutdatedBranch}}red
 	{{- else if .IsBlockedByChangedProtectedFiles}}red
-	{{- else if and .EnableStatusCheck (or .RequiredStatusCheckState.IsFailure .RequiredStatusCheckState.IsError)}}red
-	{{- else if and .EnableStatusCheck (or (not $.LatestCommitStatus) .RequiredStatusCheckState.IsPending .RequiredStatusCheckState.IsWarning)}}yellow
+	{{- else if and .EnableStatusCheck (or $requiredStatusCheckState.IsFailure $requiredStatusCheckState.IsError)}}red
+	{{- else if and .EnableStatusCheck (or (not $.LatestCommitStatus) $requiredStatusCheckState.IsPending $requiredStatusCheckState.IsWarning)}}yellow
 	{{- else if and .AllowMerge .RequireSigned (not .WillSign)}}red
 	{{- else if .Issue.PullRequest.IsChecking}}yellow
 	{{- else if .Issue.PullRequest.IsEmpty}}grey
@@ -32,7 +34,7 @@
 			"CommitStatus" .LatestCommitStatus
 			"CommitStatuses" .LatestCommitStatuses
 			"ShowHideChecks" true
-			"StatusCheckData" .StatusCheckData
+			"StatusCheckData" $statusCheckData
 		)}}
 		</div>
 		{{end}}
@@ -145,12 +147,12 @@
 						<li>{{.}}</li>
 						{{end}}
 					</ul>
-				{{else if and .EnableStatusCheck (or .RequiredStatusCheckState.IsError .RequiredStatusCheckState.IsFailure)}}
+				{{else if and .EnableStatusCheck (or $requiredStatusCheckState.IsError $requiredStatusCheckState.IsFailure)}}
 					<div class="item">
 						{{svg "octicon-x"}}
 						{{ctx.Locale.Tr "repo.pulls.required_status_check_failed"}}
 					</div>
-				{{else if and .EnableStatusCheck (not .RequiredStatusCheckState.IsSuccess)}}
+				{{else if and .EnableStatusCheck (not $requiredStatusCheckState.IsSuccess)}}
 					<div class="item">
 						{{svg "octicon-x"}}
 						{{ctx.Locale.Tr "repo.pulls.required_status_check_missing"}}
@@ -166,7 +168,7 @@
 					</div>
 				{{end}}
 
-				{{$notAllOverridableChecksOk := or .IsBlockedByApprovals .IsBlockedByRejection .IsBlockedByOfficialReviewRequests .IsBlockedByOutdatedBranch .IsBlockedByChangedProtectedFiles (and .EnableStatusCheck (not .RequiredStatusCheckState.IsSuccess))}}
+				{{$notAllOverridableChecksOk := or .IsBlockedByApprovals .IsBlockedByRejection .IsBlockedByOfficialReviewRequests .IsBlockedByOutdatedBranch .IsBlockedByChangedProtectedFiles (and .EnableStatusCheck (not $requiredStatusCheckState.IsSuccess))}}
 
 				{{/* admin can merge without checks, writer can merge when checks succeed */}}
 				{{$canMergeNow := and (or (and (not $.ProtectedBranch.BlockAdminMergeOverride) $.IsRepoAdmin) (not $notAllOverridableChecksOk)) (or (not .AllowMerge) (not .RequireSigned) .WillSign)}}
@@ -351,7 +353,7 @@
 						<li>{{.}}</li>
 						{{end}}
 					</ul>
-				{{else if and .EnableStatusCheck (not .RequiredStatusCheckState.IsSuccess)}}
+				{{else if and .EnableStatusCheck (not $requiredStatusCheckState.IsSuccess)}}
 					<div class="item text red">
 						{{svg "octicon-x"}}
 						{{ctx.Locale.Tr "repo.pulls.required_status_check_failed"}}

--- a/templates/repo/pulls/status.tmpl
+++ b/templates/repo/pulls/status.tmpl
@@ -14,6 +14,8 @@
 			{{ctx.Locale.Tr "repo.pulls.status_checks_success"}}
 		{{else if eq .CommitStatus.State "warning"}}
 			{{ctx.Locale.Tr "repo.pulls.status_checks_warning"}}
+		{{else if and $statusCheckData $statusCheckData.OnlyOptionalChecksFailed}}
+			{{ctx.Locale.Tr "repo.pulls.status_checks_failure_optional"}}
 		{{else if eq .CommitStatus.State "failure"}}
 			{{ctx.Locale.Tr "repo.pulls.status_checks_failure"}}
 		{{else if eq .CommitStatus.State "error"}}

--- a/templates/repo/pulls/status.tmpl
+++ b/templates/repo/pulls/status.tmpl
@@ -8,21 +8,7 @@
 {{if .CommitStatus}}
 <div class="commit-status-panel">
 	<div class="ui top attached header commit-status-header">
-		{{if or (eq .CommitStatus.State "pending") (.MissingRequiredChecks)}}
-			{{ctx.Locale.Tr "repo.pulls.status_checking"}}
-		{{else if eq .CommitStatus.State "success"}}
-			{{ctx.Locale.Tr "repo.pulls.status_checks_success"}}
-		{{else if eq .CommitStatus.State "warning"}}
-			{{ctx.Locale.Tr "repo.pulls.status_checks_warning"}}
-		{{else if and $statusCheckData $statusCheckData.OnlyOptionalChecksFailed}}
-			{{ctx.Locale.Tr "repo.pulls.status_checks_failure_optional"}}
-		{{else if eq .CommitStatus.State "failure"}}
-			{{ctx.Locale.Tr "repo.pulls.status_checks_failure"}}
-		{{else if eq .CommitStatus.State "error"}}
-			{{ctx.Locale.Tr "repo.pulls.status_checks_error"}}
-		{{else}}
-			{{ctx.Locale.Tr "repo.pulls.status_checking"}}
-		{{end}}
+		{{$statusCheckData.CommitStatusCheckPrompt ctx.Locale}}
 
 		{{if .ShowHideChecks}}
 		<div class="ui right">


### PR DESCRIPTION
Currently it's not clear that you can merge a PR when only optional checks failed:

<img width="922" height="447" alt="Screenshot 2026-01-14 at 4 08 17 pm" src="https://github.com/user-attachments/assets/e11670c7-5ab9-42d7-af09-2d8a8fd532d3" />

This PR changes the text to say "Some optional checks failed" when only optional checks failed:

<img width="922" height="443" alt="Screenshot 2026-01-14 at 3 59 08 pm" src="https://github.com/user-attachments/assets/9ea69b13-38d6-4cfc-b4f7-952eff58e546" />

When a required check fails it'll still say "Some checks failed":

<img width="928" height="343" alt="Screenshot 2026-01-14 at 3 59 20 pm" src="https://github.com/user-attachments/assets/d3764a95-9737-4482-851e-d3406b1e4d76" />