### PR TITLE
Indicate form field readonly via background

### DIFF
--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -269,7 +269,7 @@
   "install.lfs_path": "Git LFS Root Path",
   "install.lfs_path_helper": "Files tracked by Git LFS will be stored in this directory. Leave empty to disable.",
   "install.run_user": "Run As Username",
-  "install.run_user_helper": "The operating system username that Gitea runs as, it must have write access to the data paths. This value is auto-detected and cannot be changed here. To use a different user, restart Gitea under that account.",
+  "install.run_user_helper": "The operating system username that Gitea runs as, it must have write access to the data paths. This value is auto-detected and cannot be changed here.
   "install.domain": "Server Domain",
   "install.domain_helper": "Domain or host address for the server.",
   "install.ssh_port": "SSH Server Port",

--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -269,7 +269,7 @@
   "install.lfs_path": "Git LFS Root Path",
   "install.lfs_path_helper": "Files tracked by Git LFS will be stored in this directory. Leave empty to disable.",
   "install.run_user": "Run As Username",
-  "install.run_user_helper": "The operating system username that Gitea runs as. Note that this user must have access to the repository root path.",
+  "install.run_user_helper": "The operating system username that Gitea runs as. This value is auto-detected and cannot be changed here. To use a different user, restart Gitea under that account.",
   "install.domain": "Server Domain",
   "install.domain_helper": "Domain or host address for the server.",
   "install.ssh_port": "SSH Server Port",

--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -269,7 +269,7 @@
   "install.lfs_path": "Git LFS Root Path",
   "install.lfs_path_helper": "Files tracked by Git LFS will be stored in this directory. Leave empty to disable.",
   "install.run_user": "Run As Username",
-  "install.run_user_helper": "The operating system username that Gitea runs as, it must have write access to the data paths. This value is auto-detected and cannot be changed here.
+  "install.run_user_helper": "The operating system username that Gitea runs as, it must have write access to the data paths. This value is auto-detected and cannot be changed here. To use a different user, restart Gitea under that account.",
   "install.domain": "Server Domain",
   "install.domain_helper": "Domain or host address for the server.",
   "install.ssh_port": "SSH Server Port",

--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -269,7 +269,7 @@
   "install.lfs_path": "Git LFS Root Path",
   "install.lfs_path_helper": "Files tracked by Git LFS will be stored in this directory. Leave empty to disable.",
   "install.run_user": "Run As Username",
-  "install.run_user_helper": "The operating system username that Gitea runs as. This value is auto-detected and cannot be changed here. To use a different user, restart Gitea under that account.",
+  "install.run_user_helper": "The operating system username that Gitea runs as, it must have write access to the data paths. This value is auto-detected and cannot be changed here. To use a different user, restart Gitea under that account.",
   "install.domain": "Server Domain",
   "install.domain_helper": "Domain or host address for the server.",
   "install.ssh_port": "SSH Server Port",

