### PR TITLE
prefer ReleaseAsset DownloadFunc and add migration client coverage

### DIFF
--- a/services/migrations/dump.go
+++ b/services/migrations/dump.go
@@ -287,6 +287,7 @@ func (g *RepositoryDumper) CreateLabels(_ context.Context, labels ...*base.Label
 // CreateReleases creates releases
 func (g *RepositoryDumper) CreateReleases(_ context.Context, releases ...*base.Release) error {
 	if g.opts.ReleaseAssets {
+		httpClient := NewMigrationHTTPClient()
 		for _, release := range releases {
 			attachDir := filepath.Join("release_assets", release.TagName)
 			if err := os.MkdirAll(filepath.Join(g.baseDir, attachDir), os.ModePerm); err != nil {
@@ -307,7 +308,7 @@ func (g *RepositoryDumper) CreateReleases(_ context.Context, releases ...*base.R
 						}
 						defer rc.Close()
 					} else if asset.DownloadURL != nil {
-						resp, err := NewMigrationHTTPClient().Get(*asset.DownloadURL)
+						resp, err := httpClient.Get(*asset.DownloadURL)
 						if err != nil {
 							return err
 						}

--- a/services/migrations/dump.go
+++ b/services/migrations/dump.go
@@ -295,25 +295,26 @@ func (g *RepositoryDumper) CreateReleases(_ context.Context, releases ...*base.R
 			for _, asset := range release.Assets {
 				attachLocalPath := filepath.Join(attachDir, asset.Name)
 
-				// SECURITY: We cannot check the DownloadURL and DownloadFunc are safe here
-				// ... we must assume that they are safe and simply download the attachment
+				// SECURITY: Prefer DownloadFunc and fall back to a migration-filtered HTTP client.
 				// download attachment
 				err := func(attachPath string) error {
 					var rc io.ReadCloser
 					var err error
-					if asset.DownloadURL == nil {
+					if asset.DownloadFunc != nil {
 						rc, err = asset.DownloadFunc()
 						if err != nil {
 							return err
 						}
 						defer rc.Close()
-					} else {
-						resp, err := http.Get(*asset.DownloadURL)
+					} else if asset.DownloadURL != nil {
+						resp, err := NewMigrationHTTPClient().Get(*asset.DownloadURL)
 						if err != nil {
 							return err
 						}
 						defer resp.Body.Close()
 						rc = resp.Body
+					} else {
+						return errors.New("missing download URL and download function")
 					}
 
 					fw, err := os.Create(attachPath)

--- a/services/migrations/dump_test.go
+++ b/services/migrations/dump_test.go
@@ -1,0 +1,105 @@
+// Copyright 2025 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package migrations
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	base "code.gitea.io/gitea/modules/migration"
+	"code.gitea.io/gitea/modules/setting"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepositoryDumperReleaseAssetPrefersDownloadFunc(t *testing.T) {
+	var downloadURLHits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&downloadURLHits, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("remote"))
+	}))
+	t.Cleanup(server.Close)
+
+	downloadURL := server.URL + "/asset"
+	var downloadFuncCalls int32
+	asset := &base.ReleaseAsset{
+		Name:        "asset.txt",
+		DownloadURL: &downloadURL,
+		DownloadFunc: func() (io.ReadCloser, error) {
+			atomic.AddInt32(&downloadFuncCalls, 1)
+			return io.NopCloser(strings.NewReader("local")), nil
+		},
+	}
+	release := &base.Release{
+		TagName: "v1.0.0",
+		Assets:  []*base.ReleaseAsset{asset},
+	}
+
+	baseDir := t.TempDir()
+	dumper, err := NewRepositoryDumper(context.Background(), baseDir, "owner", "repo", base.MigrateOptions{})
+	require.NoError(t, err)
+
+	require.NoError(t, dumper.CreateReleases(context.Background(), release))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&downloadFuncCalls))
+	assert.Equal(t, int32(0), atomic.LoadInt32(&downloadURLHits))
+
+	attachRelative := filepath.Join("release_assets", release.TagName, asset.Name)
+	attachPath := filepath.Join(baseDir, "owner", "repo", attachRelative)
+	data, err := os.ReadFile(attachPath)
+	require.NoError(t, err)
+	assert.Equal(t, "local", string(data))
+	require.NotNil(t, asset.DownloadURL)
+	assert.Equal(t, attachRelative, *asset.DownloadURL)
+}
+
+func TestRepositoryDumperReleaseAssetUsesMigrationClient(t *testing.T) {
+	oldAllowed := setting.Migrations.AllowedDomains
+	oldBlocked := setting.Migrations.BlockedDomains
+	oldAllowLocal := setting.Migrations.AllowLocalNetworks
+	t.Cleanup(func() {
+		setting.Migrations.AllowedDomains = oldAllowed
+		setting.Migrations.BlockedDomains = oldBlocked
+		setting.Migrations.AllowLocalNetworks = oldAllowLocal
+		_ = Init()
+	})
+
+	setting.Migrations.AllowedDomains = ""
+	setting.Migrations.BlockedDomains = ""
+	setting.Migrations.AllowLocalNetworks = false
+	require.NoError(t, Init())
+
+	var downloadURLHits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&downloadURLHits, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("remote"))
+	}))
+	t.Cleanup(server.Close)
+
+	downloadURL := server.URL + "/asset"
+	asset := &base.ReleaseAsset{
+		Name:        "asset.txt",
+		DownloadURL: &downloadURL,
+	}
+	release := &base.Release{
+		TagName: "v1.0.0",
+		Assets:  []*base.ReleaseAsset{asset},
+	}
+
+	baseDir := t.TempDir()
+	dumper, err := NewRepositoryDumper(context.Background(), baseDir, "owner", "repo", base.MigrateOptions{})
+	require.NoError(t, err)
+
+	assert.Error(t, dumper.CreateReleases(context.Background(), release))
+	assert.Equal(t, int32(0), atomic.LoadInt32(&downloadURLHits))
+}

