### PR TITLE
Fix theme discovery and Vite dev server in dev mode

### DIFF
--- a/modules/assetfs/layered.go
+++ b/modules/assetfs/layered.go
@@ -9,7 +9,9 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
+	"strings"
 	"time"
 
 	"code.gitea.io/gitea/modules/container"
@@ -61,6 +63,8 @@ type LayeredFS struct {
 	layers []*Layer
 }
 
+var _ fs.ReadDirFS = (*LayeredFS)(nil)
+
 // Layered returns a new LayeredFS with the given layers. The first layer is the top layer.
 func Layered(layers ...*Layer) *LayeredFS {
 	return &LayeredFS{layers: layers}
@@ -81,6 +85,26 @@ func (l *LayeredFS) Open(name string) (fs.File, error) {
 func (l *LayeredFS) ReadFile(elems ...string) ([]byte, error) {
 	bs, _, err := l.ReadLayeredFile(elems...)
 	return bs, err
+}
+
+func (l *LayeredFS) ReadDir(name string) (files []fs.DirEntry, _ error) {
+	filesMap := map[string]fs.DirEntry{}
+	for _, layer := range l.layers {
+		entries, err := readDirOptional(layer, name)
+		if err != nil {
+			return nil, err
+		}
+		for _, entry := range entries {
+			if shouldInclude(entry) {
+				filesMap[entry.Name()] = entry
+			}
+		}
+	}
+	for _, file := range filesMap {
+		files = append(files, file)
+	}
+	slices.SortFunc(files, func(a, b fs.DirEntry) int { return strings.Compare(a.Name(), b.Name()) })
+	return files, nil
 }
 
 // ReadLayeredFile reads the named file, and returns the layer name.

--- a/modules/assetfs/layered.go
+++ b/modules/assetfs/layered.go
@@ -95,8 +95,9 @@ func (l *LayeredFS) ReadDir(name string) (files []fs.DirEntry, _ error) {
 			return nil, err
 		}
 		for _, entry := range entries {
-			if shouldInclude(entry) {
-				filesMap[entry.Name()] = entry
+			entryName := entry.Name()
+			if _, exist := filesMap[entryName]; !exist && shouldInclude(entry) {
+				filesMap[entryName] = entry
 			}
 		}
 	}

--- a/modules/public/vitedev.go
+++ b/modules/public/vitedev.go
@@ -45,7 +45,7 @@ func getViteDevProxy() *httputil.ReverseProxy {
 
 	target, err := url.Parse(viteDevServerBaseURL)
 	if err != nil {
-		log.Error("Failed to parse vite dev server base url %s, err: %v", viteDevServerBaseURL, err)
+		log.Error("Failed to parse Vite dev server base URL %s, err: %v", viteDevServerBaseURL, err)
 		return nil
 	}
 
@@ -103,7 +103,7 @@ var viteDevModeCheck atomic.Pointer[struct {
 	time  time.Time
 }]
 
-// IsViteDevMode returns true if the Vite dev server port file exists and is alive
+// IsViteDevMode returns true if the Vite dev server port file exists and the server is alive
 func IsViteDevMode() bool {
 	if setting.IsProd {
 		return false
@@ -122,6 +122,9 @@ func IsViteDevMode() bool {
 
 	req := httplib.NewRequest(viteDevServerBaseURL+"/web_src/js/__vite_dev_server_check", "GET")
 	resp, _ := req.Response()
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
 	isDev := resp != nil && resp.StatusCode == http.StatusOK
 	viteDevModeCheck.Store(&struct {
 		isDev bool

--- a/modules/public/vitedev.go
+++ b/modules/public/vitedev.go
@@ -89,14 +89,33 @@ func ViteDevMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+var viteDevModeCheck atomic.Pointer[struct {
+	isDev bool
+	time  time.Time
+}]
+
 // IsViteDevMode returns true if the Vite dev server port file exists and is alive
 func IsViteDevMode() bool {
 	if setting.IsProd {
 		return false
 	}
+
+	now := time.Now()
+	lastCheck := viteDevModeCheck.Load()
+	if lastCheck != nil && time.Now().Sub(lastCheck.time) < time.Second {
+		return lastCheck.isDev
+	}
 	portFile := filepath.Join(setting.StaticRootPath, viteDevPortFile)
 	stat, err := os.Stat(portFile)
-	return err == nil && time.Now().Sub(stat.ModTime()) < 10*time.Second
+	isDev := err == nil && time.Now().Sub(stat.ModTime()) < 10*time.Second
+	viteDevModeCheck.Store(&struct {
+		isDev bool
+		time  time.Time
+	}{
+		isDev: isDev,
+		time:  now,
+	})
+	return isDev
 }
 
 func viteDevSourceURL(name string) string {

--- a/modules/public/vitedev.go
+++ b/modules/public/vitedev.go
@@ -28,18 +28,15 @@ func getViteDevProxy() *httputil.ReverseProxy {
 	}
 
 	portFile := filepath.Join(setting.StaticRootPath, viteDevPortFile)
-	data, err := os.ReadFile(portFile)
+	portContent, err := os.ReadFile(portFile)
 	if err != nil {
 		return nil
 	}
-	port := strings.TrimSpace(string(data))
-	if port == "" {
-		return nil
-	}
+	viteDevServerPort := strings.TrimSpace(string(portContent))
 
-	target, err := url.Parse("http://localhost:" + port)
+	target, err := url.Parse("http://localhost:" + viteDevServerPort)
 	if err != nil {
-		log.Error("Failed to parse Vite dev server URL: %v", err)
+		log.Error("Failed to use dev port (%s) to construct URL: %v", viteDevServerPort, err)
 		return nil
 	}
 
@@ -60,7 +57,7 @@ func getViteDevProxy() *httputil.ReverseProxy {
 		ModifyResponse: func(resp *http.Response) error {
 			// add a header to indicate the Vite dev server port,
 			// make developers know that this request is proxied to Vite dev server and which port it is
-			resp.Header.Add("X-Gitea-Vite-Port", port)
+			resp.Header.Add("X-Gitea-Vite-Port", viteDevServerPort)
 			return nil
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
@@ -92,19 +89,18 @@ func ViteDevMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// isViteDevMode returns true if the Vite dev server port file exists.
-// In production mode, the result is cached after the first check.
-func isViteDevMode() bool {
+// IsViteDevMode returns true if the Vite dev server port file exists and is alive
+func IsViteDevMode() bool {
 	if setting.IsProd {
 		return false
 	}
 	portFile := filepath.Join(setting.StaticRootPath, viteDevPortFile)
-	_, err := os.Stat(portFile)
-	return err == nil
+	stat, err := os.Stat(portFile)
+	return err == nil && time.Now().Sub(stat.ModTime()) < 10*time.Second
 }
 
 func viteDevSourceURL(name string) string {
-	if !isViteDevMode() {
+	if !IsViteDevMode() {
 		return ""
 	}
 	if strings.HasPrefix(name, "css/theme-") {

--- a/modules/public/vitedev.go
+++ b/modules/public/vitedev.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"code.gitea.io/gitea/modules/httplib"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/web/routing"
@@ -22,21 +23,29 @@ const viteDevPortFile = "public/assets/.vite/dev-port"
 
 var viteDevProxy atomic.Pointer[httputil.ReverseProxy]
 
+func getViteDevServerBaseURL() string {
+	portFile := filepath.Join(setting.StaticRootPath, viteDevPortFile)
+	portContent, _ := os.ReadFile(portFile)
+	port := strings.TrimSpace(string(portContent))
+	if port == "" {
+		return ""
+	}
+	return "http://localhost:" + port
+}
+
 func getViteDevProxy() *httputil.ReverseProxy {
 	if proxy := viteDevProxy.Load(); proxy != nil {
 		return proxy
 	}
 
-	portFile := filepath.Join(setting.StaticRootPath, viteDevPortFile)
-	portContent, err := os.ReadFile(portFile)
-	if err != nil {
+	viteDevServerBaseURL := getViteDevServerBaseURL()
+	if viteDevServerBaseURL == "" {
 		return nil
 	}
-	viteDevServerPort := strings.TrimSpace(string(portContent))
 
-	target, err := url.Parse("http://localhost:" + viteDevServerPort)
+	target, err := url.Parse(viteDevServerBaseURL)
 	if err != nil {
-		log.Error("Failed to use dev port (%s) to construct URL: %v", viteDevServerPort, err)
+		log.Error("Failed to parse vite dev server base url %s, err: %v", viteDevServerBaseURL, err)
 		return nil
 	}
 
@@ -57,7 +66,7 @@ func getViteDevProxy() *httputil.ReverseProxy {
 		ModifyResponse: func(resp *http.Response) error {
 			// add a header to indicate the Vite dev server port,
 			// make developers know that this request is proxied to Vite dev server and which port it is
-			resp.Header.Add("X-Gitea-Vite-Port", viteDevServerPort)
+			resp.Header.Add("X-Gitea-Vite-Dev-Server", viteDevServerBaseURL)
 			return nil
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
@@ -105,9 +114,15 @@ func IsViteDevMode() bool {
 	if lastCheck != nil && time.Now().Sub(lastCheck.time) < time.Second {
 		return lastCheck.isDev
 	}
-	portFile := filepath.Join(setting.StaticRootPath, viteDevPortFile)
-	stat, err := os.Stat(portFile)
-	isDev := err == nil && time.Now().Sub(stat.ModTime()) < 10*time.Second
+
+	viteDevServerBaseURL := getViteDevServerBaseURL()
+	if viteDevServerBaseURL == "" {
+		return false
+	}
+
+	req := httplib.NewRequest(viteDevServerBaseURL+"/web_src/js/__vite_dev_server_check", "GET")
+	resp, _ := req.Response()
+	isDev := resp != nil && resp.StatusCode == http.StatusOK
 	viteDevModeCheck.Store(&struct {
 		isDev bool
 		time  time.Time

--- a/modules/web/middleware/data.go
+++ b/modules/web/middleware/data.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"time"
 
+	"code.gitea.io/gitea/modules/public"
 	"code.gitea.io/gitea/modules/reqctx"
 	"code.gitea.io/gitea/modules/setting"
 )
@@ -36,5 +37,6 @@ func CommonTemplateContextData() reqctx.ContextData {
 		"PageStartTime":      time.Now(),
 
 		"RunModeIsProd": setting.IsProd,
+		"ViteModeIsDev": public.IsViteDevMode(),
 	}
 }

--- a/routers/common/middleware.go
+++ b/routers/common/middleware.go
@@ -12,6 +12,7 @@ import (
 	"code.gitea.io/gitea/modules/gtprof"
 	"code.gitea.io/gitea/modules/httplib"
 	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/public"
 	"code.gitea.io/gitea/modules/reqctx"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/web/routing"
@@ -38,6 +39,10 @@ func ProtocolMiddlewares() (handlers []any) {
 
 	if setting.IsAccessLogEnabled() {
 		handlers = append(handlers, context.AccessLogger())
+	}
+
+	if !setting.IsProd {
+		handlers = append(handlers, public.ViteDevMiddleware)
 	}
 
 	return handlers

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -259,10 +259,6 @@ func Routes() *web.Router {
 	// GetHead allows a HEAD request redirect to GET if HEAD method is not defined for that route
 	routes.BeforeRouting(chi_middleware.GetHead)
 
-	if !setting.IsProd {
-		routes.BeforeRouting(public.ViteDevMiddleware)
-	}
-
 	routes.Head("/", misc.DummyOK) // for health check - doesn't need to be passed through gzip handler
 	routes.Methods("GET, HEAD, OPTIONS", "/assets/*", routing.MarkLogLevelTrace, optionsCorsHandler(), public.FileHandlerFunc())
 	routes.Methods("GET, HEAD", "/avatars/*", avatarStorageHandler(setting.Avatar.Storage, "avatars", storage.Avatars))

--- a/services/webtheme/webtheme.go
+++ b/services/webtheme/webtheme.go
@@ -167,8 +167,8 @@ func loadThemesFromAssets() (themeList []*ThemeMetaInfo, themeMap map[string]*Th
 	var themeDir fs.ReadDirFS
 	var themePath string
 
-	if !setting.IsProd {
-		// In dev mode, Vite serves themes directly from source files.
+	if public.IsViteDevMode() {
+		// In vite dev mode, Vite serves themes directly from source files.
 		themeDir, themePath = os.DirFS(setting.StaticRootPath).(fs.ReadDirFS), "web_src/css/themes"
 	} else {
 		// In prod mode, use built assets from AssetFS.

--- a/services/webtheme/webtheme.go
+++ b/services/webtheme/webtheme.go
@@ -10,7 +10,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"sync"
+	"sync/atomic"
+	"time"
 
 	"code.gitea.io/gitea/modules/container"
 	"code.gitea.io/gitea/modules/log"
@@ -19,15 +20,15 @@ import (
 	"code.gitea.io/gitea/modules/util"
 )
 
-type themeCollection struct {
+type themeCollectionStruct struct {
+	lastCheckTime    time.Time
+	usingViteDevMode bool
+
 	themeList []*ThemeMetaInfo
 	themeMap  map[string]*ThemeMetaInfo
 }
 
-var (
-	themeMu         sync.RWMutex
-	availableThemes *themeCollection
-)
+var themeCollection atomic.Pointer[themeCollectionStruct]
 
 const (
 	fileNamePrefix = "theme-"
@@ -163,11 +164,11 @@ func collectThemeFiles(dirFS fs.ReadDirFS, fsPath string) (themes []*ThemeMetaIn
 	return themes, nil
 }
 
-func loadThemesFromAssets() (themeList []*ThemeMetaInfo, themeMap map[string]*ThemeMetaInfo) {
+func loadThemesFromAssets(isViteDevMode bool) (themeList []*ThemeMetaInfo, themeMap map[string]*ThemeMetaInfo) {
 	var themeDir fs.ReadDirFS
 	var themePath string
 
-	if public.IsViteDevMode() {
+	if isViteDevMode {
 		// In vite dev mode, Vite serves themes directly from source files.
 		themeDir, themePath = os.DirFS(setting.StaticRootPath).(fs.ReadDirFS), "web_src/css/themes"
 	} else {
@@ -209,20 +210,21 @@ func loadThemesFromAssets() (themeList []*ThemeMetaInfo, themeMap map[string]*Th
 	return themeList, themeMap
 }
 
-func getAvailableThemes() (themeList []*ThemeMetaInfo, themeMap map[string]*ThemeMetaInfo) {
-	themeMu.RLock()
-	if availableThemes != nil {
-		themeList, themeMap = availableThemes.themeList, availableThemes.themeMap
-	}
-	themeMu.RUnlock()
-	if len(themeList) != 0 {
-		return themeList, themeMap
+func getAvailableThemes() *themeCollectionStruct {
+	themes := themeCollection.Load()
+
+	now := time.Now()
+	if themes != nil && now.Sub(themes.lastCheckTime) < time.Second {
+		return themes
 	}
 
-	themeMu.Lock()
-	defer themeMu.Unlock()
-	// no need to double-check "availableThemes.themeList" since the loading isn't really slow, to keep code simple
-	themeList, themeMap = loadThemesFromAssets()
+	isViteDevMode := public.IsViteDevMode()
+	useLoadedThemes := themes != nil && (setting.IsProd || themes.usingViteDevMode == isViteDevMode)
+	if useLoadedThemes && len(themes.themeList) > 0 {
+		return themes
+	}
+
+	themeList, themeMap := loadThemesFromAssets(isViteDevMode)
 	hasAvailableThemes := len(themeList) > 0
 	if !hasAvailableThemes {
 		defaultTheme := defaultThemeMetaInfoByInternalName(setting.UI.DefaultTheme)
@@ -237,27 +239,19 @@ func getAvailableThemes() (themeList []*ThemeMetaInfo, themeMap map[string]*Them
 		if themeMap[setting.UI.DefaultTheme] == nil {
 			setting.LogStartupProblem(1, log.ERROR, "Default theme %q is not available, please correct the '[ui].DEFAULT_THEME' setting in the config file", setting.UI.DefaultTheme)
 		}
-		availableThemes = &themeCollection{themeList, themeMap}
-		return themeList, themeMap
 	}
 
-	// In dev mode, only store the loaded themes if the list is not empty, in case the frontend is still being built.
-	// TBH, there still could be a data-race that the themes are only partially built then the list is incomplete for first time loading.
-	// Such edge case can be handled by checking whether the loaded themes are the same in a period or there is a flag file, but it is an over-kill, so, no.
-	if hasAvailableThemes {
-		availableThemes = &themeCollection{themeList, themeMap}
-	}
-	return themeList, themeMap
-}
-
-func GetAvailableThemes() []*ThemeMetaInfo {
-	themes, _ := getAvailableThemes()
+	themes = &themeCollectionStruct{now, isViteDevMode, themeList, themeMap}
+	themeCollection.Store(themes)
 	return themes
 }
 
+func GetAvailableThemes() []*ThemeMetaInfo {
+	return getAvailableThemes().themeList
+}
+
 func GetThemeMetaInfo(internalName string) *ThemeMetaInfo {
-	_, themeMap := getAvailableThemes()
-	return themeMap[internalName]
+	return getAvailableThemes().themeMap[internalName]
 }
 
 // GuaranteeGetThemeMetaInfo guarantees to return a non-nil ThemeMetaInfo,

--- a/services/webtheme/webtheme.go
+++ b/services/webtheme/webtheme.go
@@ -142,55 +142,49 @@ func parseThemeMetaInfo(fileName, cssContent string) *ThemeMetaInfo {
 	return themeInfo
 }
 
+func collectThemeFiles(fileNames []string, readFile func(string) ([]byte, error)) []*ThemeMetaInfo {
+	var themes []*ThemeMetaInfo
+	for _, fileName := range fileNames {
+		if !strings.HasPrefix(fileName, fileNamePrefix) || !strings.HasSuffix(fileName, fileNameSuffix) {
+			continue
+		}
+		content, err := readFile(fileName)
+		if err != nil {
+			log.Error("Failed to read theme file %q: %v", fileName, err)
+			continue
+		}
+		themes = append(themes, parseThemeMetaInfo(fileName, util.UnsafeBytesToString(content)))
+	}
+	return themes
+}
+
 func loadThemesFromAssets() (themeList []*ThemeMetaInfo, themeMap map[string]*ThemeMetaInfo) {
 	var foundThemes []*ThemeMetaInfo
-	seenNames := make(container.Set[string])
 
-	// In dev mode, use source theme files directly instead of relying on built assets.
 	if !setting.IsProd {
+		// In dev mode, Vite serves themes directly from source files.
 		srcDir := filepath.Join(setting.StaticRootPath, "web_src/css/themes")
-		if entries, err := os.ReadDir(srcDir); err == nil {
+		entries, err := os.ReadDir(srcDir)
+		if err != nil {
+			log.Warn("Failed to read theme source directory %q: %v", srcDir, err)
+		} else {
+			fileNames := make([]string, 0, len(entries))
 			for _, entry := range entries {
-				fileName := entry.Name()
-				if !strings.HasPrefix(fileName, fileNamePrefix) || !strings.HasSuffix(fileName, fileNameSuffix) {
-					continue
-				}
-				content, err := os.ReadFile(filepath.Join(srcDir, fileName))
-				if err != nil {
-					log.Error("Failed to read theme source file %q: %v", fileName, err)
-					continue
-				}
-				themeInfo := parseThemeMetaInfo(fileName, util.UnsafeBytesToString(content))
-				foundThemes = append(foundThemes, themeInfo)
-				seenNames.Add(themeInfo.InternalName)
+				fileNames = append(fileNames, entry.Name())
 			}
+			foundThemes = collectThemeFiles(fileNames, func(name string) ([]byte, error) {
+				return os.ReadFile(filepath.Join(srcDir, name))
+			})
 		}
-	}
-
-	// Check custom assets
-	cssFiles, err := public.AssetFS().ListFiles("assets/css")
-	if err != nil {
-		if len(foundThemes) == 0 {
+	} else {
+		cssFiles, err := public.AssetFS().ListFiles("assets/css")
+		if err != nil {
 			log.Error("Failed to list themes: %v", err)
 			return nil, nil
 		}
-	} else {
-		for _, fileName := range cssFiles {
-			if !strings.HasPrefix(fileName, fileNamePrefix) || !strings.HasSuffix(fileName, fileNameSuffix) {
-				continue
-			}
-			content, err := public.AssetFS().ReadFile("/assets/css/" + fileName)
-			if err != nil {
-				log.Error("Failed to read theme file %q: %v", fileName, err)
-				continue
-			}
-			themeInfo := parseThemeMetaInfo(fileName, util.UnsafeBytesToString(content))
-			if seenNames.Contains(themeInfo.InternalName) {
-				continue
-			}
-			foundThemes = append(foundThemes, themeInfo)
-			seenNames.Add(themeInfo.InternalName)
-		}
+		foundThemes = collectThemeFiles(cssFiles, func(name string) ([]byte, error) {
+			return public.AssetFS().ReadFile("/assets/css/" + name)
+		})
 	}
 
 	themeList = foundThemes

--- a/services/webtheme/webtheme.go
+++ b/services/webtheme/webtheme.go
@@ -172,7 +172,7 @@ func loadThemesFromAssets(isViteDevMode bool) (themeList []*ThemeMetaInfo, theme
 		// In vite dev mode, Vite serves themes directly from source files.
 		themeDir, themePath = os.DirFS(setting.StaticRootPath).(fs.ReadDirFS), "web_src/css/themes"
 	} else {
-		// In prod mode, use built assets from AssetFS.
+		// Without vite dev server, use built assets from AssetFS.
 		themeDir, themePath = public.AssetFS(), "assets/css"
 	}
 

--- a/services/webtheme/webtheme.go
+++ b/services/webtheme/webtheme.go
@@ -178,7 +178,7 @@ func loadThemesFromAssets() (themeList []*ThemeMetaInfo, themeMap map[string]*Th
 	foundThemes, err := collectThemeFiles(themeDir, themePath)
 	if err != nil {
 		log.Error("Failed to load theme files: %v", err)
-		return
+		return themeList, themeMap
 	}
 
 	themeList = foundThemes

--- a/services/webtheme/webtheme.go
+++ b/services/webtheme/webtheme.go
@@ -4,8 +4,9 @@
 package webtheme
 
 import (
+	"io/fs"
 	"os"
-	"path/filepath"
+	"path"
 	"regexp"
 	"sort"
 	"strings"
@@ -142,50 +143,42 @@ func parseThemeMetaInfo(fileName, cssContent string) *ThemeMetaInfo {
 	return themeInfo
 }
 
-func collectThemeFiles(fileNames []string, readFile func(string) ([]byte, error)) []*ThemeMetaInfo {
-	var themes []*ThemeMetaInfo
-	for _, fileName := range fileNames {
+func collectThemeFiles(dirFS fs.ReadDirFS, fsPath string) (themes []*ThemeMetaInfo, _ error) {
+	files, err := dirFS.ReadDir(fsPath)
+	if err != nil {
+		return nil, err
+	}
+	for _, file := range files {
+		fileName := file.Name()
 		if !strings.HasPrefix(fileName, fileNamePrefix) || !strings.HasSuffix(fileName, fileNameSuffix) {
 			continue
 		}
-		content, err := readFile(fileName)
+		content, err := fs.ReadFile(dirFS, path.Join(fsPath, file.Name()))
 		if err != nil {
 			log.Error("Failed to read theme file %q: %v", fileName, err)
 			continue
 		}
 		themes = append(themes, parseThemeMetaInfo(fileName, util.UnsafeBytesToString(content)))
 	}
-	return themes
+	return themes, nil
 }
 
 func loadThemesFromAssets() (themeList []*ThemeMetaInfo, themeMap map[string]*ThemeMetaInfo) {
-	var foundThemes []*ThemeMetaInfo
+	var themeDir fs.ReadDirFS
+	var themePath string
 
 	if !setting.IsProd {
 		// In dev mode, Vite serves themes directly from source files.
-		srcDir := filepath.Join(setting.StaticRootPath, "web_src/css/themes")
-		entries, err := os.ReadDir(srcDir)
-		if err != nil {
-			log.Warn("Failed to read theme source directory %q: %v", srcDir, err)
-		} else {
-			fileNames := make([]string, 0, len(entries))
-			for _, entry := range entries {
-				fileNames = append(fileNames, entry.Name())
-			}
-			foundThemes = collectThemeFiles(fileNames, func(name string) ([]byte, error) {
-				return os.ReadFile(filepath.Join(srcDir, name))
-			})
-		}
+		themeDir, themePath = os.DirFS(setting.StaticRootPath).(fs.ReadDirFS), "web_src/css/themes"
 	} else {
 		// In prod mode, use built assets from AssetFS.
-		cssFiles, err := public.AssetFS().ListFiles("assets/css")
-		if err != nil {
-			log.Error("Failed to list themes: %v", err)
-			return nil, nil
-		}
-		foundThemes = collectThemeFiles(cssFiles, func(name string) ([]byte, error) {
-			return public.AssetFS().ReadFile("/assets/css/" + name)
-		})
+		themeDir, themePath = public.AssetFS(), "assets/css"
+	}
+
+	foundThemes, err := collectThemeFiles(themeDir, themePath)
+	if err != nil {
+		log.Error("Failed to load theme files: %v", err)
+		return
 	}
 
 	themeList = foundThemes

--- a/services/webtheme/webtheme.go
+++ b/services/webtheme/webtheme.go
@@ -177,7 +177,7 @@ func loadThemesFromAssets() (themeList []*ThemeMetaInfo, themeMap map[string]*Th
 			})
 		}
 	} else {
-		// In production, use built assets from AssetFS.
+		// In prod mode, use built assets from AssetFS.
 		cssFiles, err := public.AssetFS().ListFiles("assets/css")
 		if err != nil {
 			log.Error("Failed to list themes: %v", err)

--- a/services/webtheme/webtheme.go
+++ b/services/webtheme/webtheme.go
@@ -177,6 +177,7 @@ func loadThemesFromAssets() (themeList []*ThemeMetaInfo, themeMap map[string]*Th
 			})
 		}
 	} else {
+		// In production, use built assets from AssetFS.
 		cssFiles, err := public.AssetFS().ListFiles("assets/css")
 		if err != nil {
 			log.Error("Failed to list themes: %v", err)

--- a/services/webtheme/webtheme.go
+++ b/services/webtheme/webtheme.go
@@ -4,6 +4,8 @@
 package webtheme
 
 import (
+	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -141,21 +143,53 @@ func parseThemeMetaInfo(fileName, cssContent string) *ThemeMetaInfo {
 }
 
 func loadThemesFromAssets() (themeList []*ThemeMetaInfo, themeMap map[string]*ThemeMetaInfo) {
-	cssFiles, err := public.AssetFS().ListFiles("assets/css")
-	if err != nil {
-		log.Error("Failed to list themes: %v", err)
-		return nil, nil
+	var foundThemes []*ThemeMetaInfo
+	seenNames := make(container.Set[string])
+
+	// In dev mode, use source theme files directly instead of relying on built assets.
+	if !setting.IsProd {
+		srcDir := filepath.Join(setting.StaticRootPath, "web_src/css/themes")
+		if entries, err := os.ReadDir(srcDir); err == nil {
+			for _, entry := range entries {
+				fileName := entry.Name()
+				if !strings.HasPrefix(fileName, fileNamePrefix) || !strings.HasSuffix(fileName, fileNameSuffix) {
+					continue
+				}
+				content, err := os.ReadFile(filepath.Join(srcDir, fileName))
+				if err != nil {
+					log.Error("Failed to read theme source file %q: %v", fileName, err)
+					continue
+				}
+				themeInfo := parseThemeMetaInfo(fileName, util.UnsafeBytesToString(content))
+				foundThemes = append(foundThemes, themeInfo)
+				seenNames.Add(themeInfo.InternalName)
+			}
+		}
 	}
 
-	var foundThemes []*ThemeMetaInfo
-	for _, fileName := range cssFiles {
-		if strings.HasPrefix(fileName, fileNamePrefix) && strings.HasSuffix(fileName, fileNameSuffix) {
+	// Check custom assets
+	cssFiles, err := public.AssetFS().ListFiles("assets/css")
+	if err != nil {
+		if len(foundThemes) == 0 {
+			log.Error("Failed to list themes: %v", err)
+			return nil, nil
+		}
+	} else {
+		for _, fileName := range cssFiles {
+			if !strings.HasPrefix(fileName, fileNamePrefix) || !strings.HasSuffix(fileName, fileNameSuffix) {
+				continue
+			}
 			content, err := public.AssetFS().ReadFile("/assets/css/" + fileName)
 			if err != nil {
 				log.Error("Failed to read theme file %q: %v", fileName, err)
 				continue
 			}
-			foundThemes = append(foundThemes, parseThemeMetaInfo(fileName, util.UnsafeBytesToString(content)))
+			themeInfo := parseThemeMetaInfo(fileName, util.UnsafeBytesToString(content))
+			if seenNames.Contains(themeInfo.InternalName) {
+				continue
+			}
+			foundThemes = append(foundThemes, themeInfo)
+			seenNames.Add(themeInfo.InternalName)
 		}
 	}
 

--- a/templates/base/footer_content.tmpl
+++ b/templates/base/footer_content.tmpl
@@ -4,17 +4,22 @@
 			<a target="_blank" href="https://about.gitea.com">{{ctx.Locale.Tr "powered_by" "Gitea"}}</a>
 		{{end}}
 		{{if (or .ShowFooterVersion .PageIsAdmin)}}
+			<span>
 			{{ctx.Locale.Tr "version"}}:
 			{{if .IsAdmin}}
 				<a href="{{AppSubUrl}}/-/admin/config">{{AppVer}}</a>
 			{{else}}
 				{{AppVer}}
 			{{end}}
+			</span>
 		{{end}}
 		{{if and .TemplateLoadTimes ShowFooterTemplateLoadTime}}
-			{{ctx.Locale.Tr "page"}}: <strong>{{LoadTimes .PageStartTime}}</strong>
-			{{ctx.Locale.Tr "template"}}{{if .TemplateName}} {{.TemplateName}}{{end}}: <strong>{{call .TemplateLoadTimes}}</strong>
+			<span>
+				{{ctx.Locale.Tr "page"}}: <strong>{{LoadTimes .PageStartTime}}</strong>
+				{{ctx.Locale.Tr "template"}}{{if .TemplateName}} {{.TemplateName}}{{end}}: <strong>{{call .TemplateLoadTimes}}</strong>
+			</span>
 		{{end}}
+		{{if $.ViteModeIsDev}}<span class="ui basic label primary">ViteDevMode</span>{{end}}
 	</div>
 	<div class="right-links" role="group" aria-label="{{ctx.Locale.Tr "aria.footer.links"}}">
 		<div class="ui dropdown custom" id="footer-theme-selector">

--- a/templates/base/head_navbar.tmpl
+++ b/templates/base/head_navbar.tmpl
@@ -7,7 +7,6 @@
 
 		<!-- mobile right menu, it must be here because in mobile view, each item is a flex column, the first item is a full row column -->
 		<div class="ui secondary menu navbar-mobile-right only-mobile">
-			{{if $.ViteModeIsDev}}<span class="ui basic label primary">ViteDevMode</span>{{end}}
 			{{template "base/head_navbar_icons" dict "PageGlobalData" .PageGlobalData}}
 			<button class="item ui icon mini button tw-m-0" id="navbar-expand-toggle" aria-label="{{ctx.Locale.Tr "home.nav_menu"}}">{{svg "octicon-three-bars"}}</button>
 		</div>
@@ -43,7 +42,6 @@
 
 	<!-- the full dropdown menus -->
 	<div class="navbar-right">
-		{{if $.ViteModeIsDev}}<span class="not-mobile ui basic label primary">ViteDevMode</span>{{end}}
 		{{if and .IsSigned .MustChangePassword}}
 			<div class="ui dropdown jump item" data-tooltip-content="{{ctx.Locale.Tr "user_profile_and_more"}}">
 				<span class="text">

--- a/templates/base/head_navbar.tmpl
+++ b/templates/base/head_navbar.tmpl
@@ -7,6 +7,7 @@
 
 		<!-- mobile right menu, it must be here because in mobile view, each item is a flex column, the first item is a full row column -->
 		<div class="ui secondary menu navbar-mobile-right only-mobile">
+			{{if $.ViteModeIsDev}}<span class="ui basic label primary">ViteDevMode</span>{{end}}
 			{{template "base/head_navbar_icons" dict "PageGlobalData" .PageGlobalData}}
 			<button class="item ui icon mini button tw-m-0" id="navbar-expand-toggle" aria-label="{{ctx.Locale.Tr "home.nav_menu"}}">{{svg "octicon-three-bars"}}</button>
 		</div>
@@ -42,6 +43,7 @@
 
 	<!-- the full dropdown menus -->
 	<div class="navbar-right">
+		{{if $.ViteModeIsDev}}<span class="not-mobile ui basic label primary">ViteDevMode</span>{{end}}
 		{{if and .IsSigned .MustChangePassword}}
 			<div class="ui dropdown jump item" data-tooltip-content="{{ctx.Locale.Tr "user_profile_and_more"}}">
 				<span class="text">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import {build, defineConfig} from 'vite';
 import vuePlugin from '@vitejs/plugin-vue';
 import {stringPlugin} from 'vite-string-plugin';
-import {readFileSync, writeFileSync, mkdirSync, unlinkSync, globSync, utimesSync} from 'node:fs';
+import {readFileSync, writeFileSync, mkdirSync, unlinkSync, globSync, utimesSync, rmSync} from 'node:fs';
 import path, {join, parse} from 'node:path';
 import {env} from 'node:process';
 import tailwindcss from 'tailwindcss';
@@ -201,8 +201,25 @@ function viteDevServerPortPlugin(): Plugin {
         if (typeof addr === 'object' && addr) {
           mkdirSync(path.dirname(viteDevPortFilePath), {recursive: true});
           writeFileSync(viteDevPortFilePath, String(addr.port));
+
+          let cleanedUp = false;
           // keep updating the timestamp of the file to tell the Gitea vite dev proxy that the server is still alive
-          setInterval(() => utimesSync(viteDevPortFilePath, new Date(), new Date()), 2000);
+          setInterval(() => {
+            if (cleanedUp) return;
+            utimesSync(viteDevPortFilePath, new Date(), new Date());
+          }, 2000);
+
+          // clean up the port file on exit to prevent stale port info for the next dev server or interfere the Gitea vite dev proxy
+          const viteDevServerCleanUp = () => {
+            if (cleanedUp) return;
+            console.info('cleaning up vite dev server...');
+            rmSync(viteDevPortFilePath);
+            server.close();
+            cleanedUp = true;
+            process.exit(0);
+          };
+          process.on('SIGINT', viteDevServerCleanUp);
+          process.on('SIGTERM', viteDevServerCleanUp);
         }
       });
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ import tailwindConfig from './tailwind.config.ts';
 import wrapAnsi from 'wrap-ansi';
 import licensePlugin from 'rollup-plugin-license';
 import type {InlineConfig, Plugin, Rolldown} from 'vite';
-import {setInterval} from "node:timers";
+import {setInterval} from 'node:timers';
 
 const isProduction = env.NODE_ENV !== 'development';
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import {build, defineConfig} from 'vite';
 import vuePlugin from '@vitejs/plugin-vue';
 import {stringPlugin} from 'vite-string-plugin';
-import {readFileSync, writeFileSync, mkdirSync, unlinkSync, globSync, utimesSync, rmSync} from 'node:fs';
+import {readFileSync, writeFileSync, mkdirSync, unlinkSync, globSync} from 'node:fs';
 import path, {join, parse} from 'node:path';
 import {env} from 'node:process';
 import tailwindcss from 'tailwindcss';
@@ -9,7 +9,6 @@ import tailwindConfig from './tailwind.config.ts';
 import wrapAnsi from 'wrap-ansi';
 import licensePlugin from 'rollup-plugin-license';
 import type {InlineConfig, Plugin, Rolldown} from 'vite';
-import {setInterval} from 'node:timers';
 
 const isProduction = env.NODE_ENV !== 'development';
 
@@ -133,7 +132,9 @@ function iifePlugin(): Plugin {
       server.middlewares.use((req, res, next) => {
         // "__vite_iife" is a virtual file in memory, serve it directly
         const pathname = req.url!.split('?')[0];
-        if (pathname === '/web_src/js/__vite_iife.js') {
+        if (pathname === '/web_src/js/__vite_dev_server_check') {
+          res.end('ok');
+        } else if (pathname === '/web_src/js/__vite_iife.js') {
           res.setHeader('Content-Type', 'application/javascript');
           res.setHeader('Cache-Control', 'no-store');
           res.end(iifeCode);
@@ -201,25 +202,6 @@ function viteDevServerPortPlugin(): Plugin {
         if (typeof addr === 'object' && addr) {
           mkdirSync(path.dirname(viteDevPortFilePath), {recursive: true});
           writeFileSync(viteDevPortFilePath, String(addr.port));
-
-          let cleanedUp = false;
-          // keep updating the timestamp of the file to tell the Gitea vite dev proxy that the server is still alive
-          setInterval(() => {
-            if (cleanedUp) return;
-            utimesSync(viteDevPortFilePath, new Date(), new Date());
-          }, 2000);
-
-          // clean up the port file on exit to prevent stale port info for the next dev server or interfere the Gitea vite dev proxy
-          const viteDevServerCleanUp = () => {
-            if (cleanedUp) return;
-            console.info('cleaning up vite dev server...');
-            rmSync(viteDevPortFilePath);
-            server.close();
-            cleanedUp = true;
-            process.exit(0);
-          };
-          process.on('SIGINT', viteDevServerCleanUp);
-          process.on('SIGTERM', viteDevServerCleanUp);
         }
       });
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import {build, defineConfig} from 'vite';
 import vuePlugin from '@vitejs/plugin-vue';
 import {stringPlugin} from 'vite-string-plugin';
-import {readFileSync, writeFileSync, unlinkSync, globSync} from 'node:fs';
+import {readFileSync, writeFileSync, mkdirSync, unlinkSync, globSync} from 'node:fs';
 import {join, parse} from 'node:path';
 import {env} from 'node:process';
 import tailwindcss from 'tailwindcss';
@@ -198,6 +198,7 @@ function viteDevServerPortPlugin(): Plugin {
       server.httpServer!.once('listening', () => {
         const addr = server.httpServer!.address();
         if (typeof addr === 'object' && addr) {
+          mkdirSync(join(outDir, '.vite'), {recursive: true});
           writeFileSync(viteDevPortFilePath, String(addr.port));
         }
       });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,15 @@
 import {build, defineConfig} from 'vite';
 import vuePlugin from '@vitejs/plugin-vue';
 import {stringPlugin} from 'vite-string-plugin';
-import {readFileSync, writeFileSync, mkdirSync, unlinkSync, globSync} from 'node:fs';
-import {join, parse} from 'node:path';
+import {readFileSync, writeFileSync, mkdirSync, unlinkSync, globSync, utimesSync} from 'node:fs';
+import path, {join, parse} from 'node:path';
 import {env} from 'node:process';
 import tailwindcss from 'tailwindcss';
 import tailwindConfig from './tailwind.config.ts';
 import wrapAnsi from 'wrap-ansi';
 import licensePlugin from 'rollup-plugin-license';
 import type {InlineConfig, Plugin, Rolldown} from 'vite';
+import {setInterval} from "node:timers";
 
 const isProduction = env.NODE_ENV !== 'development';
 
@@ -198,8 +199,10 @@ function viteDevServerPortPlugin(): Plugin {
       server.httpServer!.once('listening', () => {
         const addr = server.httpServer!.address();
         if (typeof addr === 'object' && addr) {
-          mkdirSync(join(outDir, '.vite'), {recursive: true});
+          mkdirSync(path.dirname(viteDevPortFilePath), {recursive: true});
           writeFileSync(viteDevPortFilePath, String(addr.port));
+          // keep updating the timestamp of the file to tell the Gitea vite dev proxy that the server is still alive
+          setInterval(() => utimesSync(viteDevPortFilePath, new Date(), new Date()), 2000);
         }
       });
     },

--- a/web_src/css/home.css
+++ b/web_src/css/home.css
@@ -56,7 +56,7 @@
   flex-wrap: wrap;
   align-items: center;
   justify-content: center;
-  gap: 0.25em;
+  gap: 0.5em;
 }
 
 .page-footer .right-links {

--- a/web_src/css/modules/navbar.css
+++ b/web_src/css/modules/navbar.css
@@ -68,6 +68,7 @@
   }
   #navbar .navbar-mobile-right {
     display: flex;
+    align-items: center;
     margin: 0 0 0 auto;
     width: auto;
   }
@@ -97,7 +98,6 @@
   }
   #navbar.navbar-menu-open .navbar-left .navbar-mobile-right {
     justify-content: flex-end;
-    width: 50%;
     min-height: 49px;
   }
   #navbar #mobile-stopwatch-icon,


### PR DESCRIPTION
1. In dev mode, discover themes from source files in `web_src/css/themes/` instead of AssetFS. In prod, use AssetFS only. Extract shared `collectThemeFiles` helper to deduplicate theme file handling.
2. Implement `fs.ReadDirFS` on `LayeredFS` to support theme file discovery.
3. `IsViteDevMode` now performs an HTTP health check against the vite dev server instead of only checking the port file exists. Result is cached with a 1-second TTL.
4. Refactor theme caching from mutex to atomic pointer with time-based invalidation, allowing themes to refresh when vite dev mode state changes.
5. Move `ViteDevMiddleware` into `ProtocolMiddlewares` so it applies to both install and web routes.
6. Show a `ViteDevMode` label in the page footer when vite dev server is active.
7. Add `/__vite_dev_server_check` endpoint to vite dev server for the health check.
8. Ensure `.vite` directory exists before writing the dev-port file.
9. Minor CSS fixes: footer gap, navbar mobile alignment.

---
This PR was written with the help of Claude Opus 4.6