### PR TITLE
Use JWT-based Actions auth for git/LFS requests

### DIFF
--- a/models/actions/task_token_metadata.go
+++ b/models/actions/task_token_metadata.go
@@ -1,0 +1,85 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package actions
+
+import (
+	"context"
+	"encoding/base64"
+
+	repo_model "code.gitea.io/gitea/models/repo"
+	"code.gitea.io/gitea/models/unit"
+	"code.gitea.io/gitea/modules/json"
+)
+
+// TaskTokenMetadata carries the task context needed to authorize Actions API/git/LFS
+// requests without reloading the task row on every request.
+type TaskTokenMetadata struct {
+	TaskID            int64                               `json:"task_id"`
+	RepoID            int64                               `json:"repo_id"`
+	OwnerID           int64                               `json:"owner_id"`
+	TaskRepoIsPrivate bool                                `json:"task_repo_is_private"`
+	IsForkPullRequest bool                                `json:"is_fork_pull_request"`
+	TokenPermissions  *repo_model.ActionsTokenPermissions `json:"token_permissions,omitempty"`
+}
+
+func NewTaskTokenMetadata(task *ActionTask) *TaskTokenMetadata {
+	if task == nil || task.Job == nil || task.Job.Repo == nil {
+		return nil
+	}
+
+	return &TaskTokenMetadata{
+		TaskID:            task.ID,
+		RepoID:            task.RepoID,
+		OwnerID:           task.Job.Repo.OwnerID,
+		TaskRepoIsPrivate: task.Job.Repo.IsPrivate,
+		IsForkPullRequest: task.IsForkPullRequest,
+		TokenPermissions:  task.Job.TokenPermissions,
+	}
+}
+
+func EncodeTaskTokenMetadata(meta *TaskTokenMetadata) (string, error) {
+	if meta == nil {
+		return "", nil
+	}
+
+	bs, err := json.Marshal(meta)
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(bs), nil
+}
+
+func DecodeTaskTokenMetadata(encoded string) (*TaskTokenMetadata, error) {
+	if encoded == "" {
+		return nil, nil //nolint:nilnil // not applicable
+	}
+
+	bs, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, err
+	}
+
+	meta := new(TaskTokenMetadata)
+	if err := json.Unmarshal(bs, meta); err != nil {
+		return nil, err
+	}
+	return meta, nil
+}
+
+// ComputeTaskTokenPermissionsFromMetadata computes the effective permissions for a job
+// token against the target repository using token metadata instead of reloading the task row.
+func ComputeTaskTokenPermissionsFromMetadata(ctx context.Context, taskMeta *TaskTokenMetadata, taskRepo, targetRepo *repo_model.Repository) (ret repo_model.ActionsTokenPermissions, err error) {
+	if err := taskRepo.LoadUnits(ctx); err != nil {
+		return ret, err
+	}
+
+	repoActionsCfg := taskRepo.MustGetUnit(ctx, unit.TypeActions).ActionsConfig()
+	ownerActionsCfg, err := GetOwnerActionsConfig(ctx, taskMeta.OwnerID)
+	if err != nil {
+		return ret, err
+	}
+
+	isCrossRepo := taskMeta.RepoID != targetRepo.ID
+	return applyTokenPermissions(taskMeta.TokenPermissions, repoActionsCfg, ownerActionsCfg, taskMeta.IsForkPullRequest, isCrossRepo), nil
+}

--- a/models/actions/task_token_metadata_test.go
+++ b/models/actions/task_token_metadata_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package actions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaskTokenMetadataEncoding(t *testing.T) {
+	t.Run("NilAndEmpty", func(t *testing.T) {
+		encoded, err := EncodeTaskTokenMetadata(nil)
+		require.NoError(t, err)
+		assert.Empty(t, encoded)
+
+		meta, err := DecodeTaskTokenMetadata("")
+		require.NoError(t, err)
+		assert.Nil(t, meta)
+	})
+
+	t.Run("RoundTrip", func(t *testing.T) {
+		original := &TaskTokenMetadata{
+			TaskID:            53,
+			RepoID:            2,
+			OwnerID:           2,
+			TaskRepoIsPrivate: true,
+			IsForkPullRequest: false,
+		}
+		encoded, err := EncodeTaskTokenMetadata(original)
+		require.NoError(t, err)
+		require.NotEmpty(t, encoded)
+
+		decoded, err := DecodeTaskTokenMetadata(encoded)
+		require.NoError(t, err)
+		assert.Equal(t, original, decoded)
+	})
+}

--- a/models/actions/token_permissions.go
+++ b/models/actions/token_permissions.go
@@ -32,9 +32,22 @@ func ComputeTaskTokenPermissions(ctx context.Context, task *ActionTask, targetRe
 		return ret, err
 	}
 
