### PR TITLE
web: add pagination to webhook settings pages

### DIFF
--- a/templates/repo/settings/webhook/base_list.tmpl
+++ b/templates/repo/settings/webhook/base_list.tmpl
@@ -25,3 +25,4 @@
 		{{end}}
 	</div>
 </div>
+{{template "base/paginate" .}}


### PR DESCRIPTION
This PR addresses a UI limitation where webhook settings pages did not support pagination. When a repository, organization, or user had a large number of webhooks, the page would become unwieldy and potentially hit performance issues.

I have implemented pagination for all three webhook settings tabs by:

Updating the Webhooks controller logic in repo, org, and user contexts to respect db.ListOptions.

Integrating the base/paginate template into the webhook list views to provide a consistent navigation experience.

Ensuring the backend correctly calculates the total count and slices the results based on the system's default PageSize (setting.UI.Admin.UserPagingNum).

Related Issue
Fixes: #36522


Attached screenshots of the three pages i've added pagination
<img width="1211" height="779" alt="Screenshot 2026-02-25 at 22 14 08" src="https://github.com/user-attachments/assets/2382f84c-5924-4d4f-ac47-a8e2562f7be5" />
<img width="1177" height="778" alt="Screenshot 2026-02-25 at 22 14 23" src="https://github.com/user-attachments/assets/234924ae-95f9-4606-9652-14ff62308f57" />
<img width="1208" height="786" alt="Screenshot 2026-02-25 at 22 15 40" src="https://github.com/user-attachments/assets/5637c6d6-eca3-43dd-a84f-4f80db894700" />

