### PR TITLE
Fix missing repository id when migrating release attachments (#36389)

### DIFF
--- a/models/repo/release_test.go
+++ b/models/repo/release_test.go
@@ -6,6 +6,7 @@ package repo
 import (
 	"testing"
 
+	"code.gitea.io/gitea/models/db"
 	"code.gitea.io/gitea/models/unittest"
 	"code.gitea.io/gitea/modules/util"
 
@@ -50,4 +51,42 @@ func TestAddReleaseAttachmentsRejectsDifferentRepo(t *testing.T) {
 	attach, err := GetAttachmentByUUID(t.Context(), uuid)
 	assert.NoError(t, err)
 	assert.Zero(t, attach.ReleaseID, "attachment should not be linked to release on failure")
+}
+
+func TestAddReleaseAttachmentsAllowsLegacyMissingRepoID(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	legacyUUID := "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a20" // attachment 10 has repo_id 0
+	err := AddReleaseAttachments(t.Context(), 1, []string{legacyUUID})
+	assert.NoError(t, err)
+
+	attach, err := GetAttachmentByUUID(t.Context(), legacyUUID)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, attach.RepoID)
+	assert.EqualValues(t, 1, attach.ReleaseID)
+}
+
+func TestAddReleaseAttachmentsRejectsRecentZeroRepoID(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	recentUUID := "a0eebc99-9c0b-4ef8-bb6d-6bb9bd3800aa"
+	attachment := &Attachment{
+		UUID:        recentUUID,
+		RepoID:      0,
+		IssueID:     0,
+		ReleaseID:   0,
+		CommentID:   0,
+		Name:        "recent-zero",
+		CreatedUnix: LegacyAttachmentMissingRepoIDCutoff + 1,
+	}
+	assert.NoError(t, db.Insert(t.Context(), attachment))
+
+	err := AddReleaseAttachments(t.Context(), 1, []string{recentUUID})
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, util.ErrPermissionDenied)
+
+	attach, err := GetAttachmentByUUID(t.Context(), recentUUID)
+	assert.NoError(t, err)
+	assert.Zero(t, attach.ReleaseID)
+	assert.Zero(t, attach.RepoID)
 }

--- a/services/migrations/gitea_uploader.go
+++ b/services/migrations/gitea_uploader.go
@@ -320,6 +320,7 @@ func (g *GiteaLocalUploader) CreateReleases(ctx context.Context, releases ...*ba
 			}
 			attach := repo_model.Attachment{
 				UUID:          uuid.New().String(),
+				RepoID:        g.repo.ID,
 				Name:          asset.Name,
 				DownloadCount: int64(*asset.DownloadCount),
 				Size:          int64(*asset.Size),

--- a/services/repository/repository.go
+++ b/services/repository/repository.go
@@ -224,25 +224,28 @@ func MakeRepoPrivate(ctx context.Context, repo *repo_model.Repository) (err erro
 	})
 }
 
-// GetAttachmentLinkedType returns the linked type of attachment if any
-func GetAttachmentLinkedType(ctx context.Context, a *repo_model.Attachment) (unit.Type, error) {
+// GetAttachmentLinkedTypeAndRepoID returns the linked type and repository id of attachment if any
+func GetAttachmentLinkedTypeAndRepoID(ctx context.Context, a *repo_model.Attachment) (unit.Type, int64, error) {
 	if a.IssueID != 0 {
 		iss, err := issues_model.GetIssueByID(ctx, a.IssueID)
 		if err != nil {
-			return unit.TypeIssues, err
+			return unit.TypeIssues, 0, err
 		}
 		unitType := unit.TypeIssues
 		if iss.IsPull {
 			unitType = unit.TypePullRequests
 		}
-		return unitType, nil
+		return unitType, iss.RepoID, nil
 	}
 
 	if a.ReleaseID != 0 {
-		_, err := repo_model.GetReleaseByID(ctx, a.ReleaseID)
-		return unit.TypeReleases, err
+		rel, err := repo_model.GetReleaseByID(ctx, a.ReleaseID)
+		if err != nil {
+			return unit.TypeReleases, 0, err
+		}
+		return unit.TypeReleases, rel.RepoID, nil
 	}
-	return unit.TypeInvalid, nil
+	return unit.TypeInvalid, 0, nil
 }
 
 // CheckDaemonExportOK creates/removes git-daemon-export-ok for git-daemon...

--- a/services/repository/repository_test.go
+++ b/services/repository/repository_test.go
@@ -16,25 +16,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAttachLinkedType(t *testing.T) {
+func TestAttachLinkedTypeAndRepoID(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
 	testCases := []struct {
 		name             string
 		attachID         int64
 		expectedUnitType unit.Type
+		expectedRepoID   int64
 	}{
-		{"LinkedIssue", 1, unit.TypeIssues},
-		{"LinkedComment", 3, unit.TypePullRequests},
-		{"LinkedRelease", 9, unit.TypeReleases},
-		{"Notlinked", 10, unit.TypeInvalid},
+		{"LinkedIssue", 1, unit.TypeIssues, 1},
+		{"LinkedComment", 3, unit.TypePullRequests, 1},
+		{"LinkedRelease", 9, unit.TypeReleases, 1},
+		{"Notlinked", 10, unit.TypeInvalid, 0},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			attach, err := repo_model.GetAttachmentByID(t.Context(), tc.attachID)
 			assert.NoError(t, err)
-			unitType, err := GetAttachmentLinkedType(t.Context(), attach)
+			unitType, repoID, err := GetAttachmentLinkedTypeAndRepoID(t.Context(), attach)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedUnitType, unitType)
+			assert.Equal(t, tc.expectedRepoID, repoID)
 		})
 	}
 }


### PR DESCRIPTION
This PR fixes missed repo_id on the migration of attachments to Gitea. It also provides a doctor check to fix the dirty data on the database.

Backport #36389 
