### PR TITLE
Allow `write:issue` token scope for pull request reviews

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -299,6 +299,15 @@ func checkTokenPublicOnly() func(ctx *context.APIContext) {
 // if a token is being used for auth, we check that it contains the required scope
 // if a token is not being used, reqToken will enforce other sign in methods
 func tokenRequiresScopes(requiredScopeCategories ...auth_model.AccessTokenScopeCategory) func(ctx *context.APIContext) {
+	return tokenRequiresScopesImpl(false, requiredScopeCategories...)
+}
+
+// tokenRequiresAnyScopeCategory checks that the token has at least one of the required scope categories
+func tokenRequiresAnyScopeCategory(requiredScopeCategories ...auth_model.AccessTokenScopeCategory) func(ctx *context.APIContext) {
+	return tokenRequiresScopesImpl(true, requiredScopeCategories...)
+}
+
+func tokenRequiresScopesImpl(anyScope bool, requiredScopeCategories ...auth_model.AccessTokenScopeCategory) func(ctx *context.APIContext) {
 	return func(ctx *context.APIContext) {
 		// no scope required
 		if len(requiredScopeCategories) == 0 {
@@ -319,7 +328,13 @@ func tokenRequiresScopes(requiredScopeCategories ...auth_model.AccessTokenScopeC
 
 		// get the required scope for the given access level and category
 		requiredScopes := auth_model.GetRequiredScopes(requiredScopeLevel, requiredScopeCategories...)
-		allow, err := scope.HasScope(requiredScopes...)
+		var allow bool
+		var err error
+		if anyScope {
+			allow, err = scope.HasAnyScope(requiredScopes...)
+		} else {
+			allow, err = scope.HasScope(requiredScopes...)
+		}
 		if err != nil {
 			ctx.APIError(http.StatusForbidden, "checking scope failed: "+err.Error())
 			return
@@ -1335,8 +1350,6 @@ func Routes() *web.Router {
 					m.Combo("").Get(repo.ListPullRequests).
 						Post(reqToken(), mustNotBeArchived, bind(api.CreatePullRequestOption{}), repo.CreatePullRequest)
 					m.Get("/pinned", repo.ListPinnedPullRequests)
-					m.Post("/comments/{id}/resolve", reqToken(), mustNotBeArchived, repo.ResolvePullReviewComment)
-					m.Post("/comments/{id}/unresolve", reqToken(), mustNotBeArchived, repo.UnresolvePullReviewComment)
 					m.Group("/{index}", func() {
 						m.Combo("").Get(repo.GetPullRequest).
 							Patch(reqToken(), bind(api.EditPullRequestOption{}), repo.EditPullRequest)
@@ -1347,24 +1360,6 @@ func Routes() *web.Router {
 						m.Combo("/merge").Get(repo.IsPullRequestMerged).
 							Post(reqToken(), mustNotBeArchived, bind(forms.MergePullRequestForm{}), repo.MergePullRequest).
 							Delete(reqToken(), mustNotBeArchived, repo.CancelScheduledAutoMerge)
-						m.Group("/reviews", func() {
-							m.Combo("").
-								Get(repo.ListPullReviews).
-								Post(reqToken(), bind(api.CreatePullReviewOptions{}), repo.CreatePullReview)
-							m.Group("/{id}", func() {
-								m.Combo("").
-									Get(repo.GetPullReview).
-									Delete(reqToken(), repo.DeletePullReview).
-									Post(reqToken(), bind(api.SubmitPullReviewOptions{}), repo.SubmitPullReview)
-								m.Combo("/comments").
-									Get(repo.GetPullReviewComments)
-								m.Post("/dismissals", reqToken(), bind(api.DismissPullReviewOptions{}), repo.DismissPullReview)
-								m.Post("/undismissals", reqToken(), repo.UnDismissPullReview)
-							})
-						})
-						m.Combo("/requested_reviewers", reqToken()).
-							Delete(bind(api.PullReviewRequestOptions{}), repo.DeleteReviewRequests).
-							Post(bind(api.PullReviewRequestOptions{}), repo.CreateReviewRequests)
 					})
 					m.Get("/{base}/*", repo.GetPullRequestByBaseHead)
 				}, mustAllowPulls, reqRepoReader(unit.TypeCode), context.ReferencesGitRepo())
@@ -1444,6 +1439,36 @@ func Routes() *web.Router {
 		// Artifacts direct download endpoint authenticates via signed url
 		// it is protected by the "sig" parameter (to help to access private repo), so no need to use other middlewares
 		m.Get("/repos/{username}/{reponame}/actions/artifacts/{artifact_id}/zip/raw", repo.DownloadArtifactRaw)
+
+		// Pull request reviews (requires issue or repository scope)
+		m.Group("/repos", func() {
+			m.Group("/{username}/{reponame}", func() {
+				m.Group("/pulls", func() {
+					m.Post("/comments/{id}/resolve", reqToken(), mustNotBeArchived, repo.ResolvePullReviewComment)
+					m.Post("/comments/{id}/unresolve", reqToken(), mustNotBeArchived, repo.UnresolvePullReviewComment)
+					m.Group("/{index}", func() {
+						m.Group("/reviews", func() {
+							m.Combo("").
+								Get(repo.ListPullReviews).
+								Post(reqToken(), bind(api.CreatePullReviewOptions{}), repo.CreatePullReview)
+							m.Group("/{id}", func() {
+								m.Combo("").
+									Get(repo.GetPullReview).
+									Delete(reqToken(), repo.DeletePullReview).
+									Post(reqToken(), bind(api.SubmitPullReviewOptions{}), repo.SubmitPullReview)
+								m.Combo("/comments").
+									Get(repo.GetPullReviewComments)
+								m.Post("/dismissals", reqToken(), bind(api.DismissPullReviewOptions{}), repo.DismissPullReview)
+								m.Post("/undismissals", reqToken(), repo.UnDismissPullReview)
+							})
+						})
+						m.Combo("/requested_reviewers", reqToken()).
+							Delete(bind(api.PullReviewRequestOptions{}), repo.DeleteReviewRequests).
+							Post(bind(api.PullReviewRequestOptions{}), repo.CreateReviewRequests)
+					})
+				}, mustAllowPulls, reqRepoReader(unit.TypeCode), context.ReferencesGitRepo())
+			}, repoAssignment(), checkTokenPublicOnly())
+		}, tokenRequiresAnyScopeCategory(auth_model.AccessTokenScopeCategoryRepository, auth_model.AccessTokenScopeCategoryIssue))
 
 		// Notifications (requires notifications scope)
 		m.Group("/repos", func() {

--- a/tests/integration/api_pull_review_test.go
+++ b/tests/integration/api_pull_review_test.go
@@ -236,6 +236,36 @@ func TestAPIPullReview(t *testing.T) {
 	assert.EqualValues(t, 1, reviews[1].Reviewer.ID)
 }
 
+func TestAPIPullReviewIssueScope(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+	pullIssue := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{ID: 3})
+	assert.NoError(t, pullIssue.LoadAttributes(t.Context()))
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: pullIssue.RepoID})
+
+	session := loginUser(t, "user2")
+	token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteIssue)
+
+	// test ListPullReviews with issue scope
+	req := NewRequestf(t, http.MethodGet, "/api/v1/repos/%s/%s/pulls/%d/reviews", repo.OwnerName, repo.Name, pullIssue.Index).
+		AddTokenAuth(token)
+	MakeRequest(t, req, http.StatusOK)
+
+	// test CreatePullReview with issue scope
+	req = NewRequestWithJSON(t, http.MethodPost, fmt.Sprintf("/api/v1/repos/%s/%s/pulls/%d/reviews", repo.OwnerName, repo.Name, pullIssue.Index), &api.CreatePullReviewOptions{
+		Body:  "comment via issue scope",
+		Event: "COMMENT",
+	}).AddTokenAuth(token)
+	resp := MakeRequest(t, req, http.StatusOK)
+	var review api.PullReview
+	DecodeJSON(t, resp, &review)
+	assert.EqualValues(t, "COMMENT", review.State)
+
+	// test DeletePullReview with issue scope
+	req = NewRequestf(t, http.MethodDelete, "/api/v1/repos/%s/%s/pulls/%d/reviews/%d", repo.OwnerName, repo.Name, pullIssue.Index, review.ID).
+		AddTokenAuth(token)
+	MakeRequest(t, req, http.StatusNoContent)
+}
+
 func TestAPIPullReviewRequest(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
 	pullIssue := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{ID: 3})


### PR DESCRIPTION
Move pull request review routes into a separate route group that accepts either `write:repository` or `write:issue` token scope.

Ideally `write:issue` (or even a new `write:pull-request` like GitHub) would be the only scope for review comments, but for backward compat I kept `write:repository` working.

Fixes https://github.com/go-gitea/gitea/issues/36873