### PR TITLE
Add configurable color support for the instance web banner

### DIFF
--- a/modules/label/label.go
+++ b/modules/label/label.go
@@ -4,11 +4,6 @@
 package label
 
 import (
-	"fmt"
-	"regexp"
-	"strings"
-	"sync"
-
 	"code.gitea.io/gitea/modules/util"
 )
 
@@ -21,31 +16,7 @@ type Label struct {
 	ExclusiveOrder int    `yaml:"exclusive_order,omitempty"`
 }
 
-var colorPattern = sync.OnceValue(func() *regexp.Regexp {
-	return regexp.MustCompile(`^#([\da-fA-F]{3}|[\da-fA-F]{6})$`)
-})
-
-// NormalizeColor normalizes a color string to a 6-character hex code
+// NormalizeColor normalizes a color string to a lowercase 6-character hex code, e.g. "#aabbcc"
 func NormalizeColor(color string) (string, error) {
-	// normalize case
-	color = strings.TrimSpace(strings.ToLower(color))
-
-	// add leading hash
-	if len(color) == 6 || len(color) == 3 {
-		color = "#" + color
-	}
-
-	if !colorPattern().MatchString(color) {
-		return "", util.NewInvalidArgumentErrorf("invalid color: %s", color)
-	}
-
-	// convert 3-character shorthand into 6-character version
-	if len(color) == 4 {
-		r := color[1]
-		g := color[2]
-		b := color[3]
-		color = fmt.Sprintf("#%c%c%c%c%c%c", r, r, g, g, b, b)
-	}
-
-	return color, nil
+	return util.NormalizeColor(color)
 }

