### PR TITLE
Use `make backend` in VS Code tasks.json

### DIFF
--- a/contrib/ide/vscode/tasks.json
+++ b/contrib/ide/vscode/tasks.json
@@ -19,7 +19,12 @@
       "label": "Build (with SQLite3)",
       "type": "shell",
       "command": "make",
-      "args": ["backend", "TAGS=\"sqlite sqlite_unlock_notify\""],
+      "args": ["backend"],
+      "options": {
+        "env": {
+          "TAGS": "sqlite sqlite_unlock_notify"
+        }
+      },
       "group": "build",
       "presentation": {
         "echo": true,

--- a/contrib/ide/vscode/tasks.json
+++ b/contrib/ide/vscode/tasks.json
@@ -4,44 +4,28 @@
     {
       "label": "Build",
       "type": "shell",
-      "command": "go",
+      "command": "make",
+      "args": ["backend"],
       "group": "build",
       "presentation": {
         "echo": true,
         "reveal": "always",
         "focus": false,
         "panel": "shared"
-      },
-      "linux": {
-        "args": ["build", "-o", "gitea", "${workspaceRoot}/main.go" ]
-      },
-      "osx": {
-        "args": ["build", "-o", "gitea", "${workspaceRoot}/main.go" ]
-      },
-      "windows": {
-        "args": ["build", "-o", "gitea.exe", "\"${workspaceRoot}\\main.go\""]
       },
       "problemMatcher": ["$go"]
     },
     {
       "label": "Build (with SQLite3)",
       "type": "shell",
-      "command": "go",
+      "command": "make",
+      "args": ["backend", "TAGS=\"sqlite sqlite_unlock_notify\""],
       "group": "build",
       "presentation": {
         "echo": true,
         "reveal": "always",
         "focus": false,
         "panel": "shared"
-      },
-      "linux": {
-        "args": ["build", "-tags=\"sqlite sqlite_unlock_notify\"", "-o", "gitea", "${workspaceRoot}/main.go"]
-      },
-      "osx": {
-        "args": ["build", "-tags=\"sqlite sqlite_unlock_notify\"", "-o", "gitea", "${workspaceRoot}/main.go"]
-      },
-      "windows": {
-        "args": ["build", "-tags=\"sqlite sqlite_unlock_notify\"", "-o", "gitea.exe", "\"${workspaceRoot}\\main.go\""]
       },
       "problemMatcher": ["$go"]
     }


### PR DESCRIPTION
The previous bare `go build` did not pass `-ldflags`, so `main.Version` was never set and defaulted to `"development"`. This caused `AssetVersion` to always be `"development"`, meaning browser cache was never busted between frontend rebuilds during development.

AssetVersion before: `1.26.0+dev`
AssetVersion after: `1.26.0+dev-548-g6e8f78ae27`