### PR TITLE
fix: show source URL on migration status page for API-created migrations

### DIFF
--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -181,7 +181,7 @@ func checkHomeCodeViewable(ctx *context.Context) {
 			if err != nil {
 				if admin_model.IsErrTaskDoesNotExist(err) {
 					ctx.Data["Repo"] = ctx.Repo
-					ctx.Data["CloneAddr"] = ""
+					ctx.Data["CloneAddr"] = ctx.Repo.Repository.SanitizedOriginalURL()
 					ctx.Data["Failed"] = true
 					ctx.HTML(http.StatusOK, tplMigrating)
 					return


### PR DESCRIPTION
Fix #36952

When a repository migration is created via the API (not the web UI),
no migration task is created because the API runs the migration
synchronously. The migration status page was showing an empty source
URL in this case because it only looked at the task's config.

This change uses the repository's `OriginalURL` (which is always set
during repo creation for both API and web migrations) as the displayed
clone address when no migration task exists.