### PR TITLE
Introduce Gitea Apps

### DIFF
--- a/models/application/application.go
+++ b/models/application/application.go
@@ -1,0 +1,322 @@
+// Copyright 2025 Gitea. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package application
+
+import (
+	"context"
+	"fmt"
+	"html/template"
+	"net/url"
+	"strings"
+
+	auth_model "code.gitea.io/gitea/models/auth"
+	"code.gitea.io/gitea/models/db"
+	org_model "code.gitea.io/gitea/models/organization"
+	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/structs"
+	"code.gitea.io/gitea/modules/util"
+	"xorm.io/xorm"
+)
+
+type Application user_model.User
+
+// AppFromUser converts user to application
+func AppFromUser(user *user_model.User) *Application {
+	return (*Application)(user)
+}
+
+type JWTPubKey struct {
+	RawKey    string `json:"key"`
+	RawKeySHA string `json:"key_sha"`
+}
+
+type AppExternalData struct {
+	ID  int64 `xorm:"pk autoincr"`
+	UID int64 `xorm:"INDEX"`
+
+	OwnerID int64            `xorm:"INDEX"`
+	Owner   *user_model.User `xorm:"-"`
+
+	SetupURL                   string `xorm:"TEXT"`
+	RedirectToSetupURLOnUpdate bool
+
+	HomePageURL string `xorm:"TEXT"`
+
+	Readme         string        `xorm:"TEXT"`
+	RenderedReadme template.HTML `xorm:"-"`
+
+	ClientID   string      `xorm:"INDEX"`
+	JWTKeyList []JWTPubKey `xorm:"JSON TEXT"`
+
+	Permission AppPermList `xorm:"TEXT"`
+}
+
+func init() {
+	db.RegisterModel(new(AppExternalData))
+	db.RegisterModel(new(AppInstallation))
+}
+
+// TableName represents the real table name of Application
+func (Application) TableName() string {
+	return "user"
+}
+
+func (app *Application) LoadExternalData(ctx context.Context) error {
+	if app.ExternalData != nil {
+		return nil
+	}
+
+	extData := &AppExternalData{}
+
+	ok, err := db.GetEngine(ctx).Where("uid = ?", app.ID).Get(extData)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return ErrAppNotExist{ID: app.ID, Name: app.Name}
+	}
+
+	app.ExternalData = extData
+
+	return nil
+}
+
+func (app *Application) AppExternalData() *AppExternalData {
+	return app.ExternalData.(*AppExternalData)
+}
+
+func (app *Application) AsUser() *user_model.User {
+	return (*user_model.User)(app)
+}
+
+func ListAppsByOwnerID(ctx context.Context, ownerID int64) ([]*Application, error) {
+	type joinedApp struct {
+		App          *Application     `xorm:"extends"`
+		ExternalData *AppExternalData `xorm:"extends"`
+	}
+
+	var results *xorm.Rows
+	var err error
+	if results, err = db.GetEngine(ctx).
+		Table("user").
+		Where("owner_id = ?", ownerID).
+		Join("INNER", "app_external_data", "uid = user.id").
+		Rows(new(joinedApp)); err != nil {
+		return nil, err
+	}
+	defer results.Close()
+
+	apps := make([]*Application, 0)
+	for results.Next() {
+		joinedApp := new(joinedApp)
+		if err := results.Scan(joinedApp); err != nil {
+			return nil, err
+		}
+		joinedApp.App.ExternalData = joinedApp.ExternalData
+		apps = append(apps, joinedApp.App)
+	}
+
+	return apps, err
+}
+
+type CreateApplicationOptions struct {
+	Owner                      *user_model.User
+	Permission                 AppPermList
+	Readme                     string
+	SetupURL                   string
+	RedirectToSetupURLOnUpdate bool
+	HomePageURL                string
+	Private                    bool
+}
+
+// CreateApplication creates record of a new application.
+func CreateApplication(ctx context.Context, app *Application, opts *CreateApplicationOptions) (err error) {
+	// if !owner.CanCreateOrganization() {
+	// 	return ErrUserNotAllowedCreateOrg{}
+	// }
+
+	if opts.Private {
+		app.Visibility = structs.VisibleTypePrivate
+	} else {
+		app.Visibility = structs.VisibleTypePublic
+	}
+
+	if err = user_model.IsUsableUsername(app.Name); err != nil {
+		return err
+	}
+
+	isExist, err := user_model.IsUserExist(ctx, 0, app.Name)
+	if err != nil {
+		return err
+	} else if isExist {
+		return user_model.ErrUserAlreadyExist{Name: app.Name}
+	}
+
+	app.LowerName = strings.ToLower(app.Name)
+	if app.Rands, err = user_model.GetUserSalt(); err != nil {
+		return err
+	}
+	if app.Salt, err = user_model.GetUserSalt(); err != nil {
+		return err
+	}
+	app.UseCustomAvatar = true
+	app.MaxRepoCreation = 0
+	app.Type = user_model.UserTypeBot
+	app.IsActive = true
+
+	return db.WithTx(ctx, func(ctx context.Context) error {
+		if err = user_model.DeleteUserRedirect(ctx, app.Name); err != nil {
+			return err
+		}
+
+		if err = db.Insert(ctx, app); err != nil {
+			return fmt.Errorf("insert application: %w", err)
+		}
+		if err = user_model.GenerateRandomAvatar(ctx, app.AsUser()); err != nil {
+			return fmt.Errorf("generate random avatar: %w", err)
+		}
+
+		oauth2App, err := auth_model.CreateOAuth2Application(ctx, auth_model.CreateOAuth2ApplicationOptions{
+			GiteaAppID: app.ID,
+		})
+		if err != nil {
+			return err
+		}
+
+		app.ExternalData = &AppExternalData{
+			UID:                        app.ID,
+			OwnerID:                    opts.Owner.ID,
+			SetupURL:                   opts.SetupURL,
+			RedirectToSetupURLOnUpdate: opts.RedirectToSetupURLOnUpdate,
+			HomePageURL:                opts.HomePageURL,
+			Permission:                 opts.Permission,
+			Readme:                     opts.Readme,
+			ClientID:                   oauth2App.ClientID,
+		}
+
+		if err = db.Insert(ctx, app.ExternalData); err != nil {
+			return fmt.Errorf("insert org-user relation: %w", err)
+		}
+
+		return nil
+	})
+}
+
+func (app *Application) HomeLink() string {
+	return setting.AppSubURL + "/-/apps/" + url.PathEscape(app.Name)
+}
+
+func (app *Application) InstallURL() string {
+	return app.HomeLink() + "/installations"
+}
+
+func (app *Application) SettingsURL() string {
+	return app.HomeLink() + "/settings"
+}
+
+type ErrAppNotExist struct {
+	ID       int64
+	Name     string
+	ClientID string
+}
+
+func (err ErrAppNotExist) Error() string {
+	return fmt.Sprintf("app does not exist [id: %d, name: %s, client_id: %s]", err.ID, err.Name, err.ClientID)
+}
+
+func (err ErrAppNotExist) Unwrap() error {
+	return util.ErrNotExist
+}
+
+// GetAppByName returns application by given name.
+func GetAppByName(ctx context.Context, name string) (*Application, error) {
+	if len(name) == 0 {
+		return nil, ErrAppNotExist{Name: name}
+	}
+	u := &Application{
+		LowerName: strings.ToLower(name),
+		Type:      user_model.UserTypeBot,
+	}
+	has, err := db.GetEngine(ctx).Get(u)
+	if err != nil {
+		return nil, err
+	} else if !has {
+		return nil, ErrAppNotExist{Name: name}
+	}
+
+	return u, u.LoadExternalData(ctx)
+}
+
+func (app *Application) CanViewBy(ctx context.Context, doer *user_model.User) (bool, error) {
+	if app.Visibility == structs.VisibleTypePublic {
+		return true, nil
+	}
+
+	if doer == nil {
+		return false, nil
+	}
+
+	if doer.IsAdmin || doer.ID == app.AppExternalData().OwnerID {
+		return true, nil
+	}
+
+	if err := app.LoadOwner(ctx); err != nil {
+		return false, err
+	}
+
+	if !app.AppExternalData().Owner.IsOrganization() {
+		return false, nil
+	}
+
+	return org_model.IsOrganizationMember(ctx, app.AppExternalData().Owner.ID, doer.ID)
+}
+
+func (app *Application) LoadOwner(ctx context.Context) error {
+	if app.AppExternalData() == nil {
+		return ErrAppNotExist{ID: app.ID, Name: app.Name}
+	}
+
+	if app.AppExternalData().Owner != nil {
+		return nil
+	}
+
+	u := &user_model.User{ID: app.AppExternalData().OwnerID}
+	has, err := db.GetEngine(ctx).Get(u)
+	if err != nil {
+		return err
+	} else if !has {
+		return user_model.ErrUserNotExist{UID: app.AppExternalData().OwnerID}
+	}
+
+	app.AppExternalData().Owner = u
+
+	return nil
+}
+
+func (app *Application) IsAppManager(user *user_model.User) bool {
+	if user == nil {
+		return false
+	}
+
+	if user.IsAdmin {
+		return true
+	}
+
+	if user.ID == app.AppExternalData().OwnerID {
+		return true
+	}
+
+	if app.AppExternalData().Owner != nil && app.AppExternalData().Owner.IsOrganization() {
+		isOwner, err := org_model.IsOrganizationOwner(context.Background(), app.AppExternalData().Owner.ID, user.ID)
+		if err != nil {
+			return false
+		}
+		if isOwner {
+			return true
+		}
+	}
+
+	return false
+}

