### PR TITLE
Fix focus lost bugs in the Monaco editor 

### DIFF
--- a/web_src/js/features/codeeditor.ts
+++ b/web_src/js/features/codeeditor.ts
@@ -38,6 +38,7 @@ const baseOptions: MonacoOpts = {
   scrollbar: {horizontalScrollbarSize: 6, verticalScrollbarSize: 6, alwaysConsumeMouseWheel: false},
   scrollBeyondLastLine: false,
   automaticLayout: true,
+  editContext: false, // https://github.com/microsoft/monaco-editor/issues/5081
 };
 
 function getEditorconfig(input: HTMLInputElement): EditorConfig | null {


### PR DESCRIPTION
…t focus (#36585)

Currently, pressing the space key in the Monaco editor scrolls the page instead of inserting a space
if the editor is focused. This PR stops the space key event from propagating to parent elements,
which prevents unwanted page scrolling while still allowing Monaco to handle space input normally.

Changes:
 - disable Monaco editContext

No changes to default editor behavior are needed; Monaco automatically inserts the space character.