### PR TITLE
Forbid localStorage access in eslint

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -19,19 +19,16 @@ import {defineConfig, globalIgnores} from 'eslint/config';
 const jsExts = ['js', 'mjs', 'cjs'] as const;
 const tsExts = ['ts', 'mts', 'cts'] as const;
 
-const restrictedSyntax = ['WithStatement', 'ForInStatement', 'LabeledStatement', 'SequenceExpression'];
-const restrictedFetchSyntax = [
-  {selector: 'CallExpression[callee.name="fetch"]', message: 'use `modules/fetch.ts` instead.'},
-];
 const restrictedGlobals = [
-  'addEventListener', 'blur', 'close', 'closed', 'confirm', 'defaultStatus', 'defaultstatus', 'error', 'event', 'external', 'find', 'focus', 'frameElement', 'frames', 'history', 'innerHeight', 'innerWidth', 'isFinite', 'isNaN', 'length', 'locationbar', 'menubar', 'moveBy', 'moveTo', 'name', 'onblur', 'onerror', 'onfocus', 'onload', 'onresize', 'onunload', 'open', 'opener', 'opera', 'outerHeight', 'outerWidth', 'pageXOffset', 'pageYOffset', 'parent', 'print', 'removeEventListener', 'resizeBy', 'resizeTo', 'screen', 'screenLeft', 'screenTop', 'screenX', 'screenY', 'scroll', 'scrollbars', 'scrollBy', 'scrollTo', 'scrollX', 'scrollY', 'status', 'statusbar', 'stop', 'toolbar', 'top',
-];
-const restrictedLocalStorageGlobals = [
   {name: 'localStorage', message: 'Use `modules/user-settings.ts` instead.'},
+  {name: 'fetch', message: 'Use `modules/fetch.ts` instead.'},
 ];
