### PR TITLE
Only print test header on failure or timeout

### DIFF
--- a/modules/testlogger/testlogger.go
+++ b/modules/testlogger/testlogger.go
@@ -121,10 +121,11 @@ func PrintCurrentTest(t testing.TB, skip ...int) func() {
 			Printf("!!! %s defer function hasn't been run but Cleanup is called, usually caused by panic", t.Name())
 		}
 	})
-	Printf("=== %s (%s:%d)\n", log.NewColoredValue(t.Name()), strings.TrimPrefix(filename, prefix), line)
+	testHeader := fmt.Sprintf("=== %s (%s:%d)\n", log.NewColoredValue(t.Name()), strings.TrimPrefix(filename, prefix), line)
 
 	WriterCloser.pushT(t)
 	timeoutChecker := time.AfterFunc(TestTimeout, func() {
+		Printf("%s", testHeader)
 		Printf("!!! %s ... timeout: %v ... stacktrace:\n%s\n\n", log.NewColoredValue(t.Name(), log.Bold, log.FgRed), TestTimeout, getRuntimeStackAll())
 	})
 	return func() {
@@ -142,6 +143,9 @@ func PrintCurrentTest(t testing.TB, skip ...int) func() {
 
 		runDuration := time.Since(runStart)
 		flushDuration := time.Since(flushStart)
+		if t.Failed() {
+			Printf("%s", testHeader)
+		}
 		if runDuration > TestSlowRun {
 			Printf("+++ %s is a slow test (run: %v, flush: %v)\n", log.NewColoredValue(t.Name(), log.Bold, log.FgYellow), runDuration, flushDuration)
 		}

--- a/modules/testlogger/testlogger.go
+++ b/modules/testlogger/testlogger.go
@@ -121,11 +121,13 @@ func PrintCurrentTest(t testing.TB, skip ...int) func() {
 			Printf("!!! %s defer function hasn't been run but Cleanup is called, usually caused by panic", t.Name())
 		}
 	})
-	testHeader := fmt.Sprintf("=== %s (%s:%d)\n", log.NewColoredValue(t.Name()), strings.TrimPrefix(filename, prefix), line)
+	printTestHeader := func() {
+		Printf("=== %s (%s:%d)\n", log.NewColoredValue(t.Name()), strings.TrimPrefix(filename, prefix), line)
+	}
 
 	WriterCloser.pushT(t)
 	timeoutChecker := time.AfterFunc(TestTimeout, func() {
-		Printf("%s", testHeader)
+		printTestHeader()
 		Printf("!!! %s ... timeout: %v ... stacktrace:\n%s\n\n", log.NewColoredValue(t.Name(), log.Bold, log.FgRed), TestTimeout, getRuntimeStackAll())
 	})
 	return func() {
@@ -144,7 +146,7 @@ func PrintCurrentTest(t testing.TB, skip ...int) func() {
 		runDuration := time.Since(runStart)
 		flushDuration := time.Since(flushStart)
 		if t.Failed() {
-			Printf("%s", testHeader)
+			printTestHeader()
 		}
 		if runDuration > TestSlowRun {
 			Printf("+++ %s is a slow test (run: %v, flush: %v)\n", log.NewColoredValue(t.Name(), log.Bold, log.FgYellow), runDuration, flushDuration)


### PR DESCRIPTION
The `=== TestName (file:line)` header in `PrintCurrentTest` was printed unconditionally for every test, creating excessive noise in test output. Defer the header into a string and only print it when the test actually fails or times out.

Before:
```
=== TestScheduleUpdate/PullMerge/rebase-merge (tests/integration/actions_schedule_test.go:233)
=== TestScheduleUpdate/PullMerge/squash (tests/integration/actions_schedule_test.go:233)
=== TestScheduleUpdate/PullMerge/fast-forward-only (tests/integration/actions_schedule_test.go:233)
=== TestScheduleUpdate/PullMerge/manually-merged (tests/integration/actions_schedule_test.go:233)
...
```

After: only failed/timed-out tests print their header.

---
This PR was written with the help of Claude Opus 4.6