### PR TITLE
Allow OAuth2 and basic auth for actions badge SVG endpoint

### DIFF
--- a/services/auth/auth.go
+++ b/services/auth/auth.go
@@ -36,9 +36,12 @@ var globalVars = sync.OnceValue(func() *globalVarsStruct {
 		gitRawOrAttachPathRe: regexp.MustCompile(`^/[-.\w]+/[-.\w]+/(?:(?:git-(?:(?:upload)|(?:receive))-pack$)|(?:info/refs$)|(?:HEAD$)|(?:objects/)|(?:raw/)|(?:releases/download/)|(?:attachments/))`),
 		lfsPathRe:            regexp.MustCompile(`^/[-.\w]+/[-.\w]+/info/lfs/`),
 		archivePathRe:        regexp.MustCompile(`^/[-.\w]+/[-.\w]+/archive/`),
-		feedPathRe:           regexp.MustCompile(`^/[-.\w]+(/[-.\w]+)?\.(rss|atom)$`),                       // "/owner.rss" or "/owner/repo.atom"
-		feedRefPathRe:        regexp.MustCompile(`^/[-.\w]+/[-.\w]+/(rss|atom)/`),                           // "/owner/repo/rss/branch/..."
-		badgePathRe:          regexp.MustCompile(`^/[-.\w]+/[-.\w]+/actions/workflows/[-.\w]+/badge\.svg$`), // "/owner/repo/actions/workflows/foo/badge.svg"
+		// "/owner.rss" or "/owner/repo.atom"
+		feedPathRe: regexp.MustCompile(`^/[-.\w]+(/[-.\w]+)?\.(rss|atom)$`),
+		// "/owner/repo/rss/branch/..."
+		feedRefPathRe: regexp.MustCompile(`^/[-.\w]+/[-.\w]+/(rss|atom)/`),
+		// "/owner/repo/actions/workflows/foo/badge.svg"
+		badgePathRe: regexp.MustCompile(`^/[-.\w]+/[-.\w]+/actions/workflows/[-.\w]+/badge\.svg$`),
 	}
 })
 

--- a/services/auth/auth.go
+++ b/services/auth/auth.go
@@ -117,8 +117,8 @@ func (a *authPathDetector) isArchivePath() bool {
 	return a.vars.archivePathRe.MatchString(a.req.URL.Path)
 }
 
