### PR TITLE
fix(api): handle fork-only commits in compare API

### DIFF
--- a/routers/api/v1/repo/compare.go
+++ b/routers/api/v1/repo/compare.go
@@ -63,25 +63,19 @@ func CompareDiff(ctx *context.APIContext) {
 	apiCommits := make([]*api.Commit, 0, len(compareInfo.Commits))
 	userCache := make(map[string]*user_model.User)
 
-	// decide which git repo to use
-	gitRepo := ctx.Repo.GitRepo
-	if compareInfo.HeadGitRepo != nil {
-		gitRepo = compareInfo.HeadGitRepo
-	}
-
-	// decide which repository metadata to use
-	repo := ctx.Repo.Repository
-	if compareInfo.HeadRepo != nil {
-		repo = compareInfo.HeadRepo
-	}
-
 	for i := 0; i < len(compareInfo.Commits); i++ {
-		apiCommit, err := convert.ToCommit(ctx, repo, gitRepo, compareInfo.Commits[i], userCache,
+		apiCommit, err := convert.ToCommit(
+			ctx,
+			compareInfo.HeadRepo,
+			compareInfo.HeadGitRepo,
+			compareInfo.Commits[i],
+			userCache,
 			convert.ToCommitOptions{
 				Stat:         true,
 				Verification: verification,
 				Files:        files,
-			})
+			},
+		)
 		if err != nil {
 			ctx.APIErrorInternal(err)
 			return

--- a/routers/api/v1/repo/compare.go
+++ b/routers/api/v1/repo/compare.go
@@ -62,8 +62,21 @@ func CompareDiff(ctx *context.APIContext) {
 
 	apiCommits := make([]*api.Commit, 0, len(compareInfo.Commits))
 	userCache := make(map[string]*user_model.User)
+
+	// decide which git repo to use
+	gitRepo := ctx.Repo.GitRepo
+	if compareInfo.HeadGitRepo != nil {
+		gitRepo = compareInfo.HeadGitRepo
+	}
+
+	// decide which repository metadata to use
+	repo := ctx.Repo.Repository
+	if compareInfo.HeadRepo != nil {
+		repo = compareInfo.HeadRepo
+	}
+
 	for i := 0; i < len(compareInfo.Commits); i++ {
-		apiCommit, err := convert.ToCommit(ctx, ctx.Repo.Repository, ctx.Repo.GitRepo, compareInfo.Commits[i], userCache,
+		apiCommit, err := convert.ToCommit(ctx, repo, gitRepo, compareInfo.Commits[i], userCache,
 			convert.ToCommitOptions{
 				Stat:         true,
 				Verification: verification,

--- a/tests/integration/api_repo_compare_test.go
+++ b/tests/integration/api_repo_compare_test.go
@@ -47,4 +47,24 @@ func TestAPICompareBranches(t *testing.T) {
 		assert.Equal(t, 1, apiResp.TotalCommits)
 		assert.Len(t, apiResp.Commits, 1)
 	})
+	t.Run("CompareForkOnlyCommit", func(t *testing.T) {
+		defer tests.PrintCurrentTest(t)()
+
+		user1Sess := loginUser(t, "user1")
+		user1Token := getTokenForLoggedInUser(t, user1Sess, auth_model.AccessTokenScopeWriteRepository)
+
+		req := NewRequestWithJSON(t, "POST", "/api/v1/repos/user2/repo1/forks", &api.CreateForkOption{}).
+			AddTokenAuth(user1Token)
+		MakeRequest(t, req, http.StatusAccepted)
+
+		req = NewRequestf(t, "GET", "/api/v1/repos/user2/repo1/compare/master...user1:master").
+			AddTokenAuth(user1Token)
+		resp := MakeRequest(t, req, http.StatusOK)
+
+		var apiResp *api.Compare
+		DecodeJSON(t, resp, &apiResp)
+
+		assert.NotNil(t, apiResp)
+		assert.GreaterOrEqual(t, apiResp.TotalCommits, 0)
+	})
 }

--- a/tests/integration/api_repo_compare_test.go
+++ b/tests/integration/api_repo_compare_test.go
@@ -6,6 +6,7 @@ package integration
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	auth_model "code.gitea.io/gitea/models/auth"
 	"code.gitea.io/gitea/models/unittest"
@@ -57,6 +58,8 @@ func TestAPICompareBranches(t *testing.T) {
 			AddTokenAuth(user1Token)
 		MakeRequest(t, req, http.StatusAccepted)
 
+		time.Sleep(500 * time.Millisecond)
+
 		req = NewRequestf(t, "GET", "/api/v1/repos/user2/repo1/compare/master...user1:master").
 			AddTokenAuth(user1Token)
 		resp := MakeRequest(t, req, http.StatusOK)
@@ -65,6 +68,5 @@ func TestAPICompareBranches(t *testing.T) {
 		DecodeJSON(t, resp, &apiResp)
 
 		assert.NotNil(t, apiResp)
-		assert.GreaterOrEqual(t, apiResp.TotalCommits, 0)
 	})
 }

--- a/tests/integration/api_repo_compare_test.go
+++ b/tests/integration/api_repo_compare_test.go
@@ -21,38 +21,32 @@ import (
 
 func TestAPICompareBranches(t *testing.T) {
 	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
-
-		user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
-		// Login as User2.
-		session := loginUser(t, user.Name)
-		token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteRepository)
+		session2 := loginUser(t, "user2")
+		token2 := getTokenForLoggedInUser(t, session2, auth_model.AccessTokenScopeWriteRepository)
 
 		t.Run("CompareBranches", func(t *testing.T) {
 			defer tests.PrintCurrentTest(t)()
-			req := NewRequestf(t, "GET", "/api/v1/repos/user2/repo20/compare/add-csv...remove-files-b").AddTokenAuth(token)
+
+			req := NewRequestf(t, "GET", "/api/v1/repos/user2/repo20/compare/add-csv...remove-files-b").AddTokenAuth(token2)
 			resp := MakeRequest(t, req, http.StatusOK)
-
-			var apiResp *api.Compare
-			DecodeJSON(t, resp, &apiResp)
-
+			apiResp := DecodeJSON(t, resp, &api.Compare{})
 			assert.Equal(t, 2, apiResp.TotalCommits)
 			assert.Len(t, apiResp.Commits, 2)
 		})
 
 		t.Run("CompareCommits", func(t *testing.T) {
 			defer tests.PrintCurrentTest(t)()
-			req := NewRequestf(t, "GET", "/api/v1/repos/user2/repo20/compare/808038d2f71b0ab02099...c8e31bc7688741a5287f").AddTokenAuth(token)
+
+			req := NewRequestf(t, "GET", "/api/v1/repos/user2/repo20/compare/808038d2f71b0ab02099...c8e31bc7688741a5287f").AddTokenAuth(token2)
 			resp := MakeRequest(t, req, http.StatusOK)
-
-			var apiResp *api.Compare
-			DecodeJSON(t, resp, &apiResp)
-
+			apiResp := DecodeJSON(t, resp, &api.Compare{})
 			assert.Equal(t, 1, apiResp.TotalCommits)
 			assert.Len(t, apiResp.Commits, 1)
 		})
 
 		t.Run("CompareForkOnlyCommit", func(t *testing.T) {
 			defer tests.PrintCurrentTest(t)()
+
 			user13 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 13})
 			repo11 := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 11})
 			user13Sess := loginUser(t, "user13")
@@ -61,7 +55,10 @@ func TestAPICompareBranches(t *testing.T) {
 			_, err := createFileInBranch(user13, repo11, createFileInBranchOptions{OldBranch: "master", NewBranch: "new-branch"}, map[string]string{"file.txt": "content"})
 			require.NoError(t, err)
 			req := NewRequestf(t, "GET", "/api/v1/repos/user12/repo10/compare/master...user13:new-branch").AddTokenAuth(user13Token)
-			MakeRequest(t, req, http.StatusOK)
+			resp := MakeRequest(t, req, http.StatusOK)
+			apiResp := DecodeJSON(t, resp, &api.Compare{})
+			assert.Equal(t, 1, apiResp.TotalCommits)
+			assert.Len(t, apiResp.Commits, 1)
 		})
 	})
 }