+
 const restrictedProperties = [
   {object: 'window', property: 'localStorage', message: 'Use `modules/user-settings.ts` instead.'},
   {object: 'globalThis', property: 'localStorage', message: 'Use `modules/user-settings.ts` instead.'},
+  {object: 'window', property: 'fetch', message: 'Use `modules/fetch.ts` instead.'},
+  {object: 'globalThis', property: 'fetch', message: 'Use `modules/fetch.ts` instead.'},
 ];
 
 export default defineConfig([
@@ -79,7 +76,7 @@ export default defineConfig([
       'import-x/resolver': {'typescript': true},
     },
     rules: {
-      '@eslint-community/eslint-comments/disable-enable-pair': [2],
+      '@eslint-community/eslint-comments/disable-enable-pair': [0],
       '@eslint-community/eslint-comments/no-aggregating-enable': [2],
       '@eslint-community/eslint-comments/no-duplicate-disable': [2],
       '@eslint-community/eslint-comments/no-restricted-disable': [0],
@@ -569,10 +566,10 @@ export default defineConfig([
       'no-redeclare': [0], // must be disabled for typescript overloads
       'no-regex-spaces': [2],
       'no-restricted-exports': [0],
-      'no-restricted-globals': [2, ...restrictedGlobals, ...restrictedLocalStorageGlobals],
+      'no-restricted-globals': [2, ...restrictedGlobals],
       'no-restricted-properties': [2, ...restrictedProperties],
       'no-restricted-imports': [0],
-      'no-restricted-syntax': [2, ...restrictedSyntax, ...restrictedFetchSyntax],
+      'no-restricted-syntax': [2, 'WithStatement', 'ForInStatement', 'LabeledStatement', 'SequenceExpression'],
       'no-return-assign': [0],
       'no-script-url': [2],
       'no-self-assign': [2, {props: true}],
@@ -936,19 +933,6 @@ export default defineConfig([
       'vue/max-attributes-per-line': [0],
       'vue/singleline-html-element-content-newline': [0],
       'vue/require-typed-ref': [2],
-    },
-  },
-  {
-    files: ['web_src/js/modules/fetch.ts', 'web_src/js/standalone/**/*'],
-    rules: {
-      'no-restricted-syntax': [2, ...restrictedSyntax],
-    },
-  },
-  {
-    files: ['web_src/js/modules/user-settings.ts'],
-    rules: {
-      'no-restricted-globals': [2, ...restrictedGlobals],
-      'no-restricted-properties': [0],
     },
   },
   {

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -21,7 +21,7 @@ const tsExts = ['ts', 'mts', 'cts'] as const;
 
 const restrictedSyntax = ['WithStatement', 'ForInStatement', 'LabeledStatement', 'SequenceExpression'];
 const restrictedFetchSyntax = [
-  {selector: 'CallExpression[callee.name="fetch"]', message: 'use `modules/fetch.ts` instead'},
+  {selector: 'CallExpression[callee.name="fetch"]', message: 'use `modules/fetch.ts` instead.'},
 ];
 const restrictedGlobals = [
   'addEventListener', 'blur', 'close', 'closed', 'confirm', 'defaultStatus', 'defaultstatus', 'error', 'event', 'external', 'find', 'focus', 'frameElement', 'frames', 'history', 'innerHeight', 'innerWidth', 'isFinite', 'isNaN', 'length', 'locationbar', 'menubar', 'moveBy', 'moveTo', 'name', 'onblur', 'onerror', 'onfocus', 'onload', 'onresize', 'onunload', 'open', 'opener', 'opera', 'outerHeight', 'outerWidth', 'pageXOffset', 'pageYOffset', 'parent', 'print', 'removeEventListener', 'resizeBy', 'resizeTo', 'screen', 'screenLeft', 'screenTop', 'screenX', 'screenY', 'scroll', 'scrollbars', 'scrollBy', 'scrollTo', 'scrollX', 'scrollY', 'status', 'statusbar', 'stop', 'toolbar', 'top',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -18,7 +18,21 @@ import {defineConfig, globalIgnores} from 'eslint/config';
 
 const jsExts = ['js', 'mjs', 'cjs'] as const;
 const tsExts = ['ts', 'mts', 'cts'] as const;
+
 const restrictedSyntax = ['WithStatement', 'ForInStatement', 'LabeledStatement', 'SequenceExpression'];
+const restrictedFetchSyntax = [
+  {selector: 'CallExpression[callee.name="fetch"]', message: 'use `modules/fetch.ts` instead'},
+];
+const restrictedGlobals = [
+  'addEventListener', 'blur', 'close', 'closed', 'confirm', 'defaultStatus', 'defaultstatus', 'error', 'event', 'external', 'find', 'focus', 'frameElement', 'frames', 'history', 'innerHeight', 'innerWidth', 'isFinite', 'isNaN', 'length', 'locationbar', 'menubar', 'moveBy', 'moveTo', 'name', 'onblur', 'onerror', 'onfocus', 'onload', 'onresize', 'onunload', 'open', 'opener', 'opera', 'outerHeight', 'outerWidth', 'pageXOffset', 'pageYOffset', 'parent', 'print', 'removeEventListener', 'resizeBy', 'resizeTo', 'screen', 'screenLeft', 'screenTop', 'screenX', 'screenY', 'scroll', 'scrollbars', 'scrollBy', 'scrollTo', 'scrollX', 'scrollY', 'status', 'statusbar', 'stop', 'toolbar', 'top',
+];
+const restrictedLocalStorageGlobals = [
+  {name: 'localStorage', message: 'Use `modules/user-settings.ts` instead.'},
+];
+const restrictedProperties = [
+  {object: 'window', property: 'localStorage', message: 'Use `modules/user-settings.ts` instead.'},
+  {object: 'globalThis', property: 'localStorage', message: 'Use `modules/user-settings.ts` instead.'},
+];
 
 export default defineConfig([
   globalIgnores([
@@ -555,9 +569,10 @@ export default defineConfig([
       'no-redeclare': [0], // must be disabled for typescript overloads
       'no-regex-spaces': [2],
       'no-restricted-exports': [0],
-      'no-restricted-globals': [2, 'addEventListener', 'blur', 'close', 'closed', 'confirm', 'defaultStatus', 'defaultstatus', 'error', 'event', 'external', 'find', 'focus', 'frameElement', 'frames', 'history', 'innerHeight', 'innerWidth', 'isFinite', 'isNaN', 'length', 'locationbar', 'menubar', 'moveBy', 'moveTo', 'name', 'onblur', 'onerror', 'onfocus', 'onload', 'onresize', 'onunload', 'open', 'opener', 'opera', 'outerHeight', 'outerWidth', 'pageXOffset', 'pageYOffset', 'parent', 'print', 'removeEventListener', 'resizeBy', 'resizeTo', 'screen', 'screenLeft', 'screenTop', 'screenX', 'screenY', 'scroll', 'scrollbars', 'scrollBy', 'scrollTo', 'scrollX', 'scrollY', 'status', 'statusbar', 'stop', 'toolbar', 'top'],
+      'no-restricted-globals': [2, ...restrictedGlobals, ...restrictedLocalStorageGlobals],
+      'no-restricted-properties': [2, ...restrictedProperties],
       'no-restricted-imports': [0],
-      'no-restricted-syntax': [2, ...restrictedSyntax, {selector: 'CallExpression[callee.name="fetch"]', message: 'use modules/fetch.ts instead'}],
+      'no-restricted-syntax': [2, ...restrictedSyntax, ...restrictedFetchSyntax],
       'no-return-assign': [0],
       'no-script-url': [2],
       'no-self-assign': [2, {props: true}],
@@ -927,6 +942,13 @@ export default defineConfig([
     files: ['web_src/js/modules/fetch.ts', 'web_src/js/standalone/**/*'],
     rules: {
       'no-restricted-syntax': [2, ...restrictedSyntax],
+    },
+  },
+  {
+    files: ['web_src/js/modules/user-settings.ts'],
+    rules: {
+      'no-restricted-globals': [2, ...restrictedGlobals],
+      'no-restricted-properties': [0],
     },
   },
   {

--- a/web_src/js/modules/fetch.ts
+++ b/web_src/js/modules/fetch.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-globals */
 import {isObject} from '../utils.ts';
 import type {RequestOpts} from '../types.ts';
 
@@ -23,7 +22,7 @@ export function request(url: string, {method = 'GET', data, headers = {}, ...oth
     headersMerged.set(name, value);
   }
 
-  return fetch(url, {
+  return fetch(url, { // eslint-disable-line no-restricted-globals
     method,
     headers: headersMerged,
     ...other,

--- a/web_src/js/modules/fetch.ts
+++ b/web_src/js/modules/fetch.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 import {isObject} from '../utils.ts';
 import type {RequestOpts} from '../types.ts';
 

--- a/web_src/js/modules/user-settings.ts
+++ b/web_src/js/modules/user-settings.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 // Some people deploy Gitea under a subpath, so it needs prefix to avoid local storage key conflicts.
 // And these keys are for user settings only, it also needs a specific prefix,
 // in case in the future there are other uses of local storage, and/or we need to clear some keys when the quota is exceeded.

--- a/web_src/js/standalone/swagger.ts
+++ b/web_src/js/standalone/swagger.ts
@@ -7,7 +7,7 @@ window.addEventListener('load', async () => {
   const url = elSwaggerUi.getAttribute('data-source')!;
   let spec: any;
   if (url) {
-    const res = await fetch(url);
+    const res = await fetch(url); // eslint-disable-line no-restricted-globals
     spec = await res.json();
   } else {
     const elSpecContent = elSwaggerUi.querySelector<HTMLTextAreaElement>('.swagger-spec-content')!;

--- a/web_src/js/standalone/swagger.ts
+++ b/web_src/js/standalone/swagger.ts
@@ -1,13 +1,14 @@
 import SwaggerUI from 'swagger-ui-dist/swagger-ui-es-bundle.js';
 import 'swagger-ui-dist/swagger-ui.css';
 import {load as loadYaml} from 'js-yaml';
+import {GET} from '../modules/fetch.ts';
 
 window.addEventListener('load', async () => {
   const elSwaggerUi = document.querySelector('#swagger-ui')!;
   const url = elSwaggerUi.getAttribute('data-source')!;
   let spec: any;
   if (url) {
-    const res = await fetch(url); // eslint-disable-line no-restricted-globals
+    const res = await GET(url);
     spec = await res.json();
   } else {
     const elSpecContent = elSwaggerUi.querySelector<HTMLTextAreaElement>('.swagger-spec-content')!;

--- a/web_src/js/utils/image.test.ts
+++ b/web_src/js/utils/image.test.ts
@@ -5,7 +5,7 @@ const pngPhys = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91
 const pngEmpty = 'data:image/png;base64,';
 
 async function dataUriToBlob(datauri: string) {
-  return await (await globalThis.fetch(datauri)).blob();
+  return await (await globalThis.fetch(datauri)).blob(); // eslint-disable-line no-restricted-properties
 }
 
 test('pngChunks', async () => {


### PR DESCRIPTION
Followup to https://github.com/go-gitea/gitea/commit/59f812bc1cc52f15d66d1b233f11e43339c09cec, enforce using our localStorage wrapper in eslint.

Also did a few tweaks in the eslint config, like removing the incomplete list of globals, this is a non-issue with typescript.