### PR TITLE
Fix flaky `TestLDAPAuthChange`

### DIFF
--- a/tests/integration/auth_ldap_test.go
+++ b/tests/integration/auth_ldap_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -197,19 +198,13 @@ func TestLDAPAuthChange(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
 	te.addAuthSource(t)
 
+	authSource := unittest.AssertExistsAndLoadBean(t, &auth_model.Source{Name: "ldap"})
+	href := fmt.Sprintf("/-/admin/auths/%d", authSource.ID)
+
 	session := loginUser(t, "user1")
-	req := NewRequest(t, "GET", "/-/admin/auths")
+	req := NewRequest(t, "GET", href)
 	resp := session.MakeRequest(t, req, http.StatusOK)
 	doc := NewHTMLParser(t, resp.Body)
-	href, exists := doc.Find("table.table td a").Attr("href")
-	if !exists {
-		assert.True(t, exists, "No authentication source found")
-		return
-	}
-
-	req = NewRequest(t, "GET", href)
-	resp = session.MakeRequest(t, req, http.StatusOK)
-	doc = NewHTMLParser(t, resp.Body)
 	host, _ := doc.Find(`input[name="host"]`).Attr("value")
 	assert.Equal(t, te.serverHost, host)
 	binddn, _ := doc.Find(`input[name="bind_dn"]`).Attr("value")


### PR DESCRIPTION
Fixes #37263.

The assertion scraped the admin auth list HTML to rediscover the URL of the
source we just created:

```go
href, exists := doc.Find("table.table td a").Attr("href")
if !exists {
    assert.True(t, exists, "No authentication source found")
    return
}
```

When the page rendered with an empty table for any reason, the selector
returned no match and the failure surfaced as "No authentication source
found" with no hint of the real cause. The `POST /-/admin/auths/new` in the
same test returned `303`, so the source was actually created — the
flakiness was in the HTML scraping / list render, not in the insert.

Look the source up directly from the database (matching the pattern already
used later in the same file, e.g. `TestLDAPUserSyncWithEmptyUsernameAttribute`)
and build the URL from its ID. This:

- makes the test deterministic — no more dependency on the list page render
- removes an unnecessary HTTP round trip
- produces a clear `AssertExistsAndLoadBean` error if the insert really
  failed, rather than conflating DB state with DOM scraping

---
This PR was written with the help of Claude Opus 4.7