### PR TITLE
Quick fix uploadAttachment wrong logic and the config file comments

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1994,8 +1994,11 @@ LEVEL = Info
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; Whether issue and pull request attachments are enabled. Defaults to `true`
+;; Whether issue, pull request and release attachments are enabled. Defaults to `true`
 ;ENABLED = true
+;;
+;; The follow configuration items only apply to issue and pull request attachments. 
+;; For release attachments, see `[repository.release]`.
 ;;
 ;; Comma-separated list of allowed file extensions (`.zip`), mime types (`text/plain`) or wildcard type (`image/*`, `audio/*`, `video/*`). Empty value or `*/*` allows all types.
 ;ALLOWED_TYPES = .avif,.cpuprofile,.csv,.dmp,.docx,.fodg,.fodp,.fods,.fodt,.gif,.gz,.jpeg,.jpg,.json,.jsonc,.log,.md,.mov,.mp4,.odf,.odg,.odp,.ods,.odt,.patch,.pdf,.png,.pptx,.svg,.tgz,.txt,.webm,.webp,.xls,.xlsx,.zip

--- a/routers/api/v1/repo/issue_attachment.go
+++ b/routers/api/v1/repo/issue_attachment.go
@@ -186,12 +186,12 @@ func CreateIssueAttachment(ctx *context.APIContext) {
 	}
 
 	uploaderFile := attachment_service.NewLimitedUploaderKnownSize(file, header.Size)
