### PR TITLE
Clean up checkbox cursor styles

### DIFF
--- a/web_src/css/modules/checkbox.css
+++ b/web_src/css/modules/checkbox.css
@@ -92,13 +92,11 @@ input[type="checkbox"]:indeterminate::before {
 }
 
 .ui.checkbox input[type="checkbox"]:enabled,
-.ui.checkbox input[type="radio"]:enabled,
-.ui.checkbox label:enabled {
+.ui.checkbox input[type="radio"]:enabled {
   cursor: pointer;
 }
 
 .ui.checkbox label {
-  cursor: auto;
   position: relative;
   display: block;
 }

--- a/web_src/css/modules/checkbox.css
+++ b/web_src/css/modules/checkbox.css
@@ -91,11 +91,6 @@ input[type="checkbox"]:indeterminate::before {
   height: var(--checkbox-size);
 }
 
-.ui.checkbox input[type="checkbox"]:enabled,
-.ui.checkbox input[type="radio"]:enabled {
-  cursor: pointer;
-}
-
 .ui.checkbox label {
   position: relative;
   display: block;


### PR DESCRIPTION
1. Remove non-functional `label:enabled` selector (`:enabled` only works on [form controls](https://html.spec.whatwg.org/multipage/semantics-other.html#concept-element-disabled), not labels)
2. Remove `cursor: auto` which caused an I-beam text selection cursor on checkbox labels. The default browser styles work find and show regular cursor.
3. Remove `cursor: pointer` on checkbox itself, opinionated and not needed.
---
This PR was written with the help of Claude Opus 4.6