--- a/models/application/application_install.go
+++ b/models/application/application_install.go
@@ -1,0 +1,129 @@
+// Copyright 2025 Gitea. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package application
+
+import (
+	"context"
+
+	"code.gitea.io/gitea/models/db"
+	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/structs"
+	"code.gitea.io/gitea/modules/timeutil"
+)
+
+type AppInstallationType int64
+
+const (
+	AppInstallationAdmin AppInstallationType = iota
+	AppInstallationOrganization
+	AppInstallationUser
+)
+
+type AppInstallationStatus int64
+
+const (
+	AppInstallationStatusActive AppInstallationStatus = iota
+	AppInstallationStatusSuspended
+	AppInstallationStatusNotInstalled
+)
+
+type AppInstallation struct {
+	ID      int64 `xorm:"pk autoincr"`
+	Type    AppInstallationType
+	OwnerID int64            `xorm:"INDEX"`
+	Owner   *user_model.User `xorm:"-"`
+
+	InstalledBy int64
+	SuspendedBy int64
+
+	AppID      int64       `xorm:"INDEX"`
+	Permission AppPermList `xorm:"TEXT"`
+
+	SelectAllRepositories bool    `xorm:"INDEX"`
+	SelectedRepoIDs       []int64 `xorm:"JSON TEXT"`
+
+	Status AppInstallationStatus
+
+	CreatedUnix   timeutil.TimeStamp `xorm:"created"`
+	UpdatedUnix   timeutil.TimeStamp `xorm:"updated"`
+	SuspendedUnix timeutil.TimeStamp
+}
+
+func (i *AppInstallation) IsInstalled() bool {
+	return i.Status == AppInstallationStatusActive
+}
+
+type AppRepoInstallation struct {
+	ID                int64       `xorm:"pk autoincr"`
+	AppInstallationID int64       `xorm:"INDEX"`
+	RepoID            int64       `xorm:"INDEX"`
+	AppID             int64       `xorm:"INDEX"`
+	Permission        AppPermList `xorm:"TEXT"`
+}
+
+func (a *Application) IsInstallableByOwernerID(ownerID int64) bool {
+	if ownerID == user_model.SystemAdminUserID {
+		return true
+	}
+
+	if ownerID == a.AppExternalData().OwnerID {
+		return true
+	}
+
+	if a.Visibility == structs.VisibleTypePublic {
+		return true
+	}
+
+	// TODO: will have app grant logic in future
+
+	return false
+}
+
+func (a *Application) GetInstallationByOwnerID(ctx context.Context, ownerID int64) (*AppInstallation, error) {
+	installation := &AppInstallation{}
+	has, err := db.GetEngine(ctx).Where("app_id = ? AND owner_id = ?", a.ID, ownerID).Get(installation)
+	if err != nil {
+		return nil, err
+	}
+	if !has {
+		if !a.IsInstallableByOwernerID(ownerID) {
+			return nil, err
+		}
+
+		return &AppInstallation{
+			AppID:   a.ID,
+			OwnerID: ownerID,
+			Status:  AppInstallationStatusNotInstalled,
+		}, nil
+	}
+	return installation, nil
+}
+
+func (a *Application) GetInstallationByOwnerIDs(ctx context.Context, actorIDs []int64) (map[int64]*AppInstallation, error) {
+	installations := make([]*AppInstallation, 0, len(actorIDs))
+
+	err := db.GetEngine(ctx).
+		In("owner_id", actorIDs).
+		Find(&installations)
+	if err != nil {
+		return nil, err
+	}
+
+	installationMap := make(map[int64]*AppInstallation, len(installations))
+	for _, installation := range installations {
+		installationMap[installation.OwnerID] = installation
+	}
+
+	for _, actorID := range actorIDs {
+		if _, ok := installationMap[actorID]; !ok {
+			installationMap[actorID] = &AppInstallation{
+				AppID:   a.ID,
+				OwnerID: actorID,
+				Status:  AppInstallationStatusNotInstalled,
+			}
+		}
+	}
+
+	return installationMap, nil
+}

--- a/models/application/application_permission.go
+++ b/models/application/application_permission.go
@@ -1,0 +1,216 @@
+// Copyright 2025 Gitea. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package application
+
+import (
+	"sort"
+	"strings"
+)
+
+// that's similar with oauth2 scope but more fine-grained
+
+type AppPermMap map[AppPermGroup]AppPermGroupMap
+
+type AppPermGroup string
+
+type AppPermGroupMap map[AppPermItem]AppPermLevel
+
+type AppPermItem string
+
+type AppPermLevel string
+
+const (
+	PermLevelNone  AppPermLevel = "none"
+	PermLevelRead  AppPermLevel = "read"
+	PermLevelWrite AppPermLevel = "write"
+)
+
+const (
+	PermGroupRepository   AppPermGroup = "repository"
+	PermGroupOrganization AppPermGroup = "organization"
+	PermGroupAccount      AppPermGroup = "account"
+	PermGroupSystem       AppPermGroup = "system"
+)
+
+func (g AppPermGroup) defPermItem(item string) AppPermItem {
+	return AppPermItem(string(g) + "." + item)
+}
+
+var (
+	// Repository permissions
+	PermItemRepoActions        = PermGroupRepository.defPermItem("actions")
+	PermItemRepoAdministration = PermGroupRepository.defPermItem("administration")
+	PermItemRepoContents       = PermGroupRepository.defPermItem("contents")
+	PermItemRepoIssues         = PermGroupRepository.defPermItem("issues")
+	PermItemRepoPullRequests   = PermGroupRepository.defPermItem("pull_requests")
+	PermItemRepoReleases       = PermGroupRepository.defPermItem("releases")
+	PermItemRepoWebhooks       = PermGroupRepository.defPermItem("webhooks")
+	PermItemRepoPackages       = PermGroupRepository.defPermItem("packages")
+	PermItemRepoChecks         = PermGroupRepository.defPermItem("checks") // used for commit status also
+	PermItemRepoSecrets        = PermGroupRepository.defPermItem("secrets")
+
+	// Organization permissions
+	PermItemOrgAdministration = PermGroupOrganization.defPermItem("administration")
+	PermItemOrgMembers        = PermGroupOrganization.defPermItem("members")
+	PermItemOrgProjects       = PermGroupOrganization.defPermItem("projects")
+	PermItemOrgTeams          = PermGroupOrganization.defPermItem("teams")
+
+	// Account permissions
+	PermItemAccountEmails        = PermGroupAccount.defPermItem("emails")
+	PermItemAccountFollowers     = PermGroupAccount.defPermItem("followers")
+	PermItemAccountGpgKeys       = PermGroupAccount.defPermItem("gpg_keys")
+	PermItemAccountSshKeys       = PermGroupAccount.defPermItem("ssh_keys")
+	PermItemAccountSubscriptions = PermGroupAccount.defPermItem("subscriptions")
+
+	// System permissions
+	PermItemSystemAdministration = PermGroupSystem.defPermItem("administration")
+	PermItemSystemStats          = PermGroupSystem.defPermItem("stats")
+)
+
+func (g AppPermGroup) NewEmptyAppPermGroupMap() AppPermGroupMap {
+	switch g {
+	case PermGroupRepository:
+		return AppPermGroupMap{
+			PermItemRepoActions:        PermLevelNone,
+			PermItemRepoAdministration: PermLevelNone,
+			PermItemRepoContents:       PermLevelNone,
+			PermItemRepoIssues:         PermLevelNone,
+			PermItemRepoPullRequests:   PermLevelNone,
+			PermItemRepoReleases:       PermLevelNone,
+			PermItemRepoWebhooks:       PermLevelNone,
+			PermItemRepoPackages:       PermLevelNone,
+			PermItemRepoChecks:         PermLevelNone,
+			PermItemRepoSecrets:        PermLevelNone,
+		}
+	case PermGroupOrganization:
+		return AppPermGroupMap{
+			PermItemOrgAdministration: PermLevelNone,
+			PermItemOrgMembers:        PermLevelNone,
+			PermItemOrgProjects:       PermLevelNone,
+			PermItemOrgTeams:          PermLevelNone,
+		}
+	case PermGroupAccount:
+		return AppPermGroupMap{
+			PermItemAccountEmails:        PermLevelNone,
+			PermItemAccountFollowers:     PermLevelNone,
+			PermItemAccountGpgKeys:       PermLevelNone,
+			PermItemAccountSshKeys:       PermLevelNone,
+			PermItemAccountSubscriptions: PermLevelNone,
+		}
+	case PermGroupSystem:
+		return AppPermGroupMap{
+			PermItemSystemAdministration: PermLevelNone,
+			PermItemSystemStats:          PermLevelNone,
+		}
+	default:
+		return AppPermGroupMap{}
+	}
+}
+
+func NewEmptyAppPermMap() AppPermMap {
+	return AppPermMap{
+		PermGroupRepository:   PermGroupRepository.NewEmptyAppPermGroupMap(),
+		PermGroupOrganization: PermGroupOrganization.NewEmptyAppPermGroupMap(),
+		PermGroupAccount:      PermGroupAccount.NewEmptyAppPermGroupMap(),
+		PermGroupSystem:       PermGroupSystem.NewEmptyAppPermGroupMap(),
+	}
+}
+
+// perm format: <group>.<item>:<level>,...
+type AppPermList string
+
+func (l AppPermList) ToMap() AppPermMap {
+	m := NewEmptyAppPermMap()
+	// Split the permission list by comma
+
+	l = AppPermList(strings.TrimSpace(string(l)))
+
+	permPairs := strings.Split(string(l), ",")
+	for _, pair := range permPairs {
+		// Split each pair by colon
+		parts := strings.SplitN(pair, ":", 3)
+		if len(parts) != 2 {
+			continue
+		}
+		groupItem := parts[0]
+		level := parts[1]
+
+		// Split the group and item
+		groupItemParts := strings.SplitN(groupItem, ".", 3)
+		if len(groupItemParts) != 2 {
+			continue
+		}
+		group := AppPermGroup(groupItemParts[0])
+		item := AppPermItem(groupItem)
+
+		if _, ok := m[group]; !ok {
+			continue
+		}
+
+		if _, ok := m[group][item]; !ok {
+			continue
+		}
+
+		// Set the permission level
+		m[group][item] = AppPermLevel(level)
+	}
+
+	return m
+}
+
+func (l AppPermList) ValidOrDefault() AppPermList {
+	return l.ToMap().ToList()
+}
+
+func (m AppPermMap) ToList() AppPermList {
+	var pairs []string
+
+	for _, items := range m {
+		for item, level := range items {
+			if level == PermLevelNone {
+				continue
+			}
+
+			pair := string(item) + ":" + string(level)
+			pairs = append(pairs, pair)
+		}
+	}
+
+	sort.Strings(pairs)
+	list := AppPermList(strings.Join(pairs, ","))
+	return list
+}
+
+func (g AppPermGroup) LocalTitle() string {
+	return "gitea_apps.app_perm_group." + string(g)
+}
+
+func (i AppPermItem) LocalDesc() string {
+	return "gitea_apps.app_perm_item." + string(i) + ".desc"
+}
+
+func (i AppPermItem) LocalTitle() string {
+	return "gitea_apps.app_perm_item." + string(i) + ".title"
+}
+
+func (i AppPermItem) AllPermLevels() []AppPermLevel {
+	return []AppPermLevel{
+		PermLevelNone,
+		PermLevelRead,
+		PermLevelWrite,
+	}
+}
+
+func (i AppPermItem) FullValue(level AppPermLevel) string {
+	return string(i) + ":" + string(level)
+}
+
+func (l AppPermLevel) LocalTitle() string {
+	return "gitea_apps.app_perm_level." + string(l)
+}
+
+type AppPermRequirement struct {
+	Item  AppPermItem
+	Level AppPermLevel
+}

