### PR TITLE
Add contributors view in repo sidebar

### DIFF
--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -1197,6 +1197,7 @@
   "repo.commit": "Commit",
   "repo.release": "Release",
   "repo.releases": "Releases",
+  "repo.contributors": "Contributors",
   "repo.tag": "Tag",
   "repo.git_tag": "Git Tag",
   "repo.released_this": "released this",

--- a/routers/web/repo/view_home.go
+++ b/routers/web/repo/view_home.go
@@ -199,12 +199,15 @@ func prepareHomeSidebarContributors(ctx *context.Context) {
 		return
 	}
 
-	var sorted []*repo_service.ContributorData
+	sorted := make([]*repo_service.ContributorData, 0, len(stats)-1)
 	for key, c := range stats {
 		if key == repo_service.ContributorTotalKey {
 			continue
 		}
 		sorted = append(sorted, c)
+	}
+	if len(sorted) <= 1 {
+		return
 	}
 	slices.SortFunc(sorted, func(a, b *repo_service.ContributorData) int {
 		return cmp.Compare(b.TotalCommits, a.TotalCommits)
@@ -212,9 +215,6 @@ func prepareHomeSidebarContributors(ctx *context.Context) {
 
 	const maxDisplay = 14
 	total := len(sorted)
-	if total <= 1 {
-		return
-	}
 	if len(sorted) > maxDisplay {
 		sorted = sorted[:maxDisplay]
 	}

--- a/routers/web/repo/view_home.go
+++ b/routers/web/repo/view_home.go
@@ -4,9 +4,11 @@
 package repo
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -182,6 +184,42 @@ func prepareHomeSidebarLatestRelease(ctx *context.Context) {
 		}
 		ctx.Data["LatestRelease"] = release
 	}
+}
+
+func prepareHomeSidebarContributors(ctx *context.Context) {
+	if ctx.Repo.Repository.IsEmpty {
+		return
+	}
+	stats, err := repo_service.GetContributorStats(ctx, ctx.Cache, ctx.Repo.Repository, ctx.Repo.Repository.DefaultBranch)
+	if err != nil {
+		if errors.Is(err, repo_service.ErrAwaitGeneration) {
+			return
+		}
+		log.Error("GetContributorStats: %v", err)
+		return
+	}
+
+	var sorted []*repo_service.ContributorData
+	for key, c := range stats {
+		if key == repo_service.ContributorTotalKey {
+			continue
+		}
+		sorted = append(sorted, c)
+	}
+	slices.SortFunc(sorted, func(a, b *repo_service.ContributorData) int {
+		return cmp.Compare(b.TotalCommits, a.TotalCommits)
+	})
+
+	const maxDisplay = 14
+	total := len(sorted)
+	if total <= 1 {
+		return
+	}
+	if len(sorted) > maxDisplay {
+		sorted = sorted[:maxDisplay]
+	}
+	ctx.Data["SidebarContributors"] = sorted
+	ctx.Data["SidebarContributorsExtra"] = total - len(sorted)
 }
 
 func prepareUpstreamDivergingInfo(ctx *context.Context) {
@@ -445,6 +483,7 @@ func Home(ctx *context.Context) {
 			prepareHomeSidebarCitationFile(entry),
 			prepareHomeSidebarLanguageStats,
 			prepareHomeSidebarLatestRelease,
+			prepareHomeSidebarContributors,
 		)
 	}
 

--- a/services/repository/contributors_graph.go
+++ b/services/repository/contributors_graph.go
@@ -28,6 +28,8 @@ import (
 const (
 	contributorStatsCacheKey           = "GetContributorStats/%s/%s"
 	contributorStatsCacheTimeout int64 = 60 * 10
+	// ContributorTotalKey is the map key for the aggregate totals entry in the stats map returned by GetContributorStats.
+	ContributorTotalKey = "total"
 )
 
 var (
@@ -215,11 +217,11 @@ func generateContributorStats(genDone chan struct{}, cache cache.StringCache, ca
 
 	unknownUserAvatarLink := user_model.NewGhostUser().AvatarLinkWithSize(ctx, 0)
 	contributorsCommitStats := make(map[string]*ContributorData)
-	contributorsCommitStats["total"] = &ContributorData{
+	contributorsCommitStats[ContributorTotalKey] = &ContributorData{
 		Name:  "Total",
 		Weeks: make(map[int64]*WeekData),
 	}
-	total := contributorsCommitStats["total"]
+	total := contributorsCommitStats[ContributorTotalKey]
 
 	for _, v := range extendedCommitStats {
 		userEmail := v.Author.Email

--- a/templates/repo/home_sidebar_bottom.tmpl
+++ b/templates/repo/home_sidebar_bottom.tmpl
@@ -13,11 +13,11 @@
 						{{range .SidebarContributors}}
 						{{if .HomeLink}}
 						<a href="{{.HomeLink}}" data-tooltip-content="{{.Name}}">
-							<img class="ui avatar" src="{{.AvatarLink}}" alt="{{.Name}}" width="32" height="32">
+							<img class="ui avatar" src="{{.AvatarLink}}" alt="{{.Name}}">
 						</a>
 						{{else}}
 						<span data-tooltip-content="{{.Name}}">
-							<img class="ui avatar" src="{{.AvatarLink}}" alt="{{.Name}}" width="32" height="32">
+							<img class="ui avatar" src="{{.AvatarLink}}" alt="{{.Name}}">
 						</span>
 						{{end}}
 						{{end}}

--- a/templates/repo/home_sidebar_bottom.tmpl
+++ b/templates/repo/home_sidebar_bottom.tmpl
@@ -1,5 +1,35 @@
 <div class="repo-home-sidebar-bottom">
 	<div class="flex-list">
+		{{if .SidebarContributors}}
+		<div class="flex-item">
+			<div class="flex-item-main">
+				<div class="flex-item-title">
+					<a class="item muted" href="{{.RepoLink}}/activity/contributors">
+						{{ctx.Locale.Tr "repo.contributors"}}
+					</a>
+				</div>
+				<div class="flex-item-body">
+					<div class="repo-sidebar-contributors">
+						{{range .SidebarContributors}}
+						{{if .HomeLink}}
+						<a href="{{.HomeLink}}" data-tooltip-content="{{.Name}}">
+							<img class="ui avatar" src="{{.AvatarLink}}" alt="{{.Name}}" width="32" height="32">
+						</a>
+						{{else}}
+						<span data-tooltip-content="{{.Name}}">
+							<img class="ui avatar" src="{{.AvatarLink}}" alt="{{.Name}}" width="32" height="32">
+						</span>
+						{{end}}
+						{{end}}
+					</div>
+					{{if gt .SidebarContributorsExtra 0}}
+					<a class="tw-mt-2 tw-inline-block" href="{{.RepoLink}}/activity/contributors">+ {{.SidebarContributorsExtra}} {{ctx.Locale.Tr "repo.contributors"}}</a>
+					{{end}}
+				</div>
+			</div>
+		</div>
+		{{end}}
+
 		{{if .LatestRelease}}
 		<div class="flex-item">
 			<div class="flex-item-main">

--- a/web_src/css/repo/home.css
+++ b/web_src/css/repo/home.css
@@ -80,7 +80,7 @@
 
 .repo-sidebar-contributors {
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
+  grid-template-columns: repeat(6, 32px);
   gap: 4px;
   margin-top: 4px;
 }

--- a/web_src/css/repo/home.css
+++ b/web_src/css/repo/home.css
@@ -78,6 +78,19 @@
   min-width: 0;
 }
 
+.repo-sidebar-contributors {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.repo-sidebar-contributors .ui.avatar {
+  border-radius: 50%;
+  width: 100%;
+  aspect-ratio: 1;
+}
+
 .language-stats {
   display: flex;
   gap: 2px;


### PR DESCRIPTION
Adds a contributors view as GitHub has in the repo sidebar


<img width="1365" height="772" src="https://github.com/user-attachments/assets/6fb1fb99-c8ac-4de4-919f-a230826e7b7f" />
<img width="309" height="212" src="https://github.com/user-attachments/assets/99919af7-8002-4c08-8fa8-859933c00d6b" />
