### PR TITLE
Remove `htmx`

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -574,8 +574,6 @@ export default defineConfig([
       'no-restricted-properties': [2, ...restrictedProperties],
       'no-restricted-imports': [2, {paths: [
         {name: 'jquery', message: 'Use the global $ instead', allowTypeImports: true},
-        {name: 'htmx.org', message: 'Use the global htmx instead', allowTypeImports: true},
-        {name: 'idiomorph/htmx', message: 'Loaded in globals.ts', allowTypeImports: true},
       ]}],
       'no-restricted-syntax': [2, 'WithStatement', 'ForInStatement', 'LabeledStatement', 'SequenceExpression'],
       'no-return-assign': [0],
@@ -1022,6 +1020,6 @@ export default defineConfig([
   },
   {
     files: ['web_src/**/*'],
-    languageOptions: {globals: {...globals.browser, ...globals.jquery, htmx: false}},
+    languageOptions: {globals: {...globals.browser, ...globals.jquery}},
   },
 ]);

--- a/package.json
+++ b/package.json
@@ -49,8 +49,6 @@
     "dropzone": "6.0.0-beta.2",
     "easymde": "2.20.0",
     "esbuild": "0.27.4",
-    "htmx.org": "2.0.8",
-    "idiomorph": "0.7.4",
     "jquery": "4.0.0",
     "js-yaml": "4.1.1",
     "katex": "0.16.44",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,12 +155,6 @@ importers:
       esbuild:
         specifier: 0.27.4
         version: 0.27.4
-      htmx.org:
-        specifier: 2.0.8
-        version: 2.0.8
-      idiomorph:
-        specifier: 0.7.4
-        version: 0.7.4
       jquery:
         specifier: 4.0.0
         version: 4.0.0
@@ -2901,15 +2895,9 @@ packages:
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
-  htmx.org@2.0.8:
-    resolution: {integrity: sha512-fm297iru0iWsNJlBrjvtN7V9zjaxd+69Oqjh4F/Vq9Wwi2kFisLcrLCiv5oBX0KLfOX/zG8AUo9ROMU5XUB44Q==}
-
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
-
-  idiomorph@0.7.4:
-    resolution: {integrity: sha512-uCdSpLo3uMfqOmrwXTpR1k/sq4sSmKC7l4o/LdJOEU+MMMq+wkevRqOQYn3lP7vfz9Mv+USBEqPvi0XhdL9ENw==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -7015,13 +7003,9 @@ snapshots:
       domutils: 3.2.2
       entities: 4.5.0
 
-  htmx.org@2.0.8: {}
-
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: '@nolyfill/safer-buffer@1.0.44'
-
-  idiomorph@0.7.4: {}
 
   ieee754@1.2.1: {}
 

--- a/routers/web/repo/star.go
+++ b/routers/web/repo/star.go
@@ -26,6 +26,6 @@ func ActionStar(ctx *context.Context) {
 		ctx.ServerError("GetRepositoryByName", err)
 		return
 	}
-	ctx.RespHeader().Add("hx-trigger", "refreshUserCards") // see the `hx-trigger="refreshUserCards ..."` comments in tmpl
+	ctx.RespHeader().Add("X-Gitea-Dispatch-Event", "refreshUserCards")
 	ctx.HTML(http.StatusOK, tplStarUnstar)
 }

--- a/routers/web/repo/watch.go
+++ b/routers/web/repo/watch.go
@@ -26,6 +26,6 @@ func ActionWatch(ctx *context.Context) {
 		ctx.ServerError("GetRepositoryByName", err)
 		return
 	}
-	ctx.RespHeader().Add("hx-trigger", "refreshUserCards") // see the `hx-trigger="refreshUserCards ..."` comments in tmpl
+	ctx.RespHeader().Add("X-Gitea-Dispatch-Event", "refreshUserCards")
 	ctx.HTML(http.StatusOK, tplWatchUnwatch)
 }

--- a/services/context/base.go
+++ b/services/context/base.go
@@ -159,11 +159,11 @@ func (b *Base) Redirect(location string, status ...int) {
 		// So in this case, we should remove the session cookie from the response header
 		removeSessionCookieHeader(b.Resp)
 	}
-	// in case the request is made by htmx, have it redirect the browser instead of trying to follow the redirect inside htmx
-	if b.Req.Header.Get("HX-Request") == "true" {
-		b.Resp.Header().Set("HX-Redirect", location)
-		// we have to return a non-redirect status code so XMLHTTPRequest will not immediately follow the redirect
-		// so as to give htmx redirect logic a chance to run
+	// for page-action requests (form-fetch-action with data-swap), return 204 with a redirect header
+	// instead of a 30x redirect, because fetch() auto-follows redirects and the JS handler needs
+	// to perform a full navigation instead
+	if b.Req.Header.Get("X-Gitea-Page-Action") == "true" {
+		b.Resp.Header().Set("X-Gitea-Redirect", location)
 		b.Status(http.StatusNoContent)
 		return
 	}

--- a/services/context/base_test.go
+++ b/services/context/base_test.go
@@ -38,9 +38,9 @@ func TestRedirect(t *testing.T) {
 
 	req, _ = http.NewRequest(http.MethodGet, "/", nil)
 	resp := httptest.NewRecorder()
-	req.Header.Add("HX-Request", "true")
+	req.Header.Add("X-Gitea-Page-Action", "true")
 	b := NewBaseContextForTest(resp, req)
 	b.Redirect("/other")
-	assert.Equal(t, "/other", resp.Header().Get("HX-Redirect"))
+	assert.Equal(t, "/other", resp.Header().Get("X-Gitea-Redirect"))
 	assert.Equal(t, http.StatusNoContent, resp.Code)
 }

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -228,7 +228,7 @@ func (d *DiffLine) RenderBlobExcerptButtons(fileNameHash string, data *DiffBlobE
 			link += fmt.Sprintf("&pull_issue_index=%d", data.PullIssueIndex)
 		}
 		return htmlutil.HTMLFormat(
-			`<button class="code-expander-button" hx-target="closest tr" hx-get="%s" data-hidden-comment-ids=",%s,">%s</button>`,
+			`<button class="code-expander-button" data-url="%s" data-hidden-comment-ids=",%s,">%s</button>`,
 			link, dataHiddenCommentIDs, svg.RenderHTML(svgName),
 		)
 	}

