### PR TITLE
Stop persisting migration patch files; resolve PR head SHA via downloader APIs

### DIFF
--- a/modules/git/repo_compare.go
+++ b/modules/git/repo_compare.go
@@ -5,14 +5,8 @@
 package git
 
 import (
-	"bufio"
 	"bytes"
-	"errors"
-	"fmt"
 	"io"
-	"os"
-	"path/filepath"
-	"regexp"
 	"strings"
 
 	"code.gitea.io/gitea/modules/git/gitcmd"
@@ -65,8 +59,6 @@ func (repo *Repository) GetDiffNumChangedFiles(base, head string, directComparis
 	return w.numLines, nil
 }
 
-var patchCommits = regexp.MustCompile(`^From\s(\w+)\s`)
-
 // GetDiff generates and returns patch data between given revisions, optimized for human readability
 func (repo *Repository) GetDiff(compareArg string, w io.Writer) error {
 	return gitcmd.NewCommand("diff", "-p").AddDynamicArguments(compareArg).
@@ -118,26 +110,4 @@ func (repo *Repository) GetFilesChangedBetween(base, head string) ([]string, err
 	}
 
 	return split, err
-}
-
-// ReadPatchCommit will check if a diff patch exists and return stats
-func (repo *Repository) ReadPatchCommit(prID int64) (commitSHA string, err error) {
-	// Migrated repositories download patches to "pulls" location
-	patchFile := fmt.Sprintf("pulls/%d.patch", prID)
-	loadPatch, err := os.Open(filepath.Join(repo.Path, patchFile))
-	if err != nil {
-		return "", err
-	}
-	defer loadPatch.Close()
-	// Read only the first line of the patch - usually it contains the first commit made in patch
-	scanner := bufio.NewScanner(loadPatch)
-	scanner.Scan()
-	// Parse the Patch stats, sometimes Migration returns a 404 for the patch file
-	commitSHAGroups := patchCommits.FindStringSubmatch(scanner.Text())
-	if len(commitSHAGroups) != 0 {
-		commitSHA = commitSHAGroups[1]
-	} else {
-		return "", errors.New("patch file doesn't contain valid commit ID")
-	}
-	return commitSHA, nil
 }

--- a/modules/git/repo_compare_test.go
+++ b/modules/git/repo_compare_test.go
@@ -47,36 +47,6 @@ func TestGetFormatPatch(t *testing.T) {
 	assert.Contains(t, patch, "Subject: [PATCH] Add file2.txt")
 }
 
-func TestReadPatch(t *testing.T) {
-	// Ensure we can read the patch files
-	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
-	repo, err := OpenRepository(t.Context(), bareRepo1Path)
-	if err != nil {
-		assert.NoError(t, err)
-		return
-	}
-	defer repo.Close()
-	// This patch doesn't exist
-	noFile, err := repo.ReadPatchCommit(0)
-	assert.Error(t, err)
-
-	// This patch is an empty one (sometimes it's a 404)
-	noCommit, err := repo.ReadPatchCommit(1)
-	assert.Error(t, err)
-
-	// This patch is legit and should return a commit
-	oldCommit, err := repo.ReadPatchCommit(2)
-	if err != nil {
-		assert.NoError(t, err)
-		return
-	}
-
-	assert.Empty(t, noFile)
-	assert.Empty(t, noCommit)
-	assert.Len(t, oldCommit, 40)
-	assert.Equal(t, "6e8e2a6f9efd71dbe6917816343ed8415ad696c3", oldCommit)
-}
-
 func TestReadWritePullHead(t *testing.T) {
 	// Ensure we can write SHA1 head corresponding to PR and open them
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -225,17 +225,8 @@ func GetMergedBaseCommitID(ctx *context.Context, issue *issues_model.Issue) stri
 		// If there is a head or a patch file, and it is readable, grab info
 		commitSHA, err := ctx.Repo.GitRepo.GetRefCommitID(pull.GetGitHeadRefName())
 		if err != nil {
-			// Head File does not exist, try the patch
-			commitSHA, err = ctx.Repo.GitRepo.ReadPatchCommit(pull.Index)
-			if err == nil {
-				// Recreate pull head in files for next time
-				if err := gitrepo.UpdateRef(ctx, ctx.Repo.Repository, pull.GetGitHeadRefName(), commitSHA); err != nil {
-					log.Error("Could not write head file", err)
-				}
-			} else {
-				// There is no history available
-				log.Trace("No history file available for PR %d", pull.Index)
-			}
+			// There is no history available
+			log.Trace("No history available for PR %d", pull.Index)
 		}
 		if commitSHA != "" {
 			// Get immediate parent of the first commit in the patch, grab history back

--- a/services/migrations/common.go
+++ b/services/migrations/common.go
@@ -4,7 +4,11 @@
 package migrations
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
+	"io"
+	"regexp"
 	"strings"
 
 	system_model "code.gitea.io/gitea/models/system"
@@ -26,6 +30,25 @@ func hasBaseURL(toCheck, baseURL string) bool {
 		baseURL += "/"
 	}
 	return strings.HasPrefix(toCheck, baseURL)
+}
+
+var patchCommitPattern = regexp.MustCompile(`^From\s([0-9a-fA-F]{7,64})\s`)
+
+func parsePatchHeadSHA(r io.Reader) (string, error) {
+	scanner := bufio.NewScanner(r)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return "", err
+		}
+		return "", errors.New("patch file is empty")
+	}
+
+	match := patchCommitPattern.FindStringSubmatch(scanner.Text())
+	if len(match) < 2 {
+		return "", errors.New("patch file doesn't contain valid commit ID")
+	}
+
+	return match[1], nil
 }
 
 // CheckAndEnsureSafePR will check that a given PR is safe to download

