### PR TITLE
Fix encoding for Matrix Webhooks

### DIFF
--- a/routers/web/repo/setting/webhook.go
+++ b/routers/web/repo/setting/webhook.go
@@ -456,6 +456,8 @@ func matrixHookParams(ctx *context.Context) webhookParams {
 	return webhookParams{
 		Type: webhook_module.MATRIX,
 		// See https://spec.matrix.org/latest/appendices/#room-ids
+		// Demo links: https://spec.matrix.org/latest/appendices/#matrixto-navigation
+		// It seems that only `!` needs to be kept
 		URL: fmt.Sprintf("%s/_matrix/client/r0/rooms/%s/send/m.room.message", form.HomeserverURL,
 			strings.NewReplacer("%21", "!").Replace(url.PathEscape(form.RoomID))),
 		ContentType: webhook.ContentTypeJSON,

--- a/routers/web/repo/setting/webhook.go
+++ b/routers/web/repo/setting/webhook.go
@@ -461,6 +461,7 @@ func matrixRoomIDEncode(roomID string) string {
 func matrixHookParams(ctx *context.Context) webhookParams {
 	form := web.GetForm(ctx).(*forms.NewMatrixHookForm)
 
+	// TODO: need to migrate to the latest (v3) API: https://spec.matrix.org/v1.18/client-server-api/
 	return webhookParams{
 		Type:        webhook_module.MATRIX,
 		URL:         fmt.Sprintf("%s/_matrix/client/r0/rooms/%s/send/m.room.message", form.HomeserverURL, matrixRoomIDEncode(form.RoomID)),

--- a/routers/web/repo/setting/webhook.go
+++ b/routers/web/repo/setting/webhook.go
@@ -454,8 +454,13 @@ func matrixHookParams(ctx *context.Context) webhookParams {
 	form := web.GetForm(ctx).(*forms.NewMatrixHookForm)
 
 	return webhookParams{
-		Type:        webhook_module.MATRIX,
-		URL:         fmt.Sprintf("%s/_matrix/client/r0/rooms/%s/send/m.room.message", form.HomeserverURL, strings.ReplaceAll(url.PathEscape(form.RoomID), "%21", "!")),
+		Type: webhook_module.MATRIX,
+		// Matrix room IDs are of the form "!localpart:server", where "!" and ":" are
+		// valid unencoded path segment characters per RFC 3986, but url.PathEscape
+		// encodes them. Restore them so Matrix homeservers can recognise the room ID.
+		// See https://spec.matrix.org/latest/appendices/#room-ids
+		URL: fmt.Sprintf("%s/_matrix/client/r0/rooms/%s/send/m.room.message", form.HomeserverURL,
+			strings.NewReplacer("%21", "!", "%3A", ":").Replace(url.PathEscape(form.RoomID))),
 		ContentType: webhook.ContentTypeJSON,
 		HTTPMethod:  http.MethodPut,
 		WebhookForm: form.WebhookForm,

--- a/routers/web/repo/setting/webhook.go
+++ b/routers/web/repo/setting/webhook.go
@@ -455,12 +455,9 @@ func matrixHookParams(ctx *context.Context) webhookParams {
 
 	return webhookParams{
 		Type: webhook_module.MATRIX,
-		// Matrix room IDs are of the form "!localpart:server", where "!" and ":" are
-		// valid unencoded path segment characters per RFC 3986, but url.PathEscape
-		// encodes them. Restore them so Matrix homeservers can recognise the room ID.
 		// See https://spec.matrix.org/latest/appendices/#room-ids
 		URL: fmt.Sprintf("%s/_matrix/client/r0/rooms/%s/send/m.room.message", form.HomeserverURL,
-			strings.NewReplacer("%21", "!", "%3A", ":").Replace(url.PathEscape(form.RoomID))),
+			strings.NewReplacer("%21", "!").Replace(url.PathEscape(form.RoomID))),
 		ContentType: webhook.ContentTypeJSON,
 		HTTPMethod:  http.MethodPut,
 		WebhookForm: form.WebhookForm,

--- a/routers/web/repo/setting/webhook.go
+++ b/routers/web/repo/setting/webhook.go
@@ -455,7 +455,7 @@ func matrixHookParams(ctx *context.Context) webhookParams {
 
 	return webhookParams{
 		Type:        webhook_module.MATRIX,
-		URL:         fmt.Sprintf("%s/_matrix/client/r0/rooms/%s/send/m.room.message", form.HomeserverURL, url.PathEscape(form.RoomID)),
+		URL:         fmt.Sprintf("%s/_matrix/client/r0/rooms/%s/send/m.room.message", form.HomeserverURL, strings.ReplaceAll(url.PathEscape(form.RoomID), "%21", "!")),
 		ContentType: webhook.ContentTypeJSON,
 		HTTPMethod:  http.MethodPut,
 		WebhookForm: form.WebhookForm,

--- a/routers/web/repo/setting/webhook.go
+++ b/routers/web/repo/setting/webhook.go
@@ -450,16 +450,20 @@ func MatrixHooksEditPost(ctx *context.Context) {
 	editWebhook(ctx, matrixHookParams(ctx))
 }
 
+func matrixRoomIDEncode(roomID string) string {
+	// See https://spec.matrix.org/latest/appendices/#room-ids
+	// Demo links: https://spec.matrix.org/latest/appendices/#matrixto-navigation
+	// API spec: https://spec.matrix.org/v1.18/client-server-api/#sending-events-to-a-room
+	// But some of their examples also shows links like: "PUT /rooms/!roomid:domain/state/m.example.event"
+	return strings.NewReplacer("%21", "!", "%3A", ":").Replace(url.PathEscape(roomID))
+}
+
 func matrixHookParams(ctx *context.Context) webhookParams {
 	form := web.GetForm(ctx).(*forms.NewMatrixHookForm)
 
 	return webhookParams{
-		Type: webhook_module.MATRIX,
-		// See https://spec.matrix.org/latest/appendices/#room-ids
-		// Demo links: https://spec.matrix.org/latest/appendices/#matrixto-navigation
-		// It seems that only `!` needs to be kept
-		URL: fmt.Sprintf("%s/_matrix/client/r0/rooms/%s/send/m.room.message", form.HomeserverURL,
-			strings.NewReplacer("%21", "!").Replace(url.PathEscape(form.RoomID))),
+		Type:        webhook_module.MATRIX,
+		URL:         fmt.Sprintf("%s/_matrix/client/r0/rooms/%s/send/m.room.message", form.HomeserverURL, matrixRoomIDEncode(form.RoomID)),
 		ContentType: webhook.ContentTypeJSON,
 		HTTPMethod:  http.MethodPut,
 		WebhookForm: form.WebhookForm,

--- a/routers/web/repo/setting/webhook.go
+++ b/routers/web/repo/setting/webhook.go
@@ -452,9 +452,9 @@ func MatrixHooksEditPost(ctx *context.Context) {
 
 func matrixRoomIDEncode(roomID string) string {
 	// See https://spec.matrix.org/latest/appendices/#room-ids
-	// Demo links: https://spec.matrix.org/latest/appendices/#matrixto-navigation
+	// Some (unrelated) demo links: https://spec.matrix.org/latest/appendices/#matrixto-navigation
 	// API spec: https://spec.matrix.org/v1.18/client-server-api/#sending-events-to-a-room
-	// But some of their examples also shows links like: "PUT /rooms/!roomid:domain/state/m.example.event"
+	// Some of their examples show links like: "PUT /rooms/!roomid:domain/state/m.example.event"
 	return strings.NewReplacer("%21", "!", "%3A", ":").Replace(url.PathEscape(roomID))
 }
 

--- a/routers/web/repo/setting/webhook_test.go
+++ b/routers/web/repo/setting/webhook_test.go
@@ -12,5 +12,4 @@ import (
 func TestWebhookMatrix(t *testing.T) {
 	assert.Equal(t, "!roomid:domain", matrixRoomIDEncode("!roomid:domain"))
 	assert.Equal(t, "!room%23id:domain", matrixRoomIDEncode("!room#id:domain")) // maybe it should never really happen in real world
-
 }

--- a/routers/web/repo/setting/webhook_test.go
+++ b/routers/web/repo/setting/webhook_test.go
@@ -1,0 +1,16 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package setting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWebhookMatrix(t *testing.T) {
+	assert.Equal(t, "!roomid:domain", matrixRoomIDEncode("!roomid:domain"))
+	assert.Equal(t, "!room%23id:domain", matrixRoomIDEncode("!room#id:domain")) // maybe it should never really happen in real world
+
+}


### PR DESCRIPTION
`url.PathEscape` unnecessarily encodes ! to %21, causing Matrix homeservers to reject the request with 401. Replace %21 back to ! after escaping.

Fixes #36012 