### PR TITLE
Fix Chinese translation rendering error in time tracking history

### DIFF
--- a/options/locale/locale_zh-CN.json
+++ b/options/locale/locale_zh-CN.json
@@ -1635,7 +1635,7 @@
   "repo.issues.cancel_tracking": "取消",
   "repo.issues.cancel_tracking_history": "取消时间跟踪 %s",
   "repo.issues.del_time": "删除此时间跟踪日志",
-  "repo.issues.add_time_history": "于 %[2]s 添加计时 <b>%[1]</b>",
+  "repo.issues.add_time_history": "于 %[2]s 添加计时 <b>%[1]s</b>",
   "repo.issues.del_time_history": "已删除时间 %s",
   "repo.issues.add_time_manually": "手动添加时间",
   "repo.issues.add_time_hours": "小时",


### PR DESCRIPTION
## Description

Fixed format placeholder error in Chinese (zh-CN) translation.

## Problem

When adding spent time, the Chinese locale shows rendering error:
- Error: `jeff.wu 于 24分钟前 添加计时 %!<(string=2 hours 30 minutes)/b>`
- Expected: `jeff.wu 于 24分钟前 添加计时 2 hours 30 minutes`

## Root Cause

The format placeholder `%[1]` in `repo.issues.add_time_history` was missing the `s` suffix.

## Changes

- Fixed format placeholder from `%[1]` to `%[1]s` in locale_zh-CN.json