### PR TITLE
Add wrap to runner label list

### DIFF
--- a/templates/shared/actions/runner_list.tmpl
+++ b/templates/shared/actions/runner_list.tmpl
@@ -72,7 +72,7 @@
 						<td>{{if .Version}}{{.Version}}{{else}}{{ctx.Locale.Tr "unknown"}}{{end}}</td>
 						<td><span data-tooltip-content="{{.BelongsToOwnerName}}">{{.BelongsToOwnerType.LocaleString ctx.Locale}}</span></td>
 						<td>
-							<span class="flex-text-inline">{{range .AgentLabels}}<span class="ui label">{{.}}</span>{{end}}</span>
+							<span class="flex-text-inline tw-flex-wrap">{{range .AgentLabels}}<span class="ui label">{{.}}</span>{{end}}</span>
 						</td>
 						<td>{{if .LastOnline}}{{DateUtils.TimeSince .LastOnline}}{{else}}{{ctx.Locale.Tr "never"}}{{end}}</td>
 						<td>


### PR DESCRIPTION
Before: Label list forces runner table to become scrollable if there is a large number of labels:

<img width="820" height="115" alt="Screenshot 2026-02-09 at 09 21 32" src="https://github.com/user-attachments/assets/919a3b12-c8f6-48c4-bd42-d7e267faf107" />

After: Wrapped:

<img width="821" height="128" alt="Screenshot 2026-02-09 at 09 20 31" src="https://github.com/user-attachments/assets/9f6d490c-1035-44be-97a7-20a1632dbe5e" />