--- a/services/migrations/dump_test.go
+++ b/services/migrations/dump_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Gitea Authors. All rights reserved.
+// Copyright 2026 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
 package migrations

--- a/services/migrations/dump_test.go
+++ b/services/migrations/dump_test.go
@@ -14,8 +14,10 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"code.gitea.io/gitea/models/unittest"
 	base "code.gitea.io/gitea/modules/migration"
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/test"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,7 +48,7 @@ func TestRepositoryDumperReleaseAssetPrefersDownloadFunc(t *testing.T) {
 	}
 
 	baseDir := t.TempDir()
-	dumper, err := NewRepositoryDumper(context.Background(), baseDir, "owner", "repo", base.MigrateOptions{})
+	dumper, err := NewRepositoryDumper(context.Background(), baseDir, "owner", "repo", base.MigrateOptions{ReleaseAssets: true})
 	require.NoError(t, err)
 
 	require.NoError(t, dumper.CreateReleases(context.Background(), release))
@@ -63,20 +65,11 @@ func TestRepositoryDumperReleaseAssetPrefersDownloadFunc(t *testing.T) {
 }
 
 func TestRepositoryDumperReleaseAssetUsesMigrationClient(t *testing.T) {
-	oldAllowed := setting.Migrations.AllowedDomains
-	oldBlocked := setting.Migrations.BlockedDomains
-	oldAllowLocal := setting.Migrations.AllowLocalNetworks
-	t.Cleanup(func() {
-		setting.Migrations.AllowedDomains = oldAllowed
-		setting.Migrations.BlockedDomains = oldBlocked
-		setting.Migrations.AllowLocalNetworks = oldAllowLocal
-		_ = Init()
-	})
+	assert.NoError(t, unittest.PrepareTestDatabase())
 
-	setting.Migrations.AllowedDomains = ""
-	setting.Migrations.BlockedDomains = ""
-	setting.Migrations.AllowLocalNetworks = false
-	require.NoError(t, Init())
+	test.MockVariableValue(&setting.Migrations.AllowedDomains, "github.com")()
+	test.MockVariableValue(&setting.Migrations.AllowLocalNetworks, false)()
+	assert.NoError(t, Init())
 
 	var downloadURLHits int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -97,7 +90,7 @@ func TestRepositoryDumperReleaseAssetUsesMigrationClient(t *testing.T) {
 	}
 
 	baseDir := t.TempDir()
-	dumper, err := NewRepositoryDumper(context.Background(), baseDir, "owner", "repo", base.MigrateOptions{})
+	dumper, err := NewRepositoryDumper(context.Background(), baseDir, "owner", "repo", base.MigrateOptions{ReleaseAssets: true})
 	require.NoError(t, err)
 
 	assert.Error(t, dumper.CreateReleases(context.Background(), release))


### PR DESCRIPTION
- Prefer `DownloadFunc` when exporting release assets; fall back to the migration-filtered HTTP client for `DownloadURL`, and error when neither is provided.
- Add tests to verify `DownloadFunc` precedence and that `DownloadURL` uses the migration client to block disallowed domains.