### PR TITLE
Refactor legacy delete-button to link-action with confirm dialog

### DIFF
--- a/templates/user/settings/account.tmpl
+++ b/templates/user/settings/account.tmpl
@@ -56,7 +56,7 @@
 							</div>
 							<div class="flex-text-block">
 							{{if not .IsPrimary}}
-								<button class="ui red tiny button delete-button" data-modal-id="delete-email" data-url="{{AppSubUrl}}/user/settings/account/email/delete" data-id="{{.ID}}">
+								<button class="ui red tiny button link-action" data-url="{{AppSubUrl}}/user/settings/account/email/delete?id={{.ID}}" data-modal-confirm-header="{{ctx.Locale.Tr "settings.email_deletion"}}" data-modal-confirm-content="{{ctx.Locale.Tr "settings.email_deletion_desc"}}">
 									{{ctx.Locale.Tr "settings.delete_email"}}
 								</button>
 								{{if .CanBePrimary}}
@@ -140,16 +140,5 @@
 		</div>
 		{{end}}
 	</div>
-
-<div class="ui g-modal-confirm delete modal" id="delete-email">
-	<div class="header">
-		{{svg "octicon-trash"}}
-		{{ctx.Locale.Tr "settings.email_deletion"}}
-	</div>
-	<div class="content">
-		<p>{{ctx.Locale.Tr "settings.email_deletion_desc"}}</p>
-	</div>
-	{{template "base/modal_actions_confirm" .}}
-</div>
 
 {{template "user/settings/layout_footer" .}}

--- a/templates/user/settings/applications.tmpl
+++ b/templates/user/settings/applications.tmpl
@@ -40,7 +40,7 @@
 							</div>
 						</div>
 						<div class="flex-item-trailing">
-								<button class="ui red tiny button delete-button" data-modal-id="delete-token" data-url="{{$.Link}}/delete" data-id="{{.ID}}">
+								<button class="ui red tiny button link-action" data-url="{{$.Link}}/delete?id={{.ID}}" data-modal-confirm-header="{{ctx.Locale.Tr "settings.access_token_deletion"}}" data-modal-confirm-content="{{ctx.Locale.Tr "settings.access_token_deletion_desc"}}">
 									{{svg "octicon-trash"}}
 									{{ctx.Locale.Tr "settings.delete_token"}}
 								</button>
@@ -91,16 +91,5 @@
 			{{template "user/settings/applications_oauth2" .}}
 		{{end}}
 	</div>
-
-<div class="ui g-modal-confirm delete modal" id="delete-token">
-	<div class="header">
-		{{svg "octicon-trash"}}
-		{{ctx.Locale.Tr "settings.access_token_deletion"}}
-	</div>
-	<div class="content">
-		<p>{{ctx.Locale.Tr "settings.access_token_deletion_desc"}}</p>
-	</div>
-	{{template "base/modal_actions_confirm"}}
-</div>
 
 {{template "user/settings/layout_footer" .}}

--- a/templates/user/settings/applications_oauth2_list.tmpl
+++ b/templates/user/settings/applications_oauth2_list.tmpl
@@ -24,8 +24,7 @@
 							{{svg "octicon-pencil"}}
 							{{ctx.Locale.Tr "settings.oauth2_application_edit"}}
 						</a>
-						<button class="ui red tiny button delete-button" data-modal-id="remove-gitea-oauth2-application"
-								data-url="{{$.Link}}/oauth2/{{.ID}}/delete">
+						<button class="ui red tiny button link-action" data-url="{{$.Link}}/oauth2/{{.ID}}/delete" data-modal-confirm-header="{{ctx.Locale.Tr "settings.remove_oauth2_application"}}" data-modal-confirm-content="{{ctx.Locale.Tr "settings.oauth2_application_remove_description"}}">
 							{{svg "octicon-trash"}}
 							{{ctx.Locale.Tr "settings.delete_key"}}
 						</button>
@@ -33,17 +32,6 @@
 				</div>
 			</div>
 		{{end}}
-	</div>
-
-	<div class="ui g-modal-confirm delete modal" id="remove-gitea-oauth2-application">
-		<div class="header">
-			{{svg "octicon-trash"}}
-			{{ctx.Locale.Tr "settings.remove_oauth2_application"}}
-		</div>
-		<div class="content">
-			<p>{{ctx.Locale.Tr "settings.oauth2_application_remove_description"}}</p>
-		</div>
-		{{template "base/modal_actions_confirm" .}}
 	</div>
 </div>
 

