### PR TITLE
Enable native dark mode for swagger-ui

### DIFF
--- a/web_src/css/standalone/swagger.css
+++ b/web_src/css/standalone/swagger.css
@@ -10,13 +10,22 @@ body {
 }
 
 .swagger-back-link {
-  color: #1f69c0;
+  color: #4990e2;
   text-decoration: none;
   position: absolute;
   top: 1rem;
   right: 1.5rem;
   display: flex;
   align-items: center;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #1c2022;
+  }
+  .swagger-back-link {
+    color: #51a8ff;
+  }
 }
 
 .swagger-back-link:hover {
@@ -31,16 +40,4 @@ body {
 
 .swagger-spec-content {
   display: none;
-}
-
-@media (prefers-color-scheme: dark) {
-  body {
-    background: #14171a;
-  }
-  .swagger-ui, .swagger-back-link {
-    filter: invert(88%) hue-rotate(180deg);
-  }
-  .swagger-ui .microlight {
-    filter: invert(100%) hue-rotate(180deg);
-  }
 }

--- a/web_src/css/standalone/swagger.css
+++ b/web_src/css/standalone/swagger.css
@@ -26,6 +26,9 @@ body {
   .swagger-back-link {
     color: #51a8ff;
   }
+  .swagger-ui table.headers td {
+    color: #aeb4c4; /** fix low contrast */
+  }
 }
 
 .swagger-back-link:hover {

--- a/web_src/js/standalone/swagger.ts
+++ b/web_src/js/standalone/swagger.ts
@@ -3,6 +3,11 @@ import 'swagger-ui-dist/swagger-ui.css';
 import {load as loadYaml} from 'js-yaml';
 import {GET} from '../modules/fetch.ts';
 
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+const apply = () => document.documentElement.classList.toggle('dark-mode', prefersDark.matches);
+apply();
+prefersDark.addEventListener('change', apply);
+
 window.addEventListener('load', async () => {
   const elSwaggerUi = document.querySelector('#swagger-ui')!;
   const url = elSwaggerUi.getAttribute('data-source')!;


### PR DESCRIPTION
Enable swagger-ui's dark mode support added in https://github.com/swagger-api/swagger-ui/pull/10653. Background colors match gitea, link colors match swagger-ui.

<img width="1337" height="768" alt="image" src="https://github.com/user-attachments/assets/2e36b2b4-5931-4dfd-b576-987d3a0a8747" />

One fix done for these tables which had too low contrast:

<img width="1277" height="393" alt="image" src="https://github.com/user-attachments/assets/08c1fa59-58e9-47d6-8d73-a58e41b71e21" />
