### PR TITLE
fix(dropdown): avoid duplicate remote queries for unchanged search term

### DIFF
--- a/web_src/fomantic/build/components/dropdown.js
+++ b/web_src/fomantic/build/components/dropdown.js
@@ -98,6 +98,7 @@ $.fn.dropdown = function(parameters) {
         selectObserver,
         menuObserver,
         classObserver,
+        lastText,
         module
       ;
 
@@ -764,6 +765,13 @@ $.fn.dropdown = function(parameters) {
           }
           if(settings.apiSettings) {
             if( module.can.useAPI() ) {
+              if (lastText !== " " && lastText === searchTerm) return;
+              lastText = searchTerm;
+
+              if ($item.filter('div:not(.filtered)').length !== 0) {
+                module.filterItems(searchTerm);
+                return;
+              }
               module.queryRemote(searchTerm, function() {
                 if(settings.filterRemoteData) {
                   module.filterItems(searchTerm);


### PR DESCRIPTION
This PR prevents the Fomantic dropdown remote search from repeatedly querying the API when the search term hasn't changed.

### Problem
When apiSettings is enabled, the dropdown may trigger repeated remote requests even when the user input hasn't changed. This causes unnecessary network traffic and makes the UI feel laggy.

### Solution
Track the last search term (lastText)
Skip queryRemote() when the search term is unchanged
If there are existing unfiltered items, keep using filterItems() instead of querying remote again

### Notes
This change keeps existing behavior for normal searches while reducing redundant remote requests.

### Before
![20260113_before](https://github.com/user-attachments/assets/6b92f17c-7036-4f6b-99a5-3120c0e7fc12)

### After
![20260113_after](https://github.com/user-attachments/assets/caaacdc2-2324-44a6-9ac6-2e39f79956d7)
