### PR TITLE
Use reserved .test TLD for unit tests

### DIFF
--- a/modules/setting/mailer_test.go
+++ b/modules/setting/mailer_test.go
@@ -11,12 +11,12 @@ import (
 
 func Test_loadMailerFrom(t *testing.T) {
 	kases := map[string]*Mailer{
-		"smtp.mydomain.com": {
-			SMTPAddr: "smtp.mydomain.com",
+		"smtp.mydomain.test": {
+			SMTPAddr: "smtp.mydomain.test",
 			SMTPPort: "465",
 		},
-		"smtp.mydomain.com:123": {
-			SMTPAddr: "smtp.mydomain.com",
+		"smtp.mydomain.test:123": {
+			SMTPAddr: "smtp.mydomain.test",
 			SMTPPort: "123",
 		},
 		":123": {


### PR DESCRIPTION
`smtp.mydomain.com` is a real domain that resolves to something and which is being connected to while running tests. Instead, use [.test](https://en.wikipedia.org/wiki/.test) which is guaranteed to never be registered on the internet, so all connections to it will fail with NXDOMAIN dns error.