--- a/templates/user/settings/grants_oauth2.tmpl
+++ b/templates/user/settings/grants_oauth2.tmpl
@@ -18,23 +18,11 @@
 					</div>
 				</div>
 				<div class="flex-item-trailing">
-					<button class="ui red tiny button delete-button" data-modal-id="revoke-gitea-oauth2-grant"
-							data-url="{{AppSubUrl}}/user/settings/applications/oauth2/{{.ApplicationID}}/revoke/{{.ID}}">
+					<button class="ui red tiny button link-action" data-url="{{AppSubUrl}}/user/settings/applications/oauth2/{{.ApplicationID}}/revoke/{{.ID}}" data-modal-confirm-header="{{ctx.Locale.Tr "settings.revoke_oauth2_grant"}}" data-modal-confirm-content="{{ctx.Locale.Tr "settings.revoke_oauth2_grant_description"}}">
 						{{ctx.Locale.Tr "settings.revoke_key"}}
 					</button>
 				</div>
 			</div>
 		{{end}}
-	</div>
-
-	<div class="ui g-modal-confirm delete modal" id="revoke-gitea-oauth2-grant">
-		<div class="header">
-			{{svg "octicon-shield" 16 "tw-mr-1"}}
-			{{ctx.Locale.Tr "settings.revoke_oauth2_grant"}}
-		</div>
-		<div class="content">
-			<p>{{ctx.Locale.Tr "settings.revoke_oauth2_grant_description"}}</p>
-		</div>
-		{{template "base/modal_actions_confirm" .}}
 	</div>
 </div>

--- a/templates/user/settings/keys_gpg.tmpl
+++ b/templates/user/settings/keys_gpg.tmpl
@@ -68,7 +68,7 @@
 					</div>
 				</div>
 				<div class="flex-item-trailing">
-					<button class="ui red tiny button delete-button" data-modal-id="delete-gpg" data-url="{{$.Link}}/delete?type=gpg" data-id="{{.ID}}">
+					<button class="ui red tiny button link-action" data-url="{{$.Link}}/delete?type=gpg&id={{.ID}}" data-modal-confirm-header="{{ctx.Locale.Tr "settings.gpg_key_deletion"}}" data-modal-confirm-content="{{ctx.Locale.Tr "settings.gpg_key_deletion_desc"}}">
 						{{ctx.Locale.Tr "settings.delete_key"}}
 					</button>
 					{{if and (not .Verified) (ne $.VerifyingID .KeyID)}}
@@ -107,15 +107,5 @@
 				</div>
 			{{end}}
 		{{end}}
-	</div>
-	<div class="ui g-modal-confirm delete modal" id="delete-gpg">
-		<div class="header">
-			{{svg "octicon-trash"}}
-			{{ctx.Locale.Tr "settings.gpg_key_deletion"}}
-		</div>
-		<div class="content">
-			<p>{{ctx.Locale.Tr "settings.gpg_key_deletion_desc"}}</p>
-		</div>
-		{{template "base/modal_actions_confirm" .}}
 	</div>
 </div>

--- a/templates/user/settings/keys_principal.tmpl
+++ b/templates/user/settings/keys_principal.tmpl
@@ -26,7 +26,7 @@
 						</div>
 					</div>
 					<div class="flex-item-trailing">
-						<button class="ui red tiny button delete-button" data-modal-id="delete-principal" data-url="{{$.Link}}/delete?type=principal" data-id="{{.ID}}">
+						<button class="ui red tiny button link-action" data-url="{{$.Link}}/delete?type=principal&id={{.ID}}" data-modal-confirm-header="{{ctx.Locale.Tr "settings.ssh_principal_deletion"}}" data-modal-confirm-content="{{ctx.Locale.Tr "settings.ssh_principal_deletion_desc"}}">
 							{{ctx.Locale.Tr "settings.delete_key"}}
 						</button>
 					</div>
@@ -53,16 +53,5 @@
 				</button>
 			</form>
 		</div>
