### PR TITLE
fix: correct spelling

### DIFF
--- a/cmd/mailer.go
+++ b/cmd/mailer.go
@@ -17,10 +17,10 @@ func runSendMail(ctx context.Context, c *cli.Command) error {
 	setting.MustInstalled()
 
 	subject := c.String("title")
-	confirmSkiped := c.Bool("force")
+	confirmSkipped := c.Bool("force")
 	body := c.String("content")
 
-	if !confirmSkiped {
+	if !confirmSkipped {
 		if len(body) == 0 {
 			fmt.Print("warning: Content is empty")
 		}

--- a/models/issues/review_list.go
+++ b/models/issues/review_list.go
@@ -173,9 +173,9 @@ func GetReviewsByIssueID(ctx context.Context, issueID int64) (latestReviews, mig
 	reviewersMap := make(map[int64][]*Review)         // key is reviewer id
 	originalReviewersMap := make(map[int64][]*Review) // key is original author id
 	reviewTeamsMap := make(map[int64][]*Review)       // key is reviewer team id
-	countedReivewTypes := []ReviewType{ReviewTypeApprove, ReviewTypeReject, ReviewTypeRequest, ReviewTypeComment}
+	countedReviewTypes := []ReviewType{ReviewTypeApprove, ReviewTypeReject, ReviewTypeRequest, ReviewTypeComment}
 	for _, review := range reviews {
-		if review.ReviewerTeamID == 0 && slices.Contains(countedReivewTypes, review.Type) && !review.Dismissed {
+		if review.ReviewerTeamID == 0 && slices.Contains(countedReviewTypes, review.Type) && !review.Dismissed {
 			if review.OriginalAuthorID != 0 {
 				originalReviewersMap[review.OriginalAuthorID] = append(originalReviewersMap[review.OriginalAuthorID], review)
 			} else {

--- a/models/organization/org.go
+++ b/models/organization/org.go
@@ -178,7 +178,7 @@ func (org *Organization) HomeLink() string {
 	return org.AsUser().HomeLink()
 }
 
-// FindOrgMembersOpts represensts find org members conditions
+// FindOrgMembersOpts represents find org members conditions
 type FindOrgMembersOpts struct {
 	db.ListOptions
 	Doer         *user_model.User

--- a/models/user/list.go
+++ b/models/user/list.go
@@ -24,7 +24,7 @@ func (users UserList) GetUserIDs() []int64 {
 	return userIDs
 }
 
-// GetTwoFaStatus return state of 2FA enrollement
+// GetTwoFaStatus return state of 2FA enrollment
 func (users UserList) GetTwoFaStatus(ctx context.Context) map[int64]bool {
 	results := make(map[int64]bool, len(users))
 	for _, user := range users {

--- a/models/user/user.go
+++ b/models/user/user.go
@@ -185,7 +185,7 @@ func (u *User) BeforeUpdate() {
 	}
 
 	// FIXME: this email doesn't need to be in lowercase, because the emails are mainly managed by the email table with lower_email field
-	// This trick could be removed in new releases to display the user inputed email as-is.
+	// This trick could be removed in new releases to display the user inputted email as-is.
 	u.Email = strings.ToLower(u.Email)
 	if !u.IsOrganization() {
 		if len(u.AvatarEmail) == 0 {

--- a/modules/actions/workflows_test.go
+++ b/modules/actions/workflows_test.go
@@ -190,7 +190,7 @@ func TestDetectMatched(t *testing.T) {
 			expected:     true,
 		},
 		{
-			desc:         "HookEventSchedue(schedule) matches GithubEventSchedule(schedule)",
+			desc:         "HookEventSchedule(schedule) matches GithubEventSchedule(schedule)",
 			triggedEvent: webhook_module.HookEventSchedule,
 			payload:      nil,
 			yamlOn:       "on: schedule",

--- a/modules/auth/password/hash/setting.go
+++ b/modules/auth/password/hash/setting.go
@@ -14,7 +14,7 @@ const DefaultHashAlgorithmName = "pbkdf2"
 
 var DefaultHashAlgorithm *PasswordHashAlgorithm
 
-// aliasAlgorithNames provides a mapping between the value of PASSWORD_HASH_ALGO
+// aliasAlgorithmNames provides a mapping between the value of PASSWORD_HASH_ALGO
 // configured in the app.ini and the parameters used within the hashers internally.
 //
 // If it is necessary to change the default parameters for any hasher in future you

--- a/modules/git/foreachref/format.go
+++ b/modules/git/foreachref/format.go
@@ -72,7 +72,7 @@ func (f Format) Parser(r io.Reader) *Parser {
 	return NewParser(r, f)
 }
 
-// hexEscaped produces hex-escpaed characters from a string. For example, "\n\0"
+// hexEscaped produces hex-escaped characters from a string. For example, "\n\0"
 // would turn into "%0a%00".
 func (f Format) hexEscaped(delim []byte) string {
 	var escaped strings.Builder

--- a/modules/indexer/code/elasticsearch/elasticsearch.go
+++ b/modules/indexer/code/elasticsearch/elasticsearch.go
@@ -393,7 +393,7 @@ func (b *Indexer) Search(ctx context.Context, opts *internal.SearchOptions) (int
 				elastic.NewHighlight().
 					Field("content").
 					Field("filename").
-					NumOfFragments(0). // return all highting content on fragments
+					NumOfFragments(0). // return all highlighting content on fragments
 					HighlighterType("fvh"),
 			).
 			Sort("_score", false).
@@ -426,7 +426,7 @@ func (b *Indexer) Search(ctx context.Context, opts *internal.SearchOptions) (int
 			elastic.NewHighlight().
 				Field("content").
 				Field("filename").
-				NumOfFragments(0). // return all highting content on fragments
+				NumOfFragments(0). // return all highlighting content on fragments
 				HighlighterType("fvh"),
 		).
 		Sort("_score", false).

--- a/modules/lfstransfer/backend/backend.go
+++ b/modules/lfstransfer/backend/backend.go
@@ -95,7 +95,7 @@ func (g *GiteaBackend) Batch(_ string, pointers []transfer.BatchItem, args trans
 	var respBody lfs.BatchResponse
 	err = json.Unmarshal(respBytes, &respBody)
 	if err != nil {
-		g.logger.Log("json umarshal error", err)
+		g.logger.Log("json unmarshal error", err)
 		return nil, err
 	}
 

--- a/modules/lfstransfer/backend/lock.go
+++ b/modules/lfstransfer/backend/lock.go
@@ -69,7 +69,7 @@ func (g *giteaLockBackend) Create(path, refname string) (transfer.Lock, error) {
 	var respBody lfslock.LFSLockResponse
 	err = json.Unmarshal(respBytes, &respBody)
 	if err != nil {
-		g.logger.Log("json umarshal error", err)
+		g.logger.Log("json unmarshal error", err)
 		return nil, err
 	}
 
@@ -202,7 +202,7 @@ func (g *giteaLockBackend) queryLocks(v url.Values) ([]transfer.Lock, string, er
 	var respBody lfslock.LFSLockList
 	err = json.Unmarshal(respBytes, &respBody)
 	if err != nil {
-		g.logger.Log("json umarshal error", err)
+		g.logger.Log("json unmarshal error", err)
 		return nil, "", err
 	}
 

--- a/modules/lfstransfer/logger.go
+++ b/modules/lfstransfer/logger.go
@@ -17,5 +17,5 @@ func newLogger() transfer.Logger {
 }
 
 // Log implements transfer.Logger
-func (g *GiteaLogger) Log(msg string, itms ...any) {
+func (g *GiteaLogger) Log(msg string, items ...any) {
 }

--- a/modules/markup/common/linkify.go
+++ b/modules/markup/common/linkify.go
@@ -21,7 +21,7 @@ import (
 
 type GlobalVarsType struct {
 	wwwURLRegexp *regexp.Regexp
-	LinkRegex   *regexp.Regexp // fast matching a URL link, no any extra validation.
+	LinkRegex    *regexp.Regexp // fast matching a URL link, no any extra validation.
 }
 
 var GlobalVars = sync.OnceValue(func() *GlobalVarsType {

--- a/modules/markup/common/linkify.go
+++ b/modules/markup/common/linkify.go
@@ -20,13 +20,13 @@ import (
 )
 
 type GlobalVarsType struct {
-	wwwURLRegxp *regexp.Regexp
+	wwwURLRegexp *regexp.Regexp
 	LinkRegex   *regexp.Regexp // fast matching a URL link, no any extra validation.
 }
 
 var GlobalVars = sync.OnceValue(func() *GlobalVarsType {
 	v := &GlobalVarsType{}
-	v.wwwURLRegxp = regexp.MustCompile(`^www\.[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}((?:/|[#?])[-a-zA-Z0-9@:%_\+.~#!?&//=\(\);,'">\^{}\[\]` + "`" + `]*)?`)
+	v.wwwURLRegexp = regexp.MustCompile(`^www\.[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}((?:/|[#?])[-a-zA-Z0-9@:%_\+.~#!?&//=\(\);,'">\^{}\[\]` + "`" + `]*)?`)
 	v.LinkRegex, _ = xurls.StrictMatchingScheme("https?://")
 	return v
 })
@@ -75,7 +75,7 @@ func (s *linkifyParser) Parse(parent ast.Node, block text.Reader, pc parser.Cont
 		m = GlobalVars().LinkRegex.FindSubmatchIndex(line)
 	}
 	if m == nil && bytes.HasPrefix(line, domainWWW) {
-		m = GlobalVars().wwwURLRegxp.FindSubmatchIndex(line)
+		m = GlobalVars().wwwURLRegexp.FindSubmatchIndex(line)
 		protocol = []byte("http")
 	}
 	if m != nil {

--- a/modules/markup/markdown/math/inline_parser.go
+++ b/modules/markup/markdown/math/inline_parser.go
@@ -55,7 +55,7 @@ func isAlphanumeric(b byte) bool {
 }
 
 func isInMarkdownLinkText(block text.Reader, lineAfter []byte) bool {
-	return block.PrecedingCharacter() == '[' && bytes.HasPrefix(lineAfter, []byte("]("))
+	return block.PrecendingCharacter() == '[' && bytes.HasPrefix(lineAfter, []byte("]("))
 }
 
 // Parse parses the current line and returns a result of parsing.
@@ -98,7 +98,7 @@ func (parser *inlineParser) Parse(parent ast.Node, block text.Reader, pc parser.
 	}
 
 	if checkSurrounding {
-		precedingCharacter := block.PrecedingCharacter()
+		precedingCharacter := block.PrecendingCharacter()
 		if precedingCharacter < 256 && (isAlphanumeric(byte(precedingCharacter)) || isPunctuation(byte(precedingCharacter))) {
 			// need to exclude things like `a$` from being considered a start
 			return nil

--- a/modules/markup/markdown/math/inline_parser.go
+++ b/modules/markup/markdown/math/inline_parser.go
@@ -55,7 +55,7 @@ func isAlphanumeric(b byte) bool {
 }
 
 func isInMarkdownLinkText(block text.Reader, lineAfter []byte) bool {
-	return block.PrecendingCharacter() == '[' && bytes.HasPrefix(lineAfter, []byte("]("))
+	return block.PrecedingCharacter() == '[' && bytes.HasPrefix(lineAfter, []byte("]("))
 }
 
 // Parse parses the current line and returns a result of parsing.
@@ -98,7 +98,7 @@ func (parser *inlineParser) Parse(parent ast.Node, block text.Reader, pc parser.
 	}
 
 	if checkSurrounding {
-		precedingCharacter := block.PrecendingCharacter()
+		precedingCharacter := block.PrecedingCharacter()
 		if precedingCharacter < 256 && (isAlphanumeric(byte(precedingCharacter)) || isPunctuation(byte(precedingCharacter))) {
 			// need to exclude things like `a$` from being considered a start
 			return nil

--- a/modules/setting/config/value.go
+++ b/modules/setting/config/value.go
@@ -141,7 +141,7 @@ func (opt *Option[T]) WithDefaultSimple(def T) *Option[T] {
 	switch v.(type) {
 	case string, bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
 	default:
-		// TODO: use reflect to support convertable basic types like `type State string`
+		// TODO: use reflect to support convertible basic types like `type State string`
 		r := reflect.ValueOf(v)
 		if r.Kind() != reflect.Struct {
 			panic("invalid type for default value, use WithDefaultFunc instead")

--- a/routers/api/actions/artifacts.go
+++ b/routers/api/actions/artifacts.go
@@ -112,7 +112,7 @@ func ArtifactsRoutes(prefix string) *web.Router {
 
 	m.Group(artifactRouteBase, func() {
 		// retrieve, list and confirm artifacts
-		m.Combo("").Get(r.listArtifacts).Post(r.getUploadArtifactURL).Patch(r.comfirmUploadArtifact)
+		m.Combo("").Get(r.listArtifacts).Post(r.getUploadArtifactURL).Patch(r.confirmUploadArtifact)
 		// handle container artifacts list and download
 		m.Put("/{artifact_hash}/upload", r.uploadArtifact)
 		// handle artifacts download
@@ -297,9 +297,9 @@ func (ar artifactRoutes) uploadArtifact(ctx *ArtifactContext) {
 	})
 }
 
-// comfirmUploadArtifact confirm upload artifact.
+// confirmUploadArtifact confirm upload artifact.
 // if all chunks are uploaded, merge them to one file.
-func (ar artifactRoutes) comfirmUploadArtifact(ctx *ArtifactContext) {
+func (ar artifactRoutes) confirmUploadArtifact(ctx *ArtifactContext) {
 	_, runID, ok := validateRunID(ctx)
 	if !ok {
 		return
@@ -419,8 +419,8 @@ func (ar artifactRoutes) getDownloadArtifactURL(ctx *ArtifactContext) {
 	}
 
 	if itemPath != artifacts[0].ArtifactName {
-		log.Error("Error dismatch artifact name, itemPath: %v, artifact: %v", itemPath, artifacts[0].ArtifactName)
-		ctx.HTTPError(http.StatusBadRequest, "Error dismatch artifact name")
+		log.Error("Error mismatch artifact name, itemPath: %v, artifact: %v", itemPath, artifacts[0].ArtifactName)
+		ctx.HTTPError(http.StatusBadRequest, "Error mismatch artifact name")
 		return
 	}
 

--- a/routers/api/actions/artifactsv4.go
+++ b/routers/api/actions/artifactsv4.go
@@ -267,12 +267,12 @@ func (r *artifactV4Routes) createArtifact(ctx *ArtifactContext) {
 
 	artifactName := req.Name
 
-	rententionDays := setting.Actions.ArtifactRetentionDays
+	retentionDays := setting.Actions.ArtifactRetentionDays
 	if req.ExpiresAt != nil {
-		rententionDays = int64(time.Until(req.ExpiresAt.AsTime()).Hours() / 24)
+		retentionDays = int64(time.Until(req.ExpiresAt.AsTime()).Hours() / 24)
 	}
 	// create or get artifact with name and path
-	artifact, err := actions.CreateArtifact(ctx, ctx.ActionTask, artifactName, artifactName+".zip", rententionDays)
+	artifact, err := actions.CreateArtifact(ctx, ctx.ActionTask, artifactName, artifactName+".zip", retentionDays)
 	if err != nil {
 		log.Error("Error create or get artifact: %v", err)
 		ctx.HTTPError(http.StatusInternalServerError, "Error create or get artifact")

--- a/routers/api/packages/arch/arch.go
+++ b/routers/api/packages/arch/arch.go
@@ -91,7 +91,7 @@ func UploadPackageFile(ctx *context.Context) {
 		return
 	}
 
-	release, err := arch_service.AquireRegistryLock(ctx, ctx.Package.Owner.ID)
+	release, err := arch_service.AcquireRegistryLock(ctx, ctx.Package.Owner.ID)
 	if err != nil {
 		apiError(ctx, http.StatusInternalServerError, err)
 		return
@@ -257,7 +257,7 @@ func DeletePackageVersion(ctx *context.Context) {
 	name := ctx.PathParam("name")
 	version := ctx.PathParam("version")
 
-	release, err := arch_service.AquireRegistryLock(ctx, ctx.Package.Owner.ID)
+	release, err := arch_service.AcquireRegistryLock(ctx, ctx.Package.Owner.ID)
 	if err != nil {
 		apiError(ctx, http.StatusInternalServerError, err)
 		return

--- a/routers/api/v1/org/hook.go
+++ b/routers/api/v1/org/hook.go
@@ -13,7 +13,7 @@ import (
 	webhook_service "code.gitea.io/gitea/services/webhook"
 )
 
-// ListHooks list an organziation's webhooks
+// ListHooks list an organization's webhooks
 func ListHooks(ctx *context.APIContext) {
 	// swagger:operation GET /orgs/{org}/hooks organization orgListHooks
 	// ---

--- a/routers/api/v1/org/team.go
+++ b/routers/api/v1/org/team.go
@@ -806,7 +806,7 @@ func SearchTeam(ctx *context.APIContext) {
 		ListOptions: listOptions,
 	}
 
-	// Only admin is allowd to search for all teams
+	// Only admin is allowed to search for all teams
 	if !ctx.Doer.IsAdmin {
 		opts.UserID = ctx.Doer.ID
 	}

--- a/routers/common/markup.go
+++ b/routers/common/markup.go
@@ -46,7 +46,7 @@ func RenderMarkup(ctx *context.Base, ctxRepo *context.Repository, mode, text, ur
 		return
 	}
 
-	// Ideally, this handler should be called with RepoAssigment and get the related repo from context "/owner/repo/markup"
+	// Ideally, this handler should be called with RepoAssignment and get the related repo from context "/owner/repo/markup"
 	// then render could use the repo to do various things (the permission check has passed)
 	//
 	// However, this handler is also exposed as "/markup" without any repo context,

--- a/routers/web/healthcheck/check.go
+++ b/routers/web/healthcheck/check.go
@@ -72,7 +72,7 @@ type componentStatus struct {
 // And keep in mind: this health check should NEVER be used as a "restart" trigger, for example: Docker's "HEALTHCHECK".
 // * If Gitea is upgrading and migrating database, there will be a long time before this endpoint starts to return "pass" status.
 // In this case, if the checker restarts Gitea just because it doesn't get "pass" status in short time,
-// the instance will just be restarted again and again before the migation finishes and the sitution just goes worse.
+// the instance will just be restarted again and again before the migration finishes and the situation just goes worse.
 func Check(w http.ResponseWriter, r *http.Request) {
 	rsp := response{
 		Status:      pass,

--- a/routers/web/repo/issue_dependency.go
+++ b/routers/web/repo/issue_dependency.go
@@ -119,7 +119,7 @@ func RemoveDependency(ctx *context.Context) {
 	case "blocking":
 		depType = issues_model.DependencyTypeBlocking
 	default:
-		ctx.HTTPError(http.StatusBadRequest, "GetDependecyType")
+		ctx.HTTPError(http.StatusBadRequest, "GetDependencyType")
 		return
 	}
 

--- a/routers/web/repo/repo.go
+++ b/routers/web/repo/repo.go
@@ -526,9 +526,9 @@ func SearchRepo(ctx *context.Context) {
 
 	ctx.SetTotalCountHeader(count)
 
-	latestCommitStatuses, err := commitstatus_service.FindReposLastestCommitStatuses(ctx, repos)
+	latestCommitStatuses, err := commitstatus_service.FindReposLatestCommitStatuses(ctx, repos)
 	if err != nil {
-		log.Error("FindReposLastestCommitStatuses: %v", err)
+		log.Error("FindReposLatestCommitStatuses: %v", err)
 		ctx.JSON(http.StatusInternalServerError, nil)
 		return
 	}

--- a/routers/web/repo/setting/collaboration.go
+++ b/routers/web/repo/setting/collaboration.go
@@ -208,7 +208,7 @@ func DeleteTeam(ctx *context.Context) {
 	}
 
 	if err = repo_service.RemoveRepositoryFromTeam(ctx, team, ctx.Repo.Repository.ID); err != nil {
-		ctx.ServerError("team.RemoveRepositorys", err)
+		ctx.ServerError("team.RemoveRepositories", err)
 		return
 	}
 

--- a/services/issue/assignee.go
+++ b/services/issue/assignee.go
@@ -20,10 +20,10 @@ import (
 // DeleteNotPassedAssignee deletes all assignees who aren't passed via the "assignees" array
 func DeleteNotPassedAssignee(ctx context.Context, issue *issues_model.Issue, doer *user_model.User, assignees []*user_model.User) (err error) {
 	var found bool
-	oriAssignes := make([]*user_model.User, len(issue.Assignees))
-	_ = copy(oriAssignes, issue.Assignees)
+	oriAssignees := make([]*user_model.User, len(issue.Assignees))
+	_ = copy(oriAssignees, issue.Assignees)
 
-	for _, assignee := range oriAssignes {
+	for _, assignee := range oriAssignees {
 		found = false
 		for _, alreadyAssignee := range assignees {
 			if assignee.ID == alreadyAssignee.ID {

--- a/services/issue/pull.go
+++ b/services/issue/pull.go
@@ -113,7 +113,7 @@ func PullRequestCodeOwnersReview(ctx context.Context, pr *issues_model.PullReque
 	}
 
 	// load all reviews from database
-	latestReivews, _, err := issues_model.GetReviewsByIssueID(ctx, pr.IssueID)
+	latestReviews, _, err := issues_model.GetReviewsByIssueID(ctx, pr.IssueID)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func PullRequestCodeOwnersReview(ctx context.Context, pr *issues_model.PullReque
 	}
 
 	for _, u := range uniqUsers {
-		if u.ID != issue.Poster.ID && !contain(latestReivews, u) {
+		if u.ID != issue.Poster.ID && !contain(latestReviews, u) {
 			comment, err := issues_model.AddReviewRequest(ctx, issue, u, issue.Poster, true)
 			if err != nil {
 				log.Warn("Failed add assignee user: %s to PR review: %s#%d, error: %s", u.Name, pr.BaseRepo.Name, pr.ID, err)

--- a/services/migrations/main_test.go
+++ b/services/migrations/main_test.go
@@ -218,7 +218,7 @@ func assertRepositoryEqual(t *testing.T, expected, actual *base.Repository) {
 
 func assertReviewEqual(t *testing.T, expected, actual *base.Review) {
 	assert.Equal(t, expected.ID, actual.ID, "ID")
-	assert.Equal(t, expected.IssueIndex, actual.IssueIndex, "IsssueIndex")
+	assert.Equal(t, expected.IssueIndex, actual.IssueIndex, "IssueIndex")
 	assert.Equal(t, expected.ReviewerID, actual.ReviewerID, "ReviewerID")
 	assert.Equal(t, expected.ReviewerName, actual.ReviewerName, "ReviewerName")
 	assert.Equal(t, expected.Official, actual.Official, "Official")

--- a/services/org/team.go
+++ b/services/org/team.go
@@ -312,12 +312,12 @@ func removeTeamMember(ctx context.Context, team *organization.Team, user *user_m
 			return err
 		}
 
-		// Remove watches from now unaccessible
+		// Remove watches from now inaccessible
 		if err := repo_service.ReconsiderWatches(ctx, repo, user); err != nil {
 			return err
 		}
 
-		// Remove issue assignments from now unaccessible
+		// Remove issue assignments from now inaccessible
 		if err := repo_service.ReconsiderRepoIssuesAssignee(ctx, repo, user); err != nil {
 			return err
 		}

--- a/services/packages/arch/repository.go
+++ b/services/packages/arch/repository.go
@@ -36,7 +36,7 @@ const (
 	IndexArchiveFilename = "packages.db"
 )
 
-func AquireRegistryLock(ctx context.Context, ownerID int64) (globallock.ReleaseFunc, error) {
+func AcquireRegistryLock(ctx context.Context, ownerID int64) (globallock.ReleaseFunc, error) {
 	return globallock.Lock(ctx, fmt.Sprintf("packages_arch_%d", ownerID))
 }
 

--- a/services/packages/cleanup/cleanup.go
+++ b/services/packages/cleanup/cleanup.go
@@ -134,7 +134,7 @@ func executeCleanupOneRule(ctx context.Context, pcr *packages_model.PackageClean
 				return fmt.Errorf("CleanupRule [%d]: rpm.BuildAllRepositoryFiles failed: %w", pcr.ID, err)
 			}
 		case packages_model.TypeArch:
-			release, err := arch_service.AquireRegistryLock(ctx, pcr.OwnerID)
+			release, err := arch_service.AcquireRegistryLock(ctx, pcr.OwnerID)
 			if err != nil {
 				return err
 			}

--- a/services/packages/container/blob_uploader.go
+++ b/services/packages/container/blob_uploader.go
@@ -18,8 +18,8 @@ import (
 var (
 	// errWriteAfterRead occurs if Write is called after a read operation
 	errWriteAfterRead = errors.New("write is unsupported after a read operation")
-	// errOffsetMissmatch occurs if the file offset is different than the model
-	errOffsetMissmatch = errors.New("offset mismatch between file and model")
+	// errOffsetMismatch occurs if the file offset is different than the model
+	errOffsetMismatch = errors.New("offset mismatch between file and model")
 )
 
 // BlobUploader handles chunked blob uploads
@@ -86,7 +86,7 @@ func (u *BlobUploader) Append(ctx context.Context, r io.Reader) error {
 		return err
 	}
 	if offset != u.BytesReceived {
-		return errOffsetMissmatch
+		return errOffsetMismatch
 	}
 
 	n, err := io.Copy(io.MultiWriter(u.file, u.MultiHasher), r)

--- a/services/repository/commitstatus/commitstatus.go
+++ b/services/repository/commitstatus/commitstatus.go
@@ -118,8 +118,8 @@ func CreateCommitStatus(ctx context.Context, repo *repo_model.Repository, creato
 	return nil
 }
 
-// FindReposLastestCommitStatuses loading repository default branch latest combined commit status with cache
-func FindReposLastestCommitStatuses(ctx context.Context, repos []*repo_model.Repository) ([]*git_model.CommitStatus, error) {
+// FindReposLatestCommitStatuses loading repository default branch latest combined commit status with cache
+func FindReposLatestCommitStatuses(ctx context.Context, repos []*repo_model.Repository) ([]*git_model.CommitStatus, error) {
 	results := make([]*git_model.CommitStatus, len(repos))
 	allCached := true
 	for i, repo := range repos {

--- a/services/repository/repo_team.go
+++ b/services/repository/repo_team.go
@@ -108,7 +108,7 @@ func removeAllRepositoriesFromTeam(ctx context.Context, t *organization.Team) (e
 			return err
 		}
 
-		// Remove watches from all users and now unaccessible repos
+		// Remove watches from all users and now inaccessible repos
 		for _, user := range t.Members {
 			has, err := access_model.HasAnyUnitAccess(ctx, user.ID, repo)
 			if err != nil {

--- a/templates/base/modal_actions_confirm.tmpl
+++ b/templates/base/modal_actions_confirm.tmpl
@@ -12,15 +12,15 @@ The ".ok.button" and ".cancel.button" selectors are also used by Fomantic Modal 
 	{{if .ModalButtonDangerText}}
 		<button class="ui danger red ok button">{{.ModalButtonDangerText}}</button>
 	{{else}}
-		{{$textNegitive := ctx.Locale.Tr "modal.no"}}
+		{{$textNegative := ctx.Locale.Tr "modal.no"}}
 		{{$textPositive := ctx.Locale.Tr "modal.yes"}}
 		{{if eq .ModalButtonTypes "confirm"}}
-			{{$textNegitive = ctx.Locale.Tr "modal.cancel"}}
+			{{$textNegative = ctx.Locale.Tr "modal.cancel"}}
 			{{$textPositive = ctx.Locale.Tr "modal.confirm"}}
 		{{end}}
-		{{if .ModalButtonCancelText}}{{$textNegitive = .ModalButtonCancelText}}{{end}}
+		{{if .ModalButtonCancelText}}{{$textNegative = .ModalButtonCancelText}}{{end}}
 		{{if .ModalButtonOkText}}{{$textPositive = .ModalButtonOkText}}{{end}}
-		<button class="ui cancel button">{{svg "octicon-x"}} {{$textNegitive}}</button>
+		<button class="ui cancel button">{{svg "octicon-x"}} {{$textNegative}}</button>
 		<button class="ui primary ok button">{{svg "octicon-check"}} {{$textPositive}}</button>
 	{{end}}
 </div>

--- a/templates/projects/view.tmpl
+++ b/templates/projects/view.tmpl
@@ -77,7 +77,7 @@
 		<div class="divider"></div>
 	</div>
 
-	<div id="project-board" class="board {{if $canWriteProject}}sortable{{end}}" data-project-borad-writable="{{$canWriteProject}}" {{if $canWriteProject}}data-url="{{$.Link}}/move"{{end}}>
+	<div id="project-board" class="board {{if $canWriteProject}}sortable{{end}}" data-project-board-writable="{{$canWriteProject}}" {{if $canWriteProject}}data-url="{{$.Link}}/move"{{end}}>
 		{{range .Columns}}
 			<div class="project-column" {{if .Color}}style="background: {{.Color}} !important; color: {{ContrastColor .Color}} !important"{{end}} data-id="{{.ID}}" data-sorting="{{.Sorting}}" data-url="{{$.Link}}/{{.ID}}">
 				<div class="project-column-header{{if $canWriteProject}} tw-cursor-grab{{end}}">

--- a/templates/repo/diff/blob_excerpt.tmpl
+++ b/templates/repo/diff/blob_excerpt.tmpl
@@ -15,7 +15,7 @@
 			<td class="lines-escape lines-escape-old">{{if and $line.LeftIdx $inlineDiff.EscapeStatus.Escaped}}<button class="toggle-escape-button btn interact-bg" title="{{template "repo/diff/escape_title" dict "diff" $inlineDiff}}"></button>{{end}}</td>
 			<td class="lines-type-marker lines-type-marker-old">{{if $line.LeftIdx}}<span class="tw-font-mono" data-type-marker=""></span>{{end}}</td>
 			<td class="lines-code lines-code-old">
-				{{/* ATTENTION: BLOB-EXCERPT-COMMENT-RIGHT: here it intentially use "right" side to comment, because the backend code depends on the assumption that the comment only happens on right side*/}}
+				{{/* ATTENTION: BLOB-EXCERPT-COMMENT-RIGHT: here it intentionally use "right" side to comment, because the backend code depends on the assumption that the comment only happens on right side*/}}
 				{{- if and $canCreateComment $line.RightIdx -}}
 					<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-right{{if (not $line.CanComment)}} tw-invisible{{end}}" data-side="right" data-idx="{{$line.RightIdx}}">
 						{{- svg "octicon-plus" -}}

--- a/tests/integration/admin_user_test.go
+++ b/tests/integration/admin_user_test.go
@@ -43,10 +43,10 @@ func TestAdminViewUser(t *testing.T) {
 func TestAdminEditUser(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
 
-	testSuccessfullEdit(t, user_model.User{ID: 2, Name: "newusername", LoginName: "otherlogin", Email: "new@e-mail.gitea"})
+	testSuccessfulEdit(t, user_model.User{ID: 2, Name: "newusername", LoginName: "otherlogin", Email: "new@e-mail.gitea"})
 }
 
-func testSuccessfullEdit(t *testing.T, formData user_model.User) {
+func testSuccessfulEdit(t *testing.T, formData user_model.User) {
 	makeRequest(t, formData, http.StatusSeeOther)
 }
 

--- a/tests/integration/api_gpg_keys_test.go
+++ b/tests/integration/api_gpg_keys_test.go
@@ -63,8 +63,8 @@ func TestGPGKeys(t *testing.T) {
 			t.Run("CreateInvalidGPGKey", func(t *testing.T) {
 				testCreateInvalidGPGKey(t, tc.makeRequest, tc.token, tc.results[4])
 			})
-			t.Run("CreateNoneRegistredEmailGPGKey", func(t *testing.T) {
-				testCreateNoneRegistredEmailGPGKey(t, tc.makeRequest, tc.token, tc.results[5])
+			t.Run("CreateNoneRegisteredEmailGPGKey", func(t *testing.T) {
+				testCreateNoneRegisteredEmailGPGKey(t, tc.makeRequest, tc.token, tc.results[5])
 			})
 			t.Run("CreateValidGPGKey", func(t *testing.T) {
 				testCreateValidGPGKey(t, tc.makeRequest, tc.token, tc.results[6])
@@ -179,7 +179,7 @@ func testCreateInvalidGPGKey(t *testing.T, makeRequest makeRequestFunc, token st
 	testCreateGPGKey(t, makeRequest, token, expected, "invalid_key")
 }
 
-func testCreateNoneRegistredEmailGPGKey(t *testing.T, makeRequest makeRequestFunc, token string, expected int) {
+func testCreateNoneRegisteredEmailGPGKey(t *testing.T, makeRequest makeRequestFunc, token string, expected int) {
 	testCreateGPGKey(t, makeRequest, token, expected, `-----BEGIN PGP PUBLIC KEY BLOCK-----
 
 mQENBFmGUygBCACjCNbKvMGgp0fd5vyFW9olE1CLCSyyF9gQN2hSuzmZLuAZF2Kh

--- a/tests/integration/api_notification_test.go
+++ b/tests/integration/api_notification_test.go
@@ -200,7 +200,7 @@ func TestAPINotificationPUT(t *testing.T) {
 	assert.False(t, apiNL[0].Pinned)
 
 	//
-	// Now nofication ID 2 is the first in the list and is unread.
+	// Now notification ID 2 is the first in the list and is unread.
 	//
 	req = NewRequest(t, "GET", "/api/v1/notifications?all=true").
 		AddTokenAuth(token)

--- a/tests/integration/api_packages_maven_test.go
+++ b/tests/integration/api_packages_maven_test.go
@@ -160,7 +160,7 @@ func TestPackageMaven(t *testing.T) {
 	t.Run("UploadVerifySHA1", func(t *testing.T) {
 		defer tests.PrintCurrentTest(t)()
 
-		t.Run("Missmatch", func(t *testing.T) {
+		t.Run("Mismatch", func(t *testing.T) {
 			defer tests.PrintCurrentTest(t)()
 
 			putFile(t, fmt.Sprintf("/%s/%s.sha1", packageVersion, filename), "test", http.StatusBadRequest)

--- a/tests/integration/api_token_test.go
+++ b/tests/integration/api_token_test.go
@@ -514,10 +514,10 @@ func runTestCase(t *testing.T, testCase *requiredScopeTestCase, user *user_model
 			if unauthorizedLevel == auth_model.NoAccess {
 				continue
 			}
-			cateogoryUnauthorizedScopes := auth_model.GetRequiredScopes(
+			categoryUnauthorizedScopes := auth_model.GetRequiredScopes(
 				unauthorizedLevel,
 				category)
-			unauthorizedScopes = append(unauthorizedScopes, cateogoryUnauthorizedScopes...)
+			unauthorizedScopes = append(unauthorizedScopes, categoryUnauthorizedScopes...)
 		}
 
 		accessToken := createAPIAccessTokenWithoutCleanUp(t, "test-token", user, unauthorizedScopes)

--- a/tests/integration/api_user_org_perm_test.go
+++ b/tests/integration/api_user_org_perm_test.go
@@ -123,7 +123,7 @@ func TestCanReadUser(t *testing.T) {
 	})
 }
 
-func TestUnknowUser(t *testing.T) {
+func TestUnknownUser(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
 
 	session := loginUser(t, "user1")

--- a/tests/integration/pull_merge_test.go
+++ b/tests/integration/pull_merge_test.go
@@ -414,7 +414,7 @@ func TestCantMergeUnrelated(t *testing.T) {
 		sha := strings.TrimSpace(stdout)
 
 		_, _, err = gitcmd.NewCommand("update-index", "--add", "--replace", "--cacheinfo").
-			AddDynamicArguments("100644", sha, "somewher-over-the-rainbow").
+			AddDynamicArguments("100644", sha, "somewhere-over-the-rainbow").
 			WithDir(path).
 			RunStdString(t.Context())
 		assert.NoError(t, err)

--- a/web_src/js/features/comp/EditorMarkdown.test.ts
+++ b/web_src/js/features/comp/EditorMarkdown.test.ts
@@ -171,9 +171,9 @@ test('EditorMarkdown', () => {
     pos: number;
   };
   const testInput = (input: ValueWithCursor, result: ValueWithCursor) => {
-    const intputValue = typeof input === 'string' ? input : input.value;
-    const inputPos = typeof input === 'string' ? intputValue.length : input.pos;
-    textarea.value = intputValue;
+    const inputValue = typeof input === 'string' ? input : input.value;
+    const inputPos = typeof input === 'string' ? inputValue.length : input.pos;
+    textarea.value = inputValue;
     textarea.setSelectionRange(inputPos, inputPos);
 
     const e = new KeyboardEvent('keydown', {key: 'Enter', cancelable: true});

--- a/web_src/js/features/repo-projects.ts
+++ b/web_src/js/features/repo-projects.ts
@@ -161,7 +161,7 @@ function initRepoProjectToggleFullScreen(): void {
 export function initRepoProject(): void {
   initRepoProjectToggleFullScreen();
 
-  const writableProjectBoard = document.querySelector('#project-board[data-project-borad-writable="true"]');
+  const writableProjectBoard = document.querySelector('#project-board[data-project-board-writable="true"]');
   if (!writableProjectBoard) return;
 
   initRepoProjectSortable(); // no await


### PR DESCRIPTION
I was testing typos-cli and fixed some misspelled wording here.
All changes are internal — no public API fields, database columns,
locale keys, or migration names are affected.