--- a/services/migrations/common_test.go
+++ b/services/migrations/common_test.go
@@ -1,0 +1,20 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package migrations
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePatchHeadSHA(t *testing.T) {
+	patchSHA := "0123456789abcdef0123456789abcdef01234567"
+	patchContent := "From " + patchSHA + " Mon Sep 17 00:00:00 2001\n"
+
+	headSHA, err := parsePatchHeadSHA(strings.NewReader(patchContent))
+	require.NoError(t, err)
+	require.Equal(t, patchSHA, headSHA)
+}

--- a/services/migrations/gitea_downloader.go
+++ b/services/migrations/gitea_downloader.go
@@ -4,6 +4,7 @@
 package migrations
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -514,6 +515,25 @@ func (g *GiteaDownloader) GetComments(ctx context.Context, commentable base.Comm
 	return allComments, true, nil
 }
 
+func (g *GiteaDownloader) fillPullRequestHeadSHA(_ context.Context, pr *base.PullRequest) error {
+	if pr.Head.SHA != "" {
+		return nil
+	}
+
+	patch, _, err := g.client.GetPullRequestPatch(g.repoOwner, g.repoName, pr.ForeignIndex)
+	if err != nil {
+		return err
+	}
+
+	headSHA, err := parsePatchHeadSHA(bytes.NewReader(patch))
+	if err != nil {
+		return err
+	}
+
+	pr.Head.SHA = headSHA
+	return nil
+}
+
 // GetPullRequests returns pull requests according page and perPage
 func (g *GiteaDownloader) GetPullRequests(ctx context.Context, page, perPage int) ([]*base.PullRequest, bool, error) {
 	if perPage > g.maxPerPage {
@@ -625,6 +645,9 @@ func (g *GiteaDownloader) GetPullRequests(ctx context.Context, page, perPage int
 		})
 		// SECURITY: Ensure that the PR is safe
 		_ = CheckAndEnsureSafePR(allPRs[len(allPRs)-1], g.baseURL, g)
+		if err := g.fillPullRequestHeadSHA(ctx, allPRs[len(allPRs)-1]); err != nil {
+			log.Warn("PR #%d in %s unable to resolve head SHA: %v", allPRs[len(allPRs)-1].Number, g, err)
+		}
 	}
 
 	isEnd := len(prs) < perPage

--- a/services/migrations/gitea_uploader.go
+++ b/services/migrations/gitea_uploader.go
@@ -574,36 +574,6 @@ func (g *GiteaLocalUploader) updateGitForPullRequest(ctx context.Context, pr *ba
 		return "", fmt.Errorf("the PR[%d] was not checked for safety", pr.Number)
 	}
 
