### PR TITLE
Fix various problems

### DIFF
--- a/modules/git/catfile_batch_reader.go
+++ b/modules/git/catfile_batch_reader.go
@@ -22,16 +22,16 @@ import (
 var catFileBatchDebugWaitClose atomic.Int64
 
 type catFileBatchCommunicator struct {
-	cancel      context.CancelFunc
+	closeFunc   func(err error)
 	reqWriter   io.Writer
 	respReader  *bufio.Reader
 	debugGitCmd *gitcmd.Command
 }
 
 func (b *catFileBatchCommunicator) Close() {
-	if b.cancel != nil {
-		b.cancel()
-		b.cancel = nil
+	if b.closeFunc != nil {
+		b.closeFunc(nil)
+		b.closeFunc = nil
 	}
 }
 
@@ -47,10 +47,20 @@ func newCatFileBatch(ctx context.Context, repoPath string, cmdCatFile *gitcmd.Co
 		}
 		stdPipeClose()
 	}
+	closeFunc := func(err error) {
+		ctxCancel(err)
+		pipeClose()
+	}
+	return newCatFileBatchWithCloseFunc(ctx, repoPath, cmdCatFile, stdinWriter, stdoutReader, closeFunc)
+}
+
+func newCatFileBatchWithCloseFunc(ctx context.Context, repoPath string, cmdCatFile *gitcmd.Command,
+	stdinWriter gitcmd.PipeWriter, stdoutReader gitcmd.PipeReader, closeFunc func(err error),
+) (ret *catFileBatchCommunicator) {
 
 	ret = &catFileBatchCommunicator{
 		debugGitCmd: cmdCatFile,
-		cancel:      func() { ctxCancel(nil) },
+		closeFunc:   closeFunc,
 		reqWriter:   stdinWriter,
 		respReader:  bufio.NewReaderSize(stdoutReader, 32*1024), // use a buffered reader for rich operations
 	}
@@ -60,8 +70,7 @@ func newCatFileBatch(ctx context.Context, repoPath string, cmdCatFile *gitcmd.Co
 		log.Error("Unable to start git command %v: %v", cmdCatFile.LogString(), err)
 		// ideally here it should return the error, but it would require refactoring all callers
 		// so just return a dummy communicator that does nothing, almost the same behavior as before, not bad
-		ctxCancel(err)
-		pipeClose()
+		closeFunc(err)
 		return ret
 	}
 
@@ -70,8 +79,7 @@ func newCatFileBatch(ctx context.Context, repoPath string, cmdCatFile *gitcmd.Co
 		if err != nil && !errors.Is(err, context.Canceled) {
 			log.Error("cat-file --batch command failed in repo %s, error: %v", repoPath, err)
 		}
-		ctxCancel(err)
-		pipeClose()
+		closeFunc(err)
 	}()
 
 	return ret

--- a/modules/git/catfile_batch_reader.go
+++ b/modules/git/catfile_batch_reader.go
@@ -56,9 +56,8 @@ func newCatFileBatch(ctx context.Context, repoPath string, cmdCatFile *gitcmd.Co
 
 func newCatFileBatchWithCloseFunc(ctx context.Context, repoPath string, cmdCatFile *gitcmd.Command,
 	stdinWriter gitcmd.PipeWriter, stdoutReader gitcmd.PipeReader, closeFunc func(err error),
-) (ret *catFileBatchCommunicator) {
-
-	ret = &catFileBatchCommunicator{
+) *catFileBatchCommunicator {
+	ret := &catFileBatchCommunicator{
 		debugGitCmd: cmdCatFile,
 		closeFunc:   closeFunc,
 		reqWriter:   stdinWriter,

--- a/modules/public/mime_types.go
+++ b/modules/public/mime_types.go
@@ -4,31 +4,36 @@
 package public
 
 import (
+	"mime"
 	"strings"
+	"sync"
 )
 
-// wellKnownMimeTypesLower comes from Golang's builtin mime package: `builtinTypesLower`, see the comment of DetectWellKnownMimeType
-var wellKnownMimeTypesLower = map[string]string{
-	".avif": "image/avif",
-	".css":  "text/css; charset=utf-8",
-	".gif":  "image/gif",
-	".htm":  "text/html; charset=utf-8",
-	".html": "text/html; charset=utf-8",
-	".jpeg": "image/jpeg",
-	".jpg":  "image/jpeg",
-	".js":   "text/javascript; charset=utf-8",
-	".json": "application/json",
-	".mjs":  "text/javascript; charset=utf-8",
-	".pdf":  "application/pdf",
-	".png":  "image/png",
-	".svg":  "image/svg+xml",
-	".wasm": "application/wasm",
-	".webp": "image/webp",
-	".xml":  "text/xml; charset=utf-8",
+// wellKnownMimeTypesLower comes from Golang's builtin mime package: `builtinTypesLower`,
+// see the comment of DetectWellKnownMimeType
+var wellKnownMimeTypesLower = sync.OnceValue(func() map[string]string {
+	return map[string]string{
+		".avif": "image/avif",
+		".css":  "text/css; charset=utf-8",
+		".gif":  "image/gif",
+		".htm":  "text/html; charset=utf-8",
+		".html": "text/html; charset=utf-8",
+		".jpeg": "image/jpeg",
+		".jpg":  "image/jpeg",
+		".js":   "text/javascript; charset=utf-8",
+		".json": "application/json",
+		".mjs":  "text/javascript; charset=utf-8",
+		".pdf":  "application/pdf",
+		".png":  "image/png",
+		".svg":  "image/svg+xml",
+		".wasm": "application/wasm",
+		".webp": "image/webp",
+		".xml":  "text/xml; charset=utf-8",
 
-	// well, there are some types missing from the builtin list
-	".txt": "text/plain; charset=utf-8",
-}
+		// well, there are some types missing from the builtin list
+		".txt": "text/plain; charset=utf-8",
+	}
+})
 
 // DetectWellKnownMimeType will return the mime-type for a well-known file ext name
 // The purpose of this function is to bypass the unstable behavior of Golang's mime.TypeByExtension
@@ -38,5 +43,8 @@ var wellKnownMimeTypesLower = map[string]string{
 // DetectWellKnownMimeType makes the Content-Type for well-known files stable.
 func DetectWellKnownMimeType(ext string) string {
 	ext = strings.ToLower(ext)
-	return wellKnownMimeTypesLower[ext]
+	if s, ok := wellKnownMimeTypesLower()[ext]; ok {
+		return s
+	}
+	return mime.TypeByExtension(ext)
 }

--- a/web_src/css/markup/content.css
+++ b/web_src/css/markup/content.css
@@ -24,8 +24,8 @@
 
 .markup .anchor {
   float: left;
-  padding-right: 4px;
-  margin-left: -20px;
+  padding-inline-end: 4px;
+  margin-inline-start: -20px;
   color: inherit;
 }
 
@@ -151,7 +151,7 @@ In markup content, we always use bottom margin for all elements */
 
 .markup ul,
 .markup ol {
-  padding-left: 2em;
+  padding-inline-start: 2em;
 }
 
 .markup ul.no-list,
@@ -173,13 +173,14 @@ In markup content, we always use bottom margin for all elements */
 }
 
 .markup .task-list-item input[type="checkbox"] {
-  margin: 0 .6em .25em -1.4em;
+  margin-bottom: 0.25em;
+  margin-inline: -1.4em 0.6em;
   vertical-align: middle;
   padding: 0;
 }
 
 .markup .task-list-item input[type="checkbox"] + p {
-  margin-left: -0.2em;
+  margin-inline-start: -0.2em;
   display: inline;
 }
 
@@ -192,7 +193,7 @@ In markup content, we always use bottom margin for all elements */
 }
 
 .markup input[type="checkbox"] {
-  margin-right: .25em;
+  margin-inline-end: .25em;
   margin-bottom: .25em;
   cursor: default;
   opacity: 1 !important; /* override fomantic on edit preview */
@@ -239,7 +240,7 @@ In markup content, we always use bottom margin for all elements */
 }
 
 .markup blockquote {
-  margin-left: 0;
+  margin-inline-start: 0;
   padding: 0 15px;
   color: var(--color-text-light-2);
   border-left: 0.25em solid var(--color-secondary);
@@ -318,12 +319,12 @@ html[data-gitea-theme-dark="false"] .markup img[src*="#gh-dark-mode-only"] {
 
 .markup img[align="right"],
 .markup video[align="right"] {
-  padding-left: 20px;
+  padding-inline-start: 20px;
 }
 
 .markup img[align="left"],
 .markup video[align="left"] {
-  padding-right: 28px;
+  padding-inline-end: 28px;
 }
 
 .markup span.frame {
@@ -395,7 +396,7 @@ html[data-gitea-theme-dark="false"] .markup img[src*="#gh-dark-mode-only"] {
 .markup span.float-left {
   display: block;
   float: left;
-  margin-right: 13px;
+  margin-inline-end: 13px;
   overflow: hidden;
 }
 
@@ -406,7 +407,7 @@ html[data-gitea-theme-dark="false"] .markup img[src*="#gh-dark-mode-only"] {
 .markup span.float-right {
   display: block;
   float: right;
-  margin-left: 13px;
+  margin-inline-start: 13px;
   overflow: hidden;
 }
 
@@ -508,7 +509,7 @@ html[data-gitea-theme-dark="false"] .markup img[src*="#gh-dark-mode-only"] {
 .markup .ui.list .list,
 .markup ol.ui.list ol,
 .markup ul.ui.list ul {
-  padding-left: 2em;
+  padding-inline-start: 2em;
 }
 
 .markup details.frontmatter-content summary {


### PR DESCRIPTION
1. Use "margin/padding inline" 
   * Fix  #37027
2. Make DetectWellKnownMimeType fallback to system mime types
3. Make catFileBatchCommunicator close pipes
   * Old behavior in 1.25: https://github.com/go-gitea/gitea/blob/release/v1.25/modules/git/batch_reader.go#L45-L55
   * Try to fix #37028