--- a/templates/admin/dashboard.tmpl
+++ b/templates/admin/dashboard.tmpl
@@ -76,8 +76,7 @@
 		</h4>
 		{{/* TODO: make these stats work in multi-server deployments, likely needs per-server stats in DB */}}
 		<div class="ui attached table segment">
-			<div class="no-loading-indicator tw-hidden"></div>
-			<div hx-get="{{$.Link}}/system_status" hx-swap="morph:innerHTML" hx-trigger="every 5s" hx-indicator=".no-loading-indicator">
+			<div data-global-init="initAdminSystemStatus" data-poll-url="{{$.Link}}/system_status">
 				{{template "admin/system_status" .}}
 			</div>
 		</div>

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -23,7 +23,7 @@
 	{{template "base/head_script" .}}
 	{{template "custom/header" .}}
 </head>
-<body hx-swap="outerHTML" hx-ext="morph" hx-push-url="false">
+<body>
 	{{template "custom/body_outer_pre" .}}
 
 	<div class="full height">

--- a/templates/org/follow_unfollow.tmpl
+++ b/templates/org/follow_unfollow.tmpl
@@ -1,7 +1,9 @@
-<button class="ui basic button tw-mr-0" hx-post="{{.Org.HomeLink}}?action={{if $.IsFollowing}}unfollow{{else}}follow{{end}}">
-	{{if $.IsFollowing}}
-		{{ctx.Locale.Tr "user.unfollow"}}
-	{{else}}
-		{{ctx.Locale.Tr "user.follow"}}
-	{{end}}
-</button>
+<form class="form-fetch-action" data-swap="this" method="post" action="{{.Org.HomeLink}}?action={{if $.IsFollowing}}unfollow{{else}}follow{{end}}">
+	<button type="submit" class="ui basic button tw-mr-0">
+		{{if $.IsFollowing}}
+			{{ctx.Locale.Tr "user.unfollow"}}
+		{{else}}
+			{{ctx.Locale.Tr "user.follow"}}
+		{{end}}
+	</button>
+</form>

--- a/templates/repo/actions/workflow_dispatch.tmpl
+++ b/templates/repo/actions/workflow_dispatch.tmpl
@@ -10,7 +10,7 @@
 					<label>{{ctx.Locale.Tr "actions.workflow.from_ref"}}:</label>
 				</span>
 				<div class="ui inline field dropdown button select-branch branch-selector-dropdown ellipsis-text-items">
-					<input type="hidden" name="ref" hx-sync="this:replace" hx-target="#runWorkflowDispatchModalInputs" hx-swap="innerHTML" hx-get="{{$.Link}}/workflow-dispatch-inputs?workflow={{$.CurWorkflow}}" hx-trigger="change" value="refs/heads/{{index .Branches 0}}">
+					<input type="hidden" name="ref" data-global-init="initWorkflowDispatchRef" data-dispatch-url="{{$.Link}}/workflow-dispatch-inputs?workflow={{$.CurWorkflow}}" data-target="#runWorkflowDispatchModalInputs" value="refs/heads/{{index .Branches 0}}">
 					{{svg "octicon-git-branch" 14}}
 					<div class="default text">{{index .Branches 0}}</div>
 					{{svg "octicon-triangle-down" 14 "dropdown icon"}}

--- a/templates/repo/actions/workflow_dispatch_inputs.tmpl
+++ b/templates/repo/actions/workflow_dispatch_inputs.tmpl
@@ -11,14 +11,14 @@
 		<div class="ui field {{if .Required}}required{{end}}">
 			{{if eq .Type "choice"}}
 				<label>{{or .Description .Name}}:</label>
-				{{/* htmx won't initialize the fomantic dropdown, so it is a standard "select" input */}}
+				{{/* this content is dynamically loaded, so use a standard "select" instead of fomantic dropdown */}}
 				<select class="ui selection dropdown" name="{{.Name}}">
 					{{range .Options}}
 						<option value="{{.}}" {{if eq $item.Default .}}selected{{end}}>{{.}}</option>
 					{{end}}
 				</select>
 			{{else if eq .Type "boolean"}}
-				{{/* htmx doesn't trigger our JS code to attach fomantic label to checkbox, so here we use standard checkbox */}}
+				{{/* this content is dynamically loaded, so use a standard checkbox instead of fomantic */}}
 				<label class="tw-flex flex-text-inline">
 					<input type="checkbox" name="{{.Name}}" {{if eq .Default "true"}}checked{{end}}>
 					{{or .Description .Name}}

--- a/templates/repo/editor/edit.tmpl
+++ b/templates/repo/editor/edit.tmpl
@@ -23,7 +23,7 @@
 										<a class="active item" data-tab="write">{{svg "octicon-code"}} {{if .IsNewFile}}{{ctx.Locale.Tr "repo.editor.new_file"}}{{else}}{{ctx.Locale.Tr "repo.editor.edit_file"}}{{end}}</a>
 										<a class="item{{if not .CodeEditorConfig.Previewable}} tw-hidden{{end}}" data-tab="preview" data-preview-url="{{.Repository.Link}}/markup" data-preview-context-ref="{{.RepoLink}}/src/{{.RefTypeNameSubURL}}">{{svg "octicon-eye"}} {{ctx.Locale.Tr "preview"}}</a>
 										{{if not .IsNewFile}}
-										<a class="item" data-tab="diff" hx-params="context,content" hx-vals='{"context":"{{.BranchLink}}"}' hx-include="#edit_area" hx-swap="innerHTML" hx-target=".tab[data-tab='diff']" hx-indicator=".tab[data-tab='diff']" hx-post="{{.RepoLink}}/_preview/{{.BranchName | PathEscapeSegments}}/{{.TreePath | PathEscapeSegments}}">{{svg "octicon-diff"}} {{ctx.Locale.Tr "repo.editor.preview_changes"}}</a>
+										<a class="item" data-tab="diff" data-diff-url="{{.RepoLink}}/_preview/{{.BranchName | PathEscapeSegments}}/{{.TreePath | PathEscapeSegments}}" data-diff-context="{{.BranchLink}}">{{svg "octicon-diff"}} {{ctx.Locale.Tr "repo.editor.preview_changes"}}</a>
 										{{end}}
 									</div>
 									{{template "repo/editor/options" dict "CodeEditorConfig" $.CodeEditorConfig}}

