### PR TITLE
Remove warning status

### DIFF
--- a/modules/commitstatus/commit_status.go
+++ b/modules/commitstatus/commit_status.go
@@ -56,6 +56,17 @@ func (css CommitStatusState) IsSkipped() bool {
 	return css == CommitStatusSkipped
 }
 
+// IsValid returns true for states that may be created via the API.
+// CommitStatusWarning is excluded: existing rows are preserved but new ones are rejected.
+func (css CommitStatusState) IsValid() bool {
+	switch css {
+	case CommitStatusPending, CommitStatusSuccess, CommitStatusError, CommitStatusFailure, CommitStatusSkipped:
+		return true
+	default:
+		return false
+	}
+}
+
 type CommitStatusStates []CommitStatusState //nolint:revive // export stutter
 
 // According to https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#get-the-combined-status-for-a-specific-reference

--- a/modules/structs/status.go
+++ b/modules/structs/status.go
@@ -9,11 +9,28 @@ import (
 	"code.gitea.io/gitea/modules/commitstatus"
 )
 
+// CreateCommitStatusState holds the state of a CommitStatus that may be created via the API.
+// swagger:enum CreateCommitStatusState
+type CreateCommitStatusState string
+
+const (
+	// CreateCommitStatusPending is for when the CommitStatus is Pending
+	CreateCommitStatusPending CreateCommitStatusState = "pending"
+	// CreateCommitStatusSuccess is for when the CommitStatus is Success
+	CreateCommitStatusSuccess CreateCommitStatusState = "success"
+	// CreateCommitStatusError is for when the CommitStatus is Error
+	CreateCommitStatusError CreateCommitStatusState = "error"
+	// CreateCommitStatusFailure is for when the CommitStatus is Failure
+	CreateCommitStatusFailure CreateCommitStatusState = "failure"
+	// CreateCommitStatusSkipped is for when CommitStatus is Skipped
+	CreateCommitStatusSkipped CreateCommitStatusState = "skipped"
+)
+
 // CommitStatus holds a single status of a single Commit
 type CommitStatus struct {
 	// ID is the unique identifier for the commit status
 	ID int64 `json:"id"`
-	// State represents the status state (pending, success, error, failure)
+	// State represents the status state (pending, success, error, failure, warning, skipped)
 	State commitstatus.CommitStatusState `json:"status"`
 	// TargetURL is the URL to link to for more details
 	TargetURL string `json:"target_url"`
@@ -51,8 +68,8 @@ type CombinedStatus struct {
 
 // CreateStatusOption holds the information needed to create a new CommitStatus for a Commit
 type CreateStatusOption struct {
-	// State represents the status state to set (pending, success, error, failure)
-	State commitstatus.CommitStatusState `json:"state"`
+	// State represents the status state to set (pending, success, error, failure, skipped)
+	State CreateCommitStatusState `json:"state"`
 	// TargetURL is the URL to link to for more details
 	TargetURL string `json:"target_url"`
 	// Description provides a brief description of the status

--- a/routers/api/v1/repo/status.go
+++ b/routers/api/v1/repo/status.go
@@ -4,12 +4,15 @@
 package repo
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
 	"code.gitea.io/gitea/models/db"
 	git_model "code.gitea.io/gitea/models/git"
+	"code.gitea.io/gitea/modules/commitstatus"
 	api "code.gitea.io/gitea/modules/structs"
+	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/modules/web"
 	"code.gitea.io/gitea/routers/api/v1/utils"
 	"code.gitea.io/gitea/services/context"
@@ -59,13 +62,17 @@ func NewCommitStatus(ctx *context.APIContext) {
 		return
 	}
 	status := &git_model.CommitStatus{
-		State:       form.State,
+		State:       commitstatus.CommitStatusState(form.State),
 		TargetURL:   form.TargetURL,
 		Description: form.Description,
 		Context:     form.Context,
 	}
 	if err := commitstatus_service.CreateCommitStatus(ctx, ctx.Repo.Repository, ctx.Doer, sha, status); err != nil {
-		ctx.APIErrorInternal(err)
+		if errors.Is(err, util.ErrInvalidArgument) {
+			ctx.APIError(http.StatusBadRequest, err)
+		} else {
+			ctx.APIErrorInternal(err)
+		}
 		return
 	}
 

--- a/services/repository/commitstatus/commitstatus.go
+++ b/services/repository/commitstatus/commitstatus.go
@@ -20,6 +20,7 @@ import (
 	"code.gitea.io/gitea/modules/json"
 	"code.gitea.io/gitea/modules/log"
 	repo_module "code.gitea.io/gitea/modules/repository"
+	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/services/notify"
 )
 
@@ -69,6 +70,9 @@ func deleteCommitStatusCache(repoID int64, branchName string) error {
 // NOTE: All text-values will be trimmed from whitespaces.
 // Requires: Repo, Creator, SHA
 func CreateCommitStatus(ctx context.Context, repo *repo_model.Repository, creator *user_model.User, sha string, status *git_model.CommitStatus) error {
+	if !status.State.IsValid() {
+		return util.NewInvalidArgumentErrorf("invalid commit status state: %s", status.State)
+	}
 	// confirm that commit is exist
 	gitRepo, closer, err := gitrepo.RepositoryFromContextOrOpen(ctx, repo)
 	if err != nil {

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -22888,7 +22888,7 @@
           "x-go-name": "ID"
         },
         "status": {
-          "description": "State represents the status state (pending, success, error, failure)\npending CommitStatusPending  CommitStatusPending is for when the CommitStatus is Pending\nsuccess CommitStatusSuccess  CommitStatusSuccess is for when the CommitStatus is Success\nerror CommitStatusError  CommitStatusError is for when the CommitStatus is Error\nfailure CommitStatusFailure  CommitStatusFailure is for when the CommitStatus is Failure\nwarning CommitStatusWarning  CommitStatusWarning is for when the CommitStatus is Warning\nskipped CommitStatusSkipped  CommitStatusSkipped is for when CommitStatus is Skipped",
+          "description": "State represents the status state (pending, success, error, failure, warning, skipped)\npending CommitStatusPending  CommitStatusPending is for when the CommitStatus is Pending\nsuccess CommitStatusSuccess  CommitStatusSuccess is for when the CommitStatus is Success\nerror CommitStatusError  CommitStatusError is for when the CommitStatus is Error\nfailure CommitStatusFailure  CommitStatusFailure is for when the CommitStatus is Failure\nwarning CommitStatusWarning  CommitStatusWarning is for when the CommitStatus is Warning\nskipped CommitStatusSkipped  CommitStatusSkipped is for when CommitStatus is Skipped",
           "type": "string",
           "enum": [
             "pending",
@@ -24075,17 +24075,16 @@
           "x-go-name": "Description"
         },
         "state": {
-          "description": "State represents the status state to set (pending, success, error, failure)\npending CommitStatusPending  CommitStatusPending is for when the CommitStatus is Pending\nsuccess CommitStatusSuccess  CommitStatusSuccess is for when the CommitStatus is Success\nerror CommitStatusError  CommitStatusError is for when the CommitStatus is Error\nfailure CommitStatusFailure  CommitStatusFailure is for when the CommitStatus is Failure\nwarning CommitStatusWarning  CommitStatusWarning is for when the CommitStatus is Warning\nskipped CommitStatusSkipped  CommitStatusSkipped is for when CommitStatus is Skipped",
+          "description": "State represents the status state to set (pending, success, error, failure, skipped)\npending CreateCommitStatusPending  CreateCommitStatusPending is for when the CommitStatus is Pending\nsuccess CreateCommitStatusSuccess  CreateCommitStatusSuccess is for when the CommitStatus is Success\nerror CreateCommitStatusError  CreateCommitStatusError is for when the CommitStatus is Error\nfailure CreateCommitStatusFailure  CreateCommitStatusFailure is for when the CommitStatus is Failure\nskipped CreateCommitStatusSkipped  CreateCommitStatusSkipped is for when CommitStatus is Skipped",
           "type": "string",
           "enum": [
             "pending",
             "success",
             "error",
             "failure",
-            "warning",
             "skipped"
           ],
-          "x-go-enum-desc": "pending CommitStatusPending  CommitStatusPending is for when the CommitStatus is Pending\nsuccess CommitStatusSuccess  CommitStatusSuccess is for when the CommitStatus is Success\nerror CommitStatusError  CommitStatusError is for when the CommitStatus is Error\nfailure CommitStatusFailure  CommitStatusFailure is for when the CommitStatus is Failure\nwarning CommitStatusWarning  CommitStatusWarning is for when the CommitStatus is Warning\nskipped CommitStatusSkipped  CommitStatusSkipped is for when CommitStatus is Skipped",
+          "x-go-enum-desc": "pending CreateCommitStatusPending  CreateCommitStatusPending is for when the CommitStatus is Pending\nsuccess CreateCommitStatusSuccess  CreateCommitStatusSuccess is for when the CommitStatus is Success\nerror CreateCommitStatusError  CreateCommitStatusError is for when the CommitStatus is Error\nfailure CreateCommitStatusFailure  CreateCommitStatusFailure is for when the CommitStatus is Failure\nskipped CreateCommitStatusSkipped  CreateCommitStatusSkipped is for when CommitStatus is Skipped",
           "x-go-name": "State"
         },
         "target_url": {

--- a/tests/integration/pull_status_test.go
+++ b/tests/integration/pull_status_test.go
@@ -21,6 +21,7 @@ import (
 	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/modules/test"
 	"code.gitea.io/gitea/services/pull"
+	"code.gitea.io/gitea/tests"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -60,7 +61,7 @@ func TestPullCreate_CommitStatus(t *testing.T) {
 			commitstatus.CommitStatusError,
 			commitstatus.CommitStatusFailure,
 			commitstatus.CommitStatusSuccess,
-			commitstatus.CommitStatusWarning,
+			commitstatus.CommitStatusSkipped,
 		}
 
 		statesIcons := map[commitstatus.CommitStatusState]string{
@@ -68,7 +69,7 @@ func TestPullCreate_CommitStatus(t *testing.T) {
 			commitstatus.CommitStatusSuccess: "octicon-check",
 			commitstatus.CommitStatusError:   "gitea-exclamation",
 			commitstatus.CommitStatusFailure: "octicon-x",
-			commitstatus.CommitStatusWarning: "gitea-exclamation",
+			commitstatus.CommitStatusSkipped: "octicon-check",
 		}
 
 		testCtx := NewAPITestContext(t, "user1", "repo1", auth_model.AccessTokenScopeWriteRepository)
@@ -102,12 +103,27 @@ func doAPICreateCommitStatusTest(ctx APITestContext, ref string, state commitsta
 	return func(t *testing.T) {
 		link := fmt.Sprintf("/api/v1/repos/%s/%s/statuses/%s", ctx.Username, ctx.Reponame, url.PathEscape(ref))
 		req := NewRequestWithJSON(t, http.MethodPost, link, api.CreateStatusOption{
-			State:     state,
+			State:     api.CreateCommitStatusState(state),
 			TargetURL: "http://test.ci/",
 			Context:   statusContext,
 		}).AddTokenAuth(ctx.Token)
 		ctx.Session.MakeRequest(t, req, ctx.ExpectedCode)
 	}
+}
+
+func TestAPICommitStatusRejectsWarningState(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	ctx := NewAPITestContext(t, "user2", "repo1", auth_model.AccessTokenScopeWriteRepository)
+	link := fmt.Sprintf("/api/v1/repos/%s/%s/statuses/%s", ctx.Username, ctx.Reponame, "65f1bf27bc3bf70f64657658635e66094edbcb4d")
+
+	req := NewRequestWithJSON(t, http.MethodPost, link, api.CreateStatusOption{
+		State:     api.CreateCommitStatusState(commitstatus.CommitStatusWarning),
+		TargetURL: "http://test.ci/",
+		Context:   "testci",
+	}).AddTokenAuth(ctx.Token)
+
+	ctx.Session.MakeRequest(t, req, http.StatusBadRequest)
 }
 
 func TestPullCreate_EmptyChangesWithDifferentCommits(t *testing.T) {


### PR DESCRIPTION
This PR removes warning as a createable commit status state.
Currently `warning` statuses no longer block PRs https://github.com/go-gitea/gitea/issues/37042
This PR completes that direction by removing warning from the commit status creation API as well.
This makes us more comply to the same stati as Github

## :warning: BREAKING :warning:

Creating a commit status with state=warning is no longer supported.

Clients using POST /repos/{owner}/{repo}/statuses/{sha} must stop sending warning and use one of the supported states instead: pending, success, error, failure, or skipped.

Existing stored warning statuses are still readable through the API, but no new warning statuses can be created.

_This PR was simplified and reviewed by Codex_