### PR TITLE
Clean up `refreshViewedFilesSummary`

### DIFF
--- a/web_src/js/features/pull-view-file.ts
+++ b/web_src/js/features/pull-view-file.ts
@@ -12,14 +12,12 @@ const collapseFilesBtnSelector = '#collapse-files-btn';
 // Refreshes the summary of viewed files if present
 // The data used will be window.config.pageData.prReview.numberOf{Viewed}Files
 function refreshViewedFilesSummary() {
-  const viewedFilesProgress = document.querySelector('#viewed-files-summary');
-  viewedFilesProgress?.setAttribute('value', prReview.numberOfViewedFiles);
-  const summaryLabel = document.querySelector<HTMLElement>('#viewed-files-summary-label');
-  if (summaryLabel) {
-    summaryLabel.textContent = summaryLabel.getAttribute('data-text-changed-template')!
-      .replace('%[1]d', prReview.numberOfViewedFiles)
-      .replace('%[2]d', prReview.numberOfFiles);
-  }
+  const viewedFilesProgress = document.querySelector('#viewed-files-summary')!;
+  viewedFilesProgress.setAttribute('value', prReview.numberOfViewedFiles);
+  const summaryLabel = document.querySelector<HTMLElement>('#viewed-files-summary-label')!;
+  summaryLabel.textContent = summaryLabel.getAttribute('data-text-changed-template')!
+    .replace('%[1]d', prReview.numberOfViewedFiles)
+    .replace('%[2]d', prReview.numberOfFiles);
 }
 
 // Initializes a listener for all children of the given html element

--- a/web_src/js/features/pull-view-file.ts
+++ b/web_src/js/features/pull-view-file.ts
@@ -9,7 +9,7 @@ const viewedCheckboxSelector = '.viewed-file-form'; // Selector under which all 
 const expandFilesBtnSelector = '#expand-files-btn';
 const collapseFilesBtnSelector = '#collapse-files-btn';
 
-// Refreshes the summary of viewed files if present
+// Refreshes the summary of viewed files
 // The data used will be window.config.pageData.prReview.numberOf{Viewed}Files
 function refreshViewedFilesSummary() {
   const viewedFilesProgress = document.querySelector('#viewed-files-summary')!;

--- a/web_src/js/features/pull-view-file.ts
+++ b/web_src/js/features/pull-view-file.ts
@@ -14,7 +14,7 @@ const collapseFilesBtnSelector = '#collapse-files-btn';
 function refreshViewedFilesSummary() {
   const viewedFilesProgress = document.querySelector('#viewed-files-summary');
   viewedFilesProgress?.setAttribute('value', prReview.numberOfViewedFiles);
-  const summaryLabel = document.querySelector('#viewed-files-summary-label')!;
+  const summaryLabel = document.querySelector<HTMLElement>('#viewed-files-summary-label');
   if (summaryLabel) {
     summaryLabel.textContent = summaryLabel.getAttribute('data-text-changed-template')!
       .replace('%[1]d', prReview.numberOfViewedFiles)

--- a/web_src/js/features/pull-view-file.ts
+++ b/web_src/js/features/pull-view-file.ts
@@ -15,9 +15,11 @@ function refreshViewedFilesSummary() {
   const viewedFilesProgress = document.querySelector('#viewed-files-summary');
   viewedFilesProgress?.setAttribute('value', prReview.numberOfViewedFiles);
   const summaryLabel = document.querySelector('#viewed-files-summary-label')!;
-  if (summaryLabel) summaryLabel.textContent = summaryLabel.getAttribute('data-text-changed-template')!
-    .replace('%[1]d', prReview.numberOfViewedFiles)
-    .replace('%[2]d', prReview.numberOfFiles);
+  if (summaryLabel) {
+    summaryLabel.textContent = summaryLabel.getAttribute('data-text-changed-template')!
+      .replace('%[1]d', prReview.numberOfViewedFiles)
+      .replace('%[2]d', prReview.numberOfFiles);
+  }
 }
 
 // Initializes a listener for all children of the given html element

--- a/web_src/js/features/pull-view-file.ts
+++ b/web_src/js/features/pull-view-file.ts
@@ -15,7 +15,7 @@ function refreshViewedFilesSummary() {
   const viewedFilesProgress = document.querySelector('#viewed-files-summary');
   viewedFilesProgress?.setAttribute('value', prReview.numberOfViewedFiles);
   const summaryLabel = document.querySelector('#viewed-files-summary-label')!;
-  if (summaryLabel) summaryLabel.innerHTML = summaryLabel.getAttribute('data-text-changed-template')!
+  if (summaryLabel) summaryLabel.textContent = summaryLabel.getAttribute('data-text-changed-template')!
     .replace('%[1]d', prReview.numberOfViewedFiles)
     .replace('%[2]d', prReview.numberOfFiles);
 }


### PR DESCRIPTION
1. Use `textContent` instead of `innerHTML` to fix https://github.com/go-gitea/gitea/security/code-scanning/170.
2. Clean up surrounding code to remove unnecessary `if` checks on elements that are guaranteed to exist.