### PR TITLE
[SECURITY] Toolchain Update to Go 1.25.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module code.gitea.io/gitea
 
 go 1.25.0
 
-toolchain go1.25.5
+toolchain go1.25.6
 
 // rfc5280 said: "The serial number is an integer assigned by the CA to each certificate."
 // But some CAs use negative serial number, just relax the check. related:


### PR DESCRIPTION
## Overview
This PR updates the Go toolchain version from `1.25.5` to `1.25.6` for the Gitea project.

## Changes

### Toolchain Update
- **Go Toolchain**: Updated from `go1.25.5` to `go1.25.6`

This is a minor toolchain version bump that ensures the project uses the latest patch release of Go 1.25.

## Security Improvements

While this PR primarily addresses the toolchain update, the project maintains a strong security posture through:

### Current Security Measures
```log
Vulnerability #1: GO-2026-4342                                                                                                                                                                                                      
    Excessive CPU consumption when building archive index in archive/zip
  More info: https://pkg.go.dev/vuln/GO-2026-4342
  Standard library
    Found in: archive/zip@go1.25.5
    Fixed in: archive/zip@go1.25.6
    Example traces found:
      #1: modules/packages/nuget/metadata.go:217:25: nuget.ParseNuspecMetaData calls zip.Reader.Open                                                                                                                                

Vulnerability #2: GO-2026-4341
    Memory exhaustion in query parameter parsing in net/url
  More info: https://pkg.go.dev/vuln/GO-2026-4341
  Standard library
    Found in: net/url@go1.25.5
    Fixed in: net/url@go1.25.6
    Example traces found:
      #1: modules/storage/minio.go:284:34: storage.MinioStorage.URL calls url.ParseQuery                                                                                                                                            
      #2: routers/api/v1/repo/action.go:1640:29: repo.DownloadArtifactRaw calls url.URL.Query

Vulnerability #3: GO-2026-4340
    Handshake messages may be processed at the incorrect encryption level in
    crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2026-4340
  Standard library
    Found in: crypto/tls@go1.25.5
    Fixed in: crypto/tls@go1.25.6
    Example traces found:
      #1: services/auth/source/ldap/source_search.go:129:25: ldap.dial calls ldap.Conn.StartTLS, which calls tls.Conn.Handshake                                                                                                     
      #2: modules/graceful/server.go:156:14: graceful.Server.Serve calls http.Server.Serve, which eventually calls tls.Conn.HandshakeContext
      #3: modules/lfs/content_store.go:132:27: lfs.hashingReader.Read calls tls.Conn.Read
      #4: modules/proxyprotocol/conn.go:91:21: proxyprotocol.Conn.Write calls tls.Conn.Write
      #5: modules/session/virtual.go:168:39: session.VirtualStore.Release calls couchbase.CouchbaseProvider.Exist, which eventually calls tls.Dial
      #6: services/auth/source/ldap/source_search.go:120:22: ldap.dial calls ldap.DialTLS, which calls tls.DialWithDialer
      #7: services/migrations/gogs.go:114:34: migrations.client calls http.Transport.RoundTrip, which eventually calls tls.Dialer.DialContext
```

## Breaking Changes
None expected. This is a minor toolchain patch update.