### PR TITLE
Bugfix: Set project field via api

### DIFF
--- a/modules/structs/issue.go
+++ b/modules/structs/issue.go
@@ -60,6 +60,7 @@ type Issue struct {
 	Attachments      []*Attachment `json:"assets"`
 	Labels           []*Label      `json:"labels"`
 	Milestone        *Milestone    `json:"milestone"`
+	Project          *ProjectMeta  `json:"project"`
 	// deprecated
 	Assignee  *User     `json:"assignee"`
 	Assignees []*User   `json:"assignees"`
@@ -98,6 +99,8 @@ type CreateIssueOption struct {
 	Deadline *time.Time `json:"due_date"`
 	// milestone id
 	Milestone int64 `json:"milestone"`
+	// project id
+	Project int64 `json:"project"`
 	// list of label ids
 	Labels []int64 `json:"labels"`
 	Closed bool    `json:"closed"`
@@ -112,6 +115,7 @@ type EditIssueOption struct {
 	Assignee  *string  `json:"assignee"`
 	Assignees []string `json:"assignees"`
 	Milestone *int64   `json:"milestone"`
+	Project   *int64   `json:"project"`
 	State     *string  `json:"state"`
 	// swagger:strfmt date-time
 	Deadline       *time.Time `json:"due_date"`

--- a/modules/structs/project.go
+++ b/modules/structs/project.go
@@ -1,0 +1,11 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package structs
+
+// ProjectMeta contains project metadata for API responses
+// swagger:model
+type ProjectMeta struct {
+	ID    int64  `json:"id"`
+	Title string `json:"title"`
+}

--- a/modules/structs/project.go
+++ b/modules/structs/project.go
@@ -6,6 +6,8 @@ package structs
 // ProjectMeta contains project metadata for API responses
 // swagger:model
 type ProjectMeta struct {
-	ID    int64  `json:"id"`
+	// ID is the unique identifier for the project
+	ID int64 `json:"id"`
+	// Title is the title of the project
 	Title string `json:"title"`
 }

--- a/routers/api/v1/repo/issue.go
+++ b/routers/api/v1/repo/issue.go
@@ -33,17 +33,6 @@ import (
 	issue_service "code.gitea.io/gitea/services/issue"
 )
 
-func apiIssueProjectError(ctx *context.APIContext, err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, util.ErrPermissionDenied) || errors.Is(err, util.ErrNotExist) {
-		ctx.APIError(http.StatusUnprocessableEntity, err)
-		return true
-	}
-	return false
-}
-
 // buildSearchIssuesRepoIDs builds the list of repository IDs for issue search based on query parameters.
 // It returns repoIDs, allPublic flag, and any error that occurred.
 func buildSearchIssuesRepoIDs(ctx *context.APIContext) (repoIDs []int64, allPublic bool, err error) {
@@ -708,8 +697,8 @@ func CreateIssue(ctx *context.APIContext) {
 			ctx.APIError(http.StatusBadRequest, err)
 		} else if errors.Is(err, user_model.ErrBlockedUser) {
 			ctx.APIError(http.StatusForbidden, err)
-		} else if apiIssueProjectError(ctx, err) {
-			return
+		} else if errors.Is(err, util.ErrPermissionDenied) || errors.Is(err, util.ErrNotExist) {
+			ctx.APIError(http.StatusUnprocessableEntity, err)
 		} else {
 			ctx.APIErrorInternal(err)
 		}
@@ -916,7 +905,8 @@ func EditIssue(ctx *context.APIContext) {
 		}
 		if currentProjectID != *form.Project {
 			if err := issues_model.IssueAssignOrRemoveProject(ctx, issue, ctx.Doer, *form.Project, 0); err != nil {
-				if apiIssueProjectError(ctx, err) {
+				if errors.Is(err, util.ErrPermissionDenied) || errors.Is(err, util.ErrNotExist) {
+					ctx.APIError(http.StatusUnprocessableEntity, err)
 					return
 				}
 				ctx.APIErrorInternal(err)

--- a/routers/api/v1/repo/issue.go
+++ b/routers/api/v1/repo/issue.go
@@ -33,6 +33,17 @@ import (
 	issue_service "code.gitea.io/gitea/services/issue"
 )
 
+func apiIssueProjectError(ctx *context.APIContext, err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, util.ErrPermissionDenied) || errors.Is(err, util.ErrNotExist) {
+		ctx.APIError(http.StatusUnprocessableEntity, err)
+		return true
+	}
+	return false
+}
+
 // buildSearchIssuesRepoIDs builds the list of repository IDs for issue search based on query parameters.
 // It returns repoIDs, allPublic flag, and any error that occurred.
 func buildSearchIssuesRepoIDs(ctx *context.APIContext) (repoIDs []int64, allPublic bool, err error) {
@@ -654,9 +665,11 @@ func CreateIssue(ctx *context.APIContext) {
 	}
 
 	assigneeIDs := make([]int64, 0)
+	var projectID int64
 	var err error
 	if ctx.Repo.CanWrite(unit.TypeIssues) {
 		issue.MilestoneID = form.Milestone
+		projectID = form.Project
 		assigneeIDs, err = issues_model.MakeIDsFromAPIAssigneesToAdd(ctx, form.Assignee, form.Assignees)
 		if err != nil {
 			if user_model.IsErrUserNotExist(err) {
@@ -690,11 +703,13 @@ func CreateIssue(ctx *context.APIContext) {
 		form.Labels = make([]int64, 0)
 	}
 
-	if err := issue_service.NewIssue(ctx, ctx.Repo.Repository, issue, form.Labels, nil, assigneeIDs, 0); err != nil {
+	if err := issue_service.NewIssue(ctx, ctx.Repo.Repository, issue, form.Labels, nil, assigneeIDs, projectID); err != nil {
 		if repo_model.IsErrUserDoesNotHaveAccessToRepo(err) {
 			ctx.APIError(http.StatusBadRequest, err)
 		} else if errors.Is(err, user_model.ErrBlockedUser) {
 			ctx.APIError(http.StatusForbidden, err)
+		} else if apiIssueProjectError(ctx, err) {
+			return
 		} else {
 			ctx.APIErrorInternal(err)
 		}
@@ -894,6 +909,22 @@ func EditIssue(ctx *context.APIContext) {
 			return
 		}
 	}
+	if canWrite && form.Project != nil {
+		currentProjectID := int64(0)
+		if issue.Project != nil {
+			currentProjectID = issue.Project.ID
+		}
+		if currentProjectID != *form.Project {
+			if err := issues_model.IssueAssignOrRemoveProject(ctx, issue, ctx.Doer, *form.Project, 0); err != nil {
+				if apiIssueProjectError(ctx, err) {
+					return
+				}
+				ctx.APIErrorInternal(err)
+				return
+			}
+		}
+	}
+
 	if form.State != nil {
 		if issue.IsPull {
 			if err := issue.LoadPullRequest(ctx); err != nil {

--- a/services/convert/issue.go
+++ b/services/convert/issue.go
@@ -11,6 +11,7 @@ import (
 
 	issues_model "code.gitea.io/gitea/models/issues"
 	access_model "code.gitea.io/gitea/models/perm/access"
+	project_model "code.gitea.io/gitea/models/project"
 	repo_model "code.gitea.io/gitea/models/repo"
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/cache"
@@ -124,13 +125,29 @@ func toIssue(ctx context.Context, doer *user_model.User, issue *issues_model.Iss
 		apiIssue.Deadline = issue.DeadlineUnix.AsTimePtr()
 	}
 
+	if err := issue.LoadProject(ctx); err != nil {
+		return &api.Issue{}
+	}
+	if issue.Project != nil {
+		apiIssue.Project = ToAPIProjectMeta(issue.Project)
+	}
+
 	return apiIssue
+}
+
+// ToAPIProjectMeta converts a Project to its API metadata representation
+func ToAPIProjectMeta(p *project_model.Project) *api.ProjectMeta {
+	return &api.ProjectMeta{
+		ID:    p.ID,
+		Title: p.Title,
+	}
 }
 
 // ToIssueList converts an IssueList to API format
 func ToIssueList(ctx context.Context, doer *user_model.User, il issues_model.IssueList) []*api.Issue {
 	result := make([]*api.Issue, len(il))
 	_ = il.LoadPinOrder(ctx)
+	_ = il.LoadProjects(ctx)
 	for i := range il {
 		result[i] = ToIssue(ctx, doer, il[i])
 	}
@@ -141,6 +158,7 @@ func ToIssueList(ctx context.Context, doer *user_model.User, il issues_model.Iss
 func ToAPIIssueList(ctx context.Context, doer *user_model.User, il issues_model.IssueList) []*api.Issue {
 	result := make([]*api.Issue, len(il))
 	_ = il.LoadPinOrder(ctx)
+	_ = il.LoadProjects(ctx)
 	for i := range il {
 		result[i] = ToAPIIssue(ctx, doer, il[i])
 	}

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -27742,11 +27742,13 @@
       "type": "object",
       "properties": {
         "id": {
+          "description": "ID is the unique identifier for the project",
           "type": "integer",
           "format": "int64",
           "x-go-name": "ID"
         },
         "title": {
+          "description": "Title is the title of the project",
           "type": "string",
           "x-go-name": "Title"
         }

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -23628,6 +23628,12 @@
           "format": "int64",
           "x-go-name": "Milestone"
         },
+        "project": {
+          "description": "project id",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Project"
+        },
         "ref": {
           "type": "string",
           "x-go-name": "Ref"
@@ -24864,6 +24870,11 @@
           "type": "integer",
           "format": "int64",
           "x-go-name": "Milestone"
+        },
+        "project": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Project"
         },
         "ref": {
           "type": "string",
@@ -26381,6 +26392,9 @@
           "format": "int64",
           "x-go-name": "PinOrder"
         },
+        "project": {
+          "$ref": "#/definitions/ProjectMeta"
+        },
         "pull_request": {
           "$ref": "#/definitions/PullRequestMeta"
         },
@@ -27719,6 +27733,22 @@
         "push": {
           "type": "boolean",
           "x-go-name": "Push"
+        }
+      },
+      "x-go-package": "code.gitea.io/gitea/modules/structs"
+    },
+    "ProjectMeta": {
+      "description": "ProjectMeta contains project metadata for API responses",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "ID"
+        },
+        "title": {
+          "type": "string",
+          "x-go-name": "Title"
         }
       },
       "x-go-package": "code.gitea.io/gitea/modules/structs"

--- a/tests/integration/api_issue_test.go
+++ b/tests/integration/api_issue_test.go
@@ -14,6 +14,7 @@ import (
 
 	auth_model "code.gitea.io/gitea/models/auth"
 	issues_model "code.gitea.io/gitea/models/issues"
+	project_model "code.gitea.io/gitea/models/project"
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unittest"
 	user_model "code.gitea.io/gitea/models/user"
@@ -35,6 +36,7 @@ func TestAPIIssue(t *testing.T) {
 	t.Run("IssueContentVersion", testAPIIssueContentVersion)
 	t.Run("CreateIssue", testAPICreateIssue)
 	t.Run("CreateIssueParallel", testAPICreateIssueParallel)
+	t.Run("IssueProject", testAPIIssueProject)
 }
 
 func testAPIListIssues(t *testing.T) {
@@ -499,4 +501,71 @@ func testAPIIssueContentVersion(t *testing.T) {
 		}).AddTokenAuth(token)
 		MakeRequest(t, req, http.StatusCreated)
 	})
+}
+
+func testAPIIssueProject(t *testing.T) {
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+	owner := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: repo.OwnerID})
+
+	session := loginUser(t, owner.Name)
+	token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteIssue)
+
+	urlStr := fmt.Sprintf("/api/v1/repos/%s/%s/issues", owner.Name, repo.Name)
+	req := NewRequestWithJSON(t, "POST", urlStr, &api.CreateIssueOption{
+		Title:   "issue with project",
+		Project: 1,
+	}).AddTokenAuth(token)
+	resp := MakeRequest(t, req, http.StatusCreated)
+	var apiIssue api.Issue
+	DecodeJSON(t, resp, &apiIssue)
+	assert.NotNil(t, apiIssue.Project)
+	assert.Equal(t, int64(1), apiIssue.Project.ID)
+	assert.NotEmpty(t, apiIssue.Project.Title)
+
+	editURL := fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d", owner.Name, repo.Name, apiIssue.Index)
+	noProject := int64(0)
+	req = NewRequestWithJSON(t, "PATCH", editURL, api.EditIssueOption{
+		Project: &noProject,
+	}).AddTokenAuth(token)
+	resp = MakeRequest(t, req, http.StatusCreated)
+	DecodeJSON(t, resp, &apiIssue)
+	assert.Nil(t, apiIssue.Project)
+
+	projectID := int64(1)
+	req = NewRequestWithJSON(t, "PATCH", editURL, api.EditIssueOption{
+		Project: &projectID,
+	}).AddTokenAuth(token)
+	resp = MakeRequest(t, req, http.StatusCreated)
+	DecodeJSON(t, resp, &apiIssue)
+	assert.NotNil(t, apiIssue.Project)
+	assert.Equal(t, int64(1), apiIssue.Project.ID)
+
+	projectIssue := unittest.AssertExistsAndLoadBean(t, &project_model.ProjectIssue{IssueID: apiIssue.ID, ProjectID: projectID})
+	projectCommentCount := unittest.GetCount(t, &issues_model.Comment{IssueID: apiIssue.ID, Type: issues_model.CommentTypeProject})
+	assert.Equal(t, 3, projectCommentCount)
+
+	req = NewRequestWithJSON(t, "PATCH", editURL, api.EditIssueOption{
+		Project: &projectID,
+	}).AddTokenAuth(token)
+	resp = MakeRequest(t, req, http.StatusCreated)
+	DecodeJSON(t, resp, &apiIssue)
+	assert.NotNil(t, apiIssue.Project)
+	assert.Equal(t, int64(1), apiIssue.Project.ID)
+
+	projectIssueAfter := unittest.AssertExistsAndLoadBean(t, &project_model.ProjectIssue{IssueID: apiIssue.ID, ProjectID: projectID})
+	assert.Equal(t, projectIssue.ID, projectIssueAfter.ID)
+	assert.Equal(t, projectIssue.Sorting, projectIssueAfter.Sorting)
+	assert.Equal(t, projectCommentCount, unittest.GetCount(t, &issues_model.Comment{IssueID: apiIssue.ID, Type: issues_model.CommentTypeProject}))
+
+	req = NewRequestWithJSON(t, "POST", urlStr, &api.CreateIssueOption{
+		Title:   "issue with invalid project",
+		Project: 999999,
+	}).AddTokenAuth(token)
+	MakeRequest(t, req, http.StatusUnprocessableEntity)
+
+	invalidProjectID := int64(999999)
+	req = NewRequestWithJSON(t, "PATCH", editURL, api.EditIssueOption{
+		Project: &invalidProjectID,
+	}).AddTokenAuth(token)
+	MakeRequest(t, req, http.StatusUnprocessableEntity)
 }


### PR DESCRIPTION
When creating or editing an issue via API, you can't set the Project field.

Fixes #37149 