### PR TITLE
Fix push time bug (#36693)

### DIFF
--- a/models/git/branch.go
+++ b/models/git/branch.go
@@ -450,7 +450,7 @@ func RenameBranch(ctx context.Context, repo *repo_model.Repository, from, to str
 type FindRecentlyPushedNewBranchesOptions struct {
 	Repo            *repo_model.Repository
 	BaseRepo        *repo_model.Repository
-	CommitAfterUnix int64
+	PushedAfterUnix int64
 	MaxCount        int
 }
 
@@ -460,11 +460,11 @@ type RecentlyPushedNewBranch struct {
 	BranchDisplayName string
 	BranchLink        string
 	BranchCompareURL  string
-	CommitTime        timeutil.TimeStamp
+	PushedTime        timeutil.TimeStamp
 }
 
 // FindRecentlyPushedNewBranches return at most 2 new branches pushed by the user in 2 hours which has no opened PRs created
-// if opts.CommitAfterUnix is 0, we will find the branches that were committed to in the last 2 hours
+// if opts.PushedAfterUnix is 0, we will find the branches that were pushed in the last 2 hours
 // if opts.ListOptions is not set, we will only display top 2 latest branches.
 // Protected branches will be skipped since they are unlikely to be used to create new PRs.
 func FindRecentlyPushedNewBranches(ctx context.Context, doer *user_model.User, opts FindRecentlyPushedNewBranchesOptions) ([]*RecentlyPushedNewBranch, error) {
@@ -492,8 +492,8 @@ func FindRecentlyPushedNewBranches(ctx context.Context, doer *user_model.User, o
 	}
 	repoIDs := builder.Select("id").From("repository").Where(repoCond)
 
-	if opts.CommitAfterUnix == 0 {
-		opts.CommitAfterUnix = time.Now().Add(-time.Hour * 2).Unix()
+	if opts.PushedAfterUnix == 0 {
+		opts.PushedAfterUnix = time.Now().Add(-time.Hour * 2).Unix()
 	}
 
 	baseBranch, err := GetBranch(ctx, opts.BaseRepo.ID, opts.BaseRepo.DefaultBranch)
@@ -509,7 +509,7 @@ func FindRecentlyPushedNewBranches(ctx context.Context, doer *user_model.User, o
 				"pusher_id":  doer.ID,
 				"is_deleted": false,
 			},
-			builder.Gte{"commit_time": opts.CommitAfterUnix},
+			builder.Gte{"updated_unix": opts.PushedAfterUnix},
 			builder.In("repo_id", repoIDs),
 			// newly created branch have no changes, so skip them
 			builder.Neq{"commit_id": baseBranch.CommitID},
@@ -562,7 +562,7 @@ func FindRecentlyPushedNewBranches(ctx context.Context, doer *user_model.User, o
 				BranchName:        branch.Name,
 				BranchLink:        fmt.Sprintf("%s/src/branch/%s", branch.Repo.Link(), util.PathEscapeSegments(branch.Name)),
 				BranchCompareURL:  branch.Repo.ComposeBranchCompareURL(opts.BaseRepo, branch.Name),
-				CommitTime:        branch.CommitTime,
+				PushedTime:        branch.UpdatedUnix,
 			})
 		}
 		if len(newBranches) == opts.MaxCount {

--- a/templates/repo/code/recently_pushed_new_branches.tmpl
+++ b/templates/repo/code/recently_pushed_new_branches.tmpl
@@ -6,7 +6,7 @@
 	{{range $recentBranch := $data.RecentlyPushedNewBranches}}
 	<div class="ui positive message flex-text-block">
 		<div class="tw-flex-1">
-			{{$timeSince := DateUtils.TimeSince $recentBranch.CommitTime}}
+			{{$timeSince := DateUtils.TimeSince $recentBranch.PushedTime}}
 			{{$branchLink := HTMLFormat `<a href="%s">%s</a>` $recentBranch.BranchLink .BranchDisplayName}}
 			{{ctx.Locale.Tr "repo.pulls.recently_pushed_new_branches" $branchLink $timeSince}}
 		</div>


### PR DESCRIPTION
When display or search branch's pushed time, we should use `updated_unix` rather than `commit_time`.

Fix #36633
Backport #36693 
