### PR TITLE
Improve AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,8 @@
-# Instructions for agents
-
 - Use `make help` to find available development targets
-- Before committing `.go` changes, run `make fmt` to format, and run `make lint-go` to lint
-- Before committing `.ts` changes, run `make lint-js` to lint
-- Before committing `go.mod` changes, run `make tidy`
-- Before committing new `.go` files, add the current year into the copyright header
-- Before committing any files, remove all trailing whitespace from source code lines
+- Run `make fmt` to format `.go` files, and run `make lint-go` to lint them
+- Run `make lint-js` to lint `.ts` files
+- Run `make tidy` after any `go.mod` changes
+- Add the current year into the copyright header of new `.go` files
+- Ensure no trailing whitespace in edited files
 - Never force-push to pull request branches
 - Always start issue and pull request comments with an authorship attribution


### PR DESCRIPTION
1. Remove header line, useless context bloat
2. Reword all "before commiting" lines because some people may not be using the agent to commit, only to write changes.