### PR TITLE
Fix OAuth2 authorization loop when grant scope changes

### DIFF
--- a/models/auth/oauth2.go
+++ b/models/auth/oauth2.go
@@ -537,6 +537,16 @@ func (grant *OAuth2Grant) SetNonce(ctx context.Context, nonce string) error {
 	return nil
 }
 
+// SetScope updates the scope of a grant
+func (grant *OAuth2Grant) SetScope(ctx context.Context, scope string) error {
+	grant.Scope = scope
+	_, err := db.GetEngine(ctx).ID(grant.ID).Cols("scope").Update(grant)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // GetOAuth2GrantByID returns the grant with the given ID
 func GetOAuth2GrantByID(ctx context.Context, id int64) (grant *OAuth2Grant, err error) {
 	grant = new(OAuth2Grant)

--- a/routers/web/auth/oauth2_provider.go
+++ b/routers/web/auth/oauth2_provider.go
@@ -286,6 +286,14 @@ func AuthorizeOAuth(ctx *context.Context) {
 	// Redirect if user already granted access and the application is confidential or trusted otherwise
 	// I.e. always require authorization for untrusted public clients as recommended by RFC 6749 Section 10.2
 	if (app.ConfidentialClient || app.SkipSecondaryAuthorization) && grant != nil {
+		// Update the grant scope if the requested scope has changed, so that
+		// confidential/trusted clients always get a token with the current scope.
+		if grant.Scope != form.Scope {
+			if err := grant.SetScope(ctx, form.Scope); err != nil {
+				handleServerError(ctx, form.State, form.RedirectURI)
+				return
+			}
+		}
 		code, err := grant.GenerateNewAuthorizationCode(ctx, form.RedirectURI, form.CodeChallenge, form.CodeChallengeMethod)
 		if err != nil {
 			handleServerError(ctx, form.State, form.RedirectURI)
@@ -388,12 +396,14 @@ func GrantApplicationOAuth(ctx *context.Context) {
 			return
 		}
 	} else if grant.Scope != form.Scope {
-		handleAuthorizeError(ctx, AuthorizeError{
-			State:            form.State,
-			ErrorDescription: "a grant exists with different scope",
-			ErrorCode:        ErrorCodeServerError,
-		}, form.RedirectURI)
-		return
+		// The user has re-authorized with a different scope. Update the
+		// existing grant to match the newly consented scope. This avoids
+		// an infinite redirect loop when the OAuth2 client changes its
+		// requested scope after the initial authorization.
+		if err := grant.SetScope(ctx, form.Scope); err != nil {
+			handleServerError(ctx, form.State, form.RedirectURI)
+			return
+		}
 	}
 
 	if len(form.Nonce) > 0 {


### PR DESCRIPTION
## Summary

- Fix infinite redirect loop when an OAuth2 client requests a different scope than a user's existing grant
- Add `OAuth2Grant.SetScope()` method to update the scope of an existing grant in the database
- Update `GrantApplicationOAuth()` to update the grant scope instead of returning a `server_error` when scopes differ
- Update `AuthorizeOAuth()` to sync grant scope for confidential/trusted clients on auto-redirect

Fixes #36762

## Details

When an OAuth2 client changes its requested scope (e.g., from `repository` to `read:repository,write:repository,read:user`), and a user has a pre-existing grant with the old scope, the `GrantApplicationOAuth` handler previously returned a `server_error` to the `redirect_uri`. Since the OAuth2 client typically retries the authorization flow upon receiving an error, this created an infinite redirect loop with no way for the user to recover through the UI.

This PR updates the grant's scope in the database when the user re-authorizes with a different scope. Since the user has already explicitly consented to the new permissions by clicking "Authorize" on the authorization page, this is safe and expected behavior.

The fix also addresses the related issue for confidential clients and applications with `skip_secondary_authorization` enabled, where `AuthorizeOAuth()` auto-redirects using the old grant's scope without updating it.

## Test plan

- [ ] Verify that re-authorizing an OAuth2 application with a different scope succeeds without redirect loops
- [ ] Verify that the `oauth2_grant` table is updated with the new scope
- [ ] Verify that confidential clients receive tokens with the updated scope when the requested scope changes
- [ ] Verify that initial authorization (no existing grant) still works correctly
- [ ] Verify that re-authorization with the same scope still works correctly