+	isSameRepo := task.Job.RepoID == targetRepo.ID
+	return applyTokenPermissions(task.Job.TokenPermissions, repoActionsCfg, ownerActionsCfg, task.IsForkPullRequest, !isSameRepo), nil
+}
+
+// applyTokenPermissions applies org/repo policy clamping and fork/cross-repo read-only restrictions
+// to produce the effective permissions for a task token.
+func applyTokenPermissions(
+	declared *repo_model.ActionsTokenPermissions,
+	repoActionsCfg *repo_model.ActionsConfig,
+	ownerActionsCfg OwnerActionsConfig,
+	isForkPR bool,
+	isCrossRepo bool,
+) repo_model.ActionsTokenPermissions {
 	var jobDeclaredPerms repo_model.ActionsTokenPermissions
-	if task.Job.TokenPermissions != nil {
-		jobDeclaredPerms = *task.Job.TokenPermissions
+	if declared != nil {
+		jobDeclaredPerms = *declared
 	} else if repoActionsCfg.OverrideOwnerConfig {
 		jobDeclaredPerms = repoActionsCfg.GetDefaultTokenPermissions()
 	} else {
@@ -50,11 +63,9 @@ func ComputeTaskTokenPermissions(ctx context.Context, task *ActionTask, targetRe
 
 	// Cross-repository access and fork pull requests are strictly read-only for security.
 	// This ensures a "task repo" cannot gain write access to other repositories via CrossRepoAccess settings.
-	isSameRepo := task.Job.RepoID == targetRepo.ID
-	restrictCrossRepoAccess := task.IsForkPullRequest || !isSameRepo
-	if restrictCrossRepoAccess {
+	if isForkPR || isCrossRepo {
 		effectivePerms = repo_model.ClampActionsTokenPermissions(effectivePerms, repo_model.MakeRestrictedPermissions())
 	}
 
-	return effectivePerms, nil
+	return effectivePerms
 }

--- a/models/perm/access/repo_permission.go
+++ b/models/perm/access/repo_permission.go
@@ -281,31 +281,72 @@ func GetActionsUserRepoPermission(ctx context.Context, repo *repo_model.Reposito
 	if actionsUser.ID != user_model.ActionsUserID {
 		return perm, errors.New("api GetActionsUserRepoPermission can only be called by the actions user")
 	}
-	task, err := actions_model.GetTaskByID(ctx, taskID)
-	if err != nil {
-		return perm, err
-	}
 
-	if err := task.LoadJob(ctx); err != nil {
-		return perm, err
-	}
+	var (
+		taskRepo          *repo_model.Repository
+		taskRepoID        int64
+		taskRepoOwnerID   int64
+		taskRepoIsPrivate bool
+		isForkPullRequest bool
+		effectivePerms    repo_model.ActionsTokenPermissions
+	)
 
-	var taskRepo *repo_model.Repository
-	if task.RepoID != repo.ID {
-		if err := task.Job.LoadRepo(ctx); err != nil {
+	if payload, ok := user_model.GetActionsUserTaskPayload(actionsUser); ok {
+		taskMeta, err := actions_model.DecodeTaskTokenMetadata(payload)
+		if err != nil {
 			return perm, err
 		}
-		taskRepo = task.Job.Repo
+
+		taskRepoID = taskMeta.RepoID
+		taskRepoOwnerID = taskMeta.OwnerID
+		taskRepoIsPrivate = taskMeta.TaskRepoIsPrivate
+		isForkPullRequest = taskMeta.IsForkPullRequest
+
+		if taskRepoID == repo.ID {
+			taskRepo = repo
+		} else {
+			taskRepo, err = repo_model.GetRepositoryByID(ctx, taskRepoID)
+			if err != nil {
+				return perm, err
+			}
+		}
+
+		effectivePerms, err = actions_model.ComputeTaskTokenPermissionsFromMetadata(ctx, taskMeta, taskRepo, repo)
+		if err != nil {
+			return perm, err
+		}
 	} else {
-		taskRepo = repo
+		task, err := actions_model.GetTaskByID(ctx, taskID)
+		if err != nil {
+			return perm, err
+		}
+
+		if err := task.LoadJob(ctx); err != nil {
+			return perm, err
+		}
+
+		taskRepoID = task.RepoID
+		taskRepoOwnerID = task.Job.OwnerID
+		isForkPullRequest = task.IsForkPullRequest
+
+		if task.RepoID != repo.ID {
+			if err := task.Job.LoadRepo(ctx); err != nil {
+				return perm, err
+			}
+			taskRepo = task.Job.Repo
+			taskRepoIsPrivate = task.Job.Repo.IsPrivate
+		} else {
+			taskRepo = repo
+			taskRepoIsPrivate = repo.IsPrivate
+		}
+
+		effectivePerms, err = actions_model.ComputeTaskTokenPermissions(ctx, task, repo)
+		if err != nil {
+			return perm, err
+		}
 	}
 
-	// Compute effective permissions for this task against the target repo
-	effectivePerms, err := actions_model.ComputeTaskTokenPermissions(ctx, task, repo)
-	if err != nil {
-		return perm, err
-	}
-	if task.RepoID != repo.ID {
+	if taskRepoID != repo.ID {
 		// Cross-repo access must also respect the target repo's permission ceiling.
 		targetRepoActionsCfg := repo.MustGetUnit(ctx, unit.TypeActions).ActionsConfig()
 		if targetRepoActionsCfg.OverrideOwnerConfig {
@@ -345,11 +386,11 @@ func GetActionsUserRepoPermission(ctx context.Context, repo *repo_model.Reposito
 		}
 	}
 
-	if task.RepoID == repo.ID {
+	if taskRepoID == repo.ID {
 		return maxPerm, nil
 	}
 
-	if checkSameOwnerCrossRepoAccess(ctx, taskRepo, repo, task.IsForkPullRequest) {
+	if taskRepoOwnerID == repo.OwnerID && checkSameOwnerCrossRepoAccess(ctx, taskRepo, repo, isForkPullRequest) {
 		// Access allowed by owner policy (grants access to private repos).
 		// Note: maxPerm has already been restricted to Read-Only in ComputeTaskTokenPermissions
 		// because isSameRepo is false.
@@ -369,9 +410,9 @@ func GetActionsUserRepoPermission(ctx context.Context, repo *repo_model.Reposito
 	// 2. The Actions Bot user has been explicitly granted access and repository is private
 	// 3. The repository is public (handled by botPerm above)
 
-	if taskRepo.IsPrivate {
+	if taskRepoIsPrivate {
 		actionsUnit := repo.MustGetUnit(ctx, unit.TypeActions)
-		if actionsUnit.ActionsConfig().IsCollaborativeOwner(taskRepo.OwnerID) {
+		if actionsUnit.ActionsConfig().IsCollaborativeOwner(taskRepoOwnerID) {
 			return maxPerm, nil
 		}
 	}

--- a/models/perm/access/repo_permission.go
+++ b/models/perm/access/repo_permission.go
@@ -276,77 +276,89 @@ func checkSameOwnerCrossRepoAccess(ctx context.Context, taskRepo, targetRepo *re
 	return slices.Contains(ownerCfg.AllowedCrossRepoIDs, targetRepo.ID)
 }
 
+// taskAuthInfo holds the task-side context needed to compute repo permissions.
+type taskAuthInfo struct {
+	taskRepo          *repo_model.Repository
+	taskRepoID        int64
+	taskRepoOwnerID   int64
+	taskRepoIsPrivate bool
+	isForkPullRequest bool
+	effectivePerms    repo_model.ActionsTokenPermissions
+}
+
+func loadTaskAuthInfoFromPayload(ctx context.Context, payload string, targetRepo *repo_model.Repository) (taskAuthInfo, error) {
+	var info taskAuthInfo
+	taskMeta, err := actions_model.DecodeTaskTokenMetadata(payload)
+	if err != nil {
+		return info, err
+	}
+
+	info.taskRepoID = taskMeta.RepoID
+	info.taskRepoOwnerID = taskMeta.OwnerID
+	info.taskRepoIsPrivate = taskMeta.TaskRepoIsPrivate
+	info.isForkPullRequest = taskMeta.IsForkPullRequest
+
+	if info.taskRepoID == targetRepo.ID {
+		info.taskRepo = targetRepo
+	} else {
+		info.taskRepo, err = repo_model.GetRepositoryByID(ctx, info.taskRepoID)
+		if err != nil {
+			return info, err
+		}
+	}
+
+	info.effectivePerms, err = actions_model.ComputeTaskTokenPermissionsFromMetadata(ctx, taskMeta, info.taskRepo, targetRepo)
+	return info, err
+}
+
+func loadTaskAuthInfoFromDB(ctx context.Context, taskID int64, targetRepo *repo_model.Repository) (taskAuthInfo, error) {
+	var info taskAuthInfo
+	task, err := actions_model.GetTaskByID(ctx, taskID)
+	if err != nil {
+		return info, err
+	}
+	if err := task.LoadJob(ctx); err != nil {
+		return info, err
+	}
+
+	info.taskRepoID = task.RepoID
+	info.taskRepoOwnerID = task.Job.OwnerID
+	info.isForkPullRequest = task.IsForkPullRequest
+
+	if task.RepoID != targetRepo.ID {
+		if err := task.Job.LoadRepo(ctx); err != nil {
+			return info, err
+		}
+		info.taskRepo = task.Job.Repo
+		info.taskRepoIsPrivate = task.Job.Repo.IsPrivate
+	} else {
+		info.taskRepo = targetRepo
+		info.taskRepoIsPrivate = targetRepo.IsPrivate
+	}
+
+	info.effectivePerms, err = actions_model.ComputeTaskTokenPermissions(ctx, task, targetRepo)
+	return info, err
+}
+
 // GetActionsUserRepoPermission returns the actions user permissions to the repository
 func GetActionsUserRepoPermission(ctx context.Context, repo *repo_model.Repository, actionsUser *user_model.User, taskID int64) (perm Permission, err error) {
 	if actionsUser.ID != user_model.ActionsUserID {
 		return perm, errors.New("api GetActionsUserRepoPermission can only be called by the actions user")
 	}
 
-	var (
-		taskRepo          *repo_model.Repository
-		taskRepoID        int64
-		taskRepoOwnerID   int64
-		taskRepoIsPrivate bool
-		isForkPullRequest bool
-		effectivePerms    repo_model.ActionsTokenPermissions
-	)
-
+	var info taskAuthInfo
 	if payload, ok := user_model.GetActionsUserTaskPayload(actionsUser); ok {
-		taskMeta, err := actions_model.DecodeTaskTokenMetadata(payload)
-		if err != nil {
-			return perm, err
-		}
-
-		taskRepoID = taskMeta.RepoID
-		taskRepoOwnerID = taskMeta.OwnerID
-		taskRepoIsPrivate = taskMeta.TaskRepoIsPrivate
-		isForkPullRequest = taskMeta.IsForkPullRequest
-
-		if taskRepoID == repo.ID {
-			taskRepo = repo
-		} else {
-			taskRepo, err = repo_model.GetRepositoryByID(ctx, taskRepoID)
-			if err != nil {
-				return perm, err
-			}
-		}
-
-		effectivePerms, err = actions_model.ComputeTaskTokenPermissionsFromMetadata(ctx, taskMeta, taskRepo, repo)
-		if err != nil {
-			return perm, err
-		}
+		info, err = loadTaskAuthInfoFromPayload(ctx, payload, repo)
 	} else {
-		task, err := actions_model.GetTaskByID(ctx, taskID)
-		if err != nil {
-			return perm, err
-		}
-
-		if err := task.LoadJob(ctx); err != nil {
-			return perm, err
-		}
-
-		taskRepoID = task.RepoID
-		taskRepoOwnerID = task.Job.OwnerID
-		isForkPullRequest = task.IsForkPullRequest
-
-		if task.RepoID != repo.ID {
-			if err := task.Job.LoadRepo(ctx); err != nil {
-				return perm, err
-			}
-			taskRepo = task.Job.Repo
-			taskRepoIsPrivate = task.Job.Repo.IsPrivate
-		} else {
-			taskRepo = repo
-			taskRepoIsPrivate = repo.IsPrivate
-		}
-
-		effectivePerms, err = actions_model.ComputeTaskTokenPermissions(ctx, task, repo)
-		if err != nil {
-			return perm, err
-		}
+		info, err = loadTaskAuthInfoFromDB(ctx, taskID, repo)
+	}
+	if err != nil {
+		return perm, err
 	}
 
-	if taskRepoID != repo.ID {
+	effectivePerms := info.effectivePerms
+
+	if info.taskRepoID != repo.ID {
 		// Cross-repo access must also respect the target repo's permission ceiling.
 		targetRepoActionsCfg := repo.MustGetUnit(ctx, unit.TypeActions).ActionsConfig()
 		if targetRepoActionsCfg.OverrideOwnerConfig {
@@ -365,20 +377,16 @@ func GetActionsUserRepoPermission(ctx context.Context, repo *repo_model.Reposito
 	}
 
 	var maxPerm Permission
-
-	// Set up per-unit access modes based on configured permissions
 	maxPerm.units = repo.Units
 	maxPerm.unitsMode = maps.Clone(effectivePerms.UnitAccessModes)
 
-	// Check permission like simple user but limit to read-only (PR #36095)
-	// Enhanced to also grant read-only access if isSameRepo is true and target repository is public
 	botPerm, err := GetUserRepoPermission(ctx, repo, user_model.NewActionsUser())
 	if err != nil {
 		return perm, err
 	}
 	if botPerm.AccessMode >= perm_model.AccessModeRead {
-		// Public repo allows read access, increase permissions to at least read
-		// Otherwise you cannot access your own repository if your permissions are set to none but the repository is public
+		// Public repo: raise per-unit floor to at least Read so own-repo access works
+		// when token permissions are set to none but the repository is public.
 		for _, u := range repo.Units {
 			if botPerm.CanRead(u.Type) {
 				maxPerm.unitsMode[u.Type] = max(maxPerm.unitsMode[u.Type], perm_model.AccessModeRead)
@@ -386,33 +394,26 @@ func GetActionsUserRepoPermission(ctx context.Context, repo *repo_model.Reposito
 		}
 	}
 
-	if taskRepoID == repo.ID {
+	if info.taskRepoID == repo.ID {
 		return maxPerm, nil
 	}
 
-	if taskRepoOwnerID == repo.OwnerID && checkSameOwnerCrossRepoAccess(ctx, taskRepo, repo, isForkPullRequest) {
+	if info.taskRepoOwnerID == repo.OwnerID && checkSameOwnerCrossRepoAccess(ctx, info.taskRepo, repo, info.isForkPullRequest) {
 		// Access allowed by owner policy (grants access to private repos).
 		// Note: maxPerm has already been restricted to Read-Only in ComputeTaskTokenPermissions
 		// because isSameRepo is false.
 		return maxPerm, nil
 	}
 
-	// Fall through to allow public repository read access via botPerm check below
-
-	// Check if the repo is public or the Bot has explicit access
 	if botPerm.AccessMode >= perm_model.AccessModeRead {
 		return maxPerm, nil
 	}
 
-	// Check Collaborative Owner and explicit Bot permissions
-	// We allow access if:
-	// 1. It's a collaborative owner relationship
-	// 2. The Actions Bot user has been explicitly granted access and repository is private
-	// 3. The repository is public (handled by botPerm above)
-
-	if taskRepoIsPrivate {
+	// Check Collaborative Owner access: allow if the task's owner org has been
+	// granted collaborative access to this repo and the task repo is private.
+	if info.taskRepoIsPrivate {
 		actionsUnit := repo.MustGetUnit(ctx, unit.TypeActions)
-		if actionsUnit.ActionsConfig().IsCollaborativeOwner(taskRepoOwnerID) {
+		if actionsUnit.ActionsConfig().IsCollaborativeOwner(info.taskRepoOwnerID) {
 			return maxPerm, nil
 		}
 	}

--- a/models/user/user_system.go
+++ b/models/user/user_system.go
@@ -55,10 +55,22 @@ func NewActionsUser() *User {
 }
 
 func NewActionsUserWithTaskID(id int64) *User {
+	return newActionsUserWithLoginName("@" + ActionsUserName + "/" + strconv.FormatInt(id, 10))
+}
+
+func NewActionsUserWithTaskPayload(id int64, payload string) *User {
+	loginName := "@" + ActionsUserName + "/" + strconv.FormatInt(id, 10)
+	if payload != "" {
+		loginName += "/" + payload
+	}
+	return newActionsUserWithLoginName(loginName)
+}
+
+func newActionsUserWithLoginName(loginName string) *User {
 	u := NewActionsUser()
 	// LoginName is for only internal usage in this case, so it can be moved to other fields in the future
 	u.LoginSource = -1
-	u.LoginName = "@" + ActionsUserName + "/" + strconv.FormatInt(id, 10)
+	u.LoginName = loginName
 	return u
 }
 
@@ -69,10 +81,27 @@ func GetActionsUserTaskID(u *User) (int64, bool) {
 	prefix, payload, _ := strings.Cut(u.LoginName, "/")
 	if prefix != "@"+ActionsUserName {
 		return 0, false
-	} else if taskID, err := strconv.ParseInt(payload, 10, 64); err == nil {
+	}
+	taskIDStr, _, _ := strings.Cut(payload, "/")
+	if taskID, err := strconv.ParseInt(taskIDStr, 10, 64); err == nil {
 		return taskID, true
 	}
 	return 0, false
+}
+
+func GetActionsUserTaskPayload(u *User) (string, bool) {
+	if u == nil || u.ID != ActionsUserID {
+		return "", false
+	}
+	prefix, payload, _ := strings.Cut(u.LoginName, "/")
+	if prefix != "@"+ActionsUserName {
+		return "", false
+	}
+	_, meta, ok := strings.Cut(payload, "/")
+	if !ok || meta == "" {
+		return "", false
+	}
+	return meta, true
 }
 
 func (u *User) IsGiteaActions() bool {

--- a/models/user/user_system_test.go
+++ b/models/user/user_system_test.go
@@ -34,3 +34,40 @@ func TestSystemUser(t *testing.T) {
 	_, err = GetPossibleUserByID(t.Context(), -3)
 	require.Error(t, err)
 }
+
+func TestActionsUserTaskEncoding(t *testing.T) {
+	t.Run("TaskIDOnly", func(t *testing.T) {
+		u := NewActionsUserWithTaskID(47)
+		taskID, ok := GetActionsUserTaskID(u)
+		require.True(t, ok)
+		assert.Equal(t, int64(47), taskID)
+
+		payload, ok := GetActionsUserTaskPayload(u)
+		assert.False(t, ok)
+		assert.Empty(t, payload)
+	})
+
+	t.Run("TaskIDWithPayload", func(t *testing.T) {
+		u := NewActionsUserWithTaskPayload(53, "encoded-payload")
+		taskID, ok := GetActionsUserTaskID(u)
+		require.True(t, ok)
+		assert.Equal(t, int64(53), taskID)
+
+		payload, ok := GetActionsUserTaskPayload(u)
+		require.True(t, ok)
+		assert.Equal(t, "encoded-payload", payload)
+	})
+
+	t.Run("InvalidShape", func(t *testing.T) {
+		u := NewActionsUser()
+		u.LoginName = "@gitea-actions/not-a-number/encoded-payload"
+
+		taskID, ok := GetActionsUserTaskID(u)
+		assert.False(t, ok)
+		assert.Equal(t, int64(0), taskID)
+
+		payload, ok := GetActionsUserTaskPayload(u)
+		require.True(t, ok)
+		assert.Equal(t, "encoded-payload", payload)
+	})
+}

--- a/services/actions/auth.go
+++ b/services/actions/auth.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	actions_model "code.gitea.io/gitea/models/actions"
 	"code.gitea.io/gitea/modules/json"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
@@ -24,6 +25,11 @@ type actionsClaims struct {
 	RunID  int64
 	JobID  int64
 	Ac     string `json:"ac"`
+}
+
+type taskTokenClaims struct {
+	jwt.RegisteredClaims
+	TaskToken actions_model.TaskTokenMetadata `json:"task_token"`
 }
 
 type actionsCacheScope struct {
@@ -72,6 +78,29 @@ func CreateAuthorizationToken(taskID, runID, jobID int64) (string, error) {
 	return tokenString, nil
 }
 
+func CreateTaskAuthorizationToken(task *actions_model.ActionTask) (string, error) {
+	meta := actions_model.NewTaskTokenMetadata(task)
+	if meta == nil {
+		return "", errors.New("missing task metadata")
+	}
+
+	now := time.Now()
+	claims := taskTokenClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(now.Add(1*time.Hour + setting.Actions.EndlessTaskTimeout)),
+			NotBefore: jwt.NewNumericDate(now),
+		},
+		TaskToken: *meta,
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+
+	tokenString, err := token.SignedString(setting.GetGeneralTokenSigningSecret())
+	if err != nil {
+		return "", err
+	}
+	return tokenString, nil
+}
+
 func ParseAuthorizationToken(req *http.Request) (int64, error) {
 	h := req.Header.Get("Authorization")
 	if h == "" {
@@ -105,4 +134,26 @@ func TokenToTaskID(token string) (int64, error) {
 	}
 
 	return c.TaskID, nil
+}
+
+func ParseTaskAuthorizationToken(token string) (*actions_model.TaskTokenMetadata, error) {
+	parsedToken, err := jwt.ParseWithClaims(token, &taskTokenClaims{}, func(t *jwt.Token) (any, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		return setting.GetGeneralTokenSigningSecret(), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	c, ok := parsedToken.Claims.(*taskTokenClaims)
+	if !parsedToken.Valid || !ok {
+		return nil, errors.New("invalid token claim")
+	}
+	if c.TaskToken.TaskID == 0 || c.TaskToken.RepoID == 0 || c.TaskToken.OwnerID == 0 {
+		return nil, errors.New("invalid task token claim")
+	}
+
+	return &c.TaskToken, nil
 }

--- a/services/actions/auth.go
+++ b/services/actions/auth.go
@@ -116,14 +116,16 @@ func ParseAuthorizationToken(req *http.Request) (int64, error) {
 	return TokenToTaskID(parts[1])
 }
 
+func hmacKeyFunc(t *jwt.Token) (any, error) {
+	if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+		return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+	}
+	return setting.GetGeneralTokenSigningSecret(), nil
+}
+
 // TokenToTaskID returns the TaskID associated with the provided JWT token
 func TokenToTaskID(token string) (int64, error) {
-	parsedToken, err := jwt.ParseWithClaims(token, &actionsClaims{}, func(t *jwt.Token) (any, error) {
-		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
-		}
-		return setting.GetGeneralTokenSigningSecret(), nil
-	})
+	parsedToken, err := jwt.ParseWithClaims(token, &actionsClaims{}, hmacKeyFunc)
 	if err != nil {
 		return 0, err
 	}
@@ -137,12 +139,7 @@ func TokenToTaskID(token string) (int64, error) {
 }
 
 func ParseTaskAuthorizationToken(token string) (*actions_model.TaskTokenMetadata, error) {
-	parsedToken, err := jwt.ParseWithClaims(token, &taskTokenClaims{}, func(t *jwt.Token) (any, error) {
-		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
-		}
-		return setting.GetGeneralTokenSigningSecret(), nil
-	})
+	parsedToken, err := jwt.ParseWithClaims(token, &taskTokenClaims{}, hmacKeyFunc)
 	if err != nil {
 		return nil, err
 	}

--- a/services/actions/auth_test.go
+++ b/services/actions/auth_test.go
@@ -7,11 +7,14 @@ import (
 	"net/http"
 	"testing"
 
+	actions_model "code.gitea.io/gitea/models/actions"
+	"code.gitea.io/gitea/models/unittest"
 	"code.gitea.io/gitea/modules/json"
 	"code.gitea.io/gitea/modules/setting"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateAuthorizationToken(t *testing.T) {
@@ -61,4 +64,23 @@ func TestParseAuthorizationTokenNoAuthHeader(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, int64(0), rTaskID)
+}
+
+func TestCreateTaskAuthorizationToken(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	task := unittest.AssertExistsAndLoadBean(t, &actions_model.ActionTask{ID: 53})
+	require.NoError(t, task.LoadJob(t.Context()))
+	require.NoError(t, task.Job.LoadRepo(t.Context()))
+
+	token, err := CreateTaskAuthorizationToken(task)
+	require.NoError(t, err)
+
+	meta, err := ParseTaskAuthorizationToken(token)
+	require.NoError(t, err)
+	assert.Equal(t, task.ID, meta.TaskID)
+	assert.Equal(t, task.RepoID, meta.RepoID)
+	assert.Equal(t, task.Job.Repo.OwnerID, meta.OwnerID)
+	assert.Equal(t, task.Job.Repo.IsPrivate, meta.TaskRepoIsPrivate)
+	assert.Equal(t, task.IsForkPullRequest, meta.IsForkPullRequest)
 }

--- a/services/actions/task.go
+++ b/services/actions/task.go
@@ -60,6 +60,9 @@ func PickTask(ctx context.Context, runner *actions_model.ActionRunner) (*runnerv
 		if err := t.LoadAttributes(ctx); err != nil {
 			return fmt.Errorf("task LoadAttributes: %w", err)
 		}
+		if err := t.Job.LoadRepo(ctx); err != nil {
+			return fmt.Errorf("task Job.LoadRepo: %w", err)
+		}
 		job = t.Job
 		actionTask = t
 
@@ -67,6 +70,12 @@ func PickTask(ctx context.Context, runner *actions_model.ActionRunner) (*runnerv
 		if err != nil {
 			return fmt.Errorf("GetSecretsOfTask: %w", err)
 		}
+		giteaToken, err := CreateTaskAuthorizationToken(t)
+		if err != nil {
+			return fmt.Errorf("CreateTaskAuthorizationToken: %w", err)
+		}
+		secrets["GITHUB_TOKEN"] = giteaToken
+		secrets["GITEA_TOKEN"] = giteaToken
 
 		vars, err := actions_model.GetVariablesOfRun(ctx, t.Job.Run)
 		if err != nil {
@@ -78,7 +87,7 @@ func PickTask(ctx context.Context, runner *actions_model.ActionRunner) (*runnerv
 			return fmt.Errorf("findTaskNeeds: %w", err)
 		}
 
-		taskContext, err := generateTaskContext(t)
+		taskContext, err := generateTaskContext(t, giteaToken)
 		if err != nil {
 			return fmt.Errorf("generateTaskContext: %w", err)
 		}
@@ -107,14 +116,14 @@ func PickTask(ctx context.Context, runner *actions_model.ActionRunner) (*runnerv
 	return task, true, nil
 }
 
-func generateTaskContext(t *actions_model.ActionTask) (*structpb.Struct, error) {
+func generateTaskContext(t *actions_model.ActionTask, giteaToken string) (*structpb.Struct, error) {
 	giteaRuntimeToken, err := CreateAuthorizationToken(t.ID, t.Job.RunID, t.JobID)
 	if err != nil {
 		return nil, err
 	}
 
 	gitCtx := GenerateGiteaContext(t.Job.Run, t.Job)
-	gitCtx["token"] = t.Token
+	gitCtx["token"] = giteaToken
 	gitCtx["gitea_runtime_token"] = giteaRuntimeToken
 
 	return structpb.NewStruct(gitCtx)

--- a/services/auth/basic.go
+++ b/services/auth/basic.go
@@ -72,6 +72,7 @@ func (b *Basic) parseAuthBasic(req *http.Request) (ret struct{ authToken, uname,
 func (b *Basic) VerifyAuthToken(req *http.Request, w http.ResponseWriter, store DataStore, sess SessionStore, authToken string) (*user_model.User, error) {
 	var tokenLookupErr error
 
+	// Task JWT: signature + expiry provide the revocation bound; no DB hit needed.
 	if taskMeta, err := actions_service.ParseTaskAuthorizationToken(authToken); err == nil {
 		payload, err := actions_model.EncodeTaskTokenMetadata(taskMeta)
 		if err != nil {

--- a/services/auth/basic.go
+++ b/services/auth/basic.go
@@ -5,6 +5,7 @@
 package auth
 
 import (
+	"errors"
 	"net/http"
 
 	actions_model "code.gitea.io/gitea/models/actions"
@@ -15,6 +16,7 @@ import (
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/timeutil"
 	"code.gitea.io/gitea/modules/util"
+	actions_service "code.gitea.io/gitea/services/actions"
 )
 
 // Ensure the struct implements the interface.
@@ -68,6 +70,17 @@ func (b *Basic) parseAuthBasic(req *http.Request) (ret struct{ authToken, uname,
 
 // VerifyAuthToken only the access token provided as parameter, used by other auth methods that want to reuse access token verification logic
 func (b *Basic) VerifyAuthToken(req *http.Request, w http.ResponseWriter, store DataStore, sess SessionStore, authToken string) (*user_model.User, error) {
+	var tokenLookupErr error
+
+	if taskMeta, err := actions_service.ParseTaskAuthorizationToken(authToken); err == nil {
+		payload, err := actions_model.EncodeTaskTokenMetadata(taskMeta)
+		if err != nil {
+			return nil, err
+		}
+		store.GetData()["LoginMethod"] = ActionTokenMethodName
+		return user_model.NewActionsUserWithTaskPayload(taskMeta.TaskID, payload), nil
+	}
+
 	// get oauth2 token's user's ID
 	_, uid := GetOAuthAccessTokenScopeAndUserID(req.Context(), authToken)
 	if uid != 0 {
@@ -105,6 +118,7 @@ func (b *Basic) VerifyAuthToken(req *http.Request, w http.ResponseWriter, store 
 		return u, nil
 	} else if !auth_model.IsErrAccessTokenNotExist(err) && !auth_model.IsErrAccessTokenEmpty(err) {
 		log.Error("GetAccessTokenBySha: %v", err)
+		tokenLookupErr = err
 	}
 
 	// check task token
@@ -113,6 +127,19 @@ func (b *Basic) VerifyAuthToken(req *http.Request, w http.ResponseWriter, store 
 		log.Trace("Basic Authorization: Valid AccessToken for task[%d]", task.ID)
 		store.GetData()["LoginMethod"] = ActionTokenMethodName
 		return user_model.NewActionsUserWithTaskID(task.ID), nil
+	}
+	if err != nil && !errors.Is(err, util.ErrNotExist) {
+		log.Error("GetRunningTaskByToken: %v", err)
+		if tokenLookupErr == nil {
+			tokenLookupErr = err
+		}
+	}
+
+	// Do not fall through into password authentication when backend token lookup failed
+	// for a token-shaped Basic credential. Under load, that can redirect an LFS/API token
+	// request into web/LDAP auth instead of failing the token auth path explicitly.
+	if tokenLookupErr != nil && isLikelyTokenString(authToken) {
+		return nil, tokenLookupErr
 	}
 	return nil, nil //nolint:nilnil // the auth method is not applicable
 }
@@ -130,6 +157,9 @@ func (b *Basic) Verify(req *http.Request, w http.ResponseWriter, store DataStore
 	u, err := b.VerifyAuthToken(req, w, store, sess, authToken)
 	if u != nil || err != nil {
 		return u, err
+	}
+	if uname == user_model.ActionsUserName {
+		return nil, ErrUserAuthMessage("invalid actions token")
 	}
 
 	if !setting.Service.EnableBasicAuth {
@@ -197,4 +227,16 @@ func GetAccessScope(store DataStore) auth_model.AccessTokenScope {
 	default:
 		return ""
 	}
+}
+
+func isLikelyTokenString(s string) bool {
+	if len(s) != 40 {
+		return false
+	}
+	for _, x := range []byte(s) {
+		if x < '0' || (x > '9' && x < 'a') || x > 'f' {
+			return false
+		}
+	}
+	return true
 }

--- a/services/auth/basic_test.go
+++ b/services/auth/basic_test.go
@@ -1,0 +1,18 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsLikelyTokenString(t *testing.T) {
+	assert.True(t, isLikelyTokenString("d2c6c1ba3890b309189a8e618c72a162e4efbf36"))
+	assert.False(t, isLikelyTokenString(""))
+	assert.False(t, isLikelyTokenString("not-a-token"))
+	assert.False(t, isLikelyTokenString("D2C6C1BA3890B309189A8E618C72A162E4EFBF36"))
+	assert.False(t, isLikelyTokenString("d2c6c1ba3890b309189a8e618c72a162e4efbf3g"))
+}

--- a/services/auth/oauth2.go
+++ b/services/auth/oauth2.go
@@ -56,16 +56,15 @@ func GetOAuthAccessTokenScopeAndUserID(ctx context.Context, accessToken string) 
 	return accessTokenScope, grant.UserID
 }
 
-// CheckTaskIsRunning verifies that the TaskID corresponds to a running task
-func CheckTaskIsRunning(ctx context.Context, taskID int64) bool {
-	// Verify the task exists
+// CheckTaskIsRunning verifies that the TaskID corresponds to a running task.
+// It returns (false, nil) when the task exists but is not running, and
+// (false, err) when the DB lookup itself fails.
+func CheckTaskIsRunning(ctx context.Context, taskID int64) (bool, error) {
 	task, err := actions_model.GetTaskByID(ctx, taskID)
 	if err != nil {
-		return false
+		return false, err
 	}
-
-	// Verify that it's running
-	return task.Status == actions_model.StatusRunning
+	return task.Status == actions_model.StatusRunning, nil
 }
 
 // OAuth2 implements the Auth interface and authenticates requests
@@ -111,6 +110,7 @@ func parseToken(req *http.Request) (string, bool) {
 func (o *OAuth2) userFromToken(ctx context.Context, tokenSHA string, store DataStore) (*user_model.User, error) {
 	// Let's see if token is valid.
 	if strings.Contains(tokenSHA, ".") {
+		// Task JWT: signature + expiry provide the revocation bound; no DB hit needed.
 		if taskMeta, err := actions.ParseTaskAuthorizationToken(tokenSHA); err == nil {
 			payload, err := actions_model.EncodeTaskTokenMetadata(taskMeta)
 			if err != nil {
@@ -119,9 +119,13 @@ func (o *OAuth2) userFromToken(ctx context.Context, tokenSHA string, store DataS
 			return user_model.NewActionsUserWithTaskPayload(taskMeta.TaskID, payload), nil
 		}
 
-		// First attempt to decode an actions JWT, returning the actions user
+		// Legacy actions JWT (gitea_runtime_token): must verify the task is still running.
 		if taskID, err := actions.TokenToTaskID(tokenSHA); err == nil {
-			if CheckTaskIsRunning(ctx, taskID) {
+			running, err := CheckTaskIsRunning(ctx, taskID)
+			if err != nil {
+				return nil, err
+			}
+			if running {
 				return user_model.NewActionsUserWithTaskID(taskID), nil
 			}
 		}

--- a/services/auth/oauth2.go
+++ b/services/auth/oauth2.go
@@ -111,6 +111,14 @@ func parseToken(req *http.Request) (string, bool) {
 func (o *OAuth2) userFromToken(ctx context.Context, tokenSHA string, store DataStore) (*user_model.User, error) {
 	// Let's see if token is valid.
 	if strings.Contains(tokenSHA, ".") {
+		if taskMeta, err := actions.ParseTaskAuthorizationToken(tokenSHA); err == nil {
+			payload, err := actions_model.EncodeTaskTokenMetadata(taskMeta)
+			if err != nil {
+				return nil, err
+			}
+			return user_model.NewActionsUserWithTaskPayload(taskMeta.TaskID, payload), nil
+		}
+
 		// First attempt to decode an actions JWT, returning the actions user
 		if taskID, err := actions.TokenToTaskID(tokenSHA); err == nil {
 			if CheckTaskIsRunning(ctx, taskID) {

--- a/services/auth/oauth2_test.go
+++ b/services/auth/oauth2_test.go
@@ -4,11 +4,13 @@
 package auth
 
 import (
+	"errors"
 	"testing"
 
 	"code.gitea.io/gitea/models/unittest"
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/reqctx"
+	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/services/actions"
 
 	"github.com/stretchr/testify/assert"
@@ -39,18 +41,26 @@ func TestCheckTaskIsRunning(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
 
 	cases := map[string]struct {
-		TaskID   int64
-		Expected bool
+		TaskID        int64
+		Expected      bool
+		wantNotExists bool
 	}{
 		"Running":   {TaskID: 47, Expected: true},
-		"Missing":   {TaskID: 1, Expected: false},
+		"Missing":   {TaskID: 1, Expected: false, wantNotExists: true},
 		"Cancelled": {TaskID: 46, Expected: false},
 	}
 
 	for name := range cases {
 		c := cases[name]
 		t.Run(name, func(t *testing.T) {
-			actual := CheckTaskIsRunning(t.Context(), c.TaskID)
+			actual, err := CheckTaskIsRunning(t.Context(), c.TaskID)
+			if c.wantNotExists {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, util.ErrNotExist)
+				assert.False(t, actual)
+				return
+			}
+			require.NoError(t, err)
 			assert.Equal(t, c.Expected, actual)
 		})
 	}

--- a/tests/integration/actions_job_test.go
+++ b/tests/integration/actions_job_test.go
@@ -545,7 +545,7 @@ jobs:
 		assert.Equal(t, actionRun.WorkflowID, gtCtx["workflow"].GetStringValue())
 		assert.Equal(t, setting.Actions.DefaultActionsURL.URL(), gtCtx["gitea_default_actions_url"].GetStringValue())
 		token := gtCtx["token"].GetStringValue()
-		assert.Equal(t, actionTask.TokenLastEight, token[len(token)-8:])
+		assert.Contains(t, token, ".")
 	})
 }
 
@@ -637,7 +637,7 @@ jobs:
 		assert.Equal(t, actionRun.WorkflowID, gtCtx["workflow"].GetStringValue())
 		assert.Equal(t, setting.Actions.DefaultActionsURL.URL(), gtCtx["gitea_default_actions_url"].GetStringValue())
 		token := gtCtx["token"].GetStringValue()
-		assert.Equal(t, actionTask.TokenLastEight, token[len(token)-8:])
+		assert.Contains(t, token, ".")
 
 		// verify CleanupEphemeralRunners does not remove this runner
 		err = actions_service.CleanupEphemeralRunners(t.Context())

--- a/tests/integration/actions_job_test.go
+++ b/tests/integration/actions_job_test.go
@@ -545,7 +545,9 @@ jobs:
 		assert.Equal(t, actionRun.WorkflowID, gtCtx["workflow"].GetStringValue())
 		assert.Equal(t, setting.Actions.DefaultActionsURL.URL(), gtCtx["gitea_default_actions_url"].GetStringValue())
 		token := gtCtx["token"].GetStringValue()
-		assert.Contains(t, token, ".")
+		tokenMeta, err := actions_service.ParseTaskAuthorizationToken(token)
+		require.NoError(t, err)
+		assert.Equal(t, actionTask.ID, tokenMeta.TaskID)
 	})
 }
 
@@ -637,7 +639,9 @@ jobs:
 		assert.Equal(t, actionRun.WorkflowID, gtCtx["workflow"].GetStringValue())
 		assert.Equal(t, setting.Actions.DefaultActionsURL.URL(), gtCtx["gitea_default_actions_url"].GetStringValue())
 		token := gtCtx["token"].GetStringValue()
-		assert.Contains(t, token, ".")
+		tokenMeta, err := actions_service.ParseTaskAuthorizationToken(token)
+		require.NoError(t, err)
+		assert.Equal(t, actionTask.ID, tokenMeta.TaskID)
 
 		// verify CleanupEphemeralRunners does not remove this runner
 		err = actions_service.CleanupEphemeralRunners(t.Context())


### PR DESCRIPTION
This changes Actions GITEA_TOKEN auth for git/LFS/API requests to use a signed task JWT with embedded task metadata instead of relying on DB-backed task-token lookups on every request.

## Why
Under load, some LFS batch requests intermittently lost auth because the legacy gitea-actions token path depended on database lookups (GetRunningTaskByToken / related auth queries). When those lookups failed, requests could fall through into web/password auth behavior instead of consistently authenticating as the Actions user.

Code was created with the help of *Cursor*

This is still work in progress and needs further consideration and testing