--- a/templates/repo/issue/view_content/watching.tmpl
+++ b/templates/repo/issue/view_content/watching.tmpl
@@ -1,4 +1,4 @@
-<form hx-boost="true" hx-sync="this:replace" hx-target="this" method="post" action="{{.Issue.Link}}/watch">
+<form class="form-fetch-action" data-swap="this" method="post" action="{{.Issue.Link}}/watch">
 	<input type="hidden" name="watch" value="{{if $.IssueWatch.IsWatching}}0{{else}}1{{end}}">
 	<button class="fluid ui button">
 		{{if $.IssueWatch.IsWatching}}

--- a/templates/repo/star_unstar.tmpl
+++ b/templates/repo/star_unstar.tmpl
@@ -1,4 +1,4 @@
-<form class="flex-text-inline" hx-boost="true" hx-target="this" method="post" action="{{$.RepoLink}}/action/{{if $.IsStaringRepo}}unstar{{else}}star{{end}}">
+<form class="flex-text-inline form-fetch-action" data-swap="this" method="post" action="{{$.RepoLink}}/action/{{if $.IsStaringRepo}}unstar{{else}}star{{end}}">
 	<div class="ui labeled button" {{if not $.IsSigned}}data-tooltip-content="{{ctx.Locale.Tr "repo.star_guest_user"}}"{{end}}>
 		{{$buttonText := ctx.Locale.Tr "repo.star"}}
 		{{if $.IsStaringRepo}}{{$buttonText = ctx.Locale.Tr "repo.unstar"}}{{end}}
@@ -6,7 +6,7 @@
 			{{svg (Iif $.IsStaringRepo "octicon-star-fill" "octicon-star")}}
 			<span class="not-mobile" aria-hidden="true">{{$buttonText}}</span>
 		</button>
-		<a hx-boost="false" class="ui basic label" href="{{$.RepoLink}}/stars">
+		<a class="ui basic label" href="{{$.RepoLink}}/stars">
 			{{CountFmt .Repository.NumStars}}
 		</a>
 	</div>

--- a/templates/repo/user_cards.tmpl
+++ b/templates/repo/user_cards.tmpl
@@ -1,14 +1,4 @@
-<!-- Refresh the content if a htmx response contains "HX-Trigger" header.
-This usually happens when a user stays on the watchers/stargazers page
-when they watched/unwatched/starred/unstarred and the list should be refreshed.
-To test go to the watchers page and click the watch button. The user cards should reload.
-At the moment, no JS initialization would re-trigger (fortunately there is no JS for this page).
--->
-<div class="no-loading-indicator tw-hidden"></div>
-<div class="user-cards"
-		hx-trigger="refreshUserCards from:body" hx-indicator=".no-loading-indicator"
-		hx-get="" hx-swap="outerHTML" hx-select=".user-cards"
->
+<div class="user-cards">
 	{{if .CardsTitle}}
 	<h2 class="ui dividing header">
 		{{.CardsTitle}}

--- a/templates/repo/view_list.tmpl
+++ b/templates/repo/view_list.tmpl
@@ -1,5 +1,5 @@
 {{/* use grid layout, still use the old ID because there are many other CSS styles depending on this ID */}}
-<div id="repo-files-table" {{if .HasFilesWithoutLatestCommit}}hx-indicator="#repo-files-table .repo-file-cell.message" hx-trigger="load" hx-swap="morph" hx-post="{{.LastCommitLoaderURL}}"{{end}}>
+<div id="repo-files-table" {{if .HasFilesWithoutLatestCommit}}data-global-init="initLastCommitLoader" data-loader-url="{{.LastCommitLoaderURL}}"{{end}}>
 	<div class="repo-file-line repo-file-last-commit">
 		{{template "repo/latest_commit" .}}
 		<div>{{if and .LatestCommit .LatestCommit.Committer}}{{DateUtils.TimeSince .LatestCommit.Committer.When}}{{end}}</div>

--- a/templates/repo/watch_unwatch.tmpl
+++ b/templates/repo/watch_unwatch.tmpl
@@ -1,4 +1,4 @@
-<form class="flex-text-inline" hx-boost="true" hx-target="this" method="post" action="{{$.RepoLink}}/action/{{if $.IsWatchingRepo}}unwatch{{else}}watch{{end}}">
+<form class="flex-text-inline form-fetch-action" data-swap="this" method="post" action="{{$.RepoLink}}/action/{{if $.IsWatchingRepo}}unwatch{{else}}watch{{end}}">
 	<div class="ui labeled button" {{if not $.IsSigned}}data-tooltip-content="{{ctx.Locale.Tr "repo.watch_guest_user"}}"{{end}}>
 		{{$buttonText := ctx.Locale.Tr "repo.watch"}}
 		{{if $.IsWatchingRepo}}{{$buttonText = ctx.Locale.Tr "repo.unwatch"}}{{end}}
@@ -6,7 +6,7 @@
 			{{svg "octicon-eye"}}
 			<span class="not-mobile" aria-hidden="true">{{$buttonText}}</span>
 		</button>
-		<a hx-boost="false" class="ui basic label" href="{{.RepoLink}}/watchers">
+		<a class="ui basic label" href="{{.RepoLink}}/watchers">
 			{{CountFmt .Repository.NumWatches}}
 		</a>
 	</div>

--- a/templates/shared/user/profile_big_avatar.tmpl
+++ b/templates/shared/user/profile_big_avatar.tmpl
@@ -115,16 +115,12 @@
 			{{end}}
 			{{if and .IsSigned (ne .SignedUserID .ContextUser.ID)}}
 				{{if not .UserBlocking}}
-				<li class="follow" hx-target="#profile-avatar-card" hx-indicator="#profile-avatar-card">
-					{{if $.IsFollowing}}
-						<button hx-post="{{.ContextUser.HomeLink}}?action=unfollow" class="ui basic red button">
-							{{svg "octicon-person"}} {{ctx.Locale.Tr "user.unfollow"}}
+				<li class="follow">
+					<form class="form-fetch-action" data-swap="#profile-avatar-card" method="post" action="{{.ContextUser.HomeLink}}?action={{if $.IsFollowing}}unfollow{{else}}follow{{end}}">
+						<button type="submit" class="ui basic {{if $.IsFollowing}}red{{else}}primary{{end}} button">
+							{{svg "octicon-person"}} {{ctx.Locale.Tr (Iif $.IsFollowing "user.unfollow" "user.follow")}}
 						</button>