--- a/templates/devtest/form-fields.tmpl
+++ b/templates/devtest/form-fields.tmpl
@@ -1,0 +1,139 @@
+{{template "devtest/devtest-header"}}
+<div class="page-content devtest ui container">
+  <form class="ui form left-right-form">
+    <h4 class="ui dividing header">Input</h4>
+    <div class="inline field">
+      <label>Normal</label>
+      <input type="text" value="value">
+    </div>
+    <div class="inline field">
+      <label>Readonly</label>
+      <input type="text" value="value" readonly>
+    </div>
+    <div class="inline disabled field">
+      <label>Disabled</label>
+      <input type="text" value="value" disabled>
+    </div>
+    <div class="inline field error">
+      <label>Error</label>
+      <input type="text" value="value">
+    </div>
+
+    <h4 class="ui dividing header">Textarea</h4>
+    <div class="inline field">
+      <label>Normal</label>
+      <textarea rows="2">value</textarea>
+    </div>
+    <div class="inline field">
+      <label>Readonly</label>
+      <textarea rows="2" readonly>value</textarea>
+    </div>
+    <div class="inline disabled field">
+      <label>Disabled</label>
+      <textarea rows="2" disabled>value</textarea>
+    </div>
+    <div class="inline field error">
+      <label>Error</label>
+      <textarea rows="2">value</textarea>
+    </div>
+
+    <h4 class="ui dividing header">Select</h4>
+    <div class="inline field">
+      <label>Normal</label>
+      <select>
+        <option>Option A</option>
+        <option>Option B</option>
+      </select>
+    </div>
+    <div class="inline field">
+      <label>Readonly</label>
+      <select readonly>
+        <option>Option A</option>
+        <option>Option B</option>
+      </select>
+    </div>
+    <div class="inline disabled field">
+      <label>Disabled</label>
+      <select disabled>
+        <option>Option A</option>
+        <option>Option B</option>
+      </select>
+    </div>
+    <div class="inline field error">
+      <label>Error</label>
+      <select>
+        <option>Option A</option>
+        <option>Option B</option>
+      </select>
+    </div>
+
+    <h4 class="ui dividing header">Dropdown</h4>
+    <div class="inline field">
+      <label>Normal</label>
+      <div class="ui selection dropdown">
+        <input type="hidden" value="a">
+        {{svg "octicon-triangle-down" 14 "dropdown icon"}}
+        <div class="text">Option A</div>
+        <div class="menu">
+          <div class="item" data-value="a">Option A</div>
+          <div class="item" data-value="b">Option B</div>
+        </div>
+      </div>
+    </div>
+    <div class="inline field">
+      <label>Readonly</label>
+      <div class="ui selection dropdown" readonly>
+        <input type="hidden" value="a">
+        {{svg "octicon-triangle-down" 14 "dropdown icon"}}
+        <div class="text">Option A</div>
+        <div class="menu">
+          <div class="item" data-value="a">Option A</div>
+          <div class="item" data-value="b">Option B</div>
+        </div>
+      </div>
+    </div>
+    <div class="inline disabled field">
+      <label>Disabled</label>
+      <div class="ui selection dropdown">
+        <input type="hidden" value="a">
+        {{svg "octicon-triangle-down" 14 "dropdown icon"}}
+        <div class="text">Option A</div>
+        <div class="menu">
+          <div class="item" data-value="a">Option A</div>
+          <div class="item" data-value="b">Option B</div>
+        </div>
+      </div>
+    </div>
+    <div class="inline field error">
+      <label>Error</label>
+      <div class="ui selection dropdown">
+        <input type="hidden" value="a">
+        {{svg "octicon-triangle-down" 14 "dropdown icon"}}
+        <div class="text">Option A</div>
+        <div class="menu">
+          <div class="item" data-value="a">Option A</div>
+          <div class="item" data-value="b">Option B</div>
+        </div>
+      </div>
+    </div>
+
+    <h4 class="ui dividing header">Required</h4>
+    <div class="inline required field">
+      <label>Normal</label>
+      <input type="text" value="value">
+    </div>
+    <div class="inline required field">
+      <label>Readonly</label>
+      <input type="text" value="value" readonly>
+    </div>
+    <div class="inline required disabled field">
+      <label>Disabled</label>
+      <input type="text" value="value" disabled>
+    </div>
+    <div class="inline required field error">
+      <label>Error</label>
+      <input type="text" value="value">
+    </div>
+  </form>
+</div>
+{{template "devtest/devtest-footer"}}

--- a/templates/devtest/form-fields.tmpl
+++ b/templates/devtest/form-fields.tmpl
@@ -1,139 +1,139 @@
 {{template "devtest/devtest-header"}}
 <div class="page-content devtest ui container">
-  <form class="ui form left-right-form">
-    <h4 class="ui dividing header">Input</h4>
-    <div class="inline field">
-      <label>Normal</label>
-      <input type="text" value="value">
-    </div>
-    <div class="inline field">
-      <label>Readonly</label>
-      <input type="text" value="value" readonly>
-    </div>
-    <div class="inline disabled field">
-      <label>Disabled</label>
-      <input type="text" value="value" disabled>
-    </div>
-    <div class="inline field error">
-      <label>Error</label>
-      <input type="text" value="value">
-    </div>
+	<form class="ui form left-right-form">
+		<h4 class="ui dividing header">Input</h4>
+		<div class="inline field">
+			<label>Normal</label>
+			<input type="text" value="value">
+		</div>
+		<div class="inline field">
+			<label>Readonly</label>
+			<input type="text" value="value" readonly>
+		</div>
+		<div class="inline disabled field">
+			<label>Disabled</label>
+			<input type="text" value="value" disabled>
+		</div>
+		<div class="inline field error">
+			<label>Error</label>
+			<input type="text" value="value">
+		</div>
 