--- a/tests/integration/api_repo_compare_test.go
+++ b/tests/integration/api_repo_compare_test.go
@@ -5,68 +5,63 @@ package integration
 
 import (
 	"net/http"
+	"net/url"
 	"testing"
-	"time"
 
 	auth_model "code.gitea.io/gitea/models/auth"
+	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unittest"
 	user_model "code.gitea.io/gitea/models/user"
 	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/tests"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAPICompareBranches(t *testing.T) {
-	defer tests.PrepareTestEnv(t)()
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
 
-	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
-	// Login as User2.
-	session := loginUser(t, user.Name)
-	token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteRepository)
+		user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+		// Login as User2.
+		session := loginUser(t, user.Name)
+		token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteRepository)
 
-	t.Run("CompareBranches", func(t *testing.T) {
-		defer tests.PrintCurrentTest(t)()
-		req := NewRequestf(t, "GET", "/api/v1/repos/user2/repo20/compare/add-csv...remove-files-b").AddTokenAuth(token)
-		resp := MakeRequest(t, req, http.StatusOK)
+		t.Run("CompareBranches", func(t *testing.T) {
+			defer tests.PrintCurrentTest(t)()
+			req := NewRequestf(t, "GET", "/api/v1/repos/user2/repo20/compare/add-csv...remove-files-b").AddTokenAuth(token)
+			resp := MakeRequest(t, req, http.StatusOK)
 
-		var apiResp *api.Compare
-		DecodeJSON(t, resp, &apiResp)
+			var apiResp *api.Compare
+			DecodeJSON(t, resp, &apiResp)
 
-		assert.Equal(t, 2, apiResp.TotalCommits)
-		assert.Len(t, apiResp.Commits, 2)
-	})
+			assert.Equal(t, 2, apiResp.TotalCommits)
+			assert.Len(t, apiResp.Commits, 2)
+		})
 
