### PR TITLE
Fix relative-time RangeError

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -31,6 +31,10 @@ var (
 	// IsInTesting indicates whether the testing is running. A lot of unreliable code causes a lot of nonsense error logs during testing
 	// TODO: this is only a temporary solution, we should make the test code more reliable
 	IsInTesting = false
+
+	// IsE2ETest indicates whether the server is running for e2e tests, set via GITEA_E2E_TEST env var.
+	// IsInTesting is unsuitable because it has many side effects for in-process unit/integration tests.
+	IsE2ETest = os.Getenv("GITEA_E2E_TEST") == "true"
 )
 
 func init() {

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -28,8 +28,10 @@ var (
 	CfgProvider ConfigProvider
 	IsWindows   bool
 
-	// IsInTesting indicates whether the testing is running (unit test or integration test).
-	// A lot of unreliable code causes a lot of nonsense error logs during testing
+	// IsInTesting indicates whether the testing is running (unit test or integration test). It can be used for:
+	// * Skip nonsense error logs during testing caused by unreliable code
+	// * Panic in dev or testing mode to make the problem more obvious and easier to debug
+	// * Mock some functions or options to make testing easier (eg: session store, time, URL detection, etc.)
 	// TODO: this is only a temporary solution, we should make the test code more reliable
 	IsInTesting = false
 )

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -28,13 +28,10 @@ var (
 	CfgProvider ConfigProvider
 	IsWindows   bool
 
-	// IsInTesting indicates whether the testing is running. A lot of unreliable code causes a lot of nonsense error logs during testing
+	// IsInTesting indicates whether the testing is running (unit test or integration test).
+	// A lot of unreliable code causes a lot of nonsense error logs during testing
 	// TODO: this is only a temporary solution, we should make the test code more reliable
 	IsInTesting = false
-
-	// IsE2ETest indicates whether the server is running for e2e tests, set via GITEA_E2E_TEST env var.
-	// IsInTesting is unsuitable because it has many side effects for in-process unit/integration tests.
-	IsE2ETest = os.Getenv("GITEA_E2E_TEST") == "true"
 )
 
 func init() {
@@ -59,6 +56,10 @@ func IsRunUserMatchCurrentUser(runUser string) (string, bool) {
 
 	currentUser := user.CurrentUsername()
 	return currentUser, runUser == currentUser
+}
+
+func IsInE2eTesting() bool {
+	return os.Getenv("GITEA_TEST_E2E") == "true"
 }
 
 // PrepareAppDataPath creates app data directory if necessary

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -29,10 +29,9 @@ var (
 	IsWindows   bool
 
 	// IsInTesting indicates whether the testing is running (unit test or integration test). It can be used for:
-	// * Skip nonsense error logs during testing caused by unreliable code
+	// * Skip nonsense error logs during testing caused by unreliable code (TODO: this is only a temporary solution, we should make the test code more reliable)
 	// * Panic in dev or testing mode to make the problem more obvious and easier to debug
 	// * Mock some functions or options to make testing easier (eg: session store, time, URL detection, etc.)
-	// TODO: this is only a temporary solution, we should make the test code more reliable
 	IsInTesting = false
 )
 

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1740,7 +1740,7 @@ func registerWebRoutes(m *web.Router, webAuth *AuthMiddleware) {
 		m.Get("/swagger.v1.json", SwaggerV1Json)
 	}
 
-	if !setting.IsProd || setting.IsE2ETest {
+	if !setting.IsProd || setting.IsInE2eTesting() {
 		m.Group("/devtest", func() {
 			m.Any("", devtest.List)
 			m.Any("/fetch-action-test", devtest.FetchActionTest)

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1740,7 +1740,7 @@ func registerWebRoutes(m *web.Router, webAuth *AuthMiddleware) {
 		m.Get("/swagger.v1.json", SwaggerV1Json)
 	}
 
-	if !setting.IsProd {
+	if !setting.IsProd || setting.IsE2ETest {
 		m.Group("/devtest", func() {
 			m.Any("", devtest.List)
 			m.Any("/fetch-action-test", devtest.FetchActionTest)

--- a/templates/devtest/relative-time.tmpl
+++ b/templates/devtest/relative-time.tmpl
@@ -3,7 +3,7 @@
 	<div class="tw-grid tw-grid-cols-3 tw-gap-4">
 		<div>
 			<h2>Relative (auto)</h2>
-			<div>now: <relative-time datetime="{{.TimeNow.Format "2006-01-02T15:04:05Z07:00"}}"></relative-time></div>
+			<div>now: <relative-time data-testid="relative-time-now" datetime="{{.TimeNow.Format "2006-01-02T15:04:05Z07:00"}}"></relative-time></div>
 			<div>3m ago: <relative-time datetime="{{.TimePast3m.Format "2006-01-02T15:04:05Z07:00"}}"></relative-time></div>
 			<div>3h ago: <relative-time datetime="{{.TimePast3h.Format "2006-01-02T15:04:05Z07:00"}}"></relative-time></div>
 			<div>1d ago: <relative-time datetime="{{.TimePast1d.Format "2006-01-02T15:04:05Z07:00"}}"></relative-time></div>

--- a/tests/e2e/relative-time.test.ts
+++ b/tests/e2e/relative-time.test.ts
@@ -1,0 +1,10 @@
+import {test, expect} from '@playwright/test';
+import {assertNoJsError} from './utils.ts';
+
+test('relative-time renders without errors', async ({page}) => {
+  await page.goto('/devtest/relative-time');
+  const relativeTime = page.getByTestId('relative-time-now');
+  await expect(relativeTime).toHaveAttribute('data-tooltip-content', /.+/);
+  await expect(relativeTime).toHaveText('now');
+  await assertNoJsError(page);
+});

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -104,6 +104,10 @@ export async function login(page: Page, username = env.GITEA_TEST_E2E_USER, pass
   await expect(page.getByRole('link', {name: 'Sign In'})).toBeHidden();
 }
 
+export async function assertNoJsError(page: Page) {
+  await expect(page.locator('.js-global-error')).toHaveCount(0);
+}
+
 export async function logout(page: Page) {
   await page.context().clearCookies(); // workaround issues related to fomantic dropdown
   await page.goto('/');

--- a/tools/test-e2e.sh
+++ b/tools/test-e2e.sh
@@ -43,6 +43,7 @@ LEVEL = Warn
 EOF
 
 export GITEA_WORK_DIR="$WORK_DIR"
+export GITEA_E2E_TEST=true
 
 # Start Gitea server
 echo "Starting Gitea server on port $FREE_PORT (workdir: $WORK_DIR)..."

--- a/tools/test-e2e.sh
+++ b/tools/test-e2e.sh
@@ -43,7 +43,7 @@ LEVEL = Warn
 EOF
 
 export GITEA_WORK_DIR="$WORK_DIR"
-export GITEA_E2E_TEST=true
+export GITEA_TEST_E2E=true
 
 # Start Gitea server
 echo "Starting Gitea server on port $FREE_PORT (workdir: $WORK_DIR)..."

--- a/web_src/js/webcomponents/relative-time.ts
+++ b/web_src/js/webcomponents/relative-time.ts
@@ -259,12 +259,12 @@ class RelativeTime extends HTMLElement {
 
   get #lang(): string {
     const lang = this.closest('[lang]')?.getAttribute('lang');
-    if (!lang) return navigator.language;
-    try {
-      return new Intl.Locale(lang).toString();
-    } catch {
-      return navigator.language;
+    if (lang) {
+      try {
+        return new Intl.Locale(lang).toString();
+      } catch { /* invalid locale, fall through */ }
     }
+    return navigator.language ?? 'en';
   }
 
   get second(): 'numeric' | '2-digit' | undefined {


### PR DESCRIPTION
`navigator.language` can be `undefined` in headless browsers (e.g. Playwright Firefox), causing `RangeError: invalid language tag: "undefined"` in `Intl.DateTimeFormat` within the `relative-time` web component.

Also adds an e2e test that verifies `relative-time` renders correctly and a shared `assertNoJsError` helper.

Bug is als present in https://github.com/github/relative-time-element but (incorrectly) masked there.

Fixes: https://github.com/go-gitea/gitea/issues/25324