-    <h4 class="ui dividing header">Textarea</h4>
-    <div class="inline field">
-      <label>Normal</label>
-      <textarea rows="2">value</textarea>
-    </div>
-    <div class="inline field">
-      <label>Readonly</label>
-      <textarea rows="2" readonly>value</textarea>
-    </div>
-    <div class="inline disabled field">
-      <label>Disabled</label>
-      <textarea rows="2" disabled>value</textarea>
-    </div>
-    <div class="inline field error">
-      <label>Error</label>
-      <textarea rows="2">value</textarea>
-    </div>
+		<h4 class="ui dividing header">Textarea</h4>
+		<div class="inline field">
+			<label>Normal</label>
+			<textarea rows="2">value</textarea>
+		</div>
+		<div class="inline field">
+			<label>Readonly</label>
+			<textarea rows="2" readonly>value</textarea>
+		</div>
+		<div class="inline disabled field">
+			<label>Disabled</label>
+			<textarea rows="2" disabled>value</textarea>
+		</div>
+		<div class="inline field error">
+			<label>Error</label>
+			<textarea rows="2">value</textarea>
+		</div>
 
-    <h4 class="ui dividing header">Select</h4>
-    <div class="inline field">
-      <label>Normal</label>
-      <select>
-        <option>Option A</option>
-        <option>Option B</option>
-      </select>
-    </div>
-    <div class="inline field">
-      <label>Readonly</label>
-      <select readonly>
-        <option>Option A</option>
-        <option>Option B</option>
-      </select>
-    </div>
-    <div class="inline disabled field">
-      <label>Disabled</label>
-      <select disabled>
-        <option>Option A</option>
-        <option>Option B</option>
-      </select>
-    </div>
-    <div class="inline field error">
-      <label>Error</label>
-      <select>
-        <option>Option A</option>
-        <option>Option B</option>
-      </select>
-    </div>
+		<h4 class="ui dividing header">Select</h4>
+		<div class="inline field">
+			<label>Normal</label>
+			<select>
+				<option>Option A</option>
+				<option>Option B</option>
+			</select>
+		</div>
+		<div class="inline field">
+			<label>Readonly</label>
+			<select readonly>
+				<option>Option A</option>
+				<option>Option B</option>
+			</select>
+		</div>
+		<div class="inline disabled field">
+			<label>Disabled</label>
+			<select disabled>
+				<option>Option A</option>
+				<option>Option B</option>
+			</select>
+		</div>
+		<div class="inline field error">
+			<label>Error</label>
+			<select>
+				<option>Option A</option>
+				<option>Option B</option>
+			</select>
+		</div>
 