-	// Anonymous function to download the patch file (allows us to use defer)
-	err = func() error {
-		// if the patchURL is empty there is nothing to download
-		if pr.PatchURL == "" {
-			return nil
-		}
-
-		// SECURITY: We will assume that the pr.PatchURL has been checked
-		// pr.PatchURL maybe a local file - but note EnsureSafe should be asserting that this safe
-		ret, err := uri.Open(pr.PatchURL) // TODO: This probably needs to use the downloader as there may be rate limiting issues here
-		if err != nil {
-			return err
-		}
-		defer ret.Close()
-
-		f, err := gitrepo.CreateRepoFile(ctx, g.repo, fmt.Sprintf("pulls/%d.patch", pr.Number))
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-
-		// TODO: Should there be limits on the size of this file?
-		_, err = io.Copy(f, ret)
-
-		return err
-	}()
-	if err != nil {
-		return "", err
-	}
-
 	head = "unknown repository"
 	if pr.IsForkPullRequest() && pr.State != "closed" {
 		// OK we want to fetch the current head as a branch from its CloneURL

--- a/services/migrations/github.go
+++ b/services/migrations/github.go
@@ -575,6 +575,29 @@ func (g *GithubDownloaderV3) getComments(ctx context.Context, commentable base.C
 	return allComments, nil
 }
 
+func (g *GithubDownloaderV3) fillPullRequestHeadSHA(ctx context.Context, pr *base.PullRequest) error {
+	if pr.Head.SHA != "" {
+		return nil
+	}
+
+	g.waitAndPickClient(ctx)
+	patch, resp, err := g.getClient().PullRequests.GetRaw(ctx, g.repoOwner, g.repoName, int(pr.ForeignIndex), github.RawOptions{Type: github.Patch})
+	if resp != nil {
+		g.setRate(&resp.Rate)
+	}
+	if err != nil {
+		return err
+	}
+
+	headSHA, err := parsePatchHeadSHA(strings.NewReader(patch))
+	if err != nil {
+		return err
+	}
+
+	pr.Head.SHA = headSHA
+	return nil
+}
+
 // GetAllComments returns repository comments according page and perPageSize
 func (g *GithubDownloaderV3) GetAllComments(ctx context.Context, page, perPage int) ([]*base.Comment, bool, error) {
 	var (
@@ -746,6 +769,9 @@ func (g *GithubDownloaderV3) GetPullRequests(ctx context.Context, page, perPage 
 
 		// SECURITY: Ensure that the PR is safe
 		_ = CheckAndEnsureSafePR(allPRs[len(allPRs)-1], g.baseURL, g)
+		if err := g.fillPullRequestHeadSHA(ctx, allPRs[len(allPRs)-1]); err != nil {
+			log.Warn("PR #%d in %s unable to resolve head SHA: %v", allPRs[len(allPRs)-1].Number, g, err)
+		}
 	}
 
 	return allPRs, len(prs) < perPage, nil

--- a/services/migrations/gitlab.go
+++ b/services/migrations/gitlab.go
@@ -594,6 +594,52 @@ func (g *GitlabDownloader) convertNoteToComment(localIndex int64, note *gitlab.N
 	return comment
 }
 
+func (g *GitlabDownloader) fillPullRequestHeadSHA(ctx context.Context, pr *base.PullRequest) error {
+	if pr.Head.SHA != "" {
+		return nil
+	}
+
+	versions, _, err := g.client.MergeRequests.GetMergeRequestDiffVersions(g.repoID, int(pr.ForeignIndex), &gitlab.GetMergeRequestDiffVersionsOptions{
+		Page:    1,
+		PerPage: g.maxPerPage,
+	}, gitlab.WithContext(ctx))
+	if err == nil {
+		var best *gitlab.MergeRequestDiffVersion
+		for _, version := range versions {
+			if version.HeadCommitSHA == "" {
+				continue
+			}
+			switch {
+			case best == nil:
+				best = version
+			case version.CreatedAt != nil && best.CreatedAt != nil && version.CreatedAt.After(*best.CreatedAt):
+				best = version
+			case version.CreatedAt == nil || best.CreatedAt == nil:
+				if version.ID > best.ID {
+					best = version
+				}
+			}
+		}
+		if best != nil && best.HeadCommitSHA != "" {
+			pr.Head.SHA = best.HeadCommitSHA
+			return nil
+		}
+	}
+
+	commits, _, err := g.client.MergeRequests.GetMergeRequestCommits(g.repoID, int(pr.ForeignIndex), &gitlab.GetMergeRequestCommitsOptions{
+		Page:    1,
+		PerPage: g.maxPerPage,
+	}, gitlab.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+	if len(commits) == 0 {
+		return errors.New("merge request has no commits")
+	}
+	pr.Head.SHA = commits[len(commits)-1].ID
+	return nil
+}
+
 // GetPullRequests returns pull requests according page and perPage
 func (g *GitlabDownloader) GetPullRequests(ctx context.Context, page, perPage int) ([]*base.PullRequest, bool, error) {
 	if perPage > g.maxPerPage {
@@ -718,6 +764,9 @@ func (g *GitlabDownloader) GetPullRequests(ctx context.Context, page, perPage in
 
 		// SECURITY: Ensure that the PR is safe
 		_ = CheckAndEnsureSafePR(allPRs[len(allPRs)-1], g.baseURL, g)
+		if err := g.fillPullRequestHeadSHA(ctx, allPRs[len(allPRs)-1]); err != nil {
+			log.Warn("PR #%d in %s unable to resolve head SHA: %v", allPRs[len(allPRs)-1].Number, g, err)
+		}
 	}
 
 	return allPRs, len(prs) < perPage, nil


### PR DESCRIPTION
Fix #35432

This change removes the reliance on stored `pulls/<id>.patch` files and shifts PR head SHA recovery fully into the migration downloader layer using authenticated clients.

Changes:
- Resolve PR head SHA during migration download using GitHub/Gitea API patch endpoints and GitLab diff/commit APIs.
- Remove patch file downloads from the uploader and delete the migration-only URI helper.
- Drop `ReadPatchCommit` and its fallback usage in PR view logic.
- Add a focused test for parsing the patch header.

Notes:
- Patch content is now fetched via authenticated API clients only.
- PR views no longer try to recover history from on-disk patch files; the head ref should be populated during migration.

---
Generated by a coding agent with Codex 5.2