### PR TITLE
fix: typos in comments

### DIFF
--- a/services/convert/repository.go
+++ b/services/convert/repository.go
@@ -34,7 +34,7 @@ func innerToRepo(ctx context.Context, repo *repo_model.Repository, permissionInR
 		permissionInRepo.SetUnitsWithDefaultAccessMode(repo.Units, permissionInRepo.AccessMode)
 	}
 
-	// TODO: ideally we should pass "doer" into "ToRepo" to to make CloneLink could generate user-related links
+	// TODO: ideally we should pass "doer" into "ToRepo" to make CloneLink could generate user-related links
 	// And passing "doer" in will also fix other FIXMEs in this file.
 	cloneLink := repo.CloneLinkGeneral(ctx) // no doer at the moment
 	permission := &api.Permission{

--- a/services/issue/issue.go
+++ b/services/issue/issue.go
@@ -228,7 +228,7 @@ func AddAssigneeIfNotAssigned(ctx context.Context, issue *issues_model.Issue, do
 		return nil, err
 	}
 	if isAssigned {
-		// nothing to to
+		// nothing to do
 		return nil, nil
 	}
 


### PR DESCRIPTION
Fix typos: `to to` → `to do` / `to`