-    <h4 class="ui dividing header">Dropdown</h4>
-    <div class="inline field">
-      <label>Normal</label>
-      <div class="ui selection dropdown">
-        <input type="hidden" value="a">
-        {{svg "octicon-triangle-down" 14 "dropdown icon"}}
-        <div class="text">Option A</div>
-        <div class="menu">
-          <div class="item" data-value="a">Option A</div>
-          <div class="item" data-value="b">Option B</div>
-        </div>
-      </div>
-    </div>
-    <div class="inline field">
-      <label>Readonly</label>
-      <div class="ui selection dropdown" readonly>
-        <input type="hidden" value="a">
-        {{svg "octicon-triangle-down" 14 "dropdown icon"}}
-        <div class="text">Option A</div>
-        <div class="menu">
-          <div class="item" data-value="a">Option A</div>
-          <div class="item" data-value="b">Option B</div>
-        </div>
-      </div>
-    </div>
-    <div class="inline disabled field">
-      <label>Disabled</label>
-      <div class="ui selection dropdown">
-        <input type="hidden" value="a">
-        {{svg "octicon-triangle-down" 14 "dropdown icon"}}
-        <div class="text">Option A</div>
-        <div class="menu">
-          <div class="item" data-value="a">Option A</div>
-          <div class="item" data-value="b">Option B</div>
-        </div>
-      </div>
-    </div>
-    <div class="inline field error">
-      <label>Error</label>
-      <div class="ui selection dropdown">
-        <input type="hidden" value="a">
-        {{svg "octicon-triangle-down" 14 "dropdown icon"}}
-        <div class="text">Option A</div>
-        <div class="menu">
-          <div class="item" data-value="a">Option A</div>
-          <div class="item" data-value="b">Option B</div>
-        </div>
-      </div>
-    </div>
+		<h4 class="ui dividing header">Dropdown</h4>
+		<div class="inline field">
+			<label>Normal</label>
+			<div class="ui selection dropdown">
+				<input type="hidden" value="a">
+				{{svg "octicon-triangle-down" 14 "dropdown icon"}}
+				<div class="text">Option A</div>
+				<div class="menu">
+					<div class="item" data-value="a">Option A</div>
+					<div class="item" data-value="b">Option B</div>
+				</div>
+			</div>
+		</div>
+		<div class="inline field">
+			<label>Readonly</label>
+			<div class="ui selection dropdown" readonly>
+				<input type="hidden" value="a">
+				{{svg "octicon-triangle-down" 14 "dropdown icon"}}
+				<div class="text">Option A</div>
+				<div class="menu">
+					<div class="item" data-value="a">Option A</div>
+					<div class="item" data-value="b">Option B</div>
+				</div>
+			</div>
+		</div>
+		<div class="inline disabled field">
+			<label>Disabled</label>
+			<div class="ui selection dropdown">
+				<input type="hidden" value="a">
+				{{svg "octicon-triangle-down" 14 "dropdown icon"}}
+				<div class="text">Option A</div>
+				<div class="menu">
+					<div class="item" data-value="a">Option A</div>
+					<div class="item" data-value="b">Option B</div>
+				</div>
+			</div>
+		</div>
+		<div class="inline field error">
+			<label>Error</label>
+			<div class="ui selection dropdown">
+				<input type="hidden" value="a">
+				{{svg "octicon-triangle-down" 14 "dropdown icon"}}
+				<div class="text">Option A</div>
+				<div class="menu">
+					<div class="item" data-value="a">Option A</div>
+					<div class="item" data-value="b">Option B</div>
+				</div>
+			</div>
+		</div>
 
-    <h4 class="ui dividing header">Required</h4>
-    <div class="inline required field">
-      <label>Normal</label>
-      <input type="text" value="value">
-    </div>
-    <div class="inline required field">
-      <label>Readonly</label>
-      <input type="text" value="value" readonly>
-    </div>
-    <div class="inline required disabled field">
-      <label>Disabled</label>
-      <input type="text" value="value" disabled>
-    </div>
-    <div class="inline required field error">
-      <label>Error</label>
-      <input type="text" value="value">
-    </div>
-  </form>
+		<h4 class="ui dividing header">Required</h4>
+		<div class="inline required field">
+			<label>Normal</label>
+			<input type="text" value="value">
+		</div>
+		<div class="inline required field">
+			<label>Readonly</label>
+			<input type="text" value="value" readonly>
+		</div>
+		<div class="inline required disabled field">
+			<label>Disabled</label>
+			<input type="text" value="value" disabled>
+		</div>
+		<div class="inline required field error">
+			<label>Error</label>
+			<input type="text" value="value">
+		</div>
+	</form>
 </div>
 {{template "devtest/devtest-footer"}}

--- a/templates/devtest/form-fields.tmpl
+++ b/templates/devtest/form-fields.tmpl
@@ -37,36 +37,6 @@
 			<textarea rows="2">value</textarea>
 		</div>
 
