### PR TITLE
Fix issues filter dropdown showing empty label scope section

### DIFF
--- a/templates/repo/issue/filter_list.tmpl
+++ b/templates/repo/issue/filter_list.tmpl
@@ -133,11 +133,13 @@
 		<a class="{{if eq .SortType "leastcomment"}}active {{end}}item" href="{{QueryBuild $queryLink "sort" "leastcomment"}}">{{ctx.Locale.Tr "repo.issues.filter_sort.leastcomment"}}</a>
 		<a class="{{if eq .SortType "nearduedate"}}active {{end}}item" href="{{QueryBuild $queryLink "sort" "nearduedate"}}">{{ctx.Locale.Tr "repo.issues.filter_sort.nearduedate"}}</a>
 		<a class="{{if eq .SortType "farduedate"}}active {{end}}item" href="{{QueryBuild $queryLink "sort" "farduedate"}}">{{ctx.Locale.Tr "repo.issues.filter_sort.farduedate"}}</a>
-		<div class="divider"></div>
-		<div class="header">{{ctx.Locale.Tr "repo.issues.filter_label"}}</div>
-		{{range $scope := .ExclusiveLabelScopes}}
-			{{$sortType := (printf "scope-%s" $scope)}}
-			<a class="{{if eq $.SortType $sortType}}active {{end}}item" href="{{QueryBuild $queryLink "sort" $sortType}}">{{$scope}}</a>
+		{{if .ExclusiveLabelScopes}}
+			<div class="divider"></div>
+			<div class="header">{{ctx.Locale.Tr "repo.issues.filter_label"}}</div>
+			{{range $scope := .ExclusiveLabelScopes}}
+				{{$sortType := (printf "scope-%s" $scope)}}
+				<a class="{{if eq $.SortType $sortType}}active {{end}}item" href="{{QueryBuild $queryLink "sort" $sortType}}">{{$scope}}</a>
+			{{end}}
 		{{end}}
 	</div>
 </div>


### PR DESCRIPTION
The issues filter dropdown always rendered the label scope divider and header, even when .ExclusiveLabelScopes was empty.

This PR wraps the label scope section with a conditional so the divider/header and scope entries are only displayed when scopes exist.

Before

The dropdown showed a divider and “Label” header even when there were no exclusive label scopes available.
<img width="521" height="569" alt="image" src="https://github.com/user-attachments/assets/9766df6b-c11b-46f3-aabc-9fa5f4ca767d" />

After

The label scope section is hidden entirely when .ExclusiveLabelScopes is empty, keeping the dropdown clean and consistent.
<img width="329" height="485" alt="image" src="https://github.com/user-attachments/assets/e9586e57-2be5-43ea-8a13-9b87c951be6f" />

Notes

UI-only change, no behavior change to filtering logic.