### PR TITLE
Fix action run view style regressions from #36883

### DIFF
--- a/web_src/js/components/ActionRunSummaryView.vue
+++ b/web_src/js/components/ActionRunSummaryView.vue
@@ -32,7 +32,7 @@ onBeforeUnmount(() => {
   <div>
     <div class="action-run-summary-block">
       <p class="action-run-summary-trigger">
-        {{ locale.triggeredVia.replace('%s', run.triggerEvent) }}&nbsp;•&nbsp;<relative-time :datetime="runTriggeredAtIso"/>
+        {{ locale.triggeredVia.replace('%s', run.triggerEvent) }}&nbsp;•&nbsp;<relative-time :datetime="runTriggeredAtIso" prefix=""/>
       </p>
       <p class="tw-mb-0">
         <ActionRunStatus :locale-status="locale.status[run.status]" :status="run.status" :size="16"/>

--- a/web_src/js/components/ActionRunSummaryView.vue
+++ b/web_src/js/components/ActionRunSummaryView.vue
@@ -32,13 +32,11 @@ onBeforeUnmount(() => {
   <div>
     <div class="action-run-summary-block">
       <p class="action-run-summary-trigger">
-        {{ locale.triggeredVia.replace('%s', run.triggerEvent) }}
-        &nbsp;•&nbsp;<relative-time :datetime="runTriggeredAtIso" prefix=" "/>
+        {{ locale.triggeredVia.replace('%s', run.triggerEvent) }}&nbsp;•&nbsp;<relative-time :datetime="runTriggeredAtIso"/>
       </p>
       <p class="tw-mb-0">
         <ActionRunStatus :locale-status="locale.status[run.status]" :status="run.status" :size="16"/>
-        <span class="tw-ml-2">{{ locale.status[run.status] }}</span>
-        <span class="tw-ml-3">{{ locale.totalDuration }} {{ run.duration || '–' }}</span>
+        <span class="tw-ml-2">{{ locale.status[run.status] }}</span>&nbsp;•&nbsp;<span>{{ locale.totalDuration }} {{ run.duration || '–' }}</span>
       </p>
     </div>
     <WorkflowGraph
@@ -52,12 +50,25 @@ onBeforeUnmount(() => {
 </template>
 <style scoped>
 .action-run-summary-block {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   padding: 12px;
   border-bottom: 1px solid var(--color-secondary);
 }
 
 .action-run-summary-trigger {
-  margin-bottom: 6px;
+  margin-bottom: 0;
   color: var(--color-text-light-2);
+}
+
+@media (max-width: 767.98px) {
+  .action-run-summary-block {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .action-run-summary-trigger {
+    margin-bottom: 6px;
+  }
 }
 </style>

--- a/web_src/js/components/ActionRunSummaryView.vue
+++ b/web_src/js/components/ActionRunSummaryView.vue
@@ -53,6 +53,7 @@ onBeforeUnmount(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 6px;
   padding: 12px;
   border-bottom: 1px solid var(--color-secondary);
 }
@@ -66,9 +67,6 @@ onBeforeUnmount(() => {
   .action-run-summary-block {
     flex-direction: column;
     align-items: flex-start;
-  }
-  .action-run-summary-trigger {
-    margin-bottom: 6px;
   }
 }
 </style>

--- a/web_src/js/components/RepoActionView.vue
+++ b/web_src/js/components/RepoActionView.vue
@@ -235,8 +235,8 @@ async function deleteArtifact(name: string) {
 }
 
 .left-list-header {
-  font-size: 12px;
-  color: var(--color-grey);
+  font-size: 13px;
+  color: var(--color-text-light-2);
 }
 
 .job-artifacts-item {

--- a/web_src/js/components/WorkflowGraph.vue
+++ b/web_src/js/components/WorkflowGraph.vue
@@ -600,9 +600,9 @@ function onNodeClick(job: JobNode, event: MouseEvent) {
       <h4 class="graph-title">Workflow Dependencies</h4>
       <div class="graph-stats">
         {{ jobs.length }} jobs • {{ edges.length }} dependencies
-        <span v-if="graphMetrics" class="graph-metrics">
-          • {{ graphMetrics.successRate }} success
-        </span>
+        <template v-if="graphMetrics">
+          • <span class="graph-metrics">{{ graphMetrics.successRate }} success</span>
+        </template>
       </div>
       <div class="flex-text-block">
         <button @click="zoomIn" class="ui compact tiny icon button" title="Zoom in">
@@ -753,6 +753,7 @@ function onNodeClick(job: JobNode, event: MouseEvent) {
   align-items: center;
   padding: 8px 14px;
   background: var(--color-box-header);
+  border-bottom: 1px solid var(--color-secondary);
   gap: 20px;
   flex-wrap: wrap;
 }

--- a/web_src/js/components/WorkflowGraph.vue
+++ b/web_src/js/components/WorkflowGraph.vue
@@ -600,9 +600,9 @@ function onNodeClick(job: JobNode, event: MouseEvent) {
       <h4 class="graph-title">Workflow Dependencies</h4>
       <div class="graph-stats">
         {{ jobs.length }} jobs • {{ edges.length }} dependencies
-        <template v-if="graphMetrics">
+        <span v-if="graphMetrics">
           • <span class="graph-metrics">{{ graphMetrics.successRate }} success</span>
-        </template>
+        </span>
       </div>
       <div class="flex-text-block">
         <button @click="zoomIn" class="ui compact tiny icon button" title="Zoom in">


### PR DESCRIPTION
Fix style regressions introduced in #36883:

- Fix `.left-list-header` ("All jobs") unreadable on dark theme by using `--color-text-light-2` instead of `--color-grey` (`#384149` in dark theme has no contrast)
- Fix `.graph-metrics` bullet separator inheriting blue `--color-primary` color
- Improve summary block layout with horizontal flexbox and mobile breakpoint
- Add dot separator between status and duration in summary view
- Add border below header

<img width="1334" height="178" alt="Screenshot 2026-03-26 at 00 16 13" src="https://github.com/user-attachments/assets/ee2579b9-5232-4c61-9b5f-0653bfd9f531" />
<img width="1339" height="172" alt="Screenshot 2026-03-26 at 00 16 03" src="https://github.com/user-attachments/assets/87fd575b-75d3-4082-b988-74b59d80616f" />
