### PR TITLE
Add git hooks permission check when generating repository from template

### DIFF
--- a/services/repository/template.go
+++ b/services/repository/template.go
@@ -149,7 +149,7 @@ func GenerateRepository(ctx context.Context, doer, owner *user_model.User, templ
 	}
 
 	// Git Hooks
-	if opts.GitHooks {
+	if opts.GitHooks && doer.CanEditGitHook() {
 		if err = GenerateGitHooks(ctx, templateRepo, generateRepo); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The template repository might be created by a user who can create git hooks. When a regular user who cannot be allowed to edit git hooks generate repositories from that template repository, the git hooks copied.