-					{{else}}
-						<button hx-post="{{.ContextUser.HomeLink}}?action=follow" class="ui basic primary button">
-							{{svg "octicon-person"}} {{ctx.Locale.Tr "user.follow"}}
-						</button>
-					{{end}}
+					</form>
 				</li>
 				{{end}}
 				<li>

--- a/templates/user/notification/notification_div.tmpl
+++ b/templates/user/notification/notification_div.tmpl
@@ -53,8 +53,7 @@
 							{{DateUtils.TimeSince $one.UpdatedUnix}}
 						{{end}}
 					</div>
-					<form class="notifications-buttons" action="{{AppSubUrl}}/notifications/status?type={{$.PageType}}&page={{$.Page.Paginater.Current}}&perPage={{$.Page.Paginater.PagingNum}}" method="post"
-								hx-boost="true" hx-target="#notification_div" hx-swap="outerHTML"
+					<form class="notifications-buttons form-fetch-action" data-swap="#notification_div" action="{{AppSubUrl}}/notifications/status?type={{$.PageType}}&page={{$.Page.Paginater.Current}}&perPage={{$.Page.Paginater.PagingNum}}" method="post"
 					>
 						<input type="hidden" name="notification_id" value="{{$one.ID}}">
 						{{if ne $one.Status $statusPinned}}

--- a/tests/e2e/page-actions.test.ts
+++ b/tests/e2e/page-actions.test.ts
@@ -1,0 +1,191 @@
+import {env} from 'node:process';
+import {test, expect} from '@playwright/test';
+import {login, apiCreateRepo, apiDeleteRepo, apiCreateUser, apiDeleteUser, apiCreateIssue, apiUserHeaders, assertNoJsError, timeoutFactor} from './utils.ts';
+
+test('star and unstar repo', async ({page, request}) => {
+  const repoName = `e2e-star-${Date.now()}`;
+  await apiCreateRepo(request, {name: repoName});
+  try {
+    await login(page);
+    await page.goto(`/${env.GITEA_TEST_E2E_USER}/${repoName}`);
+
+    const starForm = () => page.locator('form[action$="/action/star"], form[action$="/action/unstar"]');
+
+    await expect(starForm().locator('button[aria-label="Star"]')).toBeVisible();
+    await expect(starForm().locator(`a[href$="/stars"]`)).toHaveText('0');
+
+    await starForm().locator('button').click();
+    await expect(starForm().locator('button[aria-label="Unstar"]')).toBeVisible();
+    await expect(starForm().locator(`a[href$="/stars"]`)).toHaveText('1');
+
+    await starForm().locator('button').click();
+    await expect(starForm().locator('button[aria-label="Star"]')).toBeVisible();
+    await expect(starForm().locator(`a[href$="/stars"]`)).toHaveText('0');
+    await assertNoJsError(page);
+  } finally {
+    await apiDeleteRepo(request, env.GITEA_TEST_E2E_USER, repoName);
+  }
+});
+
+test('watch and unwatch repo', async ({page, request}) => {
+  const repoName = `e2e-watch-${Date.now()}`;
+  await apiCreateRepo(request, {name: repoName});
+  try {
+    await login(page);
+    await page.goto(`/${env.GITEA_TEST_E2E_USER}/${repoName}`);
+
+    const watchForm = () => page.locator('form[action$="/action/watch"], form[action$="/action/unwatch"]');
+
+    // Repo owner auto-watches, so initial state is "Unwatch"
+    await expect(watchForm().locator('button[aria-label="Unwatch"]')).toBeVisible();
+
+    await watchForm().locator('button').click();
+    await expect(watchForm().locator('button[aria-label="Watch"]')).toBeVisible();
+
+    await watchForm().locator('button').click();
+    await expect(watchForm().locator('button[aria-label="Unwatch"]')).toBeVisible();
+    await assertNoJsError(page);
+  } finally {
+    await apiDeleteRepo(request, env.GITEA_TEST_E2E_USER, repoName);
+  }
+});
+
+test('issue subscribe toggle', async ({page, request}) => {
+  const repoName = `e2e-issuewatch-${Date.now()}`;
+  await apiCreateRepo(request, {name: repoName});
+  try {
+    await login(page);
+    await apiCreateIssue(request, env.GITEA_TEST_E2E_USER, repoName, {title: 'test issue'});
+    await page.goto(`/${env.GITEA_TEST_E2E_USER}/${repoName}/issues/1`);
+
+    await expect(page.locator('.issue-content-right form button:has-text("Unsubscribe")')).toBeVisible();
+
+    await page.locator('.issue-content-right form button:has-text("Unsubscribe")').click();
+    await expect(page.locator('.issue-content-right form button:has-text("Subscribe")')).toBeVisible();
+
+    await page.locator('.issue-content-right form button:has-text("Subscribe")').click();
+    await expect(page.locator('.issue-content-right form button:has-text("Unsubscribe")')).toBeVisible();
+    await assertNoJsError(page);
+  } finally {
+    await apiDeleteRepo(request, env.GITEA_TEST_E2E_USER, repoName);
+  }
+});
+
+test('follow and unfollow user', async ({page, request}) => {
+  const targetUser = `e2e-follow-${Date.now()}`;
+  await apiCreateUser(request, targetUser);
+  try {
+    await login(page);
+    await page.goto(`/${targetUser}`);
+
+    await expect(page.locator('#profile-avatar-card button:has-text("Follow")')).toBeVisible();
+
+    await page.locator('#profile-avatar-card button:has-text("Follow")').click();
+    await expect(page.locator('#profile-avatar-card button:has-text("Unfollow")')).toBeVisible();
+
+    await page.locator('#profile-avatar-card button:has-text("Unfollow")').click();
+    await expect(page.locator('#profile-avatar-card button:has-text("Follow")')).toBeVisible();
+    await assertNoJsError(page);
+  } finally {
+    await apiDeleteUser(request, targetUser);
+  }
+});
+
+test('notification pin', async ({page, request}) => {
+  const commenter = `e2e-notif-${Date.now()}`;
+  const repoName = `e2e-notif-${Date.now()}`;
+  await apiCreateUser(request, commenter);
+  await apiCreateRepo(request, {name: repoName});
+  try {
+    await apiCreateIssue(request, env.GITEA_TEST_E2E_USER, repoName, {
+      title: 'notification test issue',
+      headers: apiUserHeaders(commenter),
+    });
+
+    await login(page);
+    await page.goto('/notifications');
+
+    const notificationItem = page.locator('.notifications-item').first();
+    await expect(notificationItem).toBeVisible();
+
+    await notificationItem.hover();
+    await notificationItem.locator('button[name="notification_action"][value="pin"]').click();
+    await expect(page.locator('#notification_div')).toBeVisible();
+    await assertNoJsError(page);
+  } finally {
+    await apiDeleteUser(request, commenter);
+    await apiDeleteRepo(request, env.GITEA_TEST_E2E_USER, repoName);
+  }
+});
+
+test('admin system status polling', async ({page}) => {
+  await login(page);
+  await page.goto('/-/admin');
+
+  const goroutinesLabel = page.locator('dt:has-text("Current Goroutines")');
+  await expect(goroutinesLabel).toBeVisible();
+  await expect(goroutinesLabel.locator('+ dd')).toHaveText(/\d+/);
+
+  await page.waitForResponse((resp) => resp.url().includes('/system_status') && resp.ok(), {timeout: 10000 * timeoutFactor});
+  await expect(goroutinesLabel).toBeVisible();
+  await expect(goroutinesLabel.locator('+ dd')).toHaveText(/\d+/);
+  await assertNoJsError(page);
+});
+
+test('repo file list commit messages', async ({page, request}) => {
+  const repoName = `e2e-commits-${Date.now()}`;
+  await apiCreateRepo(request, {name: repoName});
+  try {
+    await login(page);
+    await page.goto(`/${env.GITEA_TEST_E2E_USER}/${repoName}`);
+
+    const fileTable = page.locator('#repo-files-table');
+    await expect(fileTable).toBeVisible();
+    await expect(fileTable.locator('.repo-file-cell.message a').first()).toBeVisible();
+    await assertNoJsError(page);
+  } finally {
+    await apiDeleteRepo(request, env.GITEA_TEST_E2E_USER, repoName);
+  }
+});
+
+test('stargazers page refreshes on star', async ({page, request}) => {
+  const repoName = `e2e-cards-${Date.now()}`;
+  await apiCreateRepo(request, {name: repoName});
+  try {
+    await login(page);
+    await page.goto(`/${env.GITEA_TEST_E2E_USER}/${repoName}/stars`);
+
+    const userCards = page.locator('.user-cards');
+    await expect(userCards).toBeVisible();
+
+    await page.locator('form[action$="/action/star"], form[action$="/action/unstar"]').locator('button').click();
+    await expect(userCards.locator('.item')).toBeVisible();
+    await assertNoJsError(page);
+  } finally {
+    await apiDeleteRepo(request, env.GITEA_TEST_E2E_USER, repoName);
+  }
+});
+
+test('editor diff preview', async ({page, request}) => {
+  const repoName = `e2e-editor-${Date.now()}`;
+  await apiCreateRepo(request, {name: repoName});
+  try {
+    await login(page);
+    await page.goto(`/${env.GITEA_TEST_E2E_USER}/${repoName}/_edit/main/README.md`);
+
+    await expect(page.locator('.editor-loading')).toBeHidden();
+    const editor = page.locator('.cm-content[role="textbox"]');
+    await expect(editor).toBeVisible();
+    await editor.click();
+    await page.keyboard.type('\nNew line added for diff test');
+
+    const diffTab = page.locator('a[data-tab="diff"]');
+    await expect(diffTab).toBeVisible();
+    await diffTab.click();
+
+    await expect(page.locator('.tab[data-tab="diff"]').locator('.diff-file-box, .diff-file-header, .markup')).toBeVisible();
+    await assertNoJsError(page);
+  } finally {
+    await apiDeleteRepo(request, env.GITEA_TEST_E2E_USER, repoName);
+  }
+});