-		<h4 class="ui dividing header">Select</h4>
-		<div class="inline field">
-			<label>Normal</label>
-			<select>
-				<option>Option A</option>
-				<option>Option B</option>
-			</select>
-		</div>
-		<div class="inline field">
-			<label>Readonly</label>
-			<select readonly>
-				<option>Option A</option>
-				<option>Option B</option>
-			</select>
-		</div>
-		<div class="inline disabled field">
-			<label>Disabled</label>
-			<select disabled>
-				<option>Option A</option>
-				<option>Option B</option>
-			</select>
-		</div>
-		<div class="inline field error">
-			<label>Error</label>
-			<select>
-				<option>Option A</option>
-				<option>Option B</option>
-			</select>
-		</div>
-
 		<h4 class="ui dividing header">Dropdown</h4>
 		<div class="inline field">
 			<label>Normal</label>

--- a/templates/install.tmpl
+++ b/templates/install.tmpl
@@ -117,7 +117,7 @@
 						<input id="lfs_root_path" name="lfs_root_path" value="{{.lfs_root_path}}">
 						<span class="help">{{ctx.Locale.Tr "install.lfs_path_helper"}}</span>
 					</div>
-					<div class="inline required field {{if .Err_RunUser}}error{{end}}">
+					<div class="inline field {{if .Err_RunUser}}error{{end}}">
 						<label for="run_user">{{ctx.Locale.Tr "install.run_user"}}</label>
 						<input id="run_user" name="run_user" value="{{.run_user}}" readonly>
 						<span class="help">{{ctx.Locale.Tr "install.run_user_helper"}}</span>

--- a/templates/install.tmpl
+++ b/templates/install.tmpl
@@ -117,7 +117,7 @@
 						<input id="lfs_root_path" name="lfs_root_path" value="{{.lfs_root_path}}">
 						<span class="help">{{ctx.Locale.Tr "install.lfs_path_helper"}}</span>
 					</div>
-					<div class="inline field {{if .Err_RunUser}}error{{end}}">
+					<div class="inline field">
 						<label for="run_user">{{ctx.Locale.Tr "install.run_user"}}</label>
 						<input id="run_user" name="run_user" value="{{.run_user}}" readonly>
 						<span class="help">{{ctx.Locale.Tr "install.run_user_helper"}}</span>

--- a/web_src/css/modules/form.css
+++ b/web_src/css/modules/form.css
@@ -360,6 +360,13 @@ textarea:focus,
   font-size: 1em;
 }
 
+.ui.form .inline.field > input[readonly] {
+  border-color: transparent !important;
+  background: transparent !important;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+}
+
 .ui.form .inline.fields .field > :first-child,
 .ui.form .inline.field > :first-child {
   margin: 0 0.85714286em 0 0;

--- a/web_src/css/modules/form.css
+++ b/web_src/css/modules/form.css
@@ -99,6 +99,13 @@ textarea:focus,
   color: var(--color-input-text);
 }
 
+.ui.form input:not([type="checkbox"], [type="radio"])[readonly],
+.ui.form textarea[readonly],
+.ui.form select[readonly],
+.ui.form .ui.selection.dropdown[readonly] {
+  background: var(--color-secondary-bg);
+}
+
 .ui.input {
   color: var(--color-input-text);
 }
@@ -358,13 +365,6 @@ textarea:focus,
   margin-bottom: 0;
   vertical-align: middle;
   font-size: 1em;
-}
-
-.ui.form .inline.field > input[readonly] {
-  border-color: transparent !important;
-  background: transparent !important;
-  padding-left: 0 !important;
-  padding-right: 0 !important;
 }
 
 .ui.form .inline.fields .field > :first-child,

--- a/web_src/css/modules/form.css
+++ b/web_src/css/modules/form.css
@@ -205,7 +205,6 @@ textarea:focus,
   background-color: var(--color-error-bg);
   border-color: var(--color-error-border);
   color: var(--color-error-text);
-  border-radius: 0;
 }
 .ui.form .field.error textarea:focus,
 .ui.form .field.error select:focus,


### PR DESCRIPTION
The `Run As Username` field on the install page was a `readonly` input that looked editable but wasn't, confusing users. Style `readonly` inputs with a subtle background, matching other frameworks.

<img width="735" height="131" alt="image" src="https://github.com/user-attachments/assets/cb76ce71-faab-4300-811e-e4c503b59f9a" />

Fixes #37174

---
This PR was written with the help of Claude Opus 4.6