### PR TITLE
Render merged pull request title as such in dashboard feed

### DIFF
--- a/templates/user/dashboard/feeds.tmpl
+++ b/templates/user/dashboard/feeds.tmpl
@@ -113,7 +113,7 @@
 						<div class="render-content markup tw-text-14">{{ctx.RenderUtils.MarkdownToHtml $comment}}</div>
 					{{end}}
 				{{else if .GetOpType.InActions "merge_pull_request"}}
-					<div class="flex-item-body text black">{{index .GetIssueInfos 1}}</div>
+					<div class="flex-item-body text black">{{index .GetIssueInfos 1 | ctx.RenderUtils.RenderIssueSimpleTitle}}</div>
 				{{else if .GetOpType.InActions "close_issue" "reopen_issue" "close_pull_request" "reopen_pull_request"}}
 					<span class="text truncate issue title">{{(.GetIssueTitle ctx) | ctx.RenderUtils.RenderIssueSimpleTitle}}</span>
 				{{else if .GetOpType.InActions "pull_review_dismissed"}}


### PR DESCRIPTION
Before:

<img width="513" height="55" alt="Screenshot 2026-01-28 at 17 24 50" src="https://github.com/user-attachments/assets/ef28d87a-9a52-4762-9ddc-c3934f5cfc7a" />

After:

<img width="509" height="64" alt="Screenshot 2026-01-28 at 17 24 39" src="https://github.com/user-attachments/assets/bc55c828-7813-47be-bef8-23eeb51bd513" />