### PR TITLE
Add console and pageerror listeners to e2e tests

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -915,6 +915,13 @@ export default defineConfig([
     rules: {
       ...playwright.configs['flat/recommended'].rules,
       'playwright/expect-expect': [0],
+      'no-restricted-imports': [2, {
+        paths: [{
+          name: '@playwright/test',
+          importNames: ['test', 'expect'],
+          message: 'Import from ./utils.ts instead',
+        }],
+      }],
     },
   },
   {
@@ -1002,7 +1009,7 @@ export default defineConfig([
     },
   },
   {
-    files: ['*', 'tools/**/*'],
+    files: ['*', 'tools/**/*', 'tests/**/*'],
     languageOptions: {globals: globals.nodeBuiltin},
   },
   {

--- a/tests/e2e/explore.test.ts
+++ b/tests/e2e/explore.test.ts
@@ -1,4 +1,4 @@
-import {test, expect} from '@playwright/test';
+import {test, expect} from './utils.ts';
 
 test('explore repositories', async ({page}) => {
   await page.goto('/explore/repos');

--- a/tests/e2e/login.test.ts
+++ b/tests/e2e/login.test.ts
@@ -1,5 +1,4 @@
-import {test, expect} from '@playwright/test';
-import {login, logout} from './utils.ts';
+import {test, expect, login, logout} from './utils.ts';
 
 test('homepage', async ({page}) => {
   await page.goto('/');

--- a/tests/e2e/milestone.test.ts
+++ b/tests/e2e/milestone.test.ts
@@ -1,6 +1,5 @@
 import {env} from 'node:process';
-import {test, expect} from '@playwright/test';
-import {login, apiCreateRepo, apiDeleteRepo} from './utils.ts';
+import {test, expect, login, apiCreateRepo, apiDeleteRepo} from './utils.ts';
 
 test('create a milestone', async ({page}) => {
   const repoName = `e2e-milestone-${Date.now()}`;

--- a/tests/e2e/org.test.ts
+++ b/tests/e2e/org.test.ts
@@ -1,5 +1,4 @@
-import {test, expect} from '@playwright/test';
-import {login, apiDeleteOrg} from './utils.ts';
+import {test, expect, login, apiDeleteOrg} from './utils.ts';
 
 test('create an organization', async ({page}) => {
   const orgName = `e2e-org-${Date.now()}`;

--- a/tests/e2e/readme.test.ts
+++ b/tests/e2e/readme.test.ts
@@ -1,6 +1,5 @@
 import {env} from 'node:process';
-import {test, expect} from '@playwright/test';
-import {apiCreateRepo, apiDeleteRepo} from './utils.ts';
+import {test, expect, apiCreateRepo, apiDeleteRepo} from './utils.ts';
 
 test('repo readme', async ({page}) => {
   const repoName = `e2e-readme-${Date.now()}`;

--- a/tests/e2e/register.test.ts
+++ b/tests/e2e/register.test.ts
@@ -1,6 +1,5 @@
 import {env} from 'node:process';
-import {test, expect} from '@playwright/test';
-import {login, logout} from './utils.ts';
+import {test, expect, login, logout} from './utils.ts';
 
 test.beforeEach(async ({page}) => {
   await page.goto('/user/sign_up');

--- a/tests/e2e/repo.test.ts
+++ b/tests/e2e/repo.test.ts
@@ -1,6 +1,5 @@
 import {env} from 'node:process';
-import {test} from '@playwright/test';
-import {login, apiDeleteRepo} from './utils.ts';
+import {test, login, apiDeleteRepo} from './utils.ts';
 
 test('create a repository', async ({page}) => {
   const repoName = `e2e-repo-${Date.now()}`;

--- a/tests/e2e/user-settings.test.ts
+++ b/tests/e2e/user-settings.test.ts
@@ -1,5 +1,4 @@
-import {test, expect} from '@playwright/test';
-import {login} from './utils.ts';
+import {test, expect, login} from './utils.ts';
 
 test('update profile biography', async ({page}) => {
   const bio = `e2e-bio-${Date.now()}`;

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -1,6 +1,22 @@
 import {env} from 'node:process';
-import {expect} from '@playwright/test';
+import {test as baseTest, expect} from '@playwright/test';
 import type {APIRequestContext, Locator, Page} from '@playwright/test';
+
+export {expect};
+
+export const test = baseTest.extend<{consoleCheck: void}>({
+  consoleCheck: [async ({page}, use) => {
+    page.on('console', (msg) => {
+      const text = msg.text();
+      if (/the server responded with a status of 4\d{2}/.test(text)) return;
+      console.info(`console.${msg.type()}: ${text}`);
+    });
+    page.on('pageerror', (err) => {
+      console.error(`pageerror: ${err.message}`);
+    });
+    await use();
+  }, {auto: true}],
+});
 
 export function apiBaseUrl() {
   return env.GITEA_TEST_E2E_URL?.replace(/\/$/g, '');


### PR DESCRIPTION
This enables playwright to show errors and console logging. It's done by adding fixtures to each test, so `test` and `expect` must now be imported via wrappers and eslint enforces it. This should be useful when debugging e2e failures on CI and during local headless testing.

- Chrome logs a lot of `the server responded with a status of 4xx` errors in the console during e2e tests, I added a suppression. This does not apply to Firefox, which does not log network errors like Chrome does.
- There are two pre-existing log messages which might be worth fixing:
  ```
  console.info: Autofocus processing was blocked because a document already has a focused element.
  pageerror: Cannot read properties of undefined (reading 'getBoolean')
  ```