--- a/models/application/application_permission_test.go
+++ b/models/application/application_permission_test.go
@@ -1,0 +1,18 @@
+package application
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppPermList_ValidOrDefault(t *testing.T) {
+	result := AppPermList("repository.contents:read,repository.issues:write,organization.members:none,unknown.unknown:unknow").ValidOrDefault()
+	assert.Equal(t, AppPermList("repository.contents:read,repository.issues:write"), result)
+
+	result = AppPermList("").ValidOrDefault()
+	assert.Equal(t, AppPermList(""), result)
+
+	result = AppPermList("xxx:yyy:zzz").ValidOrDefault()
+	assert.Equal(t, AppPermList(""), result)
+}

--- a/models/application/application_test.go
+++ b/models/application/application_test.go
@@ -1,0 +1,45 @@
+// Copyright 2025 Gitea. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package application
+
+import (
+	"testing"
+
+	"code.gitea.io/gitea/models/unittest"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListAppsByOwnerID(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+	apps, err := ListAppsByOwnerID(t.Context(), 1)
+
+	assert.NoError(t, err)
+	assert.Len(t, apps, 1)
+	assert.Equal(t, int64(43), apps[0].ID)
+}
+
+func TestNewEmptyAppPermMap(t *testing.T) {
+	permMap := NewEmptyAppPermMap()
+	assert.NotNil(t, permMap)
+	assert.Len(t, permMap, 4)
+
+	for group, permList := range permMap {
+		assert.NotNil(t, permList)
+		assert.NotNil(t, group)
+
+		for permItem, value := range permList {
+			assert.NotNil(t, permItem)
+			assert.Equal(t, PermLevelNone, value)
+		}
+	}
+}
+
+func TestGetAppByName(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+	app, err := GetAppByName(t.Context(), "app1")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(43), app.ID)
+}

--- a/models/application/jwt_token.go
+++ b/models/application/jwt_token.go
@@ -1,0 +1,264 @@
+package application
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"time"
+
+	"code.gitea.io/gitea/models/db"
+	"code.gitea.io/gitea/modules/util"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+)
+
+type ErrInvalidPublicKey struct {
+	Key string
+}
+
+func (e ErrInvalidPublicKey) Error() string {
+	return "invalid public key: " + e.Key
+}
+
+func (e ErrInvalidPublicKey) Unwrap() error {
+	return util.ErrInvalidArgument
+}
+
+func (ext *AppExternalData) AddJWTPublicKey(ctx context.Context, key string) error {
+	block, _ := pem.Decode([]byte(key))
+	if block == nil || block.Type != "PUBLIC KEY" {
+		return ErrInvalidPublicKey{Key: key}
+	}
+	_, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return ErrInvalidPublicKey{Key: key}
+	}
+
+	hash := sha256.Sum256([]byte(key))
+	sha256Str := base64.StdEncoding.EncodeToString(hash[:])
+
+	for _, k := range ext.JWTKeyList {
+		if k.RawKeySHA == sha256Str {
+			// Key already exists, do nothing
+			return nil
+		}
+	}
+
+	ext.JWTKeyList = append(ext.JWTKeyList, JWTPubKey{
+		RawKey:    key,
+		RawKeySHA: sha256Str,
+	})
+
+	_, err = db.GetEngine(ctx).ID(ext.ID).
+		Cols("jwt_key_list").Update(ext)
+	return err
+}
+
+func (ext *AppExternalData) DeleteJWTPublicKey(ctx context.Context, keySHA string) error {
+	newKeyList := make([]JWTPubKey, 0, len(ext.JWTKeyList))
+
+	for _, k := range ext.JWTKeyList {
+		if k.RawKeySHA != keySHA {
+			newKeyList = append(newKeyList, k)
+		}
+	}
+
+	if len(newKeyList) == len(ext.JWTKeyList) {
+		// Key not found, do nothing
+		return nil
+	}
+
+	ext.JWTKeyList = newKeyList
+
+	_, err := db.GetEngine(ctx).ID(ext.ID).
+		Cols("jwt_key_list").Update(ext)
+	return err
+}
+
+func (a *Application) AddJWTPublicKey(ctx context.Context, key string) error {
+
+	if err := a.LoadExternalData(ctx); err != nil {
+		return err
+	}
+
+	return a.AppExternalData().AddJWTPublicKey(ctx, key)
+}
+
+type JWTClaims struct {
+	App   *Application `json:"-"`
+	Scope string       `json:"scope,omitempty"`
+	jwt.RegisteredClaims
+}
+
+func GetAppByClientID(ctx context.Context, clientID string) (*Application, error) {
+	type joinedApp struct {
+		App          *Application     `xorm:"extends"`
+		ExternalData *AppExternalData `xorm:"extends"`
+	}
+
+	app := new(joinedApp)
+
+	if ok, err := db.GetEngine(ctx).
+		Table("user").
+		Where("client_id = ?", clientID).
+		Join("INNER", "app_external_data", "uid = user.id").
+		Get(app); err != nil {
+		return nil, err
+	} else if !ok {
+		return nil, ErrAppNotExist{ClientID: clientID}
+	}
+
+	app.App.ExternalData = app.ExternalData
+
+	return app.App, nil
+}
+
+func (k JWTPubKey) LoadRSAPublicKey() *rsa.PublicKey {
+	block, _ := pem.Decode([]byte(k.RawKey))
+	if block == nil || block.Type != "PUBLIC KEY" {
+		return nil
+	}
+
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil
+	}
+
+	rsaPub, ok := pub.(*rsa.PublicKey)
+	if !ok {
+		return nil
+	}
+
+	return rsaPub
+}
+
+func (app *Application) GetJWTVerificationKeyList() []jwt.VerificationKey {
+	verificationKeys := make([]jwt.VerificationKey, 0, len(app.AppExternalData().JWTKeyList))
+
+	for _, k := range app.AppExternalData().JWTKeyList {
+		rsaKey := k.LoadRSAPublicKey()
+		if rsaKey == nil {
+			continue
+		}
+
+		verificationKeys = append(verificationKeys, rsaKey)
+	}
+
+	return verificationKeys
+}
+
+type ErrInvalidJWTSignature struct {
+	Message string
+}
+
+func (e ErrInvalidJWTSignature) Error() string {
+	return "invalid JWT signature: " + e.Message
+}
+
+func (e ErrInvalidJWTSignature) Unwrap() error {
+	return util.ErrInvalidArgument
+}
+
+func ValidateJWTSignature(ctx context.Context, tokenString string) (*JWTClaims, error) {
+	token, err := jwt.ParseWithClaims(tokenString, &JWTClaims{}, func(token *jwt.Token) (interface{}, error) {
+		claims, ok := token.Claims.(*JWTClaims)
+		if !ok {
+			return nil, errors.New("invalid token claims structure")
+		}
+
+		clientID := claims.Issuer
+		if clientID == "" {
+			return nil, errors.New("missing issuer (client_id) in token")
+		}
+
+		app, err := GetAppByClientID(ctx, clientID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get app by client_id: %v", err)
+		}
+
+		claims.App = app
+
+		return jwt.VerificationKeySet{
+			Keys: app.GetJWTVerificationKeyList(),
+		}, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return token.Claims.(*JWTClaims), nil
+}
+
+type JWTkeyPair struct {
+	PrivateKey *rsa.PrivateKey
+}
+
+func (j *JWTkeyPair) PublicKeyPEM() (string, error) {
+	pubBytes, err := x509.MarshalPKIXPublicKey(&j.PrivateKey.PublicKey)
+	if err != nil {
+		return "", err
+	}
+
+	pubBlock := &pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: pubBytes,
+	}
+
+	writer := new(bytes.Buffer)
+	if err := pem.Encode(writer, pubBlock); err != nil {
+		return "", err
+	}
+
+	return writer.String(), nil
+}
+
+func (j *JWTkeyPair) PrivateKeyPEM() (string, error) {
+	privBytes := x509.MarshalPKCS1PrivateKey(j.PrivateKey)
+	privBlock := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: privBytes,
+	}
+
+	writer := new(bytes.Buffer)
+	if err := pem.Encode(writer, privBlock); err != nil {
+		return "", err
+	}
+
+	return writer.String(), nil
+}
+
+const DefaultJWTkeySize = 2048
+
+func GenerateKeyPair() (*JWTkeyPair, error) {
+	key, err := rsa.GenerateKey(rand.Reader, DefaultJWTkeySize)
+	if err != nil {
+		return nil, err
+	}
+
+	return &JWTkeyPair{PrivateKey: key}, nil
+}
+
+func CreateJWTToken(key *rsa.PrivateKey, clientID string, timeout int64) (string, error) {
+	claims := jwt.MapClaims{
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Unix() + timeout,
+		"iss": clientID,
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	jwtStr, err := token.SignedString(key)
+	if err != nil {
+		fmt.Printf("Failed to sign JWT: %v\n", err)
+		return "", err
+	}
+
+	return jwtStr, nil
+}

--- a/models/application/jwt_token_test.go
+++ b/models/application/jwt_token_test.go
@@ -1,0 +1,38 @@
+package application
+
+import (
+	"testing"
+
+	"code.gitea.io/gitea/models/unittest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJWTToken(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	app, err := GetAppByClientID(t.Context(), "b4732d48-a71d-4f80-9d9d-82dcfd77049c")
+	assert.NoError(t, err)
+	assert.EqualValues(t, int64(43), app.ID)
+
+	key, err := GenerateKeyPair()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, key)
+
+	pubKey, err := key.PublicKeyPEM()
+	assert.NoError(t, err)
+
+	err = app.AddJWTPublicKey(t.Context(), pubKey)
+	assert.NoError(t, err)
+
+	jwtStr, err := CreateJWTToken(key.PrivateKey, app.AppExternalData().ClientID, 600)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, jwtStr)
+
+	sign, err := ValidateJWTSignature(t.Context(), jwtStr)
+	assert.NoError(t, err)
+	assert.Equal(t, app.ID, sign.App.ID)
+
+	jwtStr += "_invalid"
+	_, err = ValidateJWTSignature(t.Context(), jwtStr)
+	assert.Contains(t, err.Error(), "token signature is invalid")
+}

--- a/models/application/main_test.go
+++ b/models/application/main_test.go
@@ -1,0 +1,17 @@
+// Copyright 2020 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package application
+
+import (
+	"testing"
+
+	"code.gitea.io/gitea/models/unittest"
+
+	_ "code.gitea.io/gitea/models"
+	_ "code.gitea.io/gitea/models/actions"
+)
+
+func TestMain(m *testing.M) {
+	unittest.MainTest(m)
+}

