### PR TITLE
Make `security-check` informational only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -713,7 +713,7 @@ generate-go: $(TAGS_PREREQ)
 
 .PHONY: security-check
 security-check:
-	GOEXPERIMENT= go run $(GOVULNCHECK_PACKAGE) -show color ./...
+	GOEXPERIMENT= go run $(GOVULNCHECK_PACKAGE) -show color ./... || true
 
 $(EXECUTABLE): $(GO_SOURCES) $(TAGS_PREREQ)
 ifneq ($(and $(STATIC),$(findstring pam,$(TAGS))),)


### PR DESCRIPTION
Change `security-check` not break the build which is a major inconvenience as it breaks CI on all PRs.

https://github.com/go-gitea/gitea/security/dependabot already provides a clean overview of outstanding security issues in dependencies and I'm using it all the time to find and update vulnerable dependencies.