### PR TITLE
[SECURITY] fix: Adjust the toolchain version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module code.gitea.io/gitea
 
 go 1.25.0
 
-toolchain go1.25.6
+toolchain go1.25.7
 
 // rfc5280 said: "The serial number is an integer assigned by the CA to each certificate."
 // But some CAs use negative serial number, just relax the check. related:


### PR DESCRIPTION
# Summary:

- Adjust the toolchain version to fix the security issues


```log
Vulnerability #1: GO-2026-4337
    Unexpected session resumption in crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2026-4337
  Standard library
    Found in: crypto/tls@go1.25.6
    Fixed in: crypto/tls@go1.25.7
    Example traces found:
```