### PR TITLE
Update toolchain to 1.25.8 for v1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module code.gitea.io/gitea
 
 go 1.25.0
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 // rfc5280 said: "The serial number is an integer assigned by the CA to each certificate."
 // But some CAs use negative serial number, just relax the check. related:


### PR DESCRIPTION
> go1.25.8 (released 2026-03-05) includes security fixes to the html/template, net/url, and os packages, as well as bug fixes to the go command, the compiler, and the os package. See the [Go 1.25.8 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.25.8+label%3ACherryPickApproved) on our issue tracker for details.