### PR TITLE
Remove dead CSS rules

### DIFF
--- a/web_src/css/actions.css
+++ b/web_src/css/actions.css
@@ -6,14 +6,6 @@
   overflow-x: auto;
 }
 
-.runner-container .runner-new-text {
-  color: var(--color-white);
-}
-
-.runner-container #runner-new:hover .runner-new-text {
-  color: var(--color-white) !important;
-}
-
 .runner-container .task-status-success {
   background-color: var(--color-green);
   color: var(--color-white);

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -643,10 +643,6 @@ overflow-menu .ui.label {
   color: var(--color-primary-contrast);
 }
 
-.archived-icon {
-  color: var(--color-secondary-dark-2) !important;
-}
-
 .oauth2-authorize-application-box {
   margin-top: 3em !important;
 }
@@ -668,10 +664,6 @@ overflow-menu .ui.label {
 
 .code-diff .lines-num {
   min-width: 50px;
-}
-
-.lines-num span.bottom-line::after {
-  border-bottom: 1px solid var(--color-secondary);
 }
 
 .lines-num span::after {
@@ -781,11 +773,6 @@ tr.top-line-blame {
 
 tr.top-line-blame:first-of-type {
   border-top: none; /* merge code lines belonging to the same commit into one block */
-}
-
-.lines-code .bottom-line,
-.lines-commit .bottom-line {
-  border-bottom: 1px solid var(--color-secondary);
 }
 
 .migrate .svg.gitea-git {

--- a/web_src/css/markup/asciicast.css
+++ b/web_src/css/markup/asciicast.css
@@ -3,7 +3,6 @@
   height: auto;
 }
 
-/* class name from asciinema-player, may change across versions */
 .ap-term {
   overflow: hidden !important;
 }

--- a/web_src/css/markup/asciicast.css
+++ b/web_src/css/markup/asciicast.css
@@ -2,3 +2,8 @@
   width: 100%;
   height: auto;
 }
+
+/* class name from asciinema-player, may change across versions */
+.ap-term {
+  overflow: hidden !important;
+}

--- a/web_src/css/markup/asciicast.css
+++ b/web_src/css/markup/asciicast.css
@@ -2,7 +2,3 @@
   width: 100%;
   height: auto;
 }
-
-.ap-terminal {
-  overflow: hidden !important;
-}

--- a/web_src/css/markup/asciicast.css
+++ b/web_src/css/markup/asciicast.css
@@ -3,6 +3,8 @@
   height: auto;
 }
 
+/* Related: https://github.com/asciinema/asciinema-player/blob/develop/src/components/Terminal.js : <div class="ap-term" ...>
+Old PR: Fix UI regression of asciinema player https://github.com/go-gitea/gitea/pull/26159 */
 .ap-term {
   overflow: hidden !important;
 }

--- a/web_src/css/markup/content.css
+++ b/web_src/css/markup/content.css
@@ -154,12 +154,6 @@ In markup content, we always use bottom margin for all elements */
   padding-inline-start: 2em;
 }
 
-.markup ul.no-list,
-.markup ol.no-list {
-  padding: 0;
-  list-style-type: none;
-}
-
 .markup .task-list-item {
   list-style-type: none;
 }
@@ -355,69 +349,6 @@ html[data-gitea-theme-dark="false"] .markup img[src*="#gh-dark-mode-only"] {
   padding: 5px 0 0;
   clear: both;
   color: var(--color-text);
-}
-
-.markup span.align-center {
-  display: block;
-  overflow: hidden;
-  clear: both;
-}
-
-.markup span.align-center > span {
-  display: block;
-  margin: 13px auto 0;
-  overflow: hidden;
-  text-align: center;
-}
-
-.markup span.align-center span img,
-.markup span.align-center span video {
-  margin: 0 auto;
-  text-align: center;
-}
-
-.markup span.align-right {
-  display: block;
-  overflow: hidden;
-  clear: both;
-}
-
-.markup span.align-right > span {
-  display: block;
-  margin: 13px 0 0;
-  overflow: hidden;
-  text-align: right;
-}
-
-.markup span.align-right span img,
-.markup span.align-right span video {
-  margin: 0;
-  text-align: right;
-}
-
-.markup span.float-left {
-  display: block;
-  float: left;
-  margin-inline-end: 13px;
-  overflow: hidden;
-}
-
-.markup span.float-left span {
-  margin: 13px 0 0;
-}
-
-.markup span.float-right {
-  display: block;
-  float: right;
-  margin-inline-start: 13px;
-  overflow: hidden;
-}
-
-.markup span.float-right > span {
-  display: block;
-  margin: 13px auto 0;
-  overflow: hidden;
-  text-align: right;
 }
 
 .markup code,

--- a/web_src/css/modules/modal.css
+++ b/web_src/css/modules/modal.css
@@ -159,17 +159,9 @@
   display: block;
 }
 
-.scrolling.dimmable.dimmed {
-  overflow: hidden;
-}
-
 .scrolling.dimmable > .dimmer {
   justify-content: flex-start;
   position: fixed;
-}
-
-.scrolling.dimmable.dimmed > .dimmer {
-  overflow: auto;
 }
 
 .modals.dimmer .ui.scrolling.modal {

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -287,10 +287,6 @@ td .commit-summary {
   min-width: 100px;
 }
 
-.repository.view.issue .instruct-toggle {
-  display: inline-block;
-}
-
 /* issue title & meta & edit */
 .issue-title-header {
   width: 100%;
@@ -1461,11 +1457,6 @@ tbody.commit-list {
   tr.commit-list {
     width: 1127px;
   }
-}
-
-.commit-list .commit-status-link {
-  display: inline-block;
-  vertical-align: middle;
 }
 
 .commit-body {


### PR DESCRIPTION
Remove CSS rules whose HTML classes/IDs are no longer referenced in any template, Go source, or JavaScript/TypeScript file:

- `.archived-icon`: removed from templates in c85bb62635
- `.bottom-line`: removed from blame rendering in 9c6aeb47f7
- `.commit-status-link`: removed from templates in f3c4baa84b
- `.instruct-toggle`: removed from templates in 75e85c25c1
- `.runner-new-text`, `#runner-new`: never referenced outside CSS
- `.ap-terminal`: stale, asciinema-player uses `.ap-term`, still not needed
- `.scrolling.dimmable.dimmed`: dimmer stand-in never adds this class
- `.markup span.align-center/align-right/float-left/float-right`: never produced by any renderer, sanitizer strips class attributes
- `.markup ul.no-list`, `.markup ol.no-list`: same as above

---
This PR was written with the help of Claude Opus 4.6