### PR TITLE
Correct spacing between username and bot label

### DIFF
--- a/templates/shared/user/authorlink.tmpl
+++ b/templates/shared/user/authorlink.tmpl
@@ -1,1 +1,1 @@
-<a class="muted text black tw-font-semibold"{{if gt .ID 0}} href="{{.HomeLink}}"{{end}}>{{.GetDisplayName}}</a>{{if .IsTypeBot}}<span class="ui basic label tw-p-1 tw-align-baseline">bot</span>{{end}}
+<a class="muted text black tw-font-semibold"{{if gt .ID 0}} href="{{.HomeLink}}"{{end}}>{{.GetDisplayName}}</a>{{if .IsTypeBot}}&nbsp;<span class="ui basic label tw-p-1 tw-align-baseline">bot</span>{{end}}


### PR DESCRIPTION
### Before:
<img width="654" height="68" alt="before" src="https://github.com/user-attachments/assets/f7283e1b-dbda-49ed-a75b-372e8c322d69" />

### After:
<img width="644" height="59" alt="after" src="https://github.com/user-attachments/assets/01aadfca-b0b7-4fef-b711-436bba409eaa" />