--- a/models/auth/oauth2.go
+++ b/models/auth/oauth2.go
@@ -34,6 +34,10 @@ type OAuth2Application struct {
 	Name         string
 	ClientID     string `xorm:"unique"`
 	ClientSecret string
+
+	// if this app is linked to a Gitea App, this is the ID of that app
+	GiteaAppID int64 `xorm:"INDEX DEFAULT 0"`
+
 	// OAuth defines both Confidential and Public client types
 	// https://datatracker.ietf.org/doc/html/rfc6749#section-2.1
 	// "Authorization servers MUST record the client type in the client registration details"
@@ -258,6 +262,7 @@ type CreateOAuth2ApplicationOptions struct {
 	ConfidentialClient         bool
 	SkipSecondaryAuthorization bool
 	RedirectURIs               []string
+	GiteaAppID                 int64
 }
 
 // CreateOAuth2Application inserts a new oauth2 application
@@ -270,6 +275,7 @@ func CreateOAuth2Application(ctx context.Context, opts CreateOAuth2ApplicationOp
 		RedirectURIs:               opts.RedirectURIs,
 		ConfidentialClient:         opts.ConfidentialClient,
 		SkipSecondaryAuthorization: opts.SkipSecondaryAuthorization,
+		GiteaAppID:                 opts.GiteaAppID,
 	}
 	if err := db.Insert(ctx, app); err != nil {
 		return nil, err

--- a/models/auth/oauth2_list.go
+++ b/models/auth/oauth2_list.go
@@ -15,6 +15,8 @@ type FindOAuth2ApplicationsOptions struct {
 	OwnerID int64
 	// find global applications, if true, then OwnerID will be igonred
 	IsGlobal bool
+	// IncludeGiteaAppLinked indicates whether to include Gitea app linked applications
+	IncludeGiteaAppLinked bool
 }
 
 func (opts FindOAuth2ApplicationsOptions) ToConds() builder.Cond {
@@ -24,6 +26,11 @@ func (opts FindOAuth2ApplicationsOptions) ToConds() builder.Cond {
 	} else if opts.OwnerID != 0 {
 		conds = conds.And(builder.Eq{"uid": opts.OwnerID})
 	}
+
+	if !opts.IncludeGiteaAppLinked {
+		conds = conds.And(builder.Eq{"gitea_app_id": 0})
+	}
+
 	return conds
 }
 

--- a/models/fixtures/app_external_data.yml
+++ b/models/fixtures/app_external_data.yml
@@ -1,0 +1,8 @@
+-
+  id: 1
+  uid: 43
+  owner_id: 1
+  setup_url: https://example.com/setup_url
+  home_page_url: https://example.com/home_page_url
+  permission: "repository.issues:read,repository.pull_requests:write"
+  client_id: "b4732d48-a71d-4f80-9d9d-82dcfd77049c"

--- a/models/fixtures/oauth2_application.yml
+++ b/models/fixtures/oauth2_application.yml
@@ -18,3 +18,12 @@
   created_unix: 1546869730
   updated_unix: 1546869730
   confidential_client: false
+
+-
+  id: 3
+  client_id: "b4732d48-a71d-4f80-9d9d-82dcfd77049c"
+  client_secret: "$2a$10$UYRgUSgekzBp6hYe8pAdc.cgB4Gn06QRKsORUnIYTYQADs.YR/uvi" # bcrypt of "4MK8Na6R55smdCY0WuCCumZ6hjRPnGY5saWVRHHjJiA=
+  gitea_app_id: 1
+  created_unix: 1759215894
+  updated_unix: 1759215894
+  confidential_client: false

--- a/models/fixtures/user.yml
+++ b/models/fixtures/user.yml
@@ -1556,3 +1556,40 @@
   repo_admin_change_team_access: false
   theme: ""
   keep_activity_private: false
+
+-
+  id: 43
+  lower_name: app1
+  name: App1
+  full_name: test app one
+  email: app1@example.com
+  keep_email_private: false
+  email_notifications_preference: onmention
+  passwd: ZogKvWdyEx:password
+  passwd_hash_algo: dummy
+  must_change_password: false
+  login_source: 0
+  login_name: app1
+  type: 4
+  salt: ZogKvWdyEx
+  max_repo_creation: 0
+  is_active: true
+  is_admin: false
+  is_restricted: false
+  allow_git_hook: false
+  allow_import_local: false
+  allow_create_organization: true
+  prohibit_login: false
+  avatar: ""
+  avatar_email: app1@example.com
+  use_custom_avatar: true
+  num_followers: 0
+  num_following: 0
+  num_stars: 0
+  num_repos: 1
+  num_teams: 0
+  num_members: 0
+  visibility: 0
+  repo_admin_change_team_access: false
+  theme: ""
+  keep_activity_private: false

--- a/models/organization/org_list.go
+++ b/models/organization/org_list.go
@@ -100,6 +100,18 @@ func GetOrgsCanCreateRepoByUserID(ctx context.Context, userID int64) ([]*Organiz
 		Find(&orgs)
 }
 
+func GetOrgsOwnedByUserID(ctx context.Context, userID int64) ([]*Organization, error) {
+	orgs := make([]*Organization, 0, 10)
+
+	return orgs, db.GetEngine(ctx).Where(builder.In("id", builder.Select("`user`.id").From("`user`").
+		Join("INNER", "`team_user`", "`team_user`.org_id = `user`.id").
+		Join("INNER", "`team`", "`team`.id = `team_user`.team_id").
+		Where(builder.Eq{"`team_user`.uid": userID}).
+		And(builder.Eq{"`team`.authorize": perm.AccessModeOwner}))).
+		Asc("`user`.name").
+		Find(&orgs)
+}
+
 // MinimalOrg represents a simple organization with only the needed columns
 type MinimalOrg = Organization
 

--- a/models/renderhelper/application.go
+++ b/models/renderhelper/application.go
@@ -1,0 +1,41 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package renderhelper
+
+import (
+	"context"
+
+	"code.gitea.io/gitea/modules/markup"
+)
+
+type Application struct {
+	ctx *markup.RenderContext
+}
+
+func (r *Application) CleanUp() {
+}
+
+func (r *Application) IsCommitIDExisting(commitID string) bool {
+	return false
+}
+
+func (r *Application) ResolveLink(link, preferLinkType string) (finalLink string) {
+	linkType, link := markup.ParseRenderedLink(link, preferLinkType)
+	switch linkType {
+	case markup.LinkTypeRoot:
+		finalLink = r.ctx.ResolveLinkRoot(link)
+	}
+	return finalLink
+}
+
+var _ markup.RenderHelper = (*Application)(nil)
+
+func NewRenderContextApplication(ctx context.Context) *markup.RenderContext {
+	helper := &Application{}
+	rctx := markup.NewRenderContext(ctx)
+	helper.ctx = rctx
+
+	rctx = rctx.WithHelper(helper)
+	return rctx
+}

--- a/models/user/user.go
+++ b/models/user/user.go
@@ -76,6 +76,9 @@ const (
 	EmailNotificationsAndYourOwn = "andyourown"
 )
 
+type UserExternalData interface {
+}
+
 // User represents the object of individual and member of organization.
 type User struct {
 	ID        int64  `xorm:"pk autoincr"`
@@ -150,6 +153,8 @@ type User struct {
 	DiffViewStyle       string `xorm:"NOT NULL DEFAULT ''"`
 	Theme               string `xorm:"NOT NULL DEFAULT ''"`
 	KeepActivityPrivate bool   `xorm:"NOT NULL DEFAULT false"`
+
+	ExternalData UserExternalData `xorm:"-"`
 }
 
 // Meta defines the meta information of a user, to be stored in the K/V table

--- a/models/user/user_system.go
+++ b/models/user/user_system.go
@@ -65,6 +65,32 @@ func (u *User) IsGiteaActions() bool {
 	return u != nil && u.ID == ActionsUserID
 }
 
+const (
+	SystemAdminUserID    int64 = -3
+	SystemAdminUserName        = ".system-admin"
+	SystemAdminUserEmail       = "system-admin@gitea.io"
+)
+
+// NewSystemAdminUser creates and returns a fake user for system admin actions.
+func NewSystemAdminUser() *User {
+	return &User{
+		ID:               SystemAdminUserID,
+		Name:             SystemAdminUserName,
+		LowerName:        SystemAdminUserName,
+		IsActive:         true,
+		FullName:         "system admin",
+		Email:            SystemAdminUserEmail,
+		KeepEmailPrivate: true,
+		Type:             UserTypeBot,
+		Visibility:       structs.VisibleTypePublic,
+		IsAdmin:          true,
+	}
+}
+
+func IsSystemAdminUserName(name string) bool {
+	return strings.EqualFold(name, SystemAdminUserName)
+}
+
 func GetSystemUserByName(name string) *User {
 	if IsGhostUserName(name) {
 		return NewGhostUser()
@@ -72,5 +98,9 @@ func GetSystemUserByName(name string) *User {
 	if IsGiteaActionsUserName(name) {
 		return NewActionsUser()
 	}
+	if IsSystemAdminUserName(name) {
+		return NewSystemAdminUser()
+	}
+
 	return nil
 }

--- a/modules/templates/util_avatar.go
+++ b/modules/templates/util_avatar.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 
 	activities_model "code.gitea.io/gitea/models/activities"
+	"code.gitea.io/gitea/models/application"
 	"code.gitea.io/gitea/models/avatars"
 	"code.gitea.io/gitea/models/organization"
 	repo_model "code.gitea.io/gitea/models/repo"
@@ -54,6 +55,11 @@ func (au *AvatarUtils) Avatar(item any, others ...any) template.HTML {
 			return AvatarHTML(src, size, class, t.DisplayName())
 		}
 	case *organization.Organization:
+		src := t.AsUser().AvatarLinkWithSize(au.ctx, size*setting.Avatar.RenderedSizeFactor)
+		if src != "" {
+			return AvatarHTML(src, size, class, t.AsUser().DisplayName())
+		}
+	case *application.Application:
 		src := t.AsUser().AvatarLinkWithSize(au.ctx, size*setting.Avatar.RenderedSizeFactor)
 		if src != "" {
 			return AvatarHTML(src, size, class, t.AsUser().DisplayName())

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -70,6 +70,7 @@ import (
 	"net/http"
 	"strings"
 
+	"code.gitea.io/gitea/models/application"
 	auth_model "code.gitea.io/gitea/models/auth"
 	"code.gitea.io/gitea/models/organization"
 	"code.gitea.io/gitea/models/perm"
@@ -343,6 +344,14 @@ func tokenRequiresScopes(requiredScopeCategories ...auth_model.AccessTokenScopeC
 
 		// assign to true so that those searching should only filter public repositories/users/organizations
 		ctx.PublicOnly = publicOnly
+	}
+}
+
+func appRequirePermissions(requiredPerms ...application.AppPermRequirement) func(ctx *context.APIContext) {
+	
+
+	return func(ctx *context.APIContext) {
+
 	}
 }
 
@@ -759,6 +768,7 @@ func buildAuthGroup() *auth.Group {
 		&auth.OAuth2{},
 		&auth.HTTPSign{},
 		&auth.Basic{}, // FIXME: this should be removed once we don't allow basic auth in API
+		&auth.JWTAuth{},
 	)
 	if setting.Service.EnableReverseProxyAuthAPI {
 		group.Add(&auth.ReverseProxy{})

--- a/routers/web/app/application.go
+++ b/routers/web/app/application.go
@@ -1,0 +1,148 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package app
+
+import (
+	"errors"
+	"net/http"
+
+	"code.gitea.io/gitea/models/application"
+	"code.gitea.io/gitea/models/organization"
+	"code.gitea.io/gitea/models/renderhelper"
+	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/markup/markdown"
+	"code.gitea.io/gitea/modules/templates"
+	"code.gitea.io/gitea/services/context"
+)
+
+const (
+	tplView              templates.TplName = "apps/view"
+	tplViewInstallations templates.TplName = "apps/view_installations"
+	tplViewInstallation  templates.TplName = "apps/view_installation_target"
+)
+
+func ViewApp(ctx *context.Context) {
+	ctx.Data["Title"] = ctx.GiteaApp.App.Name
+
+	appExt := ctx.GiteaApp.App.AppExternalData()
+
+	rctx := renderhelper.NewRenderContextApplication(ctx)
+
+	var err error
+	appExt.RenderedReadme, err = markdown.RenderString(rctx, appExt.Readme)
+	if err != nil {
+		ctx.ServerError("markdown.RenderString", err)
+		return
+	}
+
+	ctx.HTML(http.StatusOK, tplView)
+}
+
+func checkAndLoadInstallationByTargetID(ctx *context.Context, targetID int64) *application.AppInstallation {
+	var owner *user_model.User
+
+	switch targetID {
+	case user_model.SystemAdminUserID:
+		if !ctx.Doer.IsAdmin {
+			ctx.NotFound(errors.New("no permission to view system admin installations"))
+			return nil
+		}
+		owner = user_model.NewSystemAdminUser()
+		ctx.Data["IsSystemAdminInstallation"] = true
+	case ctx.Doer.ID:
+		owner = ctx.Doer
+		ctx.Data["IsUserInstallation"] = true
+	default:
+		org, err := organization.GetOrgByID(ctx, targetID)
+		if err != nil {
+			ctx.NotFound(err)
+			return nil
+		}
+
+		if isAdmin, err := org.IsOrgAdmin(ctx, ctx.Doer.ID); err != nil {
+			ctx.ServerError("IsOrgAdmin", err)
+			return nil
+		} else if !isAdmin {
+			ctx.NotFound(errors.New("no permission to view this organization's installations"))
+			return nil
+		}
+		owner = org.AsUser()
+		ctx.Data["IsOrgInstallation"] = true
+	}
+
+	installation, err := ctx.GiteaApp.App.GetInstallationByOwnerID(ctx, targetID)
+	if err != nil {
+		ctx.ServerError("GetInstallationByOwnerID", err)
+		return nil
+	}
+	installation.Owner = owner
+
+	return installation
+}
+
+func ViewAppInstallationOnTarget(ctx *context.Context, targetID int64) {
+	install := checkAndLoadInstallationByTargetID(ctx, targetID)
+	if install == nil {
+		return
+	}
+
+	ctx.Data["Title"] = ctx.Tr("apps.installations.on_target.title", ctx.GiteaApp.App.Name, install.Owner.DisplayName())
+	ctx.Data["Installation"] = install
+
+	ctx.HTML(http.StatusOK, tplViewInstallation)
+}
+
+func ViewAppInstallations(ctx *context.Context) {
+	if !ctx.IsSigned {
+		ctx.NotFound(errors.New("request sigin"))
+		return
+	}
+
+	if id := ctx.FormInt64("target_id"); id != 0 {
+		ViewAppInstallationOnTarget(ctx, id)
+		return
+	}
+
+	ctx.Data["Title"] = ctx.Tr("apps.installations.title", ctx.GiteaApp.App.Name)
+
+	actorIDs := make([]int64, 0, 5)
+	actorIDs = append(actorIDs, ctx.Doer.ID)
+
+	orgs, err := organization.GetOrgsOwnedByUserID(ctx, ctx.Doer.ID)
+	if err != nil {
+		ctx.ServerError("GetOrgsOwnedByUserID", err)
+		return
+	}
+	for _, org := range orgs {
+		actorIDs = append(actorIDs, org.ID)
+	}
+
+	if ctx.Doer.IsAdmin {
+		actorIDs = append(actorIDs, user_model.SystemAdminUserID)
+	}
+
+	installations, err := ctx.GiteaApp.App.GetInstallationByOwnerIDs(ctx, actorIDs)
+	if err != nil {
+		ctx.ServerError("GetInstallationByOwnerIDs", err)
+		return
+	}
+
+	installations[ctx.Doer.ID].Owner = ctx.Doer
+	for _, org := range orgs {
+		installations[org.ID].Owner = org.AsUser()
+	}
+
+	installationsList := make([]*application.AppInstallation, 0, len(installations))
+	for _, v := range installations {
+		installationsList = append(installationsList, v)
+	}
+	if ctx.Doer.IsAdmin {
+		systemAdmin := user_model.NewSystemAdminUser()
+		installations[systemAdmin.ID].Owner = systemAdmin
+	}
+
+	ctx.Data["Installations"] = installationsList
+
+	ctx.HTML(http.StatusOK, tplViewInstallations)
+}

--- a/routers/web/app/setting/settings.go
+++ b/routers/web/app/setting/settings.go
@@ -1,0 +1,29 @@
+package setting
+
+import (
+	"code.gitea.io/gitea/modules/templates"
+	"code.gitea.io/gitea/services/context"
+)
+
+const (
+	tplViewProfile  templates.TplName = "apps/settings/profile"
+	tplViewSecurity templates.TplName = "apps/settings/security"
+)
+
+func Profile(ctx *context.Context) {
+	ctx.Data["Title"] = ctx.Tr("app.settings")
+
+	ctx.Data["PageIsAppSettings"] = true
+	ctx.Data["PageIsSettingsProfile"] = true
+
+	ctx.HTML(200, tplViewProfile)
+}
+
+func Security(ctx *context.Context) {
+	ctx.Data["Title"] = ctx.Tr("app.settings.security")
+
+	ctx.Data["PageIsAppSettings"] = true
+	ctx.Data["PageIsSettingsSecurity"] = true
+
+	ctx.HTML(200, tplViewSecurity)
+}

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -24,6 +24,8 @@ import (
 	"code.gitea.io/gitea/modules/web/routing"
 	"code.gitea.io/gitea/routers/common"
 	"code.gitea.io/gitea/routers/web/admin"
+	"code.gitea.io/gitea/routers/web/app"
+	app_setting "code.gitea.io/gitea/routers/web/app/setting"
 	"code.gitea.io/gitea/routers/web/auth"
 	"code.gitea.io/gitea/routers/web/devtest"
 	"code.gitea.io/gitea/routers/web/events"
@@ -629,6 +631,8 @@ func registerWebRoutes(m *web.Router) {
 			m.Combo("").Get(user_setting.Applications).
 				Post(web.Bind(forms.NewAccessTokenForm{}), user_setting.ApplicationsPost)
 			m.Post("/delete", user_setting.DeleteApplication)
+
+			m.Post("/gitea_app", web.Bind(forms.NewGiteaAppForm{}), user_setting.GiteaAppPost)
 		})
 
 		m.Combo("/keys").Get(user_setting.Keys).
@@ -1647,6 +1651,26 @@ func registerWebRoutes(m *web.Router) {
 		m.Post("/action/{action:watch|unwatch}", reqSignIn, repo.ActionWatch)
 		m.Post("/action/{action:accept_transfer|reject_transfer}", reqSignIn, repo.ActionTransfer)
 	}, optSignIn, context.RepoAssignment)
+
+	m.Group("/-/apps/{appname}", func() {
+		m.Get("", app.ViewApp)
+		m.Get("/installations", app.ViewAppInstallations)
+	}, optSignIn, context.ApplicationAssignment(context.ApplicationAssignmentOptions{}))
+
+	m.Group("/-/apps/{appname}/settings", func() {
+		m.Get("", app_setting.Profile)
+		m.Get("/security", app_setting.Security)
+	}, reqSignIn, context.ApplicationAssignment(context.ApplicationAssignmentOptions{RequireAdmin: true}))
+
+	m.Group("/-/apps/{appname}", func() {
+		m.Get("", app.ViewApp)
+		m.Get("/installations", app.ViewAppInstallations)
+	}, optSignIn, context.ApplicationAssignment(context.ApplicationAssignmentOptions{}))
+
+	m.Group("/-/apps/{appname}/settings", func() {
+		m.Get("", app_setting.Profile)
+		m.Get("/security", app_setting.Security)
+	}, reqSignIn, context.ApplicationAssignment(context.ApplicationAssignmentOptions{RequireAdmin: true}))
 
 	common.AddOwnerRepoGitLFSRoutes(m, lfsServerEnabled, repo.CorsHandler(), optSignInFromAnyOrigin) // "/{username}/{reponame}/{lfs-paths}": git-lfs support, see also addOwnerRepoGitHTTPRouters
 

--- a/services/auth/jwt.go
+++ b/services/auth/jwt.go
@@ -1,0 +1,53 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"context"
+	"net/http"
+
+	app_model "code.gitea.io/gitea/models/application"
+	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/auth/httpauth"
+)
+
+// Ensure the struct implements the interface.
+var (
+	_ Method = &JWTAuth{}
+)
+
+type JWTAuth struct{}
+
+// Name represents the name of auth method
+func (j *JWTAuth) Name() string {
+	return "jwt"
+}
+
+func verifyJWTToken(ctx context.Context, tokenString string) (*user_model.User, error) {
+	claims, err := app_model.ValidateJWTSignature(ctx, tokenString)
+	if err != nil {
+		return nil, err
+	}
+
+	return claims.App.AsUser(), nil
+}
+
+func (j *JWTAuth) Verify(req *http.Request, w http.ResponseWriter, store DataStore, sess SessionStore) (*user_model.User, error) {
+	// These paths are not API paths, but we still want to check for tokens because they maybe in the API returned URLs
+	detector := newAuthPathDetector(req)
+	if !detector.isAPIPath() && !detector.isAttachmentDownload() && !detector.isAuthenticatedTokenRequest() &&
+		!detector.isGitRawOrAttachPath() && !detector.isArchivePath() {
+		return nil, nil
+	}
+
+	// check header token
+	if auHead := req.Header.Get("Authorization"); auHead != "" {
+		parsed, ok := httpauth.ParseAuthorizationHeader(auHead)
+		if ok && parsed.BearerToken != nil {
+			return verifyJWTToken(req.Context(), parsed.BearerToken.Token)
+		}
+	}
+
+	return nil, nil
+}

--- a/services/context/application.go
+++ b/services/context/application.go
@@ -1,0 +1,67 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package context
+
+import (
+	"errors"
+
+	application_model "code.gitea.io/gitea/models/application"
+	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/util"
+)
+
+type Application struct {
+	App *application_model.Application
+
+	IsAdmin    bool
+	CanInstall bool
+}
+
+type ApplicationAssignmentOptions struct {
+	RequireAdmin      bool
+	RequireCanInstall bool
+}
+
+func ApplicationAssignment(opts ApplicationAssignmentOptions) func(ctx *Context) {
+	return func(ctx *Context) {
+		if ctx.Data["GiteaApp"] != nil {
+			setting.PanicInDevOrTesting("Application should not be executed twice")
+		}
+
+		appname := ctx.PathParam("appname")
+
+		app, err := application_model.GetAppByName(ctx, appname)
+		if err != nil {
+			if errors.Is(err, util.ErrNotExist) {
+				ctx.NotFound(err)
+			} else {
+				ctx.ServerError("GetAppByName", err)
+			}
+			return
+		}
+
+		if ok, err := app.CanViewBy(ctx, ctx.Doer); err != nil {
+			ctx.ServerError("CanViewBy", err)
+			return
+		} else if !ok {
+			ctx.NotFound(err)
+			return
+		}
+
+		ctx.GiteaApp = &Application{App: app}
+		ctx.Data["GiteaApp"] = app
+		ctx.ContextUser = app.AsUser()
+
+		ctx.GiteaApp.IsAdmin = app.IsAppManager(ctx.Doer)
+
+		if opts.RequireAdmin && !ctx.GiteaApp.IsAdmin {
+			ctx.NotFound(nil)
+			return
+		}
+
+		ctx.Data["IsAppManager"] = ctx.GiteaApp.IsAdmin
+	}
+
+	// ctx.GiteaApp.CanInstall = ctx.GiteaApp.CanInstall(ctx.Doer)
+}

--- a/services/context/context.go
+++ b/services/context/context.go
@@ -58,9 +58,10 @@ type Context struct {
 
 	ContextUser *user_model.User // the user which is being visited, in most cases it differs from Doer
 
-	Repo    *Repository
-	Org     *Organization
-	Package *Package
+	Repo     *Repository
+	Org      *Organization
+	Package  *Package
+	GiteaApp *Application
 }
 
 type TemplateContext map[string]any

--- a/services/context/user.go
+++ b/services/context/user.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 
+	"code.gitea.io/gitea/models/application"
 	user_model "code.gitea.io/gitea/models/user"
 )
 
@@ -27,6 +28,10 @@ func UserAssignmentWeb() func(ctx *Context) {
 		}
 		ctx.ContextUser = userAssignment(ctx.Base, ctx.Doer, errorFn)
 		ctx.Data["ContextUser"] = ctx.ContextUser
+
+		if ctx.ContextUser != nil && ctx.ContextUser.IsTypeBot() {
+			ctx.Redirect(application.AppFromUser(ctx.ContextUser).HomeLink())
+		}
 	}
 }
 

--- a/services/forms/user_form.go
+++ b/services/forms/user_form.go
@@ -436,3 +436,13 @@ func (f *BlockUserForm) Validate(req *http.Request, errs binding.Errors) binding
 	ctx := context.GetValidateContext(req)
 	return middleware.Validate(errs, ctx.Data, f, ctx.Locale)
 }
+
+type NewGiteaAppForm struct {
+	Name             string `binding:"Required;MaxSize(255)" form:"application_name"`
+	Readme           string
+	HomePageURL      string `binding:"ValidUrl" form:"home_page_url"`
+	SetupURL         string `binding:"ValidUrl" form:"setup_url"`
+	RedirectOnUpdate bool   `form:"redirect_on_update"`
+	PermList         string `form:"perm_list"`
+	Private          bool
+}

--- a/templates/apps/settings/keys_jwt.tmpl
+++ b/templates/apps/settings/keys_jwt.tmpl
@@ -1,0 +1,123 @@
+<h4 class="ui top attached header">
+	{{ctx.Locale.Tr "settings.manage_jwt_keys"}}
+	<div class="ui right">
+		<button class="ui primary tiny show-panel toggle button" data-panel="#add-gpg-key-panel">{{ctx.Locale.Tr "settings.add_key"}}</button>
+	</div>
+</h4>
+<div class="ui attached segment">
+	<div class="{{if not .HasGPGError}}tw-hidden{{end}} tw-mb-4" id="add-gpg-key-panel">
+		<form class="ui form{{if .HasGPGError}} error{{end}}" action="{{.Link}}" method="post">
+			{{.CsrfTokenHtml}}
+			<input type="hidden" name="title" value="none">
+			<div class="field {{if .Err_Content}}error{{end}}">
+				<label for="gpg-key-content">{{ctx.Locale.Tr "settings.key_content"}}</label>
+				<textarea id="gpg-key-content" name="content" placeholder="{{ctx.Locale.Tr "settings.key_content_jwt_placeholder"}}" required>{{.content}}</textarea>
+			</div>
+			<input name="type" type="hidden" value="gpg">
+			<button class="ui primary button">
+				{{ctx.Locale.Tr "settings.add_key"}}
+			</button>
+			<button class="ui hide-panel button" data-panel="#add-gpg-key-panel">
+				{{ctx.Locale.Tr "cancel"}}
+			</button>
+			<div>you need generate a pair of jwt keys, then keeps private key and input public key here</div>
+			<div>example generate steeps: </div>
+			<div class="tw-flex">
+				<div class="tw-flex-grow">
+					<div><code>openssl genpkey -algorithm RSA -out private_key.pem -pkeyopt rsa_keygen_bits:2048</code></div>
+					<div><code>openssl rsa -pubout -in private_key.pem -out public_key.pem</code></div>
+				</div>
+				<div>
+					<button class="code-copy ui button" data-clipboard-text="openssl genpkey -algorithm RSA -out private_key.pem -pkeyopt rsa_keygen_bits:2048
+openssl rsa -pubout -in private_key.pem -out public_key.pem">
+						{{svg "octicon-copy" 14}}
+					</button>
+				</div>
+			</div>
+		</form>
+	</div>
+	<div class="flex-list">
+		<div class="flex-item">
+			<p>
+				{{ctx.Locale.Tr "settings.app_jwt_desc"}}<br>
+				<!-- {{ctx.Locale.Tr "settings.gpg_helper" "https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/about-commit-signature-verification#gpg-commit-signature-verification"}} -->
+			</p>
+		</div>
+		{{range .GPGKeys}}
+			<div class="flex-item">
+				<div class="flex-item-leading">
+					<span class="text {{if or .ExpiredUnix.IsZero ($.PageStartTime.Before .ExpiredUnix.AsTime)}}green{{end}}">{{svg "octicon-key" 32}}</span>
+				</div>
+				<div class="flex-item-main">
+					{{if .Verified}}
+						<span class="flex-text-block" data-tooltip-content="{{ctx.Locale.Tr "settings.gpg_key_verified_long"}}">{{svg "octicon-verified"}} <strong>{{ctx.Locale.Tr "settings.gpg_key_verified"}}</strong></span>
+					{{end}}
+					{{if .Emails}}
+						<span class="flex-text-block" data-tooltip-content="{{ctx.Locale.Tr "settings.gpg_key_matched_identities_long"}}">{{svg "octicon-mail"}} {{ctx.Locale.Tr "settings.gpg_key_matched_identities"}} {{range .Emails}}<strong>{{.Email}} </strong>{{end}}</span>
+					{{end}}
+					<div class="flex-item-body">
+						<b>{{ctx.Locale.Tr "settings.key_id"}}:</b> {{.PaddedKeyID}}
+						<b>{{ctx.Locale.Tr "settings.subkeys"}}:</b> {{range .SubsKey}} {{.PaddedKeyID}} {{end}}
+					</div>
+					<div class="flex-item-body">
+						<i>{{ctx.Locale.Tr "settings.added_on" (DateUtils.AbsoluteShort .AddedUnix)}}</i>
+						-
+						<i>{{if not .ExpiredUnix.IsZero}}{{ctx.Locale.Tr "settings.valid_until_date" (DateUtils.AbsoluteShort .ExpiredUnix)}}{{else}}{{ctx.Locale.Tr "settings.valid_forever"}}{{end}}</i>
+					</div>
+				</div>
+				<div class="flex-item-trailing">
+					<button class="ui red tiny button delete-button" data-modal-id="delete-gpg" data-url="{{$.Link}}/delete?type=gpg" data-id="{{.ID}}">
+						{{ctx.Locale.Tr "settings.delete_key"}}
+					</button>
+					{{if and (not .Verified) (ne $.VerifyingID .KeyID)}}
+						<a class="ui primary tiny button" href="?verify_gpg={{.KeyID}}">{{ctx.Locale.Tr "settings.gpg_key_verify"}}</a>
+					{{end}}
+				</div>
+			</div>
+			{{if and (not .Verified) (eq $.VerifyingID .KeyID)}}
+				<div class="ui  segment">
+					<h4>{{ctx.Locale.Tr "settings.gpg_token_required"}}</h4>
+					<form class="ui form{{if $.HasGPGVerifyError}} error{{end}}" action="{{$.Link}}" method="post">
+						{{$.CsrfTokenHtml}}
+						<input type="hidden" name="title" value="none">
+						<input type="hidden" name="content" value="{{.KeyID}}">
+						<input type="hidden" name="key_id" value="{{.KeyID}}">
+						<div class="field">
+							<label for="token">{{ctx.Locale.Tr "settings.gpg_token"}}</label>
+							<input readonly="" value="{{$.TokenToSign}}">
+							<div class="help">
+								<p>{{ctx.Locale.Tr "settings.gpg_token_help"}}</p>
+								<p><code>{{printf `echo "%s" | gpg -a --default-key %s --detach-sig` $.TokenToSign .PaddedKeyID}}</code></p>
+							</div>
+							<br>
+						</div>
+						<div class="field">
+							<label for="signature">{{ctx.Locale.Tr "settings.gpg_token_signature"}}</label>
+							<textarea id="gpg-key-signature" name="signature" placeholder="{{ctx.Locale.Tr "settings.key_signature_gpg_placeholder"}}" required>{{$.signature}}</textarea>
+						</div>
+						<input name="type" type="hidden" value="verify_gpg">
+						<button class="ui primary button">
+							{{ctx.Locale.Tr "settings.gpg_key_verify"}}
+						</button>
+						<button class="ui button">
+							generate by server
+						</button>
+						<a class="ui red button" href="{{$.Link}}">
+							{{ctx.Locale.Tr "settings.cancel"}}
+						</a>
+					</form>
+				</div>
+			{{end}}
+		{{end}}
+	</div>
+	<div class="ui g-modal-confirm delete modal" id="delete-gpg">
+		<div class="header">
+			{{svg "octicon-trash"}}
+			{{ctx.Locale.Tr "settings.gpg_key_deletion"}}
+		</div>
+		<div class="content">
+			<p>{{ctx.Locale.Tr "settings.gpg_key_deletion_desc"}}</p>
+		</div>
+		{{template "base/modal_actions_confirm" .}}
+	</div>
+</div>

--- a/templates/apps/settings/layout_footer.tmpl
+++ b/templates/apps/settings/layout_footer.tmpl
@@ -1,0 +1,11 @@
+{{if false}}{{/* to make html structure "likely" complete to prevent IDE warnings */}}
+<div class="page-content">
+	<div class="user-layout-right">
+		<div>
+		{{/* block: user-setting-content */}}
+{{end}}
+
+		</div>
+	</div>
+</div>
+{{template "base/footer" .}}

--- a/templates/apps/settings/layout_head.tmpl
+++ b/templates/apps/settings/layout_head.tmpl
@@ -1,0 +1,13 @@
+{{template "base/head" .ctxData}}
+<div role="main" aria-label="{{.ctxData.Title}}" class="page-content {{.pageClass}}">
+	<div class="ui container flex-container">
+		{{template "apps/settings/navbar" .ctxData}}
+		<div class="flex-container-main">
+			{{template "base/alert" .ctxData}}
+			{{/* block: apps-setting-content */}}
+
+{{if false}}{{/* to make html structure "likely" complete to prevent IDE warnings */}}
+		</div>
+	</div>
+</div>
+{{end}}

--- a/templates/apps/settings/navbar.tmpl
+++ b/templates/apps/settings/navbar.tmpl
@@ -1,0 +1,11 @@
+<div class="flex-container-nav">
+	<div class="ui fluid vertical menu">
+		<div class="header item">{{ctx.Locale.Tr "app.settings"}}</div>
+		<a class="{{if .PageIsSettingsProfile}}active {{end}}item" href="{{.GiteaApp.SettingsURL}}">
+			{{ctx.Locale.Tr "app.settings.profile"}}
+		</a>
+		<a class="{{if .PageIsSettingsSecurity}}active {{end}}item" href="{{.GiteaApp.SettingsURL}}/security">
+			{{ctx.Locale.Tr "app.settings.security"}}
+		</a>
+	</div>
+</div>

--- a/templates/apps/settings/profile.tmpl
+++ b/templates/apps/settings/profile.tmpl
@@ -1,0 +1,6 @@
+{{template "apps/settings/layout_head" (dict "ctxData" . "pageClass" "apps settings profile")}}
+
+
+<h1>{{.Title}}</h1>
+
+{{template "apps/settings/layout_footer" .}}

--- a/templates/apps/settings/security.tmpl
+++ b/templates/apps/settings/security.tmpl
@@ -1,0 +1,7 @@
+{{template "apps/settings/layout_head" (dict "ctxData" . "pageClass" "apps settings profile")}}
+
+<h1>{{.Title}}</h1>
+
+{{template "apps/settings/keys_jwt" .}}
+
+{{template "apps/settings/layout_footer" .}}

--- a/templates/apps/view.tmpl
+++ b/templates/apps/view.tmpl
@@ -1,0 +1,42 @@
+{{template "base/head" .}}
+<div role="main" aria-label="{{.Title}}" class="page-content user profile">
+	<div class="ui container">
+        <div class="ui stackable grid">
+            <div class="ui ten wide column tw-mb-4">
+                <div class="tw-flex tw-gap-4">
+                    <div id="profile-avatar" class="content tw-flex">
+                        <span class="image">
+                            {{ctx.AvatarUtils.Avatar .GiteaApp 100 "org-avatar"}}
+                        </span>
+                    </div>
+
+                    <h1>{{.GiteaApp.Name}}</h1>
+                </div>
+
+                {{if .GiteaApp.ExternalData.RenderedReadme}}
+                    <div class="divider"></div>
+                    <div id="readme_profile" class="render-content markup">{{.GiteaApp.ExternalData.RenderedReadme}}</div>
+                {{end}}
+            </div>
+            <div class="ui six wide column">
+                <div>
+                    <a href="{{.GiteaApp.InstallURL}}" class="ui primary button tw-w-full tw-pt-4">install</a>
+                    {{if .IsAppManager}}
+                        <a href="{{.GiteaApp.SettingsURL}}" class="ui button tw-w-full tw-pt-4">config</a>
+                    {{end}}
+                </div>
+
+                <div class="tw-pt-12">
+                    <p>Developer</p>
+                    <ul class="tw-list-none tw-pl-4">
+                        <li><a href="xxxxxx">xxxxxxxxx</a></li>
+                        <li><a href="xxxxxx">xxxxxxxxx</a></li>
+                        <li><a href="xxxxxx">xxxxxxxxx</a></li>
+                        <li><a href="xxxxxx">xxxxxxxxx</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{{template "base/footer" .}}

--- a/templates/apps/view_installation_target.tmpl
+++ b/templates/apps/view_installation_target.tmpl
@@ -1,0 +1,126 @@
+{{template "base/head" .}}
+<div role="main" aria-label="{{.Title}}" class="page-content user profile">
+    <div class="ui middle very relaxed page grid">
+		<div class="column tw-flex tw-flex-col tw-gap-4 tw-max-w-2xl tw-m-auto">
+            <div class="ui container fluid">
+                <h4 class="ui top attached header center"> Installe {{.Installation.Owner.DisplayName}} on xxxxx </h4>
+
+                <div class="ui attached segment">
+                    <form class="ui form" action="{{.InstallLink}}" method="post">
+			            {{.CsrfTokenHtml}}
+                    </form>
+
+                    {{if .IsSystemAdminInstallation}}
+                        <div class="inline field" data-field-patched="true">
+                            <label for="install_in_system">Install in system: </label>
+                            <div class="ui checkbox" data-checkbox-patched="true">
+                                <input id="install_in_system" name="install_in_system" type="checkbox">
+                            </div>
+                            <span class="help">
+                                Install app as a system appliaction
+                            </span>
+                        </div>
+
+                       <div class="inline field" data-field-patched="true">
+                            <label for="install_in_all_users">Install in all users: </label>
+                            <div class="ui checkbox" data-checkbox-patched="true">
+                                <input id="install_in_all_users" name="install_in_all_users" type="checkbox">
+                            </div>
+                            <span class="help">
+                                Install app for all users and organizations.
+                            </span>
+                        </div>
+
+                        <div class="inline field">
+                            <label for="install_in_system">Install for users: </label>
+
+                            <div class="flex-list">
+                                <div class="flex-item tw-items-center">
+                                    <div class="flex-item-leading">
+                                        xxxxxxx
+                                    </div>
+                                    <div class="flex-item-main">
+                                        <div class="flex-item-title">
+                                            bbbbb
+                                        </div>
+                                    </div>
+                                    <div class="flex-item-trailing">
+                                        <form>
+                                            <button class="ui red button delete-button">xxxxxxxxxx </button>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div id="search-user-box" class="ui search tw-mr-2">
+								<div class="ui input">
+									<input class="prompt" name="uname" placeholder="{{ctx.Locale.Tr "search.user_kind"}}" autocomplete="off" required>
+                                    <button class="ui primary button">add</button>
+								</div>
+							</div>
+                        </div>
+                    {{end}}
+
+                    {{if not .IsSystemAdminInstallation}}
+                        <div class="inline field" data-field-patched="true">
+                            <label for="install_in_user">Install as user app: </label>
+                            <div class="ui checkbox" data-checkbox-patched="true">
+                                <input id="install_in_user" name="install_in_all_user_repos" type="checkbox">
+                            </div>
+                        </div>
+
+                        <div class="inline field">
+                            <label for="install_in_system">Install for repositories: </label>
+
+                            <div class="flex-list">
+                                <div class="flex-item tw-items-center">
+                                    <div class="flex-item-leading">
+                                        xxxxxxx
+                                    </div>
+                                    <div class="flex-item-main">
+                                        <div class="flex-item-title">
+                                            bbbbb
+                                        </div>
+                                    </div>
+                                    <div class="flex-item-trailing">
+                                        <form>
+                                            <button class="ui red button delete-button">xxxxxxxxxx </button>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div data-global-init="initSearchRepoBox" data-uid="{{.Installation.OwnerID}}" class="ui search">
+								<div class="ui input">
+									<input class="prompt" name="repo_name" placeholder="{{ctx.Locale.Tr "search.repo_kind"}}" autocomplete="off" required>
+                                    <button class="ui primary button">add</button>
+								</div>
+							</div>
+                        </div>
+                    {{end}}
+
+                    <div class="divider"></div>
+
+                    <div class="inline fieled">
+                        with these permissions:
+                        <ul>
+                            <li>aaaaaaaaaa</li>
+                            <li>nnnnnnnnnnnn</li>
+                            <li>cdddddddddddddd</li>
+                            <li>efsg safrg sdsaarg fdbs</li>
+                        </ul>
+                    </div>
+
+                    <div class="inline field">
+                        <label></label>
+                        <button class="ui primary button">
+                            安装
+                        </button>
+				</div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+{{template "base/footer" .}}

--- a/templates/apps/view_installations.tmpl
+++ b/templates/apps/view_installations.tmpl
@@ -1,0 +1,10 @@
+{{template "base/head" .}}
+<div role="main" aria-label="{{.Title}}" class="page-content user profile">
+	<div class="ui container">
+        {{range .Installations}}
+            <div> {{.Owner.DisplayName}} - {{.IsInstalled}} </div>
+        {{end}}
+    </div>
+</div>
+
+{{template "base/footer" .}}

--- a/templates/user/settings/applications.tmpl
+++ b/templates/user/settings/applications.tmpl
@@ -90,6 +90,8 @@
 			{{template "user/settings/grants_oauth2" .}}
 			{{template "user/settings/applications_oauth2" .}}
 		{{end}}
+
+		{{template "user/settings/gitea_app" .}}
 	</div>
 
 <div class="ui g-modal-confirm delete modal" id="delete-token">

--- a/templates/user/settings/applications_gitea_app_list.tmpl
+++ b/templates/user/settings/applications_gitea_app_list.tmpl
@@ -1,0 +1,101 @@
+<div class="ui attached segment">
+	<div class="flex-list">
+		<div class="flex-item">
+			{{ctx.Locale.Tr "settings.gitea_application_list_description"}}
+		</div>
+		{{range .GiteaApps}}
+			<div class="flex-item tw-items-center">
+				<div class="flex-item-leading">
+					{{svg "octicon-apps" 32}}
+				</div>
+				<div class="flex-item-main">
+					<div class="flex-item-title">{{.Name}}</div>
+				</div>
+				<div class="flex-item-trailing">
+				<a href="{{$.Link}}/oauth2/{{.ID}}" class="ui primary tiny button">
+					{{svg "octicon-pencil" 16 "tw-mr-1"}}
+					{{ctx.Locale.Tr "settings.oauth2_application_edit"}}
+				</a>
+				</div>
+			</div>
+		{{end}}
+	</div>
+</div>
+
+<div class="ui bottom attached segment">
+	<details {{if .application_name}}open{{end}}>
+		<summary><h4 class="ui header tw-inline-block tw-my-2">{{ctx.Locale.Tr "settings.create_gitea_application"}}</h4></summary>
+		<form class="ui form ignore-dirty" name="gita-app-create" id="gita-app-create" action="{{.Link}}/gitea_app" method="post">
+			{{.CsrfTokenHtml}}
+			<div class="field {{if .Err_AppName}}error{{end}}">
+				<label for="application-name">{{ctx.Locale.Tr "settings.oauth2_application_name"}}</label>
+				<input id="application-name" name="application_name" value="{{.application_name}}" required maxlength="255">
+			</div>
+
+			<div class="field">
+				{{template "shared/combomarkdowneditor" (dict
+					"TextareaName" "readme"
+					"TextareaContent" .readme
+					"TextareaPlaceholder" (ctx.Locale.Tr "repo.projects.description_placeholder")
+				)}}
+			</div>
+
+			<div class="field {{if .Err_HomePageURL}}error{{end}}">
+				<label for="home-page-url">{{ctx.Locale.Tr "settings.oauth2_home_page_url"}}</label>
+				<input id="home-page-url" name="home_page_url" value="{{.home_page_url}}" required maxlength="255">
+			</div>
+
+			<div class="field {{if .Err_SetUpURL}}error{{end}}">
+				<label for="setup-url">{{ctx.Locale.Tr "settings.oauth2_setup_url"}}</label>
+				<input id="setup-url" name="setup_url" value="{{.setup_url}}" required maxlength="255">
+			</div>
+
+			<div class="inline field">
+				<label></label>
+				<div class="ui checkbox" id="redirect-on-update">
+					<input name="redirect_on_update" type="checkbox" {{if .redirect_on_update}}checked{{end}}>
+					<label>{{ctx.Locale.Tr "settings.gitea_app.redirect_on_update"}}</label>
+				</div>
+			</div>
+
+			<h4 class="ui header tw-inline-block tw-my-2">{{ctx.Locale.Tr "settings.gitea_app.permissions"}}</h4>
+
+			<input type="hidden" name="perm_list" value="{{.perm_list}}">
+
+			{{range $group, $permList := .GiteaAppPerms}}
+				<details>
+					<summary><h4 class="ui header tw-inline-block tw-my-2">{{ctx.Locale.Tr $group.LocalTitle}}</h4></summary>
+
+					{{range $permItem, $permValue := $permList}}
+						<div class="inline field tw-flex">
+							<div class="tw-grow">
+								<div>{{ctx.Locale.Tr $permItem.LocalTitle}}</div>
+								<div>{{ctx.Locale.Tr $permItem.LocalDesc}}</div>
+							</div>
+							<select class="ui selection dropdown gitea-app-perm-item" data-perm-item="{{$permItem}}" name="type">
+								{{range $permItem.AllPermLevels}}
+									<option value="{{.}}" {{if eq $permValue .}}selected{{end}}>{{.LocalTitle}}</option>
+								{{end}}
+							</select>
+						</div>
+					{{end}}
+				</details>
+			{{end}}
+
+			<div class="inline field">
+				<div>
+					<label>{{ctx.Locale.Tr "settings.gitea_app.visibility"}}</label>
+					<div class="ui checkbox">
+						<input name="private" type="checkbox" {{if .private}}checked{{end}}>
+						<label>{{ctx.Locale.Tr "settings.gitea_app.visibility_helper"}}</label>
+					</div>
+				</div>
+				<span class="help">{{ctx.Locale.Tr "settings.gitea_app.visibility_description"}}</span>
+			</div>
+
+			<button class="ui primary button">
+				{{ctx.Locale.Tr "settings.create_oauth2_application_button"}}
+			</button>
+		</form>
+	</details>
+</div>

--- a/templates/user/settings/gitea_app.tmpl
+++ b/templates/user/settings/gitea_app.tmpl
@@ -1,0 +1,5 @@
+<h4 class="ui top attached header">
+	{{ctx.Locale.Tr "settings.manage_gitea_applications"}}
+</h4>
+
+{{template "user/settings/applications_gitea_app_list" .}}

--- a/tests/integration/gitea_app_test.go
+++ b/tests/integration/gitea_app_test.go
@@ -1,0 +1,50 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package integration
+
+import (
+	"net/http"
+	"testing"
+
+	"code.gitea.io/gitea/modules/json"
+	"code.gitea.io/gitea/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	app_model "code.gitea.io/gitea/models/application"
+)
+
+func TestGiteaAppJWTAuth(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	app, err := app_model.GetAppByClientID(t.Context(), "b4732d48-a71d-4f80-9d9d-82dcfd77049c")
+	assert.NoError(t, err)
+
+	key, err := app_model.GenerateKeyPair()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, key)
+
+	pubKey, err := key.PublicKeyPEM()
+	assert.NoError(t, err)
+
+	err = app.AddJWTPublicKey(t.Context(), pubKey)
+	assert.NoError(t, err)
+
+	jwtStr, err := app_model.CreateJWTToken(key.PrivateKey, app.AppExternalData().ClientID, 600)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, jwtStr)
+
+	userReq := NewRequest(t, "GET", "/api/v1/user")
+	userReq.SetHeader("Authorization", "Bearer "+jwtStr)
+	userResp := MakeRequest(t, userReq, http.StatusOK)
+
+	type userResponse struct {
+		Login string `json:"login"`
+		Email string `json:"email"`
+	}
+
+	userParsed := new(userResponse)
+	require.NoError(t, json.Unmarshal(userResp.Body.Bytes(), userParsed))
+	assert.Equal(t, "App1", userParsed.Login)
+}

