### PR TITLE
Update `setup-uv` to v8.0.0

### DIFF
--- a/.github/workflows/pull-compliance.yml
+++ b/.github/workflows/pull-compliance.yml
@@ -38,7 +38,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.0.0
       - run: uv python install 3.14
       - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
@@ -58,7 +58,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.0.0
       - run: uv python install 3.14
       - run: make deps-py
       - run: make lint-yaml


### PR DESCRIPTION
Update to https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0. Note that version here must be the immutable `v8.0.0`, a mutable `v8` tag does not exist.