-func (a *authPathDetector) isActionsBadgePath() bool {
-	return a.vars.actionsBadgePathRe.MatchString(a.req.URL.Path)
+func (a *authPathDetector) isActionsBadgeRequest() bool {
+	return a.req.Method == http.MethodGet && a.vars.actionsBadgePathRe.MatchString(a.req.URL.Path)
 }
 
 func (a *authPathDetector) isAuthenticatedTokenRequest() bool {

--- a/services/auth/auth.go
+++ b/services/auth/auth.go
@@ -36,8 +36,8 @@ var globalVars = sync.OnceValue(func() *globalVarsStruct {
 		gitRawOrAttachPathRe: regexp.MustCompile(`^/[-.\w]+/[-.\w]+/(?:(?:git-(?:(?:upload)|(?:receive))-pack$)|(?:info/refs$)|(?:HEAD$)|(?:objects/)|(?:raw/)|(?:releases/download/)|(?:attachments/))`),
 		lfsPathRe:            regexp.MustCompile(`^/[-.\w]+/[-.\w]+/info/lfs/`),
 		archivePathRe:        regexp.MustCompile(`^/[-.\w]+/[-.\w]+/archive/`),
-		feedPathRe:           regexp.MustCompile(`^/[-.\w]+(/[-.\w]+)?\.(rss|atom)$`), // "/owner.rss" or "/owner/repo.atom"
-		feedRefPathRe:        regexp.MustCompile(`^/[-.\w]+/[-.\w]+/(rss|atom)/`),     // "/owner/repo/rss/branch/..."
+		feedPathRe:           regexp.MustCompile(`^/[-.\w]+(/[-.\w]+)?\.(rss|atom)$`),                       // "/owner.rss" or "/owner/repo.atom"
+		feedRefPathRe:        regexp.MustCompile(`^/[-.\w]+/[-.\w]+/(rss|atom)/`),                           // "/owner/repo/rss/branch/..."
 		badgePathRe:          regexp.MustCompile(`^/[-.\w]+/[-.\w]+/actions/workflows/[-.\w]+/badge\.svg$`), // "/owner/repo/actions/workflows/foo/badge.svg"
 	}
 })

--- a/services/auth/auth.go
+++ b/services/auth/auth.go
@@ -28,6 +28,7 @@ type globalVarsStruct struct {
 	archivePathRe        *regexp.Regexp
 	feedPathRe           *regexp.Regexp
 	feedRefPathRe        *regexp.Regexp
+	badgePathRe          *regexp.Regexp
 }
 
 var globalVars = sync.OnceValue(func() *globalVarsStruct {
@@ -37,6 +38,7 @@ var globalVars = sync.OnceValue(func() *globalVarsStruct {
 		archivePathRe:        regexp.MustCompile(`^/[-.\w]+/[-.\w]+/archive/`),
 		feedPathRe:           regexp.MustCompile(`^/[-.\w]+(/[-.\w]+)?\.(rss|atom)$`), // "/owner.rss" or "/owner/repo.atom"
 		feedRefPathRe:        regexp.MustCompile(`^/[-.\w]+/[-.\w]+/(rss|atom)/`),     // "/owner/repo/rss/branch/..."
+		badgePathRe:          regexp.MustCompile(`^/[-.\w]+/[-.\w]+/actions/workflows/[-.\w]+/badge\.svg$`), // "/owner/repo/actions/workflows/foo/badge.svg"
 	}
 })
 
@@ -110,6 +112,10 @@ func (a *authPathDetector) isGitRawOrAttachOrLFSPath() bool {
 
 func (a *authPathDetector) isArchivePath() bool {
 	return a.vars.archivePathRe.MatchString(a.req.URL.Path)
+}
+
+func (a *authPathDetector) isBadgePath() bool {
+	return a.vars.badgePathRe.MatchString(a.req.URL.Path)
 }
 
 func (a *authPathDetector) isAuthenticatedTokenRequest() bool {

--- a/services/auth/auth.go
+++ b/services/auth/auth.go
@@ -28,7 +28,7 @@ type globalVarsStruct struct {
 	archivePathRe        *regexp.Regexp
 	feedPathRe           *regexp.Regexp
 	feedRefPathRe        *regexp.Regexp
-	badgePathRe          *regexp.Regexp
+	actionsBadgePathRe   *regexp.Regexp
 }
 
 var globalVars = sync.OnceValue(func() *globalVarsStruct {
@@ -41,7 +41,7 @@ var globalVars = sync.OnceValue(func() *globalVarsStruct {
 		// "/owner/repo/rss/branch/..."
 		feedRefPathRe: regexp.MustCompile(`^/[-.\w]+/[-.\w]+/(rss|atom)/`),
 		// "/owner/repo/actions/workflows/foo/badge.svg"
-		badgePathRe: regexp.MustCompile(`^/[-.\w]+/[-.\w]+/actions/workflows/[-.\w]+/badge\.svg$`),
+		actionsBadgePathRe: regexp.MustCompile(`^/[-.\w]+/[-.\w]+/actions/workflows/[-.\w]+/badge\.svg$`),
 	}
 })
 
@@ -117,8 +117,8 @@ func (a *authPathDetector) isArchivePath() bool {
 	return a.vars.archivePathRe.MatchString(a.req.URL.Path)
 }
 
-func (a *authPathDetector) isBadgePath() bool {
-	return a.vars.badgePathRe.MatchString(a.req.URL.Path)
+func (a *authPathDetector) isActionsBadgePath() bool {
+	return a.vars.actionsBadgePathRe.MatchString(a.req.URL.Path)
 }
 
 func (a *authPathDetector) isAuthenticatedTokenRequest() bool {

--- a/services/auth/auth_test.go
+++ b/services/auth/auth_test.go
@@ -131,6 +131,11 @@ func Test_isGitRawOrLFSPath(t *testing.T) {
 	}
 }
 
+func Test_isBadgePath(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodGet, "http://localhost/owner/repo/actions/workflows/build.yml/badge.svg", nil)
+	assert.True(t, newAuthPathDetector(req).isBadgePath())
+}
+
 func Test_isFeedRequest(t *testing.T) {
 	tests := []struct {
 		want bool

--- a/services/auth/auth_test.go
+++ b/services/auth/auth_test.go
@@ -131,9 +131,9 @@ func Test_isGitRawOrLFSPath(t *testing.T) {
 	}
 }
 
-func Test_isBadgePath(t *testing.T) {
+func Test_isActionsBadgePath(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodGet, "http://localhost/owner/repo/actions/workflows/build.yml/badge.svg", nil)
-	assert.True(t, newAuthPathDetector(req).isBadgePath())
+	assert.True(t, newAuthPathDetector(req).isActionsBadgePath())
 }
 
 func Test_isFeedRequest(t *testing.T) {

--- a/services/auth/auth_test.go
+++ b/services/auth/auth_test.go
@@ -131,9 +131,9 @@ func Test_isGitRawOrLFSPath(t *testing.T) {
 	}
 }
 
-func Test_isActionsBadgePath(t *testing.T) {
+func Test_isActionsBadgeRequest(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodGet, "http://localhost/owner/repo/actions/workflows/build.yml/badge.svg", nil)
-	assert.True(t, newAuthPathDetector(req).isActionsBadgePath())
+	assert.True(t, newAuthPathDetector(req).isActionsBadgeRequest())
 }
 
 func Test_isFeedRequest(t *testing.T) {

--- a/services/auth/basic.go
+++ b/services/auth/basic.go
@@ -44,7 +44,7 @@ func (b *Basic) parseAuthBasic(req *http.Request) (ret struct{ authToken, uname,
 	// Basic authentication should only fire on API, Feed, Download, Archives or on Git or LFSPaths
 	// Not all feed (rss/atom) clients feature the ability to add cookies or headers, so we need to allow basic auth for feeds
 	detector := newAuthPathDetector(req)
-	if !detector.isAPIPath() && !detector.isFeedRequest(req) && !detector.isContainerPath() && !detector.isAttachmentDownload() && !detector.isArchivePath() && !detector.isGitRawOrAttachOrLFSPath() && !detector.isActionsBadgePath() {
+	if !detector.isAPIPath() && !detector.isFeedRequest(req) && !detector.isContainerPath() && !detector.isAttachmentDownload() && !detector.isArchivePath() && !detector.isGitRawOrAttachOrLFSPath() && !detector.isActionsBadgeRequest() {
 		return ret
 	}
 

--- a/services/auth/basic.go
+++ b/services/auth/basic.go
@@ -44,7 +44,7 @@ func (b *Basic) parseAuthBasic(req *http.Request) (ret struct{ authToken, uname,
 	// Basic authentication should only fire on API, Feed, Download, Archives or on Git or LFSPaths
 	// Not all feed (rss/atom) clients feature the ability to add cookies or headers, so we need to allow basic auth for feeds
 	detector := newAuthPathDetector(req)
-	if !detector.isAPIPath() && !detector.isFeedRequest(req) && !detector.isContainerPath() && !detector.isAttachmentDownload() && !detector.isArchivePath() && !detector.isGitRawOrAttachOrLFSPath() && !detector.isBadgePath() {
+	if !detector.isAPIPath() && !detector.isFeedRequest(req) && !detector.isContainerPath() && !detector.isAttachmentDownload() && !detector.isArchivePath() && !detector.isGitRawOrAttachOrLFSPath() && !detector.isActionsBadgePath() {
 		return ret
 	}
 

--- a/services/auth/basic.go
+++ b/services/auth/basic.go
@@ -44,7 +44,7 @@ func (b *Basic) parseAuthBasic(req *http.Request) (ret struct{ authToken, uname,
 	// Basic authentication should only fire on API, Feed, Download, Archives or on Git or LFSPaths
 	// Not all feed (rss/atom) clients feature the ability to add cookies or headers, so we need to allow basic auth for feeds
 	detector := newAuthPathDetector(req)
-	if !detector.isAPIPath() && !detector.isFeedRequest(req) && !detector.isContainerPath() && !detector.isAttachmentDownload() && !detector.isArchivePath() && !detector.isGitRawOrAttachOrLFSPath() {
+	if !detector.isAPIPath() && !detector.isFeedRequest(req) && !detector.isContainerPath() && !detector.isAttachmentDownload() && !detector.isArchivePath() && !detector.isGitRawOrAttachOrLFSPath() && !detector.isBadgePath() {
 		return ret
 	}
 

--- a/services/auth/oauth2.go
+++ b/services/auth/oauth2.go
@@ -155,7 +155,7 @@ func (o *OAuth2) Verify(req *http.Request, w http.ResponseWriter, store DataStor
 	// These paths are not API paths, but we still want to check for tokens because they maybe in the API returned URLs
 	detector := newAuthPathDetector(req)
 	if !detector.isAPIPath() && !detector.isAttachmentDownload() && !detector.isAuthenticatedTokenRequest() &&
-		!detector.isGitRawOrAttachPath() && !detector.isArchivePath() && !detector.isBadgePath() {
+		!detector.isGitRawOrAttachPath() && !detector.isArchivePath() && !detector.isActionsBadgePath() {
 		return nil, nil //nolint:nilnil // the auth method is not applicable
 	}
 

--- a/services/auth/oauth2.go
+++ b/services/auth/oauth2.go
@@ -155,7 +155,7 @@ func (o *OAuth2) Verify(req *http.Request, w http.ResponseWriter, store DataStor
 	// These paths are not API paths, but we still want to check for tokens because they maybe in the API returned URLs
 	detector := newAuthPathDetector(req)
 	if !detector.isAPIPath() && !detector.isAttachmentDownload() && !detector.isAuthenticatedTokenRequest() &&
-		!detector.isGitRawOrAttachPath() && !detector.isArchivePath() && !detector.isActionsBadgePath() {
+		!detector.isGitRawOrAttachPath() && !detector.isArchivePath() && !detector.isActionsBadgeRequest() {
 		return nil, nil //nolint:nilnil // the auth method is not applicable
 	}
 

--- a/services/auth/oauth2.go
+++ b/services/auth/oauth2.go
@@ -155,7 +155,7 @@ func (o *OAuth2) Verify(req *http.Request, w http.ResponseWriter, store DataStor
 	// These paths are not API paths, but we still want to check for tokens because they maybe in the API returned URLs
 	detector := newAuthPathDetector(req)
 	if !detector.isAPIPath() && !detector.isAttachmentDownload() && !detector.isAuthenticatedTokenRequest() &&
-		!detector.isGitRawOrAttachPath() && !detector.isArchivePath() {
+		!detector.isGitRawOrAttachPath() && !detector.isArchivePath() && !detector.isBadgePath() {
 		return nil, nil //nolint:nilnil // the auth method is not applicable
 	}
 


### PR DESCRIPTION
Add OAuth2 and basic auth support to actions workflow badges. Previously, the only way to retrieve badges from private repos was cookies, which was inconvenient.