### PR TITLE
Fix typos in code comments: doesnt, dont, wont

### DIFF
--- a/models/activities/notification_list.go
+++ b/models/activities/notification_list.go
@@ -113,7 +113,7 @@ func createOrUpdateIssueNotifications(ctx context.Context, issueID, commentID, n
 		}
 		toNotify.AddMultiple(issueParticipants...)
 
-		// dont notify user who cause notification
+		// don't notify user who cause notification
 		delete(toNotify, notificationAuthorID)
 		// explicit unwatch on issue
 		issueUnWatches, err := issues_model.GetIssueWatchersIDs(ctx, issueID, false)

--- a/models/issues/label_test.go
+++ b/models/issues/label_test.go
@@ -254,7 +254,7 @@ func TestGetLabelsByIssueID(t *testing.T) {
 func TestUpdateLabel(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
 	label := unittest.AssertExistsAndLoadBean(t, &issues_model.Label{ID: 1})
-	// make sure update wont overwrite it
+	// make sure update won't overwrite it
 	update := &issues_model.Label{
 		ID:           label.ID,
 		Color:        "#ffff00",

--- a/modules/indexer/code/bleve/token/path/path.go
+++ b/modules/indexer/code/bleve/token/path/path.go
@@ -27,7 +27,7 @@ func TokenFilterConstructor(config map[string]any, cache *registry.Cache) (analy
 
 func (s *TokenFilter) Filter(input analysis.TokenStream) analysis.TokenStream {
 	if len(input) == 1 {
-		// if there is only one token, we dont need to generate the reversed chain
+		// if there is only one token, we don't need to generate the reversed chain
 		return generatePathTokens(input, false)
 	}
 

--- a/routers/api/v1/repo/git_ref.go
+++ b/routers/api/v1/repo/git_ref.go
@@ -34,7 +34,7 @@ func GetGitAllRefs(ctx *context.APIContext) {
 	//   required: true
 	// responses:
 	//   "200":
-	// #   "$ref": "#/responses/Reference" TODO: swagger doesnt support different output formats by ref
+	// #   "$ref": "#/responses/Reference" TODO: swagger doesn't support different output formats by ref
 	//     "$ref": "#/responses/ReferenceList"
 	//   "404":
 	//     "$ref": "#/responses/notFound"
@@ -67,7 +67,7 @@ func GetGitRefs(ctx *context.APIContext) {
 	//   required: true
 	// responses:
 	//   "200":
-	// #   "$ref": "#/responses/Reference" TODO: swagger doesnt support different output formats by ref
+	// #   "$ref": "#/responses/Reference" TODO: swagger doesn't support different output formats by ref
 	//     "$ref": "#/responses/ReferenceList"
 	//   "404":
 	//     "$ref": "#/responses/notFound"

--- a/routers/api/v1/repo/issue_subscription.go
+++ b/routers/api/v1/repo/issue_subscription.go
@@ -138,7 +138,7 @@ func setIssueSubscription(ctx *context.APIContext, watch bool) {
 		return
 	}
 
-	// If watch state wont change
+	// If watch state won't change
 	if current == watch {
 		ctx.Status(http.StatusOK)
 		return

--- a/routers/api/v1/repo/release.go
+++ b/routers/api/v1/repo/release.go
@@ -150,7 +150,7 @@ func ListReleases(ctx *context.APIContext) {
 	//   required: true
 	// - name: draft
 	//   in: query
-	//   description: filter (exclude / include) drafts, if you dont have repo write access none will show
+	//   description: filter (exclude / include) drafts, if you don't have repo write access none will show
 	//   type: boolean
 	// - name: pre-release
 	//   in: query

--- a/services/migrations/gitea_downloader.go
+++ b/services/migrations/gitea_downloader.go
@@ -186,7 +186,7 @@ func (g *GiteaDownloader) GetMilestones(ctx context.Context) ([]*base.Milestone,
 		}
 
 		for i := range ms {
-			// old gitea instances dont have this information
+			// old gitea instances don't have this information
 			createdAT := time.Time{}
 			var updatedAT *time.Time
 			if ms[i].Closed != nil {

--- a/services/repository/contributors_graph.go
+++ b/services/repository/contributors_graph.go
@@ -84,7 +84,7 @@ func GetContributorStats(ctx context.Context, cache cache.StringCache, repo *rep
 	if !cache.IsExist(cacheKey) {
 		genReady := make(chan struct{})
 
-		// dont start multiple async generations
+		// don't start multiple async generations
 		_, run := generateLock.Load(cacheKey)
 		if run {
 			return nil, ErrAwaitGeneration

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -15282,7 +15282,7 @@
           },
           {
             "type": "boolean",
-            "description": "filter (exclude / include) drafts, if you dont have repo write access none will show",
+            "description": "filter (exclude / include) drafts, if you don't have repo write access none will show",
             "name": "draft",
             "in": "query"
           },


### PR DESCRIPTION
Fix missing apostrophes in contractions across multiple source files.

Changes:
- `doesnt` -> `doesn't` in `routers/api/v1/repo/git_ref.go` (2 occurrences)
- `dont` -> `don't` in `models/activities/notification_list.go`, `modules/indexer/code/bleve/token/path/path.go`, `routers/api/v1/repo/release.go`, `services/migrations/gitea_downloader.go`, `services/repository/contributors_graph.go`
- `wont` -> `won't` in `routers/api/v1/repo/issue_subscription.go`, `models/issues/label_test.go`

Ref: #35015 (good first issues - improve English)