--- a/tests/integration/compare_test.go
+++ b/tests/integration/compare_test.go
@@ -147,12 +147,12 @@ func TestCompareCodeExpand(t *testing.T) {
 		req := NewRequest(t, "GET", "/user1/test_blob_excerpt/compare/main...user2/test_blob_excerpt-fork:forked-branch")
 		resp := session.MakeRequest(t, req, http.StatusOK)
 		htmlDoc := NewHTMLParser(t, resp.Body)
-		els := htmlDoc.Find(`button.code-expander-button[hx-get]`)
+		els := htmlDoc.Find(`button.code-expander-button[data-url]`)
 
 		// all the links in the comparison should be to the forked repo&branch
 		assert.NotZero(t, els.Length())
 		for i := 0; i < els.Length(); i++ {
-			link := els.Eq(i).AttrOr("hx-get", "")
+			link := els.Eq(i).AttrOr("data-url", "")
 			assert.True(t, strings.HasPrefix(link, "/user2/test_blob_excerpt-fork/blob_excerpt/"))
 		}
 	})

--- a/tests/integration/editor_test.go
+++ b/tests/integration/editor_test.go
@@ -385,7 +385,7 @@ func testForkToEditFile(t *testing.T, session *TestSession, user, owner, repo, b
 		resp := session.MakeRequest(t, req, http.StatusOK)
 		htmlDoc := NewHTMLParser(t, resp.Body)
 
-		uploadForm := htmlDoc.doc.Find(".form-fetch-action")
+		uploadForm := htmlDoc.doc.Find("form.form-fetch-action.comment")
 		formAction := uploadForm.AttrOr("action", "")
 		assert.Equal(t, fmt.Sprintf("/%s/%s-1/_upload/%s/%s?from_base_branch=%s&foo=bar", user, repo, branch, filePath, branch), formAction)
 		uploadLink := uploadForm.Find(".dropzone").AttrOr("data-link-url", "")

--- a/types.d.ts
+++ b/types.d.ts
@@ -36,11 +36,6 @@ declare module '*.vue' {
   export function initRepositoryActionView(): void;
 }
 
-declare module 'htmx.org/dist/htmx.esm.js' {
-  const value = await import('htmx.org');
-  export default value;
-}
-
 declare module 'swagger-ui-dist/swagger-ui-es-bundle.js' {
   const value = await import('swagger-ui-dist');
   export default value.SwaggerUIBundle;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,7 +45,6 @@ function formatLicenseText(licenseText: string) {
 
 const commonRolldownOptions: Rolldown.RolldownOptions = {
   checks: {
-    eval: false, // htmx needs eval
     pluginTimings: false,
   },
 };

--- a/web_src/js/features/admin/common.ts
+++ b/web_src/js/features/admin/common.ts
@@ -1,7 +1,8 @@
 import {checkAppUrl} from '../common-page.ts';
 import {hideElem, queryElems, showElem, toggleElem} from '../../utils/dom.ts';
-import {POST} from '../../modules/fetch.ts';
+import {GET, POST} from '../../modules/fetch.ts';
 import {fomanticQuery} from '../../modules/fomantic/base.ts';
+import {registerGlobalInitFunc} from '../../modules/observer.ts';
 import {urlQueryEscape} from '../../utils.ts';
 
 const {appSubUrl} = window.config;
@@ -24,6 +25,20 @@ export function initAdminCommon(): void {
   initAdminAuthentication();
   initAdminNotice();
 }
+
+registerGlobalInitFunc('initAdminSystemStatus', (el: HTMLElement) => {
+  const url = el.getAttribute('data-poll-url')!;
+  const interval = setInterval(async () => {
+    if (!el.isConnected) {
+      clearInterval(interval);
+      return;
+    }
+    try {
+      const resp = await GET(url);
+      if (resp.ok) el.innerHTML = await resp.text();
+    } catch { /* ignore polling errors */ }
+  }, 5000);
+});
 
 function initAdminUser() {
   const pageContent = document.querySelector('.page-content.admin.edit.user, .page-content.admin.new.user');

--- a/web_src/js/features/common-fetch-action.ts
+++ b/web_src/js/features/common-fetch-action.ts
@@ -67,7 +67,53 @@ async function fetchActionDoRequest(actionElem: HTMLElement, url: string, opt: R
 
 async function onFormFetchActionSubmit(formEl: HTMLFormElement, e: SubmitEvent) {
   e.preventDefault();
-  await submitFormFetchAction(formEl, {formSubmitter: submitEventSubmitter(e)});
+  const swapTarget = formEl.getAttribute('data-swap');
+  if (swapTarget) {
+    await submitFormSwapAction(formEl, swapTarget, submitEventSubmitter(e));
+  } else {
+    await submitFormFetchAction(formEl, {formSubmitter: submitEventSubmitter(e)});
+  }
+}
+
+async function submitFormSwapAction(formEl: HTMLFormElement, swapTarget: string, submitter?: HTMLElement) {
+  if (formEl.classList.contains('is-loading')) return;
+  formEl.classList.add('is-loading');
+  const formActionUrl = formEl.getAttribute('action') || window.location.href;
+  const formMethod = formEl.getAttribute('method') || 'post';
+  try {
+    const formData = new FormData(formEl);
+    if (submitter?.getAttribute('name')) {
+      formData.append(submitter.getAttribute('name')!, submitter.getAttribute('value') || '');
+    }
+    const resp = await request(formActionUrl, {
+      method: formMethod.toUpperCase(),
+      headers: {'X-Gitea-Page-Action': 'true'},
+      data: formData,
+    });
+    const redirect = resp.headers.get('X-Gitea-Redirect');
+    if (redirect) {
+      window.location.href = redirect;
+      return;
+    }
+    if (!resp.ok) {
+      showErrorToast(`Error ${resp.status} when calling ${formActionUrl}`);
+      formEl.classList.remove('is-loading');
+      return;
+    }
+    const html = await resp.text();
+    const targetEl = swapTarget === 'this' ? formEl : document.querySelector(swapTarget);
+    if (!targetEl) {
+      formEl.classList.remove('is-loading');
+      return;
+    }
+    formEl.classList.remove('is-loading');
+    targetEl.outerHTML = html;
+    const eventName = resp.headers.get('X-Gitea-Dispatch-Event');
+    if (eventName) document.body.dispatchEvent(new CustomEvent(eventName));
+  } catch {
+    showErrorToast(`Network error when calling ${formActionUrl}`);
+    formEl.classList.remove('is-loading');
+  }
 }
 
 type SubmitFormFetchActionOpts = {

--- a/web_src/js/features/common-page.ts
+++ b/web_src/js/features/common-page.ts
@@ -5,6 +5,7 @@ import {addDelegatedEventListener, queryElems} from '../utils/dom.ts';
 import {registerGlobalInitFunc, registerGlobalSelectorFunc} from '../modules/observer.ts';
 import {initAvatarUploaderWithCropper} from './comp/Cropper.ts';
 import {initCompSearchRepoBox} from './comp/SearchRepoBox.ts';
+import {parseDom} from '../utils.ts';
 
 const {appUrl, appSubUrl} = window.config;
 
@@ -103,6 +104,7 @@ export function initGlobalComponent() {
   fomanticQuery('.ui.menu.tabular:not(.custom) .item').tab();
   registerGlobalInitFunc('initAvatarUploader', initAvatarUploaderWithCropper);
   registerGlobalInitFunc('initSearchRepoBox', initCompSearchRepoBox);
+  initUserCards();
 }
 
 // for performance considerations, it only uses performant syntax
@@ -158,6 +160,20 @@ export function checkAppUrl() {
   }
   showGlobalErrorMessage(`Your ROOT_URL in app.ini is "${appUrl}", it's unlikely matching the site you are visiting.
 Mismatched ROOT_URL config causes wrong URL links for web UI/mail content/webhook notification/OAuth2 sign-in.`, 'warning');
+}
+
+function initUserCards() {
+  document.body.addEventListener('refreshUserCards', async () => {
+    const el = document.querySelector('.user-cards');
+    if (!el) return;
+    try {
+      const resp = await GET(window.location.href);
+      if (!resp.ok) return;
+      const doc = parseDom(await resp.text(), 'text/html');
+      const newCards = doc.querySelector('.user-cards');
+      if (newCards) el.outerHTML = newCards.outerHTML;
+    } catch { /* ignore */ }
+  });
 }
 
 export function checkAppUrlScheme() {

--- a/web_src/js/features/notification.ts
+++ b/web_src/js/features/notification.ts
@@ -93,7 +93,6 @@ async function updateNotificationTable() {
       if (parseInt(el.getAttribute('data-sequence-number')!) === notificationSequenceNumber) {
         notificationDiv.outerHTML = data;
         notificationDiv = document.querySelector('#notification_div')!;
-        window.htmx.process(notificationDiv); // when using htmx, we must always remember to process the new content changed by us
       }
     } catch (error) {
       console.error(error);

--- a/web_src/js/features/repo-actions.ts
+++ b/web_src/js/features/repo-actions.ts
@@ -1,5 +1,20 @@
 import {createApp} from 'vue';
 import RepoActionView from '../components/RepoActionView.vue';
+import {registerGlobalInitFunc} from '../modules/observer.ts';
+import {GET} from '../modules/fetch.ts';
+
+registerGlobalInitFunc('initWorkflowDispatchRef', (el: HTMLElement) => {
+  let controller: AbortController | undefined;
+  el.addEventListener('change', async () => {
+    controller?.abort();
+    controller = new AbortController();
+    const url = `${el.getAttribute('data-dispatch-url')!}&ref=${encodeURIComponent((el as HTMLInputElement).value)}`;
+    try {
+      const resp = await GET(url, {signal: controller.signal});
+      if (resp.ok) document.querySelector(el.getAttribute('data-target')!)!.innerHTML = await resp.text();
+    } catch { /* aborted */ }
+  });
+});
 
 export function initRepositoryActionView() {
   const el = document.querySelector('#repo-action-view');

--- a/web_src/js/features/repo-diff.ts
+++ b/web_src/js/features/repo-diff.ts
@@ -172,7 +172,6 @@ async function loadMoreFiles(btn: Element): Promise<boolean> {
     // * append the newly loaded file list items to the existing list
     const respFileBoxesChildren = Array.from(respFileBoxes.children); // "children:HTMLCollection" will be empty after replaceWith
     document.querySelector('#diff-incomplete')!.replaceWith(...respFileBoxesChildren);
-    for (const el of respFileBoxesChildren) window.htmx.process(el);
     onShowMoreFiles();
     return true;
   } catch (error) {
@@ -204,7 +203,6 @@ function initRepoDiffShowMore() {
       const respFileBody = respDoc.querySelector('#diff-file-boxes .diff-file-body .file-body')!;
       const respFileBodyChildren = Array.from(respFileBody.children); // "children:HTMLCollection" will be empty after replaceWith
       el.parentElement!.replaceWith(...respFileBodyChildren);
-      for (const el of respFileBodyChildren) window.htmx.process(el);
       // FIXME: calling onShowMoreFiles is not quite right here.
       // But since onShowMoreFiles mixes "init diff box" and "init diff body" together,
       // so it still needs to call it to make the "ImageDiff" and something similar work.
@@ -252,7 +250,7 @@ async function onLocationHashChange() {
         if (expandButton.hasAttribute(attrAutoLoadClicked)) return;
         expandButton.setAttribute(attrAutoLoadClicked, 'true');
         expandButton.click();
-        await sleep(500); // Wait for HTMX to load the content. FIXME: need to drop htmx in the future
+        await sleep(500); // Wait for the content to load
         continue; // Try again to find the element
       }
     }
@@ -290,5 +288,13 @@ export function initRepoDiffView() {
   registerGlobalSelectorFunc('#diff-file-boxes .diff-file-box', initRepoDiffFileBox);
   addDelegatedEventListener(document, 'click', '.fold-file', (el) => {
     invertFileFolding(el.closest('.file-content')!, el);
+  });
+  addDelegatedEventListener(document, 'click', '.code-expander-button', async (el) => {
+    const url = el.getAttribute('data-url')!;
+    const tr = el.closest('tr')!;
+    try {
+      const resp = await GET(url);
+      if (resp.ok) tr.outerHTML = await resp.text();
+    } catch { /* ignore */ }
   });
 }

--- a/web_src/js/features/repo-editor.ts
+++ b/web_src/js/features/repo-editor.ts
@@ -32,6 +32,23 @@ function initEditPreviewTab(elForm: HTMLFormElement) {
     const data = await response.text();
     renderPreviewPanelContent(elPreviewPanel, data);
   });
+
+  const elDiffTab = elTabMenu.querySelector<HTMLElement>('a[data-tab="diff"]');
+  const elDiffPanel = elForm.querySelector<HTMLElement>('.tab[data-tab="diff"]');
+  if (elDiffTab && elDiffPanel) {
+    elDiffTab.addEventListener('click', async () => {
+      elDiffPanel.classList.add('is-loading');
+      try {
+        const formData = new FormData();
+        formData.append('context', elDiffTab.getAttribute('data-diff-context')!);
+        formData.append('content', elForm.querySelector<HTMLTextAreaElement>('#edit_area')!.value);
+        const resp = await POST(elDiffTab.getAttribute('data-diff-url')!, {data: formData});
+        if (resp.ok) elDiffPanel.innerHTML = await resp.text();
+      } finally {
+        elDiffPanel.classList.remove('is-loading');
+      }
+    });
+  }
 }
 
 export function initRepoEditor() {

--- a/web_src/js/features/repo-home.ts
+++ b/web_src/js/features/repo-home.ts
@@ -3,6 +3,17 @@ import {hideElem, queryElemChildren, showElem} from '../utils/dom.ts';
 import {POST} from '../modules/fetch.ts';
 import {showErrorToast, type Toast} from '../modules/toast.ts';
 import {fomanticQuery} from '../modules/fomantic/base.ts';
+import {registerGlobalInitFunc} from '../modules/observer.ts';
+
+registerGlobalInitFunc('initLastCommitLoader', async (el: HTMLElement) => {
+  for (const cell of el.querySelectorAll<HTMLElement>('.repo-file-cell.message')) {
+    cell.classList.add('is-loading');
+  }
+  try {
+    const resp = await POST(el.getAttribute('data-loader-url')!);
+    if (resp.ok) el.outerHTML = await resp.text();
+  } catch { /* ignore */ }
+});
 
 const {appSubUrl} = window.config;
 

--- a/web_src/js/features/repo-home.ts
+++ b/web_src/js/features/repo-home.ts
@@ -6,13 +6,20 @@ import {fomanticQuery} from '../modules/fomantic/base.ts';
 import {registerGlobalInitFunc} from '../modules/observer.ts';
 
 registerGlobalInitFunc('initLastCommitLoader', async (el: HTMLElement) => {
-  for (const cell of el.querySelectorAll<HTMLElement>('.repo-file-cell.message')) {
+  const cells = el.querySelectorAll<HTMLElement>('.repo-file-cell.message');
+  for (const cell of cells) {
     cell.classList.add('is-loading');
   }
   try {
     const resp = await POST(el.getAttribute('data-loader-url')!);
-    if (resp.ok) el.outerHTML = await resp.text();
+    if (resp.ok) {
+      el.outerHTML = await resp.text();
+      return;
+    }
   } catch { /* ignore */ }
+  for (const cell of cells) {
+    cell.classList.remove('is-loading');
+  }
 });
 
 const {appSubUrl} = window.config;

--- a/web_src/js/features/repo-issue-sidebar-combolist.ts
+++ b/web_src/js/features/repo-issue-sidebar-combolist.ts
@@ -28,12 +28,10 @@ export function syncIssueMainContentTimelineItems(oldMainContent: Element, newMa
         // for event item (e.g.: "add & remove labels"), we want to replace the existing one if exists
         // because the label operations can be merged into one event item, so the new item might be different from the old one
         oldItem.replaceWith(newItem);
-        window.htmx.process(newItem);
       }
       continue;
     }
     timelineEnd.insertAdjacentElement('beforebegin', newItem);
-    window.htmx.process(newItem);
   }
 }
 
@@ -92,7 +90,6 @@ export class IssueSidebarComboList {
     // we can safely replace the whole right part (sidebar) because there are only some dropdowns and lists
     const newSidebar = doc.querySelector('.issue-content-right')!;
     this.elIssueSidebar.replaceWith(newSidebar);
-    window.htmx.process(newSidebar);
 
     // for the main content (left side), at the moment we only support handling known timeline items
     const newMainContent = doc.querySelector('.issue-content-left')!;

--- a/web_src/js/globals.d.ts
+++ b/web_src/js/globals.d.ts
@@ -56,7 +56,6 @@ interface Window {
   },
   $: JQueryStatic,
   jQuery: JQueryStatic,
-  htmx: typeof import('htmx.org').default,
   _globalHandlerErrors: Array<ErrorEvent & PromiseRejectionEvent> & {
     _inited: boolean,
     push: (e: ErrorEvent & PromiseRejectionEvent) => void | number,

--- a/web_src/js/globals.ts
+++ b/web_src/js/globals.ts
@@ -1,16 +1,5 @@
 import jquery from 'jquery'; // eslint-disable-line no-restricted-imports
-import htmx from 'htmx.org'; // eslint-disable-line no-restricted-imports
-import 'idiomorph/htmx'; // eslint-disable-line no-restricted-imports
 
 // Some users still use inline scripts and expect jQuery to be available globally.
 // To avoid breaking existing users and custom plugins, import jQuery globally without ES module.
 window.$ = window.jQuery = jquery;
-
-// There is a bug in htmx, it incorrectly checks "readyState === 'complete'" when the DOM tree is ready and won't trigger DOMContentLoaded
-// The bug makes htmx impossible to be loaded from an ES module: importing the htmx in onDomReady will make htmx skip its initialization.
-// ref: https://github.com/bigskysoftware/htmx/pull/3365
-window.htmx = htmx;
-
-// https://htmx.org/reference/#config
-htmx.config.requestClass = 'is-loading';
-htmx.config.scrollIntoViewOnBoost = false;

--- a/web_src/js/index.ts
+++ b/web_src/js/index.ts
@@ -1,7 +1,5 @@
 import '../fomantic/build/fomantic.js';
 import '../css/index.css';
-import type {HtmxResponseInfo} from 'htmx.org';
-import {showErrorToast} from './modules/toast.ts';
 
 import {initDashboardRepoList} from './features/dashboard.ts';
 import {initGlobalCopyToClipboardListener} from './features/clipboard.ts';
@@ -170,17 +168,5 @@ const initDur = performance.now() - initStartTime;
 if (initDur > 500) {
   console.error(`slow init functions took ${initDur.toFixed(3)}ms`);
 }
-
-// https://htmx.org/events/#htmx:sendError
-type HtmxEvent = Event & {detail: HtmxResponseInfo};
-document.body.addEventListener('htmx:sendError', (event) => {
-  // TODO: add translations
-  showErrorToast(`Network error when calling ${(event as HtmxEvent).detail.requestConfig.path}`);
-});
-// https://htmx.org/events/#htmx:responseError
-document.body.addEventListener('htmx:responseError', (event) => {
-  // TODO: add translations
-  showErrorToast(`Error ${(event as HtmxEvent).detail.xhr.status} when calling ${(event as HtmxEvent).detail.requestConfig.path}`);
-});
 
 document.dispatchEvent(new CustomEvent('gitea:index-ready'));

--- a/web_src/js/vitest.setup.ts
+++ b/web_src/js/vitest.setup.ts
@@ -1,13 +1,3 @@
-// Stub APIs not implemented by happy-dom but needed by dependencies
-// XPathEvaluator is used by htmx at module evaluation time
-// TODO: Remove after https://github.com/capricorn86/happy-dom/pull/2103 is released
-if (!globalThis.XPathEvaluator) {
-  globalThis.XPathEvaluator = class {
-    createExpression() { return {evaluate: () => ({iterateNext: () => null})} }
-  } as any;
-}
-
-// Dynamic import so polyfills above are applied before htmx evaluates
 await import('./globals.ts');
 
 window.config = {


### PR DESCRIPTION
Replace all htmx-driven interactions with lightweight custom JS handlers:

- Extend `form-fetch-action` with `data-swap` attribute for HTML response swapping (star, watch, follow, issue subscribe, notifications)
- Add individual init functions for special patterns (admin dashboard polling, workflow dispatch, last commit loader, user cards refresh, editor diff preview, code expander buttons)
- Replace `HX-Request`/`HX-Redirect`/`hx-trigger` headers with `X-Gitea-Page-Action`/`X-Gitea-Redirect`/`X-Gitea-Dispatch-Event`
- Remove `htmx.org` and `idiomorph` packages, all `hx-*` template attributes, `htmx.process()` calls, htmx event listeners, and related config

Fixes: https://github.com/go-gitea/gitea/issues/35059

---
This PR was written with the help of Claude Opus 4.6