--- a/modules/setting/config_option_instance.go
+++ b/modules/setting/config_option_instance.go
@@ -4,18 +4,22 @@
 package setting
 
 import (
+	"fmt"
+	"math"
 	"time"
 
 	"code.gitea.io/gitea/modules/setting/config"
+	"code.gitea.io/gitea/modules/util"
 )
 
 // WebBannerType fields are directly used in templates,
 // do remember to update the template if you change the fields
 type WebBannerType struct {
-	DisplayEnabled bool
-	ContentMessage string
-	StartTimeUnix  int64
-	EndTimeUnix    int64
+	DisplayEnabled  bool
+	ContentMessage  string
+	BackgroundColor string
+	StartTimeUnix   int64
+	EndTimeUnix     int64
 }
 
 func (b WebBannerType) ShouldDisplay() bool {
@@ -30,6 +34,65 @@ func (b WebBannerType) ShouldDisplay() bool {
 		return false
 	}
 	return true
+}
+
+const defaultWebBannerBackgroundColor = "#ddf4ff"
+
+func mixWebBannerColor(baseColor, mixColor string, mixWeight float64) string {
+	if mixWeight <= 0 {
+		return baseColor
+	}
+	if mixWeight >= 1 {
+		return mixColor
+	}
+
+	baseR, baseG, baseB := util.HexToRBGColor(baseColor)
+	mixR, mixG, mixB := util.HexToRBGColor(mixColor)
+
+	r := uint8(math.Round(baseR*(1-mixWeight) + mixR*mixWeight))
+	g := uint8(math.Round(baseG*(1-mixWeight) + mixG*mixWeight))
+	b := uint8(math.Round(baseB*(1-mixWeight) + mixB*mixWeight))
+	return fmt.Sprintf("#%02x%02x%02x", r, g, b)
+}
+
+func (b WebBannerType) NormalizedBackgroundColor() string {
+	normalized, err := util.NormalizeColor(b.BackgroundColor)
+	if err != nil {
+		return ""
+	}
+	return normalized
+}
+
+func (b WebBannerType) BackgroundColorForForm() string {
+	if backgroundColor := b.NormalizedBackgroundColor(); backgroundColor != "" {
+		return backgroundColor
+	}
+	return defaultWebBannerBackgroundColor
+}
+
+func (b WebBannerType) DefaultBackgroundColor() string {
+	return defaultWebBannerBackgroundColor
+}
+
+func (b WebBannerType) TextColor() string {
+	backgroundColor := b.NormalizedBackgroundColor()
+	if backgroundColor == "" {
+		return ""
+	}
+	return util.ContrastColor(backgroundColor)
+}
+
+func (b WebBannerType) BorderColor() string {
+	backgroundColor := b.NormalizedBackgroundColor()
+	if backgroundColor == "" {
+		return ""
+	}
+	return mixWebBannerColor(backgroundColor, util.ContrastColor(backgroundColor), 0.18)
+}
+
+func (b WebBannerType) FormValue() WebBannerType {
+	b.BackgroundColor = b.BackgroundColorForForm()
+	return b
 }
 
 type MaintenanceModeType struct {

--- a/modules/setting/config_option_instance_test.go
+++ b/modules/setting/config_option_instance_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package setting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWebBannerTypeColors(t *testing.T) {
+	t.Run("normalized", func(t *testing.T) {
+		banner := WebBannerType{BackgroundColor: "abc"}
+
+		assert.Equal(t, "#aabbcc", banner.NormalizedBackgroundColor())
+		assert.Equal(t, "#000", banner.TextColor())
+		assert.Equal(t, "#8b99a7", banner.BorderColor())
+	})
+
+	t.Run("default form color", func(t *testing.T) {
+		banner := WebBannerType{}
+
+		assert.Equal(t, defaultWebBannerBackgroundColor, banner.BackgroundColorForForm())
+		assert.Equal(t, defaultWebBannerBackgroundColor, banner.FormValue().BackgroundColor)
+	})
+
+	t.Run("invalid configured color", func(t *testing.T) {
+		banner := WebBannerType{BackgroundColor: "invalid"}
+
+		assert.Empty(t, banner.NormalizedBackgroundColor())
+		assert.Empty(t, banner.TextColor())
+		assert.Empty(t, banner.BorderColor())
+		assert.Equal(t, defaultWebBannerBackgroundColor, banner.BackgroundColorForForm())
+	})
+}

--- a/modules/util/color.go
+++ b/modules/util/color.go
@@ -5,9 +5,31 @@ package util
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 )
+
+var hexColorPattern = sync.OnceValue(func() *regexp.Regexp {
+	return regexp.MustCompile(`^#([\da-fA-F]{3}|[\da-fA-F]{6})$`)
+})
+
+// NormalizeColor normalizes a color string to a lowercase 6-character hex code, e.g. "#aabbcc"
+func NormalizeColor(color string) (string, error) {
+	color = strings.TrimSpace(strings.ToLower(color))
+	if len(color) == 6 || len(color) == 3 {
+		color = "#" + color
+	}
+	if !hexColorPattern().MatchString(color) {
+		return "", NewInvalidArgumentErrorf("invalid color: %s", color)
+	}
+	if len(color) == 4 {
+		r, g, b := color[1], color[2], color[3]
+		color = fmt.Sprintf("#%c%c%c%c%c%c", r, r, g, g, b, b)
+	}
+	return color, nil
+}
 
 // HexToRBGColor parses color as RGB values in 0..255 range from the hex color string (with or without #)
 func HexToRBGColor(colorString string) (float64, float64, float64) {

--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -3318,6 +3318,8 @@
   "admin.config.instance_maintenance": "Instance Maintenance",
   "admin.config.instance_maintenance_mode.admin_web_access_only": "Only allow admin to access the web UI",
   "admin.config.instance_web_banner.enabled": "Show banner",
+  "admin.config.instance_web_banner.color": "Banner color",
+  "admin.config.instance_web_banner.color_reset": "Reset to default color",
   "admin.config.instance_web_banner.message_placeholder": "Banner message (supports markdown)",
   "admin.config.session_config": "Session Configuration",
   "admin.config.session_provider": "Session Provider",

--- a/templates/admin/config_settings/instance.tmpl
+++ b/templates/admin/config_settings/instance.tmpl
@@ -29,13 +29,24 @@
 
 		{{$cfgOpt = $.SystemConfig.Instance.WebBanner}}
 		{{$cfgKey = $cfgOpt.DynKey}}
-		{{$banner := $cfgOpt.Value ctx}}
+		{{$banner := ($cfgOpt.Value ctx).FormValue}}
 		<input type="hidden" data-config-dyn-key="{{$cfgKey}}" data-config-value-json="{{JsonUtils.EncodeToString $banner}}">
 		<div class="field">
 			<div class="ui checkbox tw-mb-2">
 				<input type="checkbox" name="{{$cfgKey}}.DisplayEnabled" value="true" {{if $banner.DisplayEnabled}}checked{{end}} data-config-value-type="boolean">
 				<label>{{ctx.Locale.Tr "admin.config.instance_web_banner.enabled"}}</label>
 			</div>
+		</div>
+		<div class="field">
+			<label>{{ctx.Locale.Tr "admin.config.instance_web_banner.color"}}</label>
+			<div class="web-banner-color-picker-row">
+				<div class="color-picker-combo web-banner-color-picker" data-global-init="initColorPicker">
+					<input class="js-web-banner-background-color" name="{{$cfgKey}}.BackgroundColor" value="{{$banner.BackgroundColor}}" placeholder="#ddf4ff" pattern="^#?([\dA-Fa-f]{3}|[\dA-Fa-f]{6})$" maxlength="7" data-config-value-type="string">
+				</div>
+				<button type="button" class="ui icon button js-web-banner-color-reset" data-tooltip-content="{{ctx.Locale.Tr "admin.config.instance_web_banner.color_reset"}}" data-default-color="{{$banner.DefaultBackgroundColor}}">{{svg "octicon-undo"}}</button>
+			</div>
+		</div>
+		<div class="field js-web-banner-preview" style="--web-banner-bg: {{$banner.BackgroundColor}}; --web-banner-border: {{$banner.BorderColor}}; --web-banner-text: {{$banner.TextColor}};">
 			{{template "shared/combomarkdowneditor" (dict
 				"ContainerClasses" "web-banner-content-editor"
 				"TextareaName" (print $cfgKey ".ContentMessage")

--- a/templates/base/head_banner.tmpl
+++ b/templates/base/head_banner.tmpl
@@ -1,6 +1,7 @@
 {{$banner := ctx.CurrentWebBanner}}
 {{if $banner}}
-<div class="ui info message web-banner-container">
+	{{$bannerColor := $banner.NormalizedBackgroundColor}}
+<div class="ui message web-banner-container"{{if $bannerColor}} style="--web-banner-bg: {{$bannerColor}}; --web-banner-border: {{$banner.BorderColor}}; --web-banner-text: {{$banner.TextColor}};"{{end}}>
 	<div class="render-content markup web-banner-content">
 		{{ctx.RenderUtils.MarkdownToHtml $banner.ContentMessage}}
 	</div>

--- a/web_src/css/admin.css
+++ b/web_src/css/admin.css
@@ -50,10 +50,39 @@
   margin-bottom: 1rem;
 }
 
-.web-banner-content-editor .render-content.render-preview {
-  /* use the styles from ".ui.message" */
+.js-web-banner-preview {
+  --web-banner-bg: var(--color-info-bg);
+  --web-banner-border: var(--color-info-border);
+  --web-banner-text: var(--color-info-text);
+}
+
+.web-banner-color-picker {
+  display: inline-flex;
+  width: auto;
+}
+
+.web-banner-color-picker-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.ui.form .web-banner-color-picker input:not([type="checkbox"], [type="radio"]) {
+  width: 10rem;
+  min-width: 10rem;
+  max-width: 10rem;
+}
+
+.web-banner-content-editor .ui.tab[data-tab-panel="markdown-previewer"] {
   padding: 1em 1.5em;
-  border: 1px solid var(--color-info-border);
-  background: var(--color-info-bg);
-  color: var(--color-info-text);
+  border: 1px solid var(--web-banner-border);
+  background: var(--web-banner-bg);
+  color: var(--web-banner-text);
+}
+
+.web-banner-content-editor .render-content.render-preview {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
 }

--- a/web_src/css/modules/container.css
+++ b/web_src/css/modules/container.css
@@ -19,6 +19,9 @@
   position: relative;
   margin: 0;
   border-radius: 0;
+  background: var(--web-banner-bg, var(--color-info-bg));
+  color: var(--web-banner-text, var(--color-info-text));
+  border-color: var(--web-banner-border, var(--color-info-border));
 }
 
 .ui.message.web-banner-container > .web-banner-content {
@@ -27,8 +30,17 @@
   margin: auto;
 }
 
+.ui.message.web-banner-container :is(a, .header, .ui.header) {
+  color: inherit;
+}
+
+.ui.message.web-banner-container a {
+  text-decoration: underline;
+}
+
 .ui.message.web-banner-container > button.dismiss-banner {
   position: absolute;
   right: 20px;
   top: 15px;
+  color: inherit;
 }

--- a/web_src/js/features/admin/config.test.ts
+++ b/web_src/js/features/admin/config.test.ts
@@ -10,6 +10,8 @@ test('ConfigFormValueMapper', () => {
 
     <input type="hidden" data-config-dyn-key="k2" data-config-value-json='"k2-val"'>
     <input name="k2">
+    <input type="hidden" data-config-dyn-key="k3" data-config-value-json='"#aabbcc"'>
+    <input name="k3" type="color" data-config-value-type="string">
 
     <textarea name="repository.open-with.editor-apps"> a = b\n</textarea>
 
@@ -40,6 +42,7 @@ test('ConfigFormValueMapper', () => {
   expect(result).toEqual({
     'k1': 'true',
     'k2': '"k2-val"',
+    'k3': '"#aabbcc"',
     'k-flipped-false': 'false',
     'k-flipped-true': 'true',
     'repository.open-with.editor-apps': '[{"DisplayName":"a","OpenURL":"b"}]', // TODO: OPEN-WITH-EDITOR-APP-JSON: it must match backend

--- a/web_src/js/features/admin/config.ts
+++ b/web_src/js/features/admin/config.ts
@@ -1,6 +1,7 @@
 import {showTemporaryTooltip} from '../../modules/tippy.ts';
 import {POST} from '../../modules/fetch.ts';
 import {registerGlobalInitFunc} from '../../modules/observer.ts';
+import {contrastColor} from '../../utils/color.ts';
 import {queryElems} from '../../utils/dom.ts';
 import {submitFormFetchAction} from '../common-fetch-action.ts';
 
@@ -103,7 +104,7 @@ export class ConfigFormValueMapper {
       if (val) el.value = toDatetimeLocalValue(val);
     } else if (el.matches('textarea')) {
       el.value = String(val ?? el.value);
-    } else if (el.matches('input') && (el.getAttribute('type') ?? 'text') === 'text') {
+    } else if (el.matches('input') && ['text', 'color'].includes(el.getAttribute('type') ?? 'text')) {
       el.value = String(val ?? el.value);
     } else {
       unsupportedElement(el);
@@ -124,7 +125,7 @@ export class ConfigFormValueMapper {
       val = Math.floor(new Date(el.value).getTime() / 1000) ?? 0; // NaN is fine to JSON.stringify, it becomes null.
     } else if (el.matches('textarea')) {
       val = el.value;
-    } else if (el.matches('input') && (el.getAttribute('type') ?? 'text') === 'text') {
+    } else if (el.matches('input') && ['text', 'color'].includes(el.getAttribute('type') ?? 'text')) {
       val = el.value;
     } else {
       unsupportedElement(el);
@@ -202,9 +203,44 @@ export class ConfigFormValueMapper {
   }
 }
 
+function updateWebBannerPreview(colorInput: HTMLInputElement, previewEl: HTMLElement) {
+  const backgroundColor = colorInput.value;
+  const textColor = contrastColor(backgroundColor);
+  previewEl.style.setProperty('--web-banner-bg', backgroundColor);
+  previewEl.style.setProperty('--web-banner-border', backgroundColor);
+  previewEl.style.setProperty('--web-banner-text', textColor);
+
+  // Links don't inherit color from CSS vars without explicit rules, so set them directly
+  for (const el of previewEl.querySelectorAll<HTMLElement>('.render-content.render-preview a, .ui.tab[data-tab-panel="markdown-previewer"] a')) {
+    el.style.color = textColor;
+  }
+}
+
+function initWebBannerColorPreview(form: HTMLFormElement) {
+  const colorInput = form.querySelector<HTMLInputElement>('.js-web-banner-background-color');
+  const previewEl = form.querySelector<HTMLElement>('.js-web-banner-preview');
+  const previewTab = form.querySelector<HTMLElement>('.web-banner-content-editor .item[data-tab-for="markdown-previewer"]');
+  const resetButton = form.querySelector<HTMLButtonElement>('.js-web-banner-color-reset');
+  if (!colorInput || !previewEl) return;
+
+  updateWebBannerPreview(colorInput, previewEl);
+  colorInput.addEventListener('input', () => updateWebBannerPreview(colorInput, previewEl));
+  previewTab?.addEventListener('click', () => {
+    // The preview DOM is updated asynchronously after clicking the tab,
+    // so re-apply the banner colors on the next macrotask.
+    window.setTimeout(() => updateWebBannerPreview(colorInput, previewEl), 0);
+  });
+  resetButton?.addEventListener('click', () => {
+    colorInput.value = resetButton.getAttribute('data-default-color')!;
+    colorInput.dispatchEvent(new Event('input', {bubbles: true}));
+    colorInput.focus();
+  });
+}
+
 function initSystemConfigForm(form: HTMLFormElement) {
   const formMapper = new ConfigFormValueMapper(form);
   formMapper.fillFromSystemConfig();
+  initWebBannerColorPreview(form);
   form.addEventListener('submit', async (e) => {
     if (!form.reportValidity()) return;
     e.preventDefault();

--- a/web_src/js/features/colorpicker.ts
+++ b/web_src/js/features/colorpicker.ts
@@ -34,6 +34,7 @@ function initPicker(el: HTMLElement): void {
   const picker = document.createElement('hex-color-picker');
   picker.addEventListener('color-changed', (e) => {
     input.value = e.detail.value;
+    input.dispatchEvent(new Event('input', {bubbles: true}));
     input.focus();
     updateSquare(square, e.detail.value);
   });
@@ -61,7 +62,7 @@ function initPicker(el: HTMLElement): void {
     input.dispatchEvent(new Event('input', {bubbles: true}));
     updateSquare(square, color);
   };
-  el.querySelector('.generate-random-color')!.addEventListener('click', () => {
+  el.querySelector<HTMLElement>('.generate-random-color')?.addEventListener('click', () => {
     const newValue = `#${Math.floor(Math.random() * 0xFFFFFF).toString(16).padStart(6, '0')}`;
     setSelectedColor(newValue);
   });


### PR DESCRIPTION
This adds configurable color support for the instance web banner in the admin config.

Admins can now:
- choose a custom banner color
- reset the color back to the default
- see the selected color reflected in the live banner styling

<img width="724" height="583" src="https://github.com/user-attachments/assets/ba6c8c39-e1d9-481b-9759-975b57a7b94d" />

_Reviewd-By: Codex (GPT-5)_
