### PR TITLE
fix(upgrade.sh): use HTTPS for GPG key import and restore SELinux context after upgrade

### DIFF
--- a/contrib/upgrade.sh
+++ b/contrib/upgrade.sh
@@ -108,7 +108,9 @@ curl --connect-timeout 10 --silent --show-error --fail --location -O "$binurl{,.
 sha256sum -c "${binname}.xz.sha256"
 if [[ -z "${ignore_gpg:-}" ]]; then
   require gpg
-  gpg --keyserver keys.openpgp.org --recv 7C9E68152594688862D62AF62D9AE806EC1592E2
+  curl -fsSL --connect-timeout 10 "https://keys.openpgp.org/vks/v1/by-fingerprint/7C9E68152594688862D62AF62D9AE806EC1592E2" | gpg --import \
+    || gpg --keyserver keyserver.ubuntu.com --recv 7C9E68152594688862D62AF62D9AE806EC1592E2 \
+    || gpg --keyserver keys.openpgp.org --recv 7C9E68152594688862D62AF62D9AE806EC1592E2
   gpg --verify "${binname}.xz.asc" "${binname}.xz" || { echo 'Signature does not match'; exit 1; }
 fi
 rm "${binname}".xz.{sha256,asc}
@@ -127,6 +129,8 @@ echo "Creating backup in $giteahome"
 giteacmd dump $backupopts
 echo "Updating binary at $giteabin"
 cp -f "$giteabin" "$giteabin.bak" && mv -f "$binname" "$giteabin"
+# Restore SELinux context if applicable (e.g. RHEL/Fedora)
+command -v restorecon &>/dev/null && restorecon -v "$giteabin" || true
 $service_start
 $service_status
 

--- a/contrib/upgrade.sh
+++ b/contrib/upgrade.sh
@@ -110,7 +110,6 @@ if [[ -z "${ignore_gpg:-}" ]]; then
   require gpg
   # try to use curl first, it uses standard tcp 443 port and works better behind strict firewall rules
   curl -fsSL --connect-timeout 10 "https://keys.openpgp.org/vks/v1/by-fingerprint/7C9E68152594688862D62AF62D9AE806EC1592E2" | gpg --import \
-    || gpg --keyserver keyserver.ubuntu.com --recv 7C9E68152594688862D62AF62D9AE806EC1592E2 \
     || gpg --keyserver keys.openpgp.org --recv 7C9E68152594688862D62AF62D9AE806EC1592E2
   gpg --verify "${binname}.xz.asc" "${binname}.xz" || { echo 'Signature does not match'; exit 1; }
 fi

--- a/contrib/upgrade.sh
+++ b/contrib/upgrade.sh
@@ -108,6 +108,7 @@ curl --connect-timeout 10 --silent --show-error --fail --location -O "$binurl{,.
 sha256sum -c "${binname}.xz.sha256"
 if [[ -z "${ignore_gpg:-}" ]]; then
   require gpg
+  # try to use curl first, it uses standard tcp 443 port and works better behind strict firewall rules
   curl -fsSL --connect-timeout 10 "https://keys.openpgp.org/vks/v1/by-fingerprint/7C9E68152594688862D62AF62D9AE806EC1592E2" | gpg --import \
     || gpg --keyserver keyserver.ubuntu.com --recv 7C9E68152594688862D62AF62D9AE806EC1592E2 \
     || gpg --keyserver keys.openpgp.org --recv 7C9E68152594688862D62AF62D9AE806EC1592E2


### PR DESCRIPTION
## Summary

Two bug fixes for `contrib/upgrade.sh` found during a real-world upgrade from 1.24.3 to 1.25.5 on Fedora.

---

### Fix 1: GPG key import fails when HKP port 11371 is blocked (closes #36928)

**Before:**
```bash
gpg --keyserver keys.openpgp.org --recv 7C9E68152594688862D62AF62D9AE806EC1592E2
```
This uses HKP port **11371**, which is blocked by many firewalls. The upgrade aborts with:
```
gpg: keyserver receive failed: Connection timed out
```

**After:**
```bash
curl -fsSL --connect-timeout 10 \
  "https://keys.openpgp.org/vks/v1/by-fingerprint/7C9E68152594688862D62AF62D9AE806EC1592E2" \
  | gpg --import \
  || gpg --keyserver keyserver.ubuntu.com --recv 7C9E68152594688862D62AF62D9AE806EC1592E2 \
  || gpg --keyserver keys.openpgp.org --recv 7C9E68152594688862D62AF62D9AE806EC1592E2
```
Same `keys.openpgp.org` server, same key — but fetched over **HTTPS port 443** which is universally accessible. Keyservers remain as fallbacks.

---

### Fix 2: Gitea fails to start after upgrade on SELinux systems (closes #36929)

**Problem:** After `mv`-ing the binary from `$giteahome` to `/usr/local/bin/gitea`, the file retains the SELinux context of the source directory. Systemd refuses to execute it, exiting with `status=203/EXEC`.

**Fix:** Add a `restorecon` call guarded by `command -v` so it is a no-op on non-SELinux systems:
```bash
command -v restorecon &>/dev/null && restorecon -v "$giteabin" || true
```
Verified: `restorecon -v /usr/local/bin/gitea` immediately restored service on the affected machine.