-	t.Run("CompareCommits", func(t *testing.T) {
-		defer tests.PrintCurrentTest(t)()
-		req := NewRequestf(t, "GET", "/api/v1/repos/user2/repo20/compare/808038d2f71b0ab02099...c8e31bc7688741a5287f").AddTokenAuth(token)
-		resp := MakeRequest(t, req, http.StatusOK)
+		t.Run("CompareCommits", func(t *testing.T) {
+			defer tests.PrintCurrentTest(t)()
+			req := NewRequestf(t, "GET", "/api/v1/repos/user2/repo20/compare/808038d2f71b0ab02099...c8e31bc7688741a5287f").AddTokenAuth(token)
+			resp := MakeRequest(t, req, http.StatusOK)
 
-		var apiResp *api.Compare
-		DecodeJSON(t, resp, &apiResp)
+			var apiResp *api.Compare
+			DecodeJSON(t, resp, &apiResp)
 
-		assert.Equal(t, 1, apiResp.TotalCommits)
-		assert.Len(t, apiResp.Commits, 1)
-	})
-	t.Run("CompareForkOnlyCommit", func(t *testing.T) {
-		defer tests.PrintCurrentTest(t)()
+			assert.Equal(t, 1, apiResp.TotalCommits)
+			assert.Len(t, apiResp.Commits, 1)
+		})
 
-		user1Sess := loginUser(t, "user1")
-		user1Token := getTokenForLoggedInUser(t, user1Sess, auth_model.AccessTokenScopeWriteRepository)
+		t.Run("CompareForkOnlyCommit", func(t *testing.T) {
+			defer tests.PrintCurrentTest(t)()
+			user13 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 13})
+			repo11 := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 11})
+			user13Sess := loginUser(t, "user13")
+			user13Token := getTokenForLoggedInUser(t, user13Sess, auth_model.AccessTokenScopeWriteRepository)
 
-		req := NewRequestWithJSON(t, "POST", "/api/v1/repos/user2/repo1/forks", &api.CreateForkOption{}).
-			AddTokenAuth(user1Token)
-		MakeRequest(t, req, http.StatusAccepted)
-
-		time.Sleep(500 * time.Millisecond)
-
-		req = NewRequestf(t, "GET", "/api/v1/repos/user2/repo1/compare/master...user1:master").
-			AddTokenAuth(user1Token)
-		resp := MakeRequest(t, req, http.StatusOK)
-
-		var apiResp *api.Compare
-		DecodeJSON(t, resp, &apiResp)
-
-		assert.NotNil(t, apiResp)
+			_, err := createFileInBranch(user13, repo11, createFileInBranchOptions{OldBranch: "master", NewBranch: "new-branch"}, map[string]string{"file.txt": "content"})
+			require.NoError(t, err)
+			req := NewRequestf(t, "GET", "/api/v1/repos/user12/repo10/compare/master...user13:new-branch").AddTokenAuth(user13Token)
+			MakeRequest(t, req, http.StatusOK)
+		})
 	})
 }


### PR DESCRIPTION
Fix 500 error when comparing branches across fork repositories

## Problem

The compare API returns a 500 Internal Server Error when comparing branches where the head commit exists only in the fork repository.

## Cause

The API was using the base repository's GitRepo and repository context when converting commits. This fails when the commit does not exist in the base repository, resulting in a "fatal: bad object" error.

## Solution

Use the head repository and HeadGitRepo when available to ensure commits are resolved in the correct repository context.

## Result

* Fixes "fatal: bad object" error
* Enables proper comparison between base and fork repositories
* Prevents 500 Internal Server Error

Fixes #37168
