### PR TITLE
Support dark/light theme images in markdown

### DIFF
--- a/web_src/css/markup/content.css
+++ b/web_src/css/markup/content.css
@@ -316,6 +316,26 @@ In markup content, we always use bottom margin for all elements */
   box-sizing: initial;
 }
 
+/* GitHub-style dark/light image switching.
+   These fragments are kept in the rendered HTML as part of the `src` attribute.
+   We decide which set to show via `data-gitea-theme` on `<html>`, which is
+   mirrored from `--is-dark-theme` in JS (so it also works with custom themes).
+*/
+.markup img[src*="#gh-dark-mode-only"],
+.markup img[src*="#gh-light-mode-only"] {
+  display: none;
+}
+
+html[data-gitea-theme="dark"] .markup img[src*="#gh-dark-mode-only"] {
+  display: inline;
+}
+
+html[data-gitea-theme="light"] .markup img[src*="#gh-light-mode-only"] {
+  display: inline;
+}
+
+/* `data-gitea-theme` is managed by JS using `isDarkTheme()` (respects explicit theme + auto). */
+
 .file-view.markup {
   padding: 1em 2em;
   font-size: 16px;

--- a/web_src/css/markup/content.css
+++ b/web_src/css/markup/content.css
@@ -318,23 +318,13 @@ In markup content, we always use bottom margin for all elements */
 
 /* GitHub-style dark/light image switching.
    These fragments are kept in the rendered HTML as part of the `src` attribute.
-   We decide which set to show via `data-gitea-theme` on `<html>`, which is
-   mirrored from `--is-dark-theme` in JS (so it also works with custom themes).
+   We decide which to show via `data-gitea-theme-dark` on `<html>`, which is
+   mirrored from `--is-dark-theme` in JS (so it also works with auto/custom themes).
 */
-.markup img[src*="#gh-dark-mode-only"],
-.markup img[src*="#gh-light-mode-only"] {
+html[data-gitea-theme-dark="true"] .markup img[src*="#gh-light-mode-only"],
+html[data-gitea-theme-dark="false"] .markup img[src*="#gh-dark-mode-only"] {
   display: none;
 }
-
-html[data-gitea-theme="dark"] .markup img[src*="#gh-dark-mode-only"] {
-  display: inline;
-}
-
-html[data-gitea-theme="light"] .markup img[src*="#gh-light-mode-only"] {
-  display: inline;
-}
-
-/* `data-gitea-theme` is managed by JS using `isDarkTheme()` (respects explicit theme + auto). */
 
 .file-view.markup {
   padding: 1em 2em;

--- a/web_src/js/features/common-page.ts
+++ b/web_src/js/features/common-page.ts
@@ -3,7 +3,6 @@ import {showGlobalErrorMessage} from '../bootstrap.ts';
 import {fomanticQuery} from '../modules/fomantic/base.ts';
 import {addDelegatedEventListener, queryElems} from '../utils/dom.ts';
 import {registerGlobalInitFunc, registerGlobalSelectorFunc} from '../modules/observer.ts';
-import {isDarkTheme} from '../utils.ts';
 import {initAvatarUploaderWithCropper} from './comp/Cropper.ts';
 import {initCompSearchRepoBox} from './comp/SearchRepoBox.ts';
 
@@ -46,27 +45,10 @@ function initFooterThemeSelector() {
   });
 }
 
-function initMarkdownDarkLightImages() {
-  // Mirror Gitea's current "darkness" into a dataset so markup/CSS can
-  // switch `#gh-dark-mode-only` / `#gh-light-mode-only` images correctly
-  // for both explicit themes and "auto" themes.
-  const root = document.documentElement;
-  const sync = () => {
-    root.setAttribute('data-gitea-theme', isDarkTheme() ? 'dark' : 'light');
-  };
-  sync();
-
-  // Track system theme changes in case Gitea is set to "auto".
-  const mql = window.matchMedia('(prefers-color-scheme: dark)');
-  const onChange = () => sync();
-  mql.addEventListener('change', onChange);
-}
-
 export function initCommmPageComponents() {
   initHeadNavbarContentToggle();
   initFooterLanguageMenu();
   initFooterThemeSelector();
-  initMarkdownDarkLightImages();
 }
 
 export function initGlobalDropdown() {

--- a/web_src/js/features/common-page.ts
+++ b/web_src/js/features/common-page.ts
@@ -3,6 +3,7 @@ import {showGlobalErrorMessage} from '../bootstrap.ts';
 import {fomanticQuery} from '../modules/fomantic/base.ts';
 import {addDelegatedEventListener, queryElems} from '../utils/dom.ts';
 import {registerGlobalInitFunc, registerGlobalSelectorFunc} from '../modules/observer.ts';
+import {isDarkTheme} from '../utils.ts';
 import {initAvatarUploaderWithCropper} from './comp/Cropper.ts';
 import {initCompSearchRepoBox} from './comp/SearchRepoBox.ts';
 
@@ -45,10 +46,27 @@ function initFooterThemeSelector() {
   });
 }
 
+function initMarkdownDarkLightImages() {
+  // Mirror Gitea's current "darkness" into a dataset so markup/CSS can
+  // switch `#gh-dark-mode-only` / `#gh-light-mode-only` images correctly
+  // for both explicit themes and "auto" themes.
+  const root = document.documentElement;
+  const sync = () => {
+    root.setAttribute('data-gitea-theme', isDarkTheme() ? 'dark' : 'light');
+  };
+  sync();
+
+  // Track system theme changes in case Gitea is set to "auto".
+  const mql = window.matchMedia('(prefers-color-scheme: dark)');
+  const onChange = () => sync();
+  mql.addEventListener('change', onChange);
+}
+
 export function initCommmPageComponents() {
   initHeadNavbarContentToggle();
   initFooterLanguageMenu();
   initFooterThemeSelector();
+  initMarkdownDarkLightImages();
 }
 
 export function initGlobalDropdown() {

--- a/web_src/js/webcomponents/index.ts
+++ b/web_src/js/webcomponents/index.ts
@@ -2,3 +2,14 @@ import './polyfills.ts';
 import './relative-time.ts';
 import './origin-url.ts';
 import './overflow-menu.ts';
+import {isDarkTheme} from '../utils.ts';
+
+function initPageThemeDarkLight() {
+  // Set page's theme color preference as early as possible, to avoid flicker of wrong theme color during page load.
+  const sync = () => document.documentElement.setAttribute('data-gitea-theme-dark', String(isDarkTheme()));
+  sync();
+  // Track system theme changes in case Gitea is using "auto" theme.
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', sync);
+}
+
+initPageThemeDarkLight();


### PR DESCRIPTION
This PR matches GitHub's behavior more closely on how to render Markdown images in light/dark mode.
Images with source suffix `#gh-dark-mode-only` / `#gh-light-mode-only` will only show when the correct theme is requested.
Closes: #35545 