### PR TITLE
Remove outdated RunUser logic

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -41,10 +41,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; App name that shows in every page title
-APP_NAME = ; Gitea: Git with a cup of tea
+;APP_NAME = Gitea: Git with a cup of tea
 ;;
 ;; RUN_USER will automatically detect the current user - but you can set it here change it if you run locally
-RUN_USER = ; git
+;RUN_USER =
 ;;
 ;; Application run mode, affects performance and debugging: "dev" or "prod", default is "prod"
 ;; Mode "dev" makes Gitea easier to develop and debug, values other than "dev" are treated as "prod" which is for production use.

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -201,7 +201,7 @@ func mustCurrentRunUserMatch(rootCfg ConfigProvider) {
 	if HasInstallLock(rootCfg) {
 		currentUser, match := IsRunUserMatchCurrentUser(RunUser)
 		if !match {
-			log.Fatal("Expect user '%s' but current user is: %s", RunUser, currentUser)
+			log.Fatal("Expect user '%s' (RUN_USER in app.ini) but current user is: %s", RunUser, currentUser)
 		}
 	}
 }

--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -316,7 +316,6 @@
   "install.invalid_db_table": "The database table \"%s\" is invalid: %v",
   "install.invalid_repo_path": "The repository root path is invalid: %v",
   "install.invalid_app_data_path": "The app data path is invalid: %v",
-  "install.run_user_not_match": "The 'run as' username is not the current username: %s -> %s",
   "install.internal_token_failed": "Failed to generate internal token: %v",
   "install.secret_key_failed": "Failed to generate secret key: %v",
   "install.save_config_failed": "Failed to save configuration: %v",

--- a/routers/install/install.go
+++ b/routers/install/install.go
@@ -26,7 +26,6 @@ import (
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/templates"
 	"code.gitea.io/gitea/modules/timeutil"
-	"code.gitea.io/gitea/modules/user"
 	"code.gitea.io/gitea/modules/web"
 	"code.gitea.io/gitea/modules/web/middleware"
 	"code.gitea.io/gitea/routers/common"
@@ -87,15 +86,7 @@ func Install(ctx *context.Context) {
 	form.AppName = setting.AppName
 	form.RepoRootPath = setting.RepoRootPath
 	form.LFSRootPath = setting.LFS.Storage.Path
-
-	// Note(unknown): it's hard for Windows users change a running user,
-	// 	so just use current one if config says default.
-	if setting.IsWindows && setting.RunUser == "git" {
-		form.RunUser = user.CurrentUsername()
-	} else {
-		form.RunUser = setting.RunUser
-	}
-
+	form.RunUser = setting.RunUser
 	form.Domain = setting.Domain
 	form.SSHPort = setting.SSH.Port
 	form.HTTPPort = setting.HTTPPort
@@ -269,13 +260,6 @@ func SubmitInstall(ctx *context.Context) {
 	if err = os.MkdirAll(form.LogRootPath, os.ModePerm); err != nil {
 		ctx.Data["Err_LogRootPath"] = true
 		ctx.RenderWithErrDeprecated(ctx.Tr("install.invalid_log_root_path", err), tplInstall, &form)
-		return
-	}
-
-	currentUser, match := setting.IsRunUserMatchCurrentUser(form.RunUser)
-	if !match {
-		ctx.Data["Err_RunUser"] = true
-		ctx.RenderWithErrDeprecated(ctx.Tr("install.run_user_not_match", form.RunUser, currentUser), tplInstall, &form)
 		return
 	}
 


### PR DESCRIPTION
That logic is from 2014~2015 https://github.com/gogs/gogs/issues/660, it unclear why it is necessary or whether it is still needed (whether Windows is still special)

The comment "so just use current one if config says default" is not right anymore: "git" isn't the "default" value of RunUser (Comment out app.example.ini #15807). The RunUser's value is from current session's username.