--- a/web_src/js/features/gitea-app-perm-setting.ts
+++ b/web_src/js/features/gitea-app-perm-setting.ts
@@ -1,0 +1,41 @@
+export function initGiteaAppPermSettingConfig() {
+  const $form = document.querySelector<HTMLFormElement>('form#gita-app-create');
+  if ($form === null) {
+    return
+  }
+
+  const $permListInput = $form.querySelector<HTMLInputElement>('input[name="perm_list"]');
+  if ($permListInput === null) {
+    return
+  }
+
+  for (const el of $form.querySelectorAll<HTMLSelectElement>('select.gitea-app-perm-item')) {
+    el.addEventListener('change', (e : Event) => {
+        if (!(e.target instanceof HTMLSelectElement)) {
+            return;
+        }
+
+        let $permList = $permListInput.value === ""? []: $permListInput.value.split(',');
+        const $permItem = e.target.getAttribute('data-perm-item');
+        if ($permItem === null) {
+            return;
+        }
+
+        const $value = e.target.value;
+        if ($value === null || $value === "none") {
+            $permList = $permList.filter(item => !item.startsWith($permItem + ':'));
+        }
+        else {
+            const newPerm = $permItem + ':' + $value;
+            const foundIndex = $permList.findIndex(item => item.startsWith($permItem + ':'));
+            if (foundIndex !== -1) {
+                $permList[foundIndex] = newPerm;
+            } else {
+                $permList.push(newPerm);
+            }
+        }
+
+        $permListInput.value = $permList.join(',');
+    });
+  }
+}

