### PR TITLE
Fix flaky `testCatFileBatch` test

### DIFF
--- a/modules/git/catfile_batch_test.go
+++ b/modules/git/catfile_batch_test.go
@@ -4,7 +4,9 @@
 package git
 
 import (
+	"errors"
 	"io"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -81,7 +83,7 @@ func testCatFileBatch(t *testing.T) {
 			_, _ = c.respReader.Read(buf)
 			n, errRead := c.respReader.Read(buf)
 			assert.Zero(t, n)
-			assert.ErrorIs(t, errRead, io.EOF) // the pipe is closed due to command being killed
+			assert.True(t, errRead == io.EOF || errors.Is(errRead, os.ErrClosed), "expected io.EOF or os.ErrClosed, got: %v", errRead) // the pipe is closed due to command being killed
 		})
 		c.debugGitCmd.DebugKill()
 		wg.Wait()


### PR DESCRIPTION
Fix flaky test introduced in https://github.com/go-gitea/gitea/commit/149f7a6f1f.
Example failure: https://github.com/go-gitea/gitea/actions/runs/21919155178/job/63294413388.

When the git command is killed, the pipe read can return either io.EOF or os.ErrClosed depending on which end of the pipe closes first. Accept both as valid outcomes.
