### PR TITLE
fix(lfs): Use full OID in relative path

### DIFF
--- a/modules/lfs/pointer.go
+++ b/modules/lfs/pointer.go
@@ -106,7 +106,7 @@ func (p Pointer) RelativePath() string {
 		return p.Oid
 	}
 
-	return path.Join(p.Oid[0:2], p.Oid[2:4], p.Oid[4:])
+	return path.Join(p.Oid[0:2], p.Oid[2:4], p.Oid)
 }
 
 func (p Pointer) LogString() string {

--- a/modules/lfs/pointer.go
+++ b/modules/lfs/pointer.go
@@ -109,6 +109,14 @@ func (p Pointer) RelativePath() string {
 	return path.Join(p.Oid[0:2], p.Oid[2:4], p.Oid)
 }
 
+// LegacyRelativePath returns the relative storage path of the pointer using the legacy format.
+func (p Pointer) LegacyRelativePath() string {
+	if len(p.Oid) < 5 {
+		return p.Oid
+	}
+	return path.Join(p.Oid[0:2], p.Oid[2:4], p.Oid[4:])
+}
+
 func (p Pointer) LogString() string {
 	if p.Oid == "" && p.Size == 0 {
 		return "<LFSPointer empty>"

--- a/modules/lfs/pointer_test.go
+++ b/modules/lfs/pointer_test.go
@@ -19,7 +19,7 @@ func TestStringContent(t *testing.T) {
 
 func TestRelativePath(t *testing.T) {
 	p := Pointer{Oid: "4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393"}
-	expected := path.Join("4d", "7a", "214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393")
+	expected := path.Join("4d", "7a", "4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393")
 	assert.Equal(t, expected, p.RelativePath())
 
 	p2 := Pointer{Oid: "4d7a"}

--- a/services/doctor/lfs_migrate.go
+++ b/services/doctor/lfs_migrate.go
@@ -1,0 +1,95 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package doctor
+
+import (
+	"context"
+	"os"
+	"path"
+
+	git_model "code.gitea.io/gitea/models/git"
+	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/setting"
+)
+
+func init() {
+	Register(&Check{
+		Title:     "Migrate LFS objects to new path format",
+		Name:      "lfs-migrate-object-paths",
+		IsDefault: false,
+		Run:       runLFSMigrateObjectPaths,
+		Priority:  8, // Run after other LFS checks
+	})
+}
+
+func runLFSMigrateObjectPaths(ctx context.Context, logger log.Logger, autofix bool) error {
+	if !setting.LFS.StartServer {
+		logger.Info("LFS support is disabled, skipping.")
+		return nil
+	}
+
+	if autofix {
+		logger.Info("Migrating LFS objects...")
+	} else {
+		logger.Info("Checking for LFS objects that need migration (dry run)...")
+	}
+
+	return lfsMigratePaths(ctx, logger, autofix)
+}
+
+func lfsMigratePaths(ctx context.Context, logger log.Logger, fix bool) error {
+	var migratedCount int64
+
+	oldPath := func(oid string) string {
+		return path.Join(setting.LFS.Storage.Path, oid[0:2], oid[2:4], oid[4:])
+	}
+	newPath := func(oid string) string {
+		return path.Join(setting.LFS.Storage.Path, oid[0:2], oid[2:4], oid)
+	}
+
+	err := git_model.IterateRepositoryIDsWithLFSMetaObjects(ctx, func(ctx context.Context, repoID, count int64) error {
+		return git_model.IterateLFSMetaObjectsForRepo(ctx, repoID, func(ctx context.Context, meta *git_model.LFSMetaObject, count int64) error {
+			oldOidPath := oldPath(meta.Oid)
+			_, err := os.Stat(oldOidPath)
+			if err != nil {
+				if os.IsNotExist(err) {
+					return nil // Does not exist at old path, so nothing to do.
+				}
+				logger.Error("Error checking for LFS object at %s: %v", oldOidPath, err)
+				return err
+			}
+
+			migratedCount++
+			newOidPath := newPath(meta.Oid)
+			if fix {
+				logger.Info("Migrating LFS object %s from %s to %s", meta.Oid, oldOidPath, newOidPath)
+				// Ensure the new directory exists
+				if err := os.MkdirAll(path.Dir(newOidPath), 0o750); err != nil {
+					logger.Error("Could not create directory for %s: %v", newOidPath, err)
+					return err
+				}
+				if err := os.Rename(oldOidPath, newOidPath); err != nil {
+					logger.Error("Could not migrate %s to %s: %v", oldOidPath, newOidPath, err)
+					return err
+				}
+			} else {
+				logger.Info("LFS object %s needs migration from %s to %s", meta.Oid, oldOidPath, newOidPath)
+			}
+			return nil
+		}, &git_model.IterateLFSMetaObjectsForRepoOptions{})
+	})
+
+	if err != nil {
+		logger.Error("Error while migrating LFS object paths: %v", err)
+		return err
+	}
+
+	if fix {
+		logger.Info("Migrated %d LFS objects.", migratedCount)
+	} else {
+		logger.Info("Found %d LFS objects that need migration.", migratedCount)
+	}
+
+	return nil
+}


### PR DESCRIPTION
The `RelativePath` function was truncating the LFS OID when constructing the path. This caused incompatibility with the `git-lfs` standard, which expects the full, untruncated OID.

This issue could prevent server-side hooks, such as `git lfs fsck`, from functioning correctly.

This commit aligns Gitea's LFS implementation with the `git-lfs` standard by using the full OID in the file path. The tests have been updated to reflect this correction.


