### PR TITLE
fix(api): handle missing base branch in PR commits API

### DIFF
--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -1427,12 +1427,26 @@ func GetPullRequestCommits(ctx *context.APIContext) {
 	if pr.HasMerged {
 		compareInfo, err = git_service.GetCompareInfo(ctx, pr.BaseRepo, pr.BaseRepo, baseGitRepo, git.RefName(pr.MergeBase), git.RefName(pr.GetGitHeadRefName()), false, false)
 	} else {
+		branchExist, err := git_model.IsBranchExist(ctx, pr.BaseRepo.ID, pr.BaseBranch)
+		if err != nil {
+			ctx.APIErrorInternal(err)
+			return
+		}
+		if !branchExist {
+			ctx.APIError(http.StatusNotFound, fmt.Errorf("base branch '%s' does not exist", pr.BaseBranch))
+			return
+		}
 		compareInfo, err = git_service.GetCompareInfo(ctx, pr.BaseRepo, pr.BaseRepo, baseGitRepo, git.RefNameFromBranch(pr.BaseBranch), git.RefName(pr.GetGitHeadRefName()), false, false)
+		if err != nil {
+			if strings.Contains(err.Error(), "bad revision") {
+				ctx.APIError(http.StatusNotFound, "invalid base branch or revision")
+				return
+			}
+			ctx.APIErrorInternal(err)
+			return
+		}
 	}
-	if err != nil {
-		ctx.APIErrorInternal(err)
-		return
-	}
+	
 
 	listOptions := utils.GetListOptions(ctx)
 

--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -22,6 +22,7 @@ import (
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/git"
+	"code.gitea.io/gitea/modules/git/gitcmd"
 	"code.gitea.io/gitea/modules/gitrepo"
 	"code.gitea.io/gitea/modules/graceful"
 	"code.gitea.io/gitea/modules/log"
@@ -1426,20 +1427,16 @@ func GetPullRequestCommits(ctx *context.APIContext) {
 
 	if pr.HasMerged {
 		compareInfo, err = git_service.GetCompareInfo(ctx, pr.BaseRepo, pr.BaseRepo, baseGitRepo, git.RefName(pr.MergeBase), git.RefName(pr.GetGitHeadRefName()), false, false)
-		if err != nil {
-			ctx.APIErrorInternal(err)
-			return
-		}
 	} else {
 		compareInfo, err = git_service.GetCompareInfo(ctx, pr.BaseRepo, pr.BaseRepo, baseGitRepo, git.RefNameFromBranch(pr.BaseBranch), git.RefName(pr.GetGitHeadRefName()), false, false)
-		if err != nil {
-			if strings.Contains(err.Error(), "bad revision") {
-				ctx.APIError(http.StatusNotFound, "invalid base branch or revision")
-				return
-			}
-			ctx.APIErrorInternal(err)
-			return
-		}
+	}
+
+	if gitcmd.StderrHasPrefix(err, "fatal: bad revision") {
+		ctx.APIError(http.StatusNotFound, "invalid base branch or revision")
+		return
+	} else if err != nil {
+		ctx.APIErrorInternal(err)
+		return
 	}
 
 	listOptions := utils.GetListOptions(ctx)

--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -1426,16 +1426,11 @@ func GetPullRequestCommits(ctx *context.APIContext) {
 
 	if pr.HasMerged {
 		compareInfo, err = git_service.GetCompareInfo(ctx, pr.BaseRepo, pr.BaseRepo, baseGitRepo, git.RefName(pr.MergeBase), git.RefName(pr.GetGitHeadRefName()), false, false)
-	} else {
-		branchExist, err := git_model.IsBranchExist(ctx, pr.BaseRepo.ID, pr.BaseBranch)
 		if err != nil {
 			ctx.APIErrorInternal(err)
 			return
 		}
-		if !branchExist {
-			ctx.APIError(http.StatusNotFound, fmt.Errorf("base branch '%s' does not exist", pr.BaseBranch))
-			return
-		}
+	} else {
 		compareInfo, err = git_service.GetCompareInfo(ctx, pr.BaseRepo, pr.BaseRepo, baseGitRepo, git.RefNameFromBranch(pr.BaseBranch), git.RefName(pr.GetGitHeadRefName()), false, false)
 		if err != nil {
 			if strings.Contains(err.Error(), "bad revision") {
@@ -1446,7 +1441,6 @@ func GetPullRequestCommits(ctx *context.APIContext) {
 			return
 		}
 	}
-	
 
 	listOptions := utils.GetListOptions(ctx)
 


### PR DESCRIPTION
fix(api): handle missing base branch in PR commits API

Closes #36366

Previously, the PR commits API returned a 500 Internal Server Error
when the base branch was missing due to an unhandled git "bad revision" error.

This change:
- Checks for base branch existence before performing git operations
- Returns 404 when the base branch does not exist
- Prevents git errors from surfacing as 500 responses

This improves API robustness and aligns behavior with expected error handling.

Tested locally by:
- Creating a pull request
- Deleting the base branch
- Verifying that the API returns 404 instead of 500