### PR TITLE
Correct asset path when listing css themes

### DIFF
--- a/services/webtheme/webtheme.go
+++ b/services/webtheme/webtheme.go
@@ -140,7 +140,7 @@ func initThemes() {
 			setting.LogStartupProblem(1, log.ERROR, "Default theme %q is not available, please correct the '[ui].DEFAULT_THEME' setting in the config file", setting.UI.DefaultTheme)
 		}
 	}()
-	cssFiles, err := public.AssetFS().ListFiles("/assets/css")
+	cssFiles, err := public.AssetFS().ListFiles("assets/css")
 	if err != nil {
 		log.Error("Failed to list themes: %v", err)
 		availableThemes = []*ThemeMetaInfo{defaultThemeMetaInfoByInternalName(setting.UI.DefaultTheme)}


### PR DESCRIPTION
Fix only one auto theme

1. Incorrect list
<img width="1149" height="161" alt="20260125_213846" src="https://github.com/user-attachments/assets/ac14a98f-7f30-4f1e-815d-d54d994df224" />

2. Correct list
<img width="1149" height="256" alt="20260125_213935" src="https://github.com/user-attachments/assets/4909510a-1680-44ab-b00b-e95580694f32" />
