### PR TITLE
Escape commit messages in branch/file feeds and add regression tests

### DIFF
--- a/routers/web/feed/branch.go
+++ b/routers/web/feed/branch.go
@@ -4,6 +4,7 @@
 package feed
 
 import (
+	"html"
 	"strings"
 	"time"
 
@@ -37,6 +38,7 @@ func ShowBranchFeed(ctx *context.Context, repo *repo.Repository, formatType stri
 	}
 
 	for _, commit := range commits {
+		message := html.EscapeString(commit.Message())
 		feed.Items = append(feed.Items, &feeds.Item{
 			Id:    commit.ID.String(),
 			Title: strings.TrimSpace(strings.Split(commit.Message(), "\n")[0]),
@@ -45,8 +47,8 @@ func ShowBranchFeed(ctx *context.Context, repo *repo.Repository, formatType stri
 				Name:  commit.Author.Name,
 				Email: commit.Author.Email,
 			},
-			Description: commit.Message(),
-			Content:     commit.Message(),
+			Description: message,
+			Content:     message,
 			Created:     commit.Committer.When,
 		})
 	}

--- a/routers/web/feed/branch_file_test.go
+++ b/routers/web/feed/branch_file_test.go
@@ -1,0 +1,85 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package feed_test
+
+import (
+	"fmt"
+	"html"
+	"testing"
+
+	repo_model "code.gitea.io/gitea/models/repo"
+	"code.gitea.io/gitea/modules/git"
+	"code.gitea.io/gitea/modules/git/gitcmd"
+	"code.gitea.io/gitea/routers/web/feed"
+	"code.gitea.io/gitea/services/contexttest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const feedCommitMessage = "fix <script>alert(1)</script>"
+
+func setupFeedTestRepo(t *testing.T) (*git.Repository, *git.Commit) {
+	repoPath := t.TempDir()
+	stdin := fmt.Sprintf(`commit refs/heads/master
+author Test <test@example.com> 1700000000 +0000
+committer Test <test@example.com> 1700000000 +0000
+data <<EOT
+%s
+EOT
+M 100644 inline test.txt
+data <<EOT
+content
+EOT
+`, feedCommitMessage)
+
+	require.NoError(t, gitcmd.NewCommand("init", "--bare", ".").WithDir(repoPath).RunWithStderr(t.Context()))
+	require.NoError(t, gitcmd.NewCommand("fast-import").WithDir(repoPath).WithStdinBytes([]byte(stdin)).RunWithStderr(t.Context()))
+
+	gitRepo, err := git.OpenRepository(t.Context(), repoPath)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = gitRepo.Close()
+	})
+
+	commit, err := gitRepo.GetBranchCommit("master")
+	require.NoError(t, err)
+
+	return gitRepo, commit
+}
+
+func TestShowBranchFeedEscapesCommitMessage(t *testing.T) {
+	gitRepo, commit := setupFeedTestRepo(t)
+	ctx, resp := contexttest.MockContext(t, "/")
+	ctx.Repo.Commit = commit
+	ctx.Repo.GitRepo = gitRepo
+	ctx.Repo.RefFullName = git.RefNameFromBranch("master")
+	ctx.Repo.BranchName = "master"
+
+	repo := &repo_model.Repository{OwnerName: "test", Name: "repo"}
+	feed.ShowBranchFeed(ctx, repo, "rss")
+
+	body := resp.Body.String()
+	expected := html.EscapeString(feedCommitMessage)
+	assert.Contains(t, body, expected)
+	assert.NotContains(t, body, "<script>")
+}
+
+func TestShowFileFeedEscapesCommitMessage(t *testing.T) {
+	gitRepo, commit := setupFeedTestRepo(t)
+	ctx, resp := contexttest.MockContext(t, "/")
+	ctx.Repo.Commit = commit
+	ctx.Repo.GitRepo = gitRepo
+	ctx.Repo.RefFullName = git.RefNameFromBranch("master")
+	ctx.Repo.BranchName = "master"
+	ctx.Repo.TreePath = "test.txt"
+
+	repo := &repo_model.Repository{OwnerName: "test", Name: "repo"}
+	feed.ShowFileFeed(ctx, repo, "rss")
+
+	body := resp.Body.String()
+	expected := html.EscapeString(feedCommitMessage)
+	assert.Contains(t, body, expected)
+	assert.NotContains(t, body, "<script>")
+}

--- a/routers/web/feed/convert.go
+++ b/routers/web/feed/convert.go
@@ -286,7 +286,7 @@ func releasesToFeedItems(ctx *context.Context, releases []*repo_model.Release) (
 		if rel.IsTag {
 			title = rel.TagName
 		} else {
-			title = rel.Title
+			title = html.EscapeString(rel.Title)
 		}
 
 		link := &feeds.Link{Href: rel.HTMLURL()}

--- a/routers/web/feed/file.go
+++ b/routers/web/feed/file.go
@@ -4,6 +4,7 @@
 package feed
 
 import (
+	"html"
 	"strings"
 	"time"
 
@@ -44,6 +45,7 @@ func ShowFileFeed(ctx *context.Context, repo *repo.Repository, formatType string
 	}
 
 	for _, commit := range commits {
+		message := html.EscapeString(commit.Message())
 		feed.Items = append(feed.Items, &feeds.Item{
 			Id:    commit.ID.String(),
 			Title: strings.TrimSpace(strings.Split(commit.Message(), "\n")[0]),
@@ -52,8 +54,8 @@ func ShowFileFeed(ctx *context.Context, repo *repo.Repository, formatType string
 				Name:  commit.Author.Name,
 				Email: commit.Author.Email,
 			},
-			Description: commit.Message(),
-			Content:     commit.Message(),
+			Description: message,
+			Content:     message,
 			Created:     commit.Committer.When,
 		})
 	}


### PR DESCRIPTION
- Escape branch/file feed commit descriptions and content to prevent HTML injection.
- Add unit tests for branch/file feed RSS output using a commit message with script tags.
- Also escape release feed titles (already present in this branch diff).
 
---
Generated by a coding agent with Codex 5.2