### PR TITLE
Enable `exhaustive` linter for new code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - depguard
     - dupl
     - errcheck
+    - exhaustive
     - forbidigo
     - gocheckcompilerdirectives
     - gocritic
@@ -105,6 +106,8 @@ linters:
       os-temp-dir: true
     perfsprint:
       concat-loop: false
+    exhaustive:
+      default-signifies-exhaustive: true
     govet:
       enable:
         - nilness

--- a/models/actions/runner.go
+++ b/models/actions/runner.go
@@ -91,7 +91,7 @@ func (r *ActionRunner) BelongsToOwnerType() types.OwnerType {
 		return types.OwnerTypeRepository
 	}
 	if r.OwnerID != 0 {
-		switch r.Owner.Type {
+		switch r.Owner.Type { //nolint:exhaustive // only relevant owner types
 		case user_model.UserTypeOrganization:
 			return types.OwnerTypeOrganization
 		case user_model.UserTypeIndividual:

--- a/models/db/log.go
+++ b/models/db/log.go
@@ -74,7 +74,7 @@ func (l *XORMLogBridge) Warnf(format string, v ...any) {
 
 // Level get logger level
 func (l *XORMLogBridge) Level() xormlog.LogLevel {
-	switch l.logger.GetLevel() {
+	switch l.logger.GetLevel() { //nolint:exhaustive // only mapped log levels
 	case log.TRACE, log.DEBUG:
 		return xormlog.LOG_DEBUG
 	case log.INFO:

--- a/models/issues/comment.go
+++ b/models/issues/comment.go
@@ -174,7 +174,7 @@ func AsCommentType(typeName string) CommentType {
 }
 
 func (t CommentType) HasContentSupport() bool {
-	switch t {
+	switch t { //nolint:exhaustive // other types have no content
 	case CommentTypeComment, CommentTypeCode, CommentTypeReview, CommentTypeDismissReview:
 		return true
 	}
@@ -182,7 +182,7 @@ func (t CommentType) HasContentSupport() bool {
 }
 
 func (t CommentType) HasAttachmentSupport() bool {
-	switch t {
+	switch t { //nolint:exhaustive // other types have no attachments
 	case CommentTypeComment, CommentTypeCode, CommentTypeReview:
 		return true
 	}
@@ -190,7 +190,7 @@ func (t CommentType) HasAttachmentSupport() bool {
 }
 
 func (t CommentType) HasMailReplySupport() bool {
-	switch t {
+	switch t { //nolint:exhaustive // other types not mail-replyable
 	case CommentTypeComment, CommentTypeCode, CommentTypeReview, CommentTypeDismissReview, CommentTypeReopen, CommentTypeClose, CommentTypeMergePull, CommentTypeAssignees:
 		return true
 	}
@@ -880,7 +880,7 @@ func CreateComment(ctx context.Context, opts *CreateCommentOptions) (_ *Comment,
 
 func updateCommentInfos(ctx context.Context, opts *CreateCommentOptions, comment *Comment) (err error) {
 	// Check comment type.
-	switch opts.Type {
+	switch opts.Type { //nolint:exhaustive // only types needing extra updates
 	case CommentTypeCode:
 		if err = UpdateCommentAttachments(ctx, comment, opts.Attachments); err != nil {
 			return err

--- a/models/issues/milestone_test.go
+++ b/models/issues/milestone_test.go
@@ -40,7 +40,7 @@ func TestGetMilestonesByRepoID(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
 	test := func(repoID int64, state api.StateType) {
 		var isClosed optional.Option[bool]
-		switch state {
+		switch state { //nolint:exhaustive // only open/closed are filtered
 		case api.StateClosed, api.StateOpen:
 			isClosed = optional.Some(state == api.StateClosed)
 		}

--- a/models/issues/review.go
+++ b/models/issues/review.go
@@ -217,7 +217,7 @@ func (r *Review) LoadAttributes(ctx context.Context) (err error) {
 
 // HTMLTypeColorClass returns the CSS class used in the ui indicating the review
 func (r *Review) HTMLTypeColorClass() string {
-	switch r.Type {
+	switch r.Type { //nolint:exhaustive // only displayable review types
 	case ReviewTypeApprove:
 		if !r.Official {
 			return "tw-text-text-light"
@@ -238,7 +238,7 @@ func (r *Review) HTMLTypeColorClass() string {
 
 // TooltipContent returns the locale string describing the review type
 func (r *Review) TooltipContent() string {
-	switch r.Type {
+	switch r.Type { //nolint:exhaustive // only displayable review types
 	case ReviewTypeApprove:
 		if r.Stale {
 			return "repo.issues.review.stale"

--- a/models/migrations/v1_8/v81.go
+++ b/models/migrations/v1_8/v81.go
@@ -13,7 +13,7 @@ import (
 func ChangeU2FCounterType(x *xorm.Engine) error {
 	var err error
 
-	switch x.Dialect().URI().DBType {
+	switch x.Dialect().URI().DBType { //nolint:exhaustive // SQLite needs no change
 	case schemas.MYSQL:
 		_, err = x.Exec("ALTER TABLE `u2f_registration` MODIFY `counter` BIGINT")
 	case schemas.POSTGRES:

--- a/models/repo/archiver.go
+++ b/models/repo/archiver.go
@@ -38,7 +38,7 @@ const (
 
 // String converts an ArchiveType to string: the extension of the archive file without prefix dot
 func (a ArchiveType) String() string {
-	switch a {
+	switch a { //nolint:exhaustive // only known archive formats
 	case ArchiveZip:
 		return "zip"
 	case ArchiveTarGz:

--- a/models/repo/transfer.go
+++ b/models/repo/transfer.go
@@ -210,7 +210,7 @@ func DeleteRepositoryTransfer(ctx context.Context, repoID int64) error {
 
 // TestRepositoryReadyForTransfer make sure repo is ready to transfer
 func TestRepositoryReadyForTransfer(status RepositoryStatus) error {
-	switch status {
+	switch status { //nolint:exhaustive // only blocking statuses
 	case RepositoryBeingMigrated:
 		return errors.New("repo is not ready, currently migrating")
 	case RepositoryPendingTransfer:

--- a/models/unittest/fixtures_loader.go
+++ b/models/unittest/fixtures_loader.go
@@ -200,7 +200,7 @@ func NewFixturesLoader(x *xorm.Engine, opts FixturesOptions) (FixturesLoader, er
 	}
 
 	f := &fixturesLoaderInternal{xormEngine: x, db: x.DB().DB, dbType: x.Dialect().URI().DBType, fixtures: fixtureItems}
-	switch f.dbType {
+	switch f.dbType { //nolint:exhaustive // only supported DB dialects
 	case schemas.SQLITE:
 		f.quoteObject = func(s string) string { return fmt.Sprintf(`"%s"`, s) }
 		f.paramPlaceholder = func(idx int) string { return "?" }

--- a/models/webhook/webhook.go
+++ b/models/webhook/webhook.go
@@ -175,7 +175,7 @@ func (w *Webhook) HasEvent(evt webhook_module.HookEventType) bool {
 		return evt == webhook_module.HookEventPush
 	}
 	checkEvt := evt
-	switch evt {
+	switch evt { //nolint:exhaustive // only sub-event aliases
 	case webhook_module.HookEventPullRequestReviewApproved, webhook_module.HookEventPullRequestReviewRejected, webhook_module.HookEventPullRequestReviewComment:
 		checkEvt = webhook_module.HookEventPullRequestReview
 	}

--- a/modules/actions/github.go
+++ b/modules/actions/github.go
@@ -27,7 +27,7 @@ const (
 
 // IsDefaultBranchWorkflow returns true if the event only triggers workflows on the default branch
 func IsDefaultBranchWorkflow(triggedEvent webhook_module.HookEventType) bool {
-	switch triggedEvent {
+	switch triggedEvent { //nolint:exhaustive // only default-branch-only events
 	case webhook_module.HookEventDelete:
 		// GitHub "delete" event
 		// https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#delete

--- a/modules/actions/workflows.go
+++ b/modules/actions/workflows.go
@@ -440,7 +440,7 @@ func matchPullRequestEvent(gitRepo *git.Repository, commit *git.Commit, prPayloa
 		// converted_to_draft, ready_for_review, locked, unlocked, auto_merge_enabled, auto_merge_disabled, enqueued, dequeued
 
 		action := prPayload.Action
-		switch action {
+		switch action { //nolint:exhaustive // only actions needing name conversion
 		case api.HookIssueSynchronized:
 			action = "synchronize"
 		case api.HookIssueLabelUpdated:
@@ -659,7 +659,7 @@ func matchReleaseEvent(payload *api.ReleasePayload, evt *jobparser.Event) bool {
 			// unpublished, created, deleted, prereleased, released
 
 			action := payload.Action
-			switch action {
+			switch action { //nolint:exhaustive // only actions needing name conversion
 			case api.HookReleaseUpdated:
 				action = "edited"
 			}
@@ -696,7 +696,7 @@ func matchPackageEvent(payload *api.PackagePayload, evt *jobparser.Event) bool {
 			// updated
 
 			action := payload.Action
-			switch action {
+			switch action { //nolint:exhaustive // only actions needing name conversion
 			case api.HookPackageCreated:
 				action = "published"
 			}

--- a/modules/git/repo_branch_nogogit.go
+++ b/modules/git/repo_branch_nogogit.go
@@ -72,7 +72,7 @@ func (repo *Repository) GetBranchNames(skip, limit int) ([]string, int, error) {
 // refType should be empty, ObjectTag or ObjectBranch. All other values are equivalent to empty.
 func (repo *Repository) WalkReferences(refType ObjectType, skip, limit int, walkfn func(sha1, refname string) error) (int, error) {
 	var args gitcmd.TrustedCmdArgs
-	switch refType {
+	switch refType { //nolint:exhaustive // only tag and branch refs
 	case ObjectTag:
 		args = gitcmd.TrustedCmdArgs{TagPrefix, "--sort=-taggerdate"}
 	case ObjectBranch:

--- a/modules/indexer/code/gitgrep/gitgrep.go
+++ b/modules/indexer/code/gitgrep/gitgrep.go
@@ -26,7 +26,7 @@ func indexSettingToGitGrepPathspecList() (list []string) {
 
 func PerformSearch(ctx context.Context, page int, repoID int64, gitRepo *git.Repository, ref git.RefName, keyword string, searchMode indexer.SearchModeType) (searchResults []*code_indexer.Result, total int64, err error) {
 	grepMode := git.GrepModeWords
-	switch searchMode {
+	switch searchMode { //nolint:exhaustive // only non-default search modes
 	case indexer.SearchModeExact:
 		grepMode = git.GrepModeExact
 	case indexer.SearchModeRegexp:

--- a/modules/issue/template/template.go
+++ b/modules/issue/template/template.go
@@ -172,7 +172,7 @@ func validateOptions(field *api.IssueFormField, idx int) error {
 
 	for optIdx, option := range options {
 		position := newErrorPosition(idx, field.Type, optIdx)
-		switch field.Type {
+		switch field.Type { //nolint:exhaustive // only field types with options
 		case api.IssueFormFieldTypeDropdown:
 			if _, ok := option.(string); !ok {
 				return position.Errorf("should be a string")
@@ -428,7 +428,7 @@ type valuedOption struct {
 }
 
 func (o *valuedOption) Label() string {
-	switch o.field.Type {
+	switch o.field.Type { //nolint:exhaustive // only field types with options
 	case api.IssueFormFieldTypeDropdown:
 		if label, ok := o.data.(string); ok {
 			return label
@@ -444,7 +444,7 @@ func (o *valuedOption) Label() string {
 }
 
 func (o *valuedOption) IsChecked() bool {
-	switch o.field.Type {
+	switch o.field.Type { //nolint:exhaustive // only field types with options
 	case api.IssueFormFieldTypeDropdown:
 		checks := strings.Split(o.field.Get("form-field-"+o.field.ID), ",")
 		idx := strconv.Itoa(o.index)

--- a/modules/packages/rubygems/marshal.go
+++ b/modules/packages/rubygems/marshal.go
@@ -96,7 +96,7 @@ func (e *MarshalEncoder) marshal(v any) error {
 		typ = typ.Elem()
 	}
 
-	switch typ.Kind() {
+	switch typ.Kind() { //nolint:exhaustive // only marshalable reflect kinds
 	case reflect.Bool:
 		return e.marshalBool(val.Bool())
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32:

--- a/modules/structs/issue.go
+++ b/modules/structs/issue.go
@@ -198,7 +198,7 @@ func (l *IssueTemplateStringSlice) UnmarshalYAML(value *yaml.Node) error {
 		*l = labels
 		return nil
 	}
-	switch value.Kind {
+	switch value.Kind { //nolint:exhaustive // only scalar and sequence nodes
 	case yaml.ScalarNode:
 		str := ""
 		err := value.Decode(&str)

--- a/modules/structs/repo.go
+++ b/modules/structs/repo.go
@@ -343,7 +343,7 @@ func (gt GitServiceType) Name() string {
 
 // Title represents the service type's proper title
 func (gt GitServiceType) Title() string {
-	switch gt {
+	switch gt { //nolint:exhaustive // only titled git services
 	case GithubService:
 		return "GitHub"
 	case GiteaService:
@@ -403,7 +403,7 @@ type MigrateRepoOptions struct {
 
 // TokenAuth represents whether a service type supports token-based auth
 func (gt GitServiceType) TokenAuth() bool {
-	switch gt {
+	switch gt { //nolint:exhaustive // only token-auth services
 	case GithubService, GiteaService, GitlabService:
 		return true
 	}

--- a/routers/api/packages/api.go
+++ b/routers/api/packages/api.go
@@ -44,7 +44,7 @@ func reqPackageAccess(accessMode perm.AccessMode) func(ctx *context.Context) {
 			if ok { // it's a personal access token but not oauth2 token
 				scopeMatched := false
 				var err error
-				switch accessMode {
+				switch accessMode { //nolint:exhaustive // only read and write are relevant
 				case perm.AccessModeRead:
 					scopeMatched, err = scope.HasScope(auth_model.AccessTokenScopeReadPackage)
 					if err != nil {

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -841,7 +841,7 @@ func verifyAuthWithOptions(options *common.VerifyOptions) func(ctx *context.APIC
 func individualPermsChecker(ctx *context.APIContext) {
 	// org permissions have been checked in context.OrgAssignment(), but individual permissions haven't been checked.
 	if ctx.ContextUser.IsIndividual() {
-		switch ctx.ContextUser.Visibility {
+		switch ctx.ContextUser.Visibility { //nolint:exhaustive // only restricted visibility types need checks
 		case api.VisibleTypePrivate:
 			if ctx.Doer == nil || (ctx.ContextUser.ID != ctx.Doer.ID && !ctx.Doer.IsAdmin) {
 				ctx.APIErrorNotFound("Visit Project", nil)

--- a/routers/web/auth/auth.go
+++ b/routers/web/auth/auth.go
@@ -593,7 +593,7 @@ func createUserInContext(ctx *context.Context, tpl templates.TplName, form any, 
 	}
 	if err := user_model.CreateUser(ctx, u, meta, overwrites); err != nil {
 		if possibleLinkAccountData != nil && (user_model.IsErrUserAlreadyExist(err) || user_model.IsErrEmailAlreadyUsed(err)) {
-			switch setting.OAuth2Client.AccountLinking {
+			switch setting.OAuth2Client.AccountLinking { //nolint:exhaustive // only auto and login linking modes
 			case setting.OAuth2AccountLinkingAuto:
 				var user *user_model.User
 				user = &user_model.User{Name: u.Name}

--- a/routers/web/auth/oauth.go
+++ b/routers/web/auth/oauth.go
@@ -152,7 +152,7 @@ func SignInOAuthCallback(ctx *context.Context) {
 				return
 			}
 			if uname == "" {
-				switch setting.OAuth2Client.Username {
+				switch setting.OAuth2Client.Username { //nolint:exhaustive // only name-based username sources
 				case setting.OAuth2UsernameNickname:
 					missingFields = append(missingFields, "nickname")
 				case setting.OAuth2UsernamePreferredUsername:

--- a/routers/web/feed/convert.go
+++ b/routers/web/feed/convert.go
@@ -198,7 +198,7 @@ func feedActionsToFeedItems(ctx *context.Context, actions activities_model.Actio
 
 		// description & content
 		{
-			switch act.OpType {
+			switch act.OpType { //nolint:exhaustive // only actions with descriptions
 			case activities_model.ActionCommitRepo, activities_model.ActionMirrorSyncPush:
 				push := templates.ActionContent2Commits(act)
 				_ = act.LoadRepo(ctx)

--- a/routers/web/repo/pull_review.go
+++ b/routers/web/repo/pull_review.go
@@ -236,7 +236,7 @@ func SubmitReview(ctx *context.Context) {
 	}
 
 	reviewType := form.ReviewType()
-	switch reviewType {
+	switch reviewType { //nolint:exhaustive // only unknown and self-review need guards
 	case issues_model.ReviewTypeUnknown:
 		ctx.ServerError("ReviewType", fmt.Errorf("unknown ReviewType: %s", form.Type))
 		return

--- a/routers/web/user/package.go
+++ b/routers/web/user/package.go
@@ -203,7 +203,7 @@ func ViewPackageVersion(ctx *context.Context) {
 	}
 	ctx.Data["PackageRegistryHost"] = registryHostURL.Host
 
-	switch pd.Package.Type {
+	switch pd.Package.Type { //nolint:exhaustive // only types with extra metadata
 	case packages_model.TypeAlpine:
 		branches := make(container.Set[string])
 		repositories := make(container.Set[string])

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -905,7 +905,7 @@ func registerWebRoutes(m *web.Router, webAuth *AuthMiddleware) {
 	individualPermsChecker := func(ctx *context.Context) {
 		// org permissions have been checked in context.OrgAssignment(), but individual permissions haven't been checked.
 		if ctx.ContextUser.IsIndividual() {
-			switch ctx.ContextUser.Visibility {
+			switch ctx.ContextUser.Visibility { //nolint:exhaustive // only restricted visibility types need checks
 			case structs.VisibleTypePrivate:
 				if ctx.Doer == nil || (ctx.ContextUser.ID != ctx.Doer.ID && !ctx.Doer.IsAdmin) {
 					ctx.NotFound(nil)

--- a/services/asymkey/sign.go
+++ b/services/asymkey/sign.go
@@ -42,7 +42,7 @@ func signingModeFromStrings(modeStrings []string) []signingMode {
 	returnable := make([]signingMode, 0, len(modeStrings))
 	for _, mode := range modeStrings {
 		signMode := signingMode(strings.ToLower(strings.TrimSpace(mode)))
-		switch signMode {
+		switch signMode { //nolint:exhaustive // skips unrecognized modes
 		case never:
 			return []signingMode{never}
 		case always:
@@ -142,7 +142,7 @@ func SignInitialCommit(ctx context.Context, u *user_model.User) (bool, *git.Sign
 
 Loop:
 	for _, rule := range rules {
-		switch rule {
+		switch rule { //nolint:exhaustive // only signing policy rules
 		case never:
 			return false, nil, nil, &ErrWontSign{never}
 		case always:
@@ -178,7 +178,7 @@ func SignWikiCommit(ctx context.Context, repo *repo_model.Repository, gitRepo *g
 
 Loop:
 	for _, rule := range rules {
-		switch rule {
+		switch rule { //nolint:exhaustive // only signing policy rules
 		case never:
 			return false, nil, nil, &ErrWontSign{never}
 		case always:
@@ -226,7 +226,7 @@ func SignCRUDAction(ctx context.Context, u *user_model.User, gitRepo *git.Reposi
 
 Loop:
 	for _, rule := range rules {
-		switch rule {
+		switch rule { //nolint:exhaustive // only signing policy rules
 		case never:
 			return false, nil, nil, &ErrWontSign{never}
 		case always:
@@ -295,7 +295,7 @@ func SignMerge(ctx context.Context, pr *issues_model.PullRequest, u *user_model.
 
 Loop:
 	for _, rule := range rules {
-		switch rule {
+		switch rule { //nolint:exhaustive // only signing policy rules
 		case never:
 			return false, nil, nil, &ErrWontSign{never}
 		case always:

--- a/services/convert/convert.go
+++ b/services/convert/convert.go
@@ -276,7 +276,7 @@ func ToActionWorkflowRun(ctx context.Context, repo *repo_model.Repository, run *
 
 func ToWorkflowRunAction(status actions_model.Status) string {
 	var action string
-	switch status {
+	switch status { //nolint:exhaustive // done statuses handled below
 	case actions_model.StatusWaiting, actions_model.StatusBlocked:
 		action = "requested"
 	case actions_model.StatusRunning:
@@ -291,7 +291,7 @@ func ToWorkflowRunAction(status actions_model.Status) string {
 func ToActionsStatus(status actions_model.Status) (string, string) {
 	var action string
 	var conclusion string
-	switch status {
+	switch status { //nolint:exhaustive // done statuses handled below
 	// This is a naming conflict of the webhook between Gitea and GitHub Actions
 	case actions_model.StatusWaiting:
 		action = "queued"
@@ -302,7 +302,7 @@ func ToActionsStatus(status actions_model.Status) (string, string) {
 	}
 	if status.IsDone() {
 		action = "completed"
-		switch status {
+		switch status { //nolint:exhaustive // only done statuses have conclusions
 		case actions_model.StatusSuccess:
 			conclusion = "success"
 		case actions_model.StatusCancelled:

--- a/services/convert/pull_review.go
+++ b/services/convert/pull_review.go
@@ -45,7 +45,7 @@ func ToPullReview(ctx context.Context, r *issues_model.Review, doer *user_model.
 		}
 	}
 
-	switch r.Type {
+	switch r.Type { //nolint:exhaustive // only maps known review states
 	case issues_model.ReviewTypeApprove:
 		result.State = api.ReviewStateApproved
 	case issues_model.ReviewTypeReject:

--- a/services/mailer/mail_issue_common.go
+++ b/services/mailer/mail_issue_common.go
@@ -287,7 +287,7 @@ func generateMessageIDForIssue(issue *issues_model.Issue, comment *issues_model.
 	if comment != nil {
 		extra = fmt.Sprintf("/comment/%d", comment.ID)
 	} else {
-		switch actionType {
+		switch actionType { //nolint:exhaustive // only state-change actions need IDs
 		case activities_model.ActionCloseIssue, activities_model.ActionClosePullRequest:
 			extra = fmt.Sprintf("/close/%d", time.Now().UnixNano()/1e6)
 		case activities_model.ActionReopenIssue, activities_model.ActionReopenPullRequest:

--- a/services/mailer/mail_workflow_run.go
+++ b/services/mailer/mail_workflow_run.go
@@ -49,7 +49,7 @@ func composeAndSendActionsWorkflowRunStatusEmail(ctx context.Context, repo *repo
 	}
 
 	var subjectTrString string
-	switch run.Status {
+	switch run.Status { //nolint:exhaustive // other statuses not emailed
 	case actions_model.StatusFailure:
 		subjectTrString = "mail.repo.actions.run.failed"
 	case actions_model.StatusCancelled:
@@ -97,7 +97,7 @@ func composeAndSendActionsWorkflowRunStatusEmail(ctx context.Context, repo *repo
 	for lang, tos := range langMap {
 		locale := translation.NewLocale(lang)
 		var runStatusTrString string
-		switch run.Status {
+		switch run.Status { //nolint:exhaustive // other statuses not emailed
 		case actions_model.StatusSuccess:
 			runStatusTrString = "mail.repo.actions.jobs.all_succeeded"
 		case actions_model.StatusFailure:

--- a/services/mailer/notify.go
+++ b/services/mailer/notify.go
@@ -32,7 +32,7 @@ func (m *mailNotifier) CreateIssueComment(ctx context.Context, doer *user_model.
 	issue *issues_model.Issue, comment *issues_model.Comment, mentions []*user_model.User,
 ) {
 	var act activities_model.ActionType
-	switch comment.Type {
+	switch comment.Type { //nolint:exhaustive // only mailable comment types
 	case issues_model.CommentTypeClose:
 		act = activities_model.ActionCloseIssue
 	case issues_model.CommentTypeReopen:
@@ -97,7 +97,7 @@ func (m *mailNotifier) NewPullRequest(ctx context.Context, pr *issues_model.Pull
 
 func (m *mailNotifier) PullRequestReview(ctx context.Context, pr *issues_model.PullRequest, r *issues_model.Review, comment *issues_model.Comment, mentions []*user_model.User) {
 	var act activities_model.ActionType
-	switch comment.Type {
+	switch comment.Type { //nolint:exhaustive // only mailable comment types
 	case issues_model.CommentTypeClose:
 		act = activities_model.ActionCloseIssue
 	case issues_model.CommentTypeReopen:

--- a/services/migrations/gitlab.go
+++ b/services/migrations/gitlab.go
@@ -165,7 +165,7 @@ func (g *GitlabDownloader) GetRepoInfo(ctx context.Context) (*base.Repository, e
 	}
 
 	var private bool
-	switch gr.Visibility {
+	switch gr.Visibility { //nolint:exhaustive // public visibility is the default
 	case gitlab.InternalVisibility:
 		private = true
 	case gitlab.PrivateVisibility:

--- a/services/packages/cleanup/cleanup.go
+++ b/services/packages/cleanup/cleanup.go
@@ -120,7 +120,7 @@ func executeCleanupOneRule(ctx context.Context, pcr *packages_model.PackageClean
 	}
 
 	if anyVersionDeleted {
-		switch pcr.Type {
+		switch pcr.Type { //nolint:exhaustive // only repo-based packages need rebuild
 		case packages_model.TypeDebian:
 			if err := debian_service.BuildAllRepositoryFiles(ctx, pcr.OwnerID); err != nil {
 				return fmt.Errorf("CleanupRule [%d]: debian.BuildAllRepositoryFiles failed: %w", pcr.ID, err)

--- a/services/repository/files/tree.go
+++ b/services/repository/files/tree.go
@@ -102,7 +102,7 @@ func GetTreeBySHA(ctx context.Context, repo *repo_model.Repository, gitRepo *git
 }
 
 func entryModeString(entryMode git.EntryMode) string {
-	switch entryMode {
+	switch entryMode { //nolint:exhaustive // unknown modes fall through
 	case git.EntryModeBlob:
 		return "blob"
 	case git.EntryModeExec:

--- a/services/webhook/dingtalk.go
+++ b/services/webhook/dingtalk.go
@@ -122,7 +122,7 @@ func (dc dingtalkConvertor) PullRequest(p *api.PullRequestPayload) (DingtalkPayl
 // Review implements PayloadConvertor Review method
 func (dc dingtalkConvertor) Review(p *api.PullRequestPayload, event webhook_module.HookEventType) (DingtalkPayload, error) {
 	var text, title string
-	switch p.Action {
+	switch p.Action { //nolint:exhaustive // only the reviewed action needs formatting
 	case api.HookIssueReviewed:
 		action, err := parseHookPullRequestEventType(event)
 		if err != nil {

--- a/services/webhook/discord.go
+++ b/services/webhook/discord.go
@@ -204,7 +204,7 @@ func (d discordConvertor) PullRequest(p *api.PullRequestPayload) (DiscordPayload
 func (d discordConvertor) Review(p *api.PullRequestPayload, event webhook_module.HookEventType) (DiscordPayload, error) {
 	var text, title string
 	var color int
-	switch p.Action {
+	switch p.Action { //nolint:exhaustive // only the reviewed action needs formatting
 	case api.HookIssueReviewed:
 		action, err := parseHookPullRequestEventType(event)
 		if err != nil {

--- a/services/webhook/general.go
+++ b/services/webhook/general.go
@@ -39,7 +39,7 @@ func getPullRequestInfo(p *api.PullRequestPayload) (title, link, by, operator, o
 	for i, user := range assignList {
 		assignStringList[i] = user.UserName
 	}
-	switch p.Action {
+	switch p.Action { //nolint:exhaustive // only assign/milestone actions set operateResult
 	case api.HookIssueAssigned:
 		operateResult = fmt.Sprintf("%s assign this to %s", p.Sender.UserName, assignList[len(assignList)-1].UserName)
 	case api.HookIssueUnassigned:
@@ -65,7 +65,7 @@ func getIssuesInfo(p *api.IssuePayload) (issueTitle, link, by, operator, operate
 	for i, user := range assignList {
 		assignStringList[i] = user.UserName
 	}
-	switch p.Action {
+	switch p.Action { //nolint:exhaustive // only assign/milestone actions set operateResult
 	case api.HookIssueAssigned:
 		operateResult = fmt.Sprintf("%s assign this to %s", p.Sender.UserName, assignList[len(assignList)-1].UserName)
 	case api.HookIssueUnassigned:
@@ -101,7 +101,7 @@ func getIssuesPayloadInfo(p *api.IssuePayload, linkFormatter linkFormatter, with
 	titleLink := linkFormatter(fmt.Sprintf("%s/issues/%d", p.Repository.HTMLURL, p.Index), issueTitle)
 	repoLink := linkFormatter(p.Repository.HTMLURL, p.Repository.FullName)
 
-	switch p.Action {
+	switch p.Action { //nolint:exhaustive // other actions use default text and color
 	case api.HookIssueOpened:
 		text = fmt.Sprintf("[%s] Issue opened: %s", repoLink, titleLink)
 		color = orangeColor
@@ -151,7 +151,7 @@ func getPullRequestPayloadInfo(p *api.PullRequestPayload, linkFormatter linkForm
 	titleLink := linkFormatter(p.PullRequest.URL, issueTitle)
 	repoLink := linkFormatter(p.Repository.HTMLURL, p.Repository.FullName)
 
-	switch p.Action {
+	switch p.Action { //nolint:exhaustive // other actions use default text and color
 	case api.HookIssueOpened:
 		text = fmt.Sprintf("[%s] Pull request opened: %s", repoLink, titleLink)
 		extraMarkdown = p.PullRequest.Body

--- a/services/webhook/matrix.go
+++ b/services/webhook/matrix.go
@@ -203,7 +203,7 @@ func (m matrixConvertor) Review(p *api.PullRequestPayload, event webhook_module.
 	repoLink := htmlLinkFormatter(p.Repository.HTMLURL, p.Repository.FullName)
 	var text string
 
-	switch p.Action {
+	switch p.Action { //nolint:exhaustive // only the reviewed action needs formatting
 	case api.HookIssueReviewed:
 		action, err := parseHookPullRequestEventType(event)
 		if err != nil {

--- a/services/webhook/msteams.go
+++ b/services/webhook/msteams.go
@@ -202,7 +202,7 @@ func (m msteamsConvertor) PullRequest(p *api.PullRequestPayload) (MSTeamsPayload
 func (m msteamsConvertor) Review(p *api.PullRequestPayload, event webhook_module.HookEventType) (MSTeamsPayload, error) {
 	var text, title string
 	var color int
-	switch p.Action {
+	switch p.Action { //nolint:exhaustive // only the reviewed action needs formatting
 	case api.HookIssueReviewed:
 		action, err := parseHookPullRequestEventType(event)
 		if err != nil {

--- a/services/webhook/payloader.go
+++ b/services/webhook/payloader.go
@@ -42,7 +42,7 @@ func convertUnmarshalledJSON[T, P any](convert func(P) (T, error), data []byte) 
 }
 
 func newPayload[T any](rc payloadConvertor[T], data []byte, event webhook_module.HookEventType) (t T, err error) {
-	switch event {
+	switch event { //nolint:exhaustive // events not listed here are unsupported
 	case webhook_module.HookEventCreate:
 		return convertUnmarshalledJSON(rc.Create, data)
 	case webhook_module.HookEventDelete:

--- a/services/webhook/slack.go
+++ b/services/webhook/slack.go
@@ -253,7 +253,7 @@ func (s slackConvertor) Review(p *api.PullRequestPayload, event webhook_module.H
 	repoLink := SlackLinkFormatter(p.Repository.HTMLURL, p.Repository.FullName)
 	var text string
 
-	switch p.Action {
+	switch p.Action { //nolint:exhaustive // only the reviewed action needs formatting
 	case api.HookIssueReviewed:
 		action, err := parseHookPullRequestEventType(event)
 		if err != nil {

--- a/services/webhook/telegram.go
+++ b/services/webhook/telegram.go
@@ -126,7 +126,7 @@ func (t telegramConvertor) PullRequest(p *api.PullRequestPayload) (TelegramPaylo
 // Review implements PayloadConvertor Review method
 func (t telegramConvertor) Review(p *api.PullRequestPayload, event webhook_module.HookEventType) (TelegramPayload, error) {
 	var text, extraMarkdown string
-	switch p.Action {
+	switch p.Action { //nolint:exhaustive // only the reviewed action needs formatting
 	case api.HookIssueReviewed:
 		action, err := parseHookPullRequestEventType(event)
 		if err != nil {

--- a/services/webhook/wechatwork.go
+++ b/services/webhook/wechatwork.go
@@ -127,7 +127,7 @@ func (wc wechatworkConvertor) PullRequest(p *api.PullRequestPayload) (Wechatwork
 // Review implements PayloadConvertor Review method
 func (wc wechatworkConvertor) Review(p *api.PullRequestPayload, event webhook_module.HookEventType) (WechatworkPayload, error) {
 	var text, title string
-	switch p.Action {
+	switch p.Action { //nolint:exhaustive // only the reviewed action needs formatting
 	case api.HookIssueReviewed:
 		action, err := parseHookPullRequestEventType(event)
 		if err != nil {


### PR DESCRIPTION
Enable the `exhaustive` linter with `default-signifies-exhaustive: true` while adding `//nolint` comments to existing violations.

Ref: https://golangci-lint.run/docs/linters/configuration/#exhaustive