### PR TITLE
Fix mixed HTML+JSON error response when issue comment creation fails

### DIFF
--- a/routers/web/repo/issue_comment.go
+++ b/routers/web/repo/issue_comment.go
@@ -79,6 +79,10 @@ func NewComment(ctx *context.Context) {
 
 	var comment *issues_model.Comment
 	defer func() {
+		if ctx.Written() {
+			return
+		}
+
 		// Check if issue admin/poster changes the status of issue.
 		if (ctx.Repo.CanWriteIssuesOrPulls(issue.IsPull) || (ctx.IsSigned && issue.IsPoster(ctx.Doer.ID))) &&
 			(form.Status == "reopen" || form.Status == "close") &&

--- a/services/issue/comments.go
+++ b/services/issue/comments.go
@@ -82,8 +82,10 @@ func CreateIssueComment(ctx context.Context, doer *user_model.User, repo *repo_m
 	}
 
 	// reload issue to ensure it has the latest data, especially the number of comments
-	if issue, err = issues_model.GetIssueByID(ctx, issue.ID); err != nil {
+	if reloadedIssue, err := issues_model.GetIssueByID(ctx, issue.ID); err != nil {
 		log.Error("GetIssueByID: %v", err)
+	} else {
+		issue = reloadedIssue
 	}
 
 	notify_service.CreateIssueComment(ctx, doer, repo, issue, comment, mentions)

--- a/services/issue/comments.go
+++ b/services/issue/comments.go
@@ -78,13 +78,12 @@ func CreateIssueComment(ctx context.Context, doer *user_model.User, repo *repo_m
 
 	mentions, err := issues_model.FindAndUpdateIssueMentions(ctx, issue, doer, comment.Content)
 	if err != nil {
-		return nil, err
+		log.Error("FindAndUpdateIssueMentions: %v", err)
 	}
 
 	// reload issue to ensure it has the latest data, especially the number of comments
-	issue, err = issues_model.GetIssueByID(ctx, issue.ID)
-	if err != nil {
-		return nil, err
+	if issue, err = issues_model.GetIssueByID(ctx, issue.ID); err != nil {
+		log.Error("GetIssueByID: %v", err)
 	}
 
 	notify_service.CreateIssueComment(ctx, doer, repo, issue, comment, mentions)


### PR DESCRIPTION
While posting issue comments on gitea.com, I notice it sometimes fails with toasts that show a HTML string:

<img width="699" height="89" alt="image" src="https://github.com/user-attachments/assets/83c0ad58-08a4-4b09-936e-a28abd294d7b" />

I checked the HTTP response and found a garbled response for `POST https://gitea.com/<owner>/<repo>/issues/<id>/comments` of content-type `text/html; charset=utf-8` that contains both html and json:

```
<html>...</html>
{"redirect":"/gitea/act_runner/issues/371"}
```

This PR is the result of Claude investigating this broken response. Full details:

---

When NewComment's CreateIssueComment call failed, ctx.ServerError wrote an HTML 500 page but the deferred function still ran and appended a JSON redirect to the response body, producing an invalid mixed HTML+JSON response shown as a toast error.

Fix by adding a ctx.Written() guard in the defer to skip writing when a response was already sent. Also make post-creation errors in CreateIssueComment (FindAndUpdateIssueMentions, GetIssueByID) non-fatal since the comment is already persisted at that point, preventing duplicate comments on retry.