### PR TITLE
fix(navbar): center header notification icon

### DIFF
--- a/templates/base/head_navbar_icons.tmpl
+++ b/templates/base/head_navbar_icons.tmpl
@@ -12,7 +12,7 @@
 	</a>
 	{{end}}
 	<a class="item {{$itemExtraClass}}" href="{{AppSubUrl}}/notifications" data-tooltip-content="{{ctx.Locale.Tr "notifications"}}">
-		<div class="tw-relative">
+		<div class="tw-relative tw-flex">
 			{{svg "octicon-bell"}}
 			<span class="notification_count{{if not $notificationUnreadCount}} tw-hidden{{end}}">{{$notificationUnreadCount}}</span>
 		</div>


### PR DESCRIPTION
### before

<img width="406" height="84" alt="image" src="https://github.com/user-attachments/assets/7fb70f37-3e1e-4619-893a-474465e0a6d2" />

### after
<img width="399" height="84" alt="image" src="https://github.com/user-attachments/assets/859dd19f-4eb2-4b7d-a89c-04112f1cb6aa" />