--- a/web_src/js/index-domready.ts
+++ b/web_src/js/index-domready.ts
@@ -64,6 +64,7 @@ import {initGlobalButtonClickOnEnter, initGlobalButtons, initGlobalDeleteButton}
 import {initGlobalComboMarkdownEditor, initGlobalEnterQuickSubmit, initGlobalFormDirtyLeaveConfirm} from './features/common-form.ts';
 import {callInitFunctions} from './modules/init.ts';
 import {initRepoViewFileTree} from './features/repo-view-file-tree.ts';
+import {initGiteaAppPermSettingConfig} from './features/gitea-app-perm-setting.ts';
 
 const initStartTime = performance.now();
 const initPerformanceTracer = callInitFunctions([
@@ -158,6 +159,8 @@ const initPerformanceTracer = callInitFunctions([
   initOAuth2SettingsDisableCheckbox,
 
   initRepoFileView,
+
+  initGiteaAppPermSettingConfig,
 ]);
 
 // it must be the last one, then the "querySelectorAll" only needs to be executed once for global init functions.


### PR DESCRIPTION
I'd like design something like [github app](https://docs.github.com/en/apps/overview), 
and imply [plugin logic](https://github.com/go-gitea/gitea/issues/20126) by some more
features than github apps.
this is a early draft for waiting more response.

It will act like a individue user, which can be cosider as a bot acount or a plugin.

features design about gitea app:
- atc like indivdue bot acount through api by JWT auth (like github app)
- provide webhook  (like github app)
- act as other user like oauth2 app (like github app)
- app will be allowed to provide service whch will be called by gitea like webhook,
and it will request ontime response, the response will affect the gitea srvice logic. (plugin logic)

installition types:
- install by a repository
- install by a user
- install by a orgnization
- install by system

...

related:
-  #13044