-	attachment, err := attachment_service.UploadAttachmentGeneralSizeLimit(ctx, uploaderFile, setting.Attachment.AllowedTypes, &repo_model.Attachment{
+	attachment, err := attachment_service.UploadAttachmentOrReleaseAttachment(ctx, uploaderFile, &repo_model.Attachment{
 		Name:       filename,
 		UploaderID: ctx.Doer.ID,
 		RepoID:     ctx.Repo.Repository.ID,
 		IssueID:    issue.ID,
-	})
+	}, false)
 	if err != nil {
 		if upload.IsErrFileTypeForbidden(err) {
 			ctx.APIError(http.StatusUnprocessableEntity, err)

--- a/routers/api/v1/repo/issue_comment_attachment.go
+++ b/routers/api/v1/repo/issue_comment_attachment.go
@@ -193,13 +193,13 @@ func CreateIssueCommentAttachment(ctx *context.APIContext) {
 	}
 
 	uploaderFile := attachment_service.NewLimitedUploaderKnownSize(file, header.Size)
-	attachment, err := attachment_service.UploadAttachmentGeneralSizeLimit(ctx, uploaderFile, setting.Attachment.AllowedTypes, &repo_model.Attachment{
+	attachment, err := attachment_service.UploadAttachmentOrReleaseAttachment(ctx, uploaderFile, &repo_model.Attachment{
 		Name:       filename,
 		UploaderID: ctx.Doer.ID,
 		RepoID:     ctx.Repo.Repository.ID,
 		IssueID:    comment.IssueID,
 		CommentID:  comment.ID,
-	})
+	}, false)
 	if err != nil {
 		if upload.IsErrFileTypeForbidden(err) {
 			ctx.APIError(http.StatusUnprocessableEntity, err)

--- a/routers/api/v1/repo/release_attachment.go
+++ b/routers/api/v1/repo/release_attachment.go
@@ -242,12 +242,12 @@ func CreateReleaseAttachment(ctx *context.APIContext) {
 	}
 
 	// Create a new attachment and save the file
-	attach, err := attachment_service.UploadAttachmentReleaseSizeLimit(ctx, uploaderFile, setting.Repository.Release.AllowedTypes, &repo_model.Attachment{
+	attach, err := attachment_service.UploadAttachmentOrReleaseAttachment(ctx, uploaderFile, &repo_model.Attachment{
 		Name:       filename,
 		UploaderID: ctx.Doer.ID,
 		RepoID:     ctx.Repo.Repository.ID,
 		ReleaseID:  releaseID,
-	})
+	}, true)
 	if err != nil {
 		if upload.IsErrFileTypeForbidden(err) {
 			ctx.APIError(http.StatusBadRequest, err)

--- a/routers/web/repo/attachment.go
+++ b/routers/web/repo/attachment.go
@@ -23,16 +23,16 @@ import (
 
 // UploadIssueAttachment response for Issue/PR attachments
 func UploadIssueAttachment(ctx *context.Context) {
-	uploadAttachment(ctx, ctx.Repo.Repository.ID, setting.Attachment.AllowedTypes)
+	uploadAttachmentOrReleaseAttachment(ctx, ctx.Repo.Repository.ID, false)
 }
 
 // UploadReleaseAttachment response for uploading release attachments
 func UploadReleaseAttachment(ctx *context.Context) {
-	uploadAttachment(ctx, ctx.Repo.Repository.ID, setting.Repository.Release.AllowedTypes)
+	uploadAttachmentOrReleaseAttachment(ctx, ctx.Repo.Repository.ID, true)
 }
 
-// UploadAttachment response for uploading attachments
-func uploadAttachment(ctx *context.Context, repoID int64, allowedTypes string) {
+// uploadAttachmentOrReleaseAttachment response for uploading attachments
+func uploadAttachmentOrReleaseAttachment(ctx *context.Context, repoID int64, isRelease bool) {
 	if !setting.Attachment.Enabled {
 		ctx.HTTPError(http.StatusNotFound, "attachment is not enabled")
 		return
@@ -46,11 +46,11 @@ func uploadAttachment(ctx *context.Context, repoID int64, allowedTypes string) {
 	defer file.Close()
 
 	uploaderFile := attachment.NewLimitedUploaderKnownSize(file, header.Size)
-	attach, err := attachment.UploadAttachmentReleaseSizeLimit(ctx, uploaderFile, allowedTypes, &repo_model.Attachment{
+	attach, err := attachment.UploadAttachmentOrReleaseAttachment(ctx, uploaderFile, &repo_model.Attachment{
 		Name:       header.Filename,
 		UploaderID: ctx.Doer.ID,
 		RepoID:     repoID,
-	})
+	}, isRelease)
 	if err != nil {
 		if upload.IsErrFileTypeForbidden(err) {
 			ctx.HTTPError(http.StatusBadRequest, err.Error())

--- a/services/attachment/attachment.go
+++ b/services/attachment/attachment.go
@@ -54,15 +54,20 @@ func NewLimitedUploaderMaxBytesReader(r io.ReadCloser, w http.ResponseWriter) *U
 	return &UploaderFile{rd: r, size: -1, respWriter: w}
 }
 
-func UploadAttachmentGeneralSizeLimit(ctx context.Context, file *UploaderFile, allowedTypes string, attach *repo_model.Attachment) (*repo_model.Attachment, error) {
-	return uploadAttachment(ctx, file, allowedTypes, setting.Attachment.MaxSize<<20, attach)
-}
+func UploadAttachmentOrReleaseAttachment(ctx context.Context, file *UploaderFile, attach *repo_model.Attachment, isRelease bool) (*repo_model.Attachment, error) {
+	var (
+		maxFileSize  int64
+		allowedTypes string
+	)
 
-func UploadAttachmentReleaseSizeLimit(ctx context.Context, file *UploaderFile, allowedTypes string, attach *repo_model.Attachment) (*repo_model.Attachment, error) {
-	return uploadAttachment(ctx, file, allowedTypes, setting.Repository.Release.FileMaxSize<<20, attach)
-}
+	if isRelease {
+		maxFileSize = setting.Repository.Release.MaxFiles
+		allowedTypes = setting.Repository.Release.AllowedTypes
+	} else {
+		maxFileSize = setting.Attachment.MaxSize
+		allowedTypes = setting.Attachment.AllowedTypes
+	}
 
-func uploadAttachment(ctx context.Context, file *UploaderFile, allowedTypes string, maxFileSize int64, attach *repo_model.Attachment) (*repo_model.Attachment, error) {
 	src := file.rd
 	if file.size < 0 {
 		src = http.MaxBytesReader(file.respWriter, src, maxFileSize)

--- a/services/mailer/incoming/incoming_handler.go
+++ b/services/mailer/incoming/incoming_handler.go
@@ -88,11 +88,11 @@ func (h *ReplyHandler) Handle(ctx context.Context, content *MailContent, doer *u
 		for _, attachment := range content.Attachments {
 			attachmentBuf := bytes.NewReader(attachment.Content)
 			uploaderFile := attachment_service.NewLimitedUploaderKnownSize(attachmentBuf, attachmentBuf.Size())
-			a, err := attachment_service.UploadAttachmentGeneralSizeLimit(ctx, uploaderFile, setting.Attachment.AllowedTypes, &repo_model.Attachment{
+			a, err := attachment_service.UploadAttachmentOrReleaseAttachment(ctx, uploaderFile, &repo_model.Attachment{
 				Name:       attachment.Name,
 				UploaderID: doer.ID,
 				RepoID:     issue.Repo.ID,
-			})
+			}, false)
 			if err != nil {
 				if upload.IsErrFileTypeForbidden(err) {
 					log.Info("Skipping disallowed attachment type: %s", attachment.Name)


### PR DESCRIPTION
@wxiaoguang think that the file size limits for issue/pull request attachments and release attachments are same is a "bug?" caused by me. Although I don't know how he came to such a conclusion, I hereby formally apologize for this issue.

This submission follow @wxiaoguang's suggestion to quick fix a logical implementation detail issue regarding the attachment upload size limit and make the relevant comments in the configuration file consistent with the actual situation. Thanks.
