### PR TITLE
Optimize Docker build with dependency layer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /src
 COPY package.json pnpm-lock.yaml .npmrc ./
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm install --frozen-lockfile
 COPY --exclude=.git/ . .
-RUN touch node_modules && make frontend
+RUN make frontend
 
 # Build backend for each target platform
 FROM docker.io/library/golang:1.26-alpine3.23 AS build-env

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@
 FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26-alpine3.23 AS frontend-build
 RUN apk --no-cache add build-base git nodejs pnpm
 WORKDIR /src
+COPY package.json pnpm-lock.yaml .npmrc ./
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm install --frozen-lockfile
 COPY --exclude=.git/ . .
-RUN --mount=type=cache,target=/root/.local/share/pnpm/store make frontend
+RUN touch node_modules && make frontend
 
 # Build backend for each target platform
 FROM docker.io/library/golang:1.26-alpine3.23 AS build-env
-
-ARG GOPROXY=direct
 
 ARG GITEA_VERSION
 ARG TAGS="sqlite sqlite_unlock_notify"
@@ -22,14 +22,15 @@ RUN apk --no-cache add \
     git
 
 WORKDIR ${GOPATH}/src/code.gitea.io/gitea
+COPY go.mod go.sum ./
+RUN go mod download
 # Use COPY instead of bind mount as read-only one breaks makefile state tracking and read-write one needs binary to be moved as it's discarded.
 # ".git" directory is mounted separately later only for version data extraction.
 COPY --exclude=.git/ . .
 COPY --from=frontend-build /src/public/assets public/assets
 
 # Build gitea, .git mount is required for version data
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target="/root/.cache/go-build" \
+RUN --mount=type=cache,target="/root/.cache/go-build" \
     --mount=type=bind,source=".git/",target=".git/" \
     make backend
 

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -6,7 +6,7 @@ WORKDIR /src
 COPY package.json pnpm-lock.yaml .npmrc ./
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm install --frozen-lockfile
 COPY --exclude=.git/ . .
-RUN touch node_modules && make frontend
+RUN make frontend
 
 # Build backend for each target platform
 FROM docker.io/library/golang:1.26-alpine3.23 AS build-env

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -3,13 +3,13 @@
 FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26-alpine3.23 AS frontend-build
 RUN apk --no-cache add build-base git nodejs pnpm
 WORKDIR /src
+COPY package.json pnpm-lock.yaml .npmrc ./
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm install --frozen-lockfile
 COPY --exclude=.git/ . .
-RUN --mount=type=cache,target=/root/.local/share/pnpm/store make frontend
+RUN touch node_modules && make frontend
 
 # Build backend for each target platform
 FROM docker.io/library/golang:1.26-alpine3.23 AS build-env
-
-ARG GOPROXY=direct
 
 ARG GITEA_VERSION
 ARG TAGS="sqlite sqlite_unlock_notify"
@@ -22,13 +22,14 @@ RUN apk --no-cache add \
     git
 
 WORKDIR ${GOPATH}/src/code.gitea.io/gitea
+COPY go.mod go.sum ./
+RUN go mod download
 # See the comments in Dockerfile
 COPY --exclude=.git/ . .
 COPY --from=frontend-build /src/public/assets public/assets
 
 # Build gitea, .git mount is required for version data
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target="/root/.cache/go-build" \
+RUN --mount=type=cache,target="/root/.cache/go-build" \
     --mount=type=bind,source=".git/",target=".git/" \
     make backend
 


### PR DESCRIPTION
1. Copy dependency manifests before the full source copy so that dependency installation gets its own cached layer. When only source code changes, the dependency layers are reused.
2. Remove the `GOPROXY=direct` override which was bypassing the Go module proxy, causing build failures when git servers are unreachable. The Go default (`https://proxy.golang.org,direct`) is now used instead.