-	</div>
-
-	<div class="ui g-modal-confirm delete modal" id="delete-principal">
-		<div class="header">
-			{{svg "octicon-trash"}}
-			{{ctx.Locale.Tr "settings.ssh_principal_deletion"}}
-		</div>
-		<div class="content">
-			<p>{{ctx.Locale.Tr "settings.ssh_principal_deletion_desc"}}</p>
-		</div>
-		{{template "base/modal_actions_confirm" .}}
 	</div>
 {{end}}

--- a/templates/user/settings/keys_ssh.tmpl
+++ b/templates/user/settings/keys_ssh.tmpl
@@ -56,7 +56,7 @@
 						</div>
 				</div>
 				<div class="flex-item-trailing">
-					<button class="ui red tiny button delete-button{{if index $.ExternalKeys $index}} disabled{{end}}" data-modal-id="delete-ssh" data-url="{{$.Link}}/delete?type=ssh" data-id="{{.ID}}"{{if index $.ExternalKeys $index}} title="{{ctx.Locale.Tr "settings.ssh_externally_managed"}}"{{end}}>
+					<button class="ui red tiny button link-action{{if index $.ExternalKeys $index}} disabled{{end}}" data-url="{{$.Link}}/delete?type=ssh&id={{.ID}}" data-modal-confirm-header="{{ctx.Locale.Tr "settings.ssh_key_deletion"}}" data-modal-confirm-content="{{ctx.Locale.Tr "settings.ssh_key_deletion_desc"}}"{{if index $.ExternalKeys $index}} title="{{ctx.Locale.Tr "settings.ssh_externally_managed"}}"{{end}}>
 						{{ctx.Locale.Tr "settings.delete_key"}}
 					</button>
 					{{if and (not .Verified) (ne $.VerifyingFingerprint .Fingerprint)}}
@@ -103,15 +103,5 @@
 				</div>
 			{{end}}
 		{{end}}
-	</div>
-	<div class="ui g-modal-confirm delete modal" id="delete-ssh">
-		<div class="header">
-			{{svg "octicon-trash"}}
-			{{ctx.Locale.Tr "settings.ssh_key_deletion"}}
-		</div>
-		<div class="content">
-			<p>{{ctx.Locale.Tr "settings.ssh_key_deletion_desc"}}</p>
-		</div>
-		{{template "base/modal_actions_confirm" .}}
 	</div>
 </div>

--- a/templates/user/settings/security/accountlinks.tmpl
+++ b/templates/user/settings/security/accountlinks.tmpl
@@ -40,23 +40,12 @@
 					{{end}}
 				</div>
 				<div class="flex-item-trailing">
-					<button class="ui red tiny button delete-button" data-modal-id="delete-account-link" data-url="{{AppSubUrl}}/user/settings/security/account_link" data-id="{{$loginSource.ID}}">
+					<button class="ui red tiny button link-action" data-url="{{AppSubUrl}}/user/settings/security/account_link?id={{$loginSource.ID}}" data-modal-confirm-header="{{ctx.Locale.Tr "settings.remove_account_link"}}" data-modal-confirm-content="{{ctx.Locale.Tr "settings.remove_account_link_desc"}}">
 						{{ctx.Locale.Tr "settings.delete_key"}}
 					</button>
 				</div>
 			</div>
 		{{end}}
-	</div>
-
-	<div class="ui g-modal-confirm delete modal" id="delete-account-link">
-		<div class="header">
-			{{svg "octicon-trash"}}
-			{{ctx.Locale.Tr "settings.remove_account_link"}}
-		</div>
-		<div class="content">
-			<p>{{ctx.Locale.Tr "settings.remove_account_link_desc"}}</p>
-		</div>
-		{{template "base/modal_actions_confirm" .}}
 	</div>
 </div>
 {{end}}

--- a/templates/user/settings/security/openid.tmpl
+++ b/templates/user/settings/security/openid.tmpl
@@ -29,7 +29,7 @@
 							</button>
 						{{end}}
 					</form>
-					<button class="ui red tiny button delete-button" data-modal-id="delete-openid" data-url="{{AppSubUrl}}/user/settings/security/openid/delete" data-id="{{.ID}}">
+					<button class="ui red tiny button link-action" data-url="{{AppSubUrl}}/user/settings/security/openid/delete?id={{.ID}}" data-modal-confirm-header="{{ctx.Locale.Tr "settings.openid_deletion"}}" data-modal-confirm-content="{{ctx.Locale.Tr "settings.openid_deletion_desc"}}">
 						{{ctx.Locale.Tr "settings.delete_key"}}
 					</button>
 				</div>
