### PR TITLE
Bugfix: Potential incorrect runID in run status update

### DIFF
--- a/services/actions/job_emitter.go
+++ b/services/actions/job_emitter.go
@@ -114,7 +114,7 @@ func checkJobsByRunID(ctx context.Context, runID int64) error {
 			}
 		}
 		if runUpdated {
-			NotifyWorkflowRunStatusUpdateWithReload(ctx, jobs[0])
+			NotifyWorkflowRunStatusUpdateWithReload(ctx, js[0])
 		}
 	}
 	return nil


### PR DESCRIPTION
`jobs[0]` may not belong to the run for `runID`.