@@ -47,15 +47,4 @@
 			{{ctx.Locale.Tr "settings.add_openid"}}
 		</button>
 	</form>
-
-	<div class="ui g-modal-confirm delete modal" id="delete-openid">
-		<div class="header">
-			{{svg "octicon-trash"}}
-			{{ctx.Locale.Tr "settings.openid_deletion"}}
-		</div>
-		<div class="content">
-			<p>{{ctx.Locale.Tr "settings.openid_deletion_desc"}}</p>
-		</div>
-		{{template "base/modal_actions_confirm" .}}
-	</div>
 </div>

--- a/templates/user/settings/security/webauthn.tmpl
+++ b/templates/user/settings/security/webauthn.tmpl
@@ -16,7 +16,7 @@
 					</div>
 				</div>
 				<div class="flex-item-trailing">
-					<button class="ui red tiny button delete-button" data-modal-id="delete-registration" data-url="{{$.Link}}/webauthn/delete" data-id="{{.ID}}">
+					<button class="ui red tiny button link-action" data-url="{{$.Link}}/webauthn/delete?id={{.ID}}" data-modal-confirm-header="{{ctx.Locale.Tr "settings.webauthn_delete_key"}}" data-modal-confirm-content="{{ctx.Locale.Tr "settings.webauthn_delete_key_desc"}}">
 					{{ctx.Locale.Tr "settings.delete_key"}}
 					</button>
 				</div>
@@ -29,15 +29,5 @@
 			<input id="nickname" name="nickname" type="text" required>
 		</div>
 		<button id="register-webauthn" class="ui primary button">{{svg "octicon-key"}} {{ctx.Locale.Tr "settings.webauthn_register_key"}}</button>
-	</div>
-	<div class="ui g-modal-confirm delete modal" id="delete-registration">
-		<div class="header">
-			{{svg "octicon-trash"}}
-			{{ctx.Locale.Tr "settings.webauthn_delete_key"}}
-		</div>
-		<div class="content">
-			<p>{{ctx.Locale.Tr "settings.webauthn_delete_key_desc"}}</p>
-		</div>
-		{{template "base/modal_actions_confirm" .}}
 	</div>
 </div>

--- a/tests/e2e/user-settings-delete.test.ts
+++ b/tests/e2e/user-settings-delete.test.ts
@@ -1,0 +1,263 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import {env} from 'node:process';
+import {test, expect} from '@playwright/test';
+import {login, apiBaseUrl, apiHeaders} from './utils.ts';
+
+test.beforeEach(async ({page}) => {
+  await login(page);
+});
+
+test.describe('User Settings - Delete Actions with Confirm Dialog', () => {
+  test('SSH key delete shows confirm dialog with correct content', async ({page}) => {
+    // Generate a unique SSH key for testing
+    const keyName = `e2e-test-key-${Date.now()}`;
+    const sshKey = 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC4cn+iXnA4KvcQYSV88vGn0Yi91vG47t1P7okprVmhNTkipNRIHWr6WdCO4VDr/cvsRkuVJAsLO2enwjGWWueOO6BodiBgyAOZ/5t5nJNMCNuLGT5UIo/RI1b0WRQwxEZTRjt6mFNw6lH14wRd8ulsr9toSWBPMOGWoYs1PDeDL0JuTjL+tr1SZi/EyxCngpYszKdXllJEHyI79KQgeD0Vt3pTrkbNVTOEcCNqZePSVmUH8X8Vhugz3bnE0/iE9Pb5fkWO9c4AnM1FgI/8Bvp27Fw2ShryIXuR6kKvUqhVMTuOSDHwu6A8jLE5Owt3GAYugDpDYuwTVNGrHLXKpPzrGGPE/jPmaLCMZcsdkec95dYeU3zKODEm8UQZFhmJmDeWVJ36nGrGZHL4J5aTTaeFUJmmXDaJYiJ+K2/ioKgXqnXvltu0A9R8/LGy4nrTJRr4JMLuJFoUXvGm1gXQ70w2LSpk6yl71RNC0hCtsBe8BP8IhYCM0EP5jh7eCMQZNvM= e2e-test@example.com';
+
+    // Add SSH key via API
+    const response = await page.request.post(`${apiBaseUrl()}/api/v1/user/keys`, {
+      headers: apiHeaders(),
+      data: {
+        title: keyName,
+        key: sshKey,
+      },
+    });
+    expect(response.ok()).toBeTruthy();
+
+    // Go to SSH keys settings
+    await page.goto('/user/settings/keys');
+
+    // Find the delete button for our test key
+    const keyRow = page.locator('.flex-item', {hasText: keyName});
+    await expect(keyRow).toBeVisible();
+
+    const deleteButton = keyRow.locator('button.link-action', {hasText: 'Delete'});
+    await expect(deleteButton).toBeVisible();
+
+    // Click delete button - should show confirm dialog
+    await deleteButton.click();
+
+    // Verify confirm dialog appears
+    const confirmModal = page.locator('.ui.g-modal-confirm.modal.visible');
+    await expect(confirmModal).toBeVisible();
+
+    // Verify dialog header
+    const modalHeader = confirmModal.locator('.header');
+    await expect(modalHeader).toContainText('SSH Key Deletion');
+
+    // Verify dialog content
+    const modalContent = confirmModal.locator('.content');
+    await expect(modalContent).toBeVisible();
+
+    // Verify buttons exist
+    const cancelButton = confirmModal.locator('button.cancel');
+    const confirmButton = confirmModal.locator('button.ok');
+    await expect(cancelButton).toBeVisible();
+    await expect(confirmButton).toBeVisible();
+
+    // Confirm button should be red (for dangerous action)
+    await expect(confirmButton).toHaveClass(/red/);
+
+    // Cancel the deletion
+    await cancelButton.click();
+    await expect(confirmModal).toBeHidden();
+
+    // Verify key still exists
+    await expect(keyRow).toBeVisible();
+
+    // Now delete for real
+    await deleteButton.click();
+    await expect(confirmModal).toBeVisible();
+    await confirmButton.click();
+
+    // Wait for page reload and verify key is gone
+    await expect(keyRow).toBeHidden();
+  });
+
+  test('Email delete shows confirm dialog', async ({page}) => {
+    // Add a test email via API
+    const testEmail = `e2e-test-${Date.now()}@${env.GITEA_TEST_E2E_DOMAIN}`;
+
+    const response = await page.request.post(`${apiBaseUrl()}/api/v1/user/emails`, {
+      headers: apiHeaders(),
+      data: {
+        emails: [testEmail],
+      },
+    });
+    expect(response.ok()).toBeTruthy();
+
+    // Go to account settings
+    await page.goto('/user/settings/account');
+
+    // Find the delete button for our test email
+    const emailRow = page.locator('.flex-item', {hasText: testEmail});
+    await expect(emailRow).toBeVisible();
+
+    const deleteButton = emailRow.locator('button.link-action', {hasText: 'Delete'});
+    await expect(deleteButton).toBeVisible();
+
+    // Click delete button
+    await deleteButton.click();
+
+    // Verify confirm dialog
+    const confirmModal = page.locator('.ui.g-modal-confirm.modal.visible');
+    await expect(confirmModal).toBeVisible();
+
+    // Cancel first
+    await confirmModal.locator('button.cancel').click();
+    await expect(confirmModal).toBeHidden();
+
+    // Verify email still exists
+    await expect(emailRow).toBeVisible();
+
+    // Now delete for real
+    await deleteButton.click();
+    await expect(confirmModal).toBeVisible();
+    await confirmModal.locator('button.ok').click();
+
+    // Verify email is gone
+    await expect(emailRow).toBeHidden();
+  });
+
+  test('Access token delete shows confirm dialog', async ({page}) => {
+    const tokenName = `e2e-test-token-${Date.now()}`;
+
+    // Create access token via API
+    const response = await page.request.post(`${apiBaseUrl()}/api/v1/user/applications/oauth2`, {
+      headers: apiHeaders(),
+      data: {
+        name: tokenName,
+        confidential_client: true,
+      },
+    });
+    expect(response.ok()).toBeTruthy();
+
+    // Go to applications settings
+    await page.goto('/user/settings/applications');
+
+    // Find the OAuth2 application we created
+    const appRow = page.locator('.flex-item', {hasText: tokenName});
+    await expect(appRow).toBeVisible();
+
+    const deleteButton = appRow.locator('button.link-action', {hasText: 'Delete'});
+    await expect(deleteButton).toBeVisible();
+
+    // Click delete and verify confirm dialog
+    await deleteButton.click();
+
+    const confirmModal = page.locator('.ui.g-modal-confirm.modal.visible');
+    await expect(confirmModal).toBeVisible();
+
+    // Cancel first
+    await confirmModal.locator('button.cancel').click();
+    await expect(confirmModal).toBeHidden();
+
+    // Delete for real
+    await deleteButton.click();
+    await expect(confirmModal).toBeVisible();
+    await confirmModal.locator('button.ok').click();
+
+    // Verify app is gone
+    await expect(appRow).toBeHidden();
+  });
+});
+
+test.describe('Confirm Modal Accessibility', () => {
+  test('confirm modal has correct ARIA attributes', async ({page}) => {
+    // Create an SSH key first to ensure we have a delete button to test
+    const keyName = `e2e-accessibility-test-${Date.now()}`;
+    const sshKey = 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC4cn+iXnA4KvcQYSV88vGn0Yi91vG47t1P7okprVmhNTkipNRIHWr6WdCO4VDr/cvsRkuVJAsLO2enwjGWWueOO6BodiBgyAOZ/5t5nJNMCNuLGT5UIo/RI1b0WRQwxEZTRjt6mFNw6lH14wRd8ulsr9toSWBPMOGWoYs1PDeDL0JuTjL+tr1SZi/EyxCngpYszKdXllJEHyI79KQgeD0Vt3pTrkbNVTOEcCNqZePSVmUH8X8Vhugz3bnE0/iE9Pb5fkWO9c4AnM1FgI/8Bvp27Fw2ShryIXuR6kKvUqhVMTuOSDHwu6A8jLE5Owt3GAYugDpDYuwTVNGrHLXKpPzrGGPE/jPmaLCMZcsdkec95dYeU3zKODEm8UQZFhmJmDeWVJ36nGrGZHL4J5aTTaeFUJmmXDaJYiJ+K2/ioKgXqnXvltu0A9R8/LGy4nrTJRr4JMLuJFoUXvGm1gXQ70w2LSpk6yl71RNC0hCtsBe8BP8IhYCM0EP5jh7eCMQZNvM= e2e-test@example.com';
+
+    const response = await page.request.post(`${apiBaseUrl()}/api/v1/user/keys`, {
+      headers: apiHeaders(),
+      data: {title: keyName, key: sshKey},
+    });
+    expect(response.ok()).toBeTruthy();
+
+    // Navigate to the SSH keys page
+    await page.goto('/user/settings/keys');
+
+    // Find the delete button for our test key
+    const keyRow = page.locator('.flex-item', {hasText: keyName});
+    await expect(keyRow).toBeVisible();
+
+    const deleteButton = keyRow.locator('button.link-action', {hasText: 'Delete'});
+    await expect(deleteButton).toBeVisible();
+
+    // Click delete to show confirm modal
+    await deleteButton.click();
+
+    const confirmModal = page.locator('.ui.g-modal-confirm.modal.visible');
+    await expect(confirmModal).toBeVisible();
+
+    // Check modal has proper role
+    await expect(confirmModal).toHaveAttribute('role', 'dialog');
+
+    // Check modal has aria-modal
+    await expect(confirmModal).toHaveAttribute('aria-modal', 'true');
+
+    // Check that focus is on the confirm button
+    const confirmButton = confirmModal.locator('button.ok');
+    await expect(confirmButton).toBeFocused();
+
+    // Close with Escape
+    await page.keyboard.press('Escape');
+    await expect(confirmModal).toBeHidden();
+
+    // Clean up - delete the key via API
+    const keyId = (await response.json()).id;
+    await page.request.delete(`${apiBaseUrl()}/api/v1/user/keys/${keyId}`, {
+      headers: apiHeaders(),
+    });
+  });
+
+  test('confirm modal keyboard navigation', async ({page}) => {
+    // Create an SSH key first
+    const keyName = `e2e-keyboard-test-${Date.now()}`;
+    const sshKey = 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC4cn+iXnA4KvcQYSV88vGn0Yi91vG47t1P7okprVmhNTkipNRIHWr6WdCO4VDr/cvsRkuVJAsLO2enwjGWWueOO6BodiBgyAOZ/5t5nJNMCNuLGT5UIo/RI1b0WRQwxEZTRjt6mFNw6lH14wRd8ulsr9toSWBPMOGWoYs1PDeDL0JuTjL+tr1SZi/EyxCngpYszKdXllJEHyI79KQgeD0Vt3pTrkbNVTOEcCNqZePSVmUH8X8Vhugz3bnE0/iE9Pb5fkWO9c4AnM1FgI/8Bvp27Fw2ShryIXuR6kKvUqhVMTuOSDHwu6A8jLE5Owt3GAYugDpDYuwTVNGrHLXKpPzrGGPE/jPmaLCMZcsdkec95dYeU3zKODEm8UQZFhmJmDeWVJ36nGrGZHL4J5aTTaeFUJmmXDaJYiJ+K2/ioKgXqnXvltu0A9R8/LGy4nrTJRr4JMLuJFoUXvGm1gXQ70w2LSpk6yl71RNC0hCtsBe8BP8IhYCM0EP5jh7eCMQZNvM= e2e-test@example.com';
+
+    const response = await page.request.post(`${apiBaseUrl()}/api/v1/user/keys`, {
+      headers: apiHeaders(),
+      data: {title: keyName, key: sshKey},
+    });
+    expect(response.ok()).toBeTruthy();
+
+    await page.goto('/user/settings/keys');
+
+    const keyRow = page.locator('.flex-item', {hasText: keyName});
+    await expect(keyRow).toBeVisible();
+
+    const deleteButton = keyRow.locator('button.link-action', {hasText: 'Delete'});
+
+    // Focus the delete button
+    await deleteButton.focus();
+    await expect(deleteButton).toBeFocused();
+
+    // Press Enter to activate
+    await page.keyboard.press('Enter');
+
+    const confirmModal = page.locator('.ui.g-modal-confirm.modal.visible');
+    await expect(confirmModal).toBeVisible();
+
+    // Tab should cycle within modal
+    await page.keyboard.press('Tab');
+    const cancelButton = confirmModal.locator('button.cancel');
+    await expect(cancelButton).toBeFocused();
+
+    // Tab again to go back to confirm button
+    await page.keyboard.press('Tab');
+    const confirmButton = confirmModal.locator('button.ok');
+    await expect(confirmButton).toBeFocused();
+
+    // Press Escape to close without deleting
+    await page.keyboard.press('Escape');
+    await expect(confirmModal).toBeHidden();
+
+    // Clean up
+    const keyId = (await response.json()).id;
+    await page.request.delete(`${apiBaseUrl()}/api/v1/user/keys/${keyId}`, {
+      headers: apiHeaders(),
+    });
+  });
+});

--- a/web_src/js/features/comp/ConfirmModal.test.ts
+++ b/web_src/js/features/comp/ConfirmModal.test.ts
@@ -1,0 +1,129 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import {createConfirmModal} from './ConfirmModal.ts';
+
+test('createConfirmModal with default options', () => {
+  const modal = createConfirmModal();
+
+  // Check basic structure
+  expect(modal).toBeTruthy();
+  expect(modal.classList.contains('ui')).toBe(true);
+  expect(modal.classList.contains('g-modal-confirm')).toBe(true);
+  expect(modal.classList.contains('modal')).toBe(true);
+
+  // Check content div exists
+  const content = modal.querySelector('.content');
+  expect(content).toBeTruthy();
+  expect(content?.textContent).toBe('');
+
+  // Check actions div exists with buttons
+  const actions = modal.querySelector('.actions');
+  expect(actions).toBeTruthy();
+
+  const cancelButton = actions?.querySelector('.cancel.button');
+  const confirmButton = actions?.querySelector('.ok.button');
+  expect(cancelButton).toBeTruthy();
+  expect(confirmButton).toBeTruthy();
+
+  // Default confirm button should be primary color
+  expect(confirmButton?.classList.contains('primary')).toBe(true);
+});
+
+test('createConfirmModal with header and content', () => {
+  const modal = createConfirmModal({
+    header: 'Delete Item',
+    content: 'Are you sure you want to delete this item?',
+  });
+
+  // Check header
+  const header = modal.querySelector('.header');
+  expect(header).toBeTruthy();
+  expect(header?.textContent).toBe('Delete Item');
+
+  // Check content
+  const content = modal.querySelector('.content');
+  expect(content).toBeTruthy();
+  expect(content?.textContent).toBe('Are you sure you want to delete this item?');
+});
+
+test('createConfirmModal with red confirm button for risky actions', () => {
+  const modal = createConfirmModal({
+    header: 'Delete Item',
+    content: 'This action cannot be undone.',
+    confirmButtonColor: 'red',
+  });
+
+  const confirmButton = modal.querySelector('.ok.button');
+  expect(confirmButton).toBeTruthy();
+  expect(confirmButton?.classList.contains('red')).toBe(true);
+  expect(confirmButton?.classList.contains('primary')).toBe(false);
+});
+
+test('createConfirmModal with green confirm button', () => {
+  const modal = createConfirmModal({
+    header: 'Confirm Action',
+    content: 'Proceed with action?',
+    confirmButtonColor: 'green',
+  });
+
+  const confirmButton = modal.querySelector('.ok.button');
+  expect(confirmButton).toBeTruthy();
+  expect(confirmButton?.classList.contains('green')).toBe(true);
+});
+
+test('createConfirmModal with blue confirm button', () => {
+  const modal = createConfirmModal({
+    header: 'Info',
+    content: 'Some information',
+    confirmButtonColor: 'blue',
+  });
+
+  const confirmButton = modal.querySelector('.ok.button');
+  expect(confirmButton).toBeTruthy();
+  expect(confirmButton?.classList.contains('blue')).toBe(true);
+});
+
+test('createConfirmModal buttons have correct icons', () => {
+  const modal = createConfirmModal();
+
+  const cancelButton = modal.querySelector('.cancel.button');
+  const confirmButton = modal.querySelector('.ok.button');
+
+  // Both buttons should contain SVG icons
+  expect(cancelButton?.querySelector('svg')).toBeTruthy();
+  expect(confirmButton?.querySelector('svg')).toBeTruthy();
+});
+
+test('createConfirmModal empty header does not create header element', () => {
+  const modal = createConfirmModal({
+    header: '',
+    content: 'Some content',
+  });
+
+  // Empty header should not create a header div
+  const header = modal.querySelector('.header');
+  expect(header).toBeFalsy();
+});
+
+test('createConfirmModal structure matches expected HTML', () => {
+  const modal = createConfirmModal({
+    header: 'Test Header',
+    content: 'Test Content',
+    confirmButtonColor: 'red',
+  });
+
+  // Verify the modal structure
+  expect(modal.tagName).toBe('DIV');
+  expect(modal.className).toContain('ui');
+  expect(modal.className).toContain('g-modal-confirm');
+  expect(modal.className).toContain('modal');
+
+  // Verify children order: header, content, actions
+  const children = Array.from(modal.children);
+  expect(children.length).toBe(3);
+
+  expect(children[0].classList.contains('header')).toBe(true);
+  expect(children[1].classList.contains('content')).toBe(true);
+  expect(children[2].classList.contains('actions')).toBe(true);
+});


### PR DESCRIPTION
## Description

This PR refactors several legacy `delete-button` usages to the newer `link-action` with `data-modal-confirm` attributes. The `delete-button` implementation is marked as legacy code that should be refactored (see comments in `web_src/js/features/common-button.ts`).

## Changes

- Convert `delete-button` to `link-action` for:
  - Email deletion in account settings
  - SSH key deletion
  - GPG key deletion
  - Access token deletion
  - SSH principal deletion
  - Account link deletion
  - WebAuthn credential deletion
  - OAuth2 grant revocation
  - OAuth2 application deletion
  - OpenID deletion
- Remove redundant modal definitions that are no longer needed
- Use `data-modal-confirm-header` and `data-modal-confirm-content` for confirmation dialogs

## Why

The `delete-button` pattern is marked as legacy in the codebase with the following comments:

```javascript
// TODO: do not use this method in new code. `show-modal` / `link-action(data-modal-confirm)` does far better than this.
// FIXME: all legacy `delete-button` should be refactored to use `show-modal` or `link-action`
```

This PR addresses part of the refactoring task mentioned in #35015.

## Testing

- Manually verify that the confirmation dialogs still appear
- Verify that delete actions still work correctly
- Verify that the UI behavior is unchanged

## Screenshots

No visual changes - the confirmation dialogs look and behave the same way.

---

Relates to #35015