### PR TITLE
Fix workflow_run webhook not delivered for non-default branches

### DIFF
--- a/routers/api/v1/repo/action.go
+++ b/routers/api/v1/repo/action.go
@@ -939,7 +939,7 @@ func ActionsGetWorkflow(ctx *context.APIContext) {
 	//     "$ref": "#/responses/error"
 
 	workflowID := ctx.PathParam("workflow_id")
-	workflow, err := convert.GetActionWorkflow(ctx, ctx.Repo.GitRepo, ctx.Repo.Repository, workflowID)
+	workflow, err := convert.GetActionWorkflow(ctx, ctx.Repo.GitRepo, ctx.Repo.Repository, workflowID, "")
 	if err != nil {
 		if errors.Is(err, util.ErrNotExist) {
 			ctx.APIError(http.StatusNotFound, err)

--- a/services/actions/notifier.go
+++ b/services/actions/notifier.go
@@ -805,7 +805,7 @@ func (n *actionsNotifier) WorkflowRunStatusUpdate(ctx context.Context, repo *rep
 	}
 	defer gitRepo.Close()
 
-	convertedWorkflow, err := convert.GetActionWorkflow(ctx, gitRepo, repo, run.WorkflowID)
+	convertedWorkflow, err := convert.GetActionWorkflow(ctx, gitRepo, repo, run.WorkflowID, run.Ref)
 	if err != nil {
 		log.Error("GetActionWorkflow: %v", err)
 		return

--- a/services/actions/workflow.go
+++ b/services/actions/workflow.go
@@ -27,7 +27,7 @@ import (
 )
 
 func EnableOrDisableWorkflow(ctx *context.APIContext, workflowID string, isEnable bool) error {
-	workflow, err := convert.GetActionWorkflow(ctx, ctx.Repo.GitRepo, ctx.Repo.Repository, workflowID)
+	workflow, err := convert.GetActionWorkflow(ctx, ctx.Repo.GitRepo, ctx.Repo.Repository, workflowID, "")
 	if err != nil {
 		return err
 	}

--- a/services/convert/convert.go
+++ b/services/convert/convert.go
@@ -463,20 +463,26 @@ func ListActionWorkflows(ctx context.Context, gitrepo *git.Repository, repo *rep
 	return workflows, nil
 }
 
-func GetActionWorkflow(ctx context.Context, gitrepo *git.Repository, repo *repo_model.Repository, workflowID string) (*api.ActionWorkflow, error) {
-	defaultBranchCommit, err := gitrepo.GetBranchCommit(repo.DefaultBranch)
+func GetActionWorkflow(ctx context.Context, gitrepo *git.Repository, repo *repo_model.Repository, workflowID, ref string) (*api.ActionWorkflow, error) {
+	if ref == "" {
+		ref = repo.DefaultBranch
+	} else if branchName := git.RefName(ref).BranchName(); branchName != "" {
+		ref = branchName
+	}
+
+	commit, err := gitrepo.GetBranchCommit(ref)
 	if err != nil {
 		return nil, err
 	}
 
-	folder, entries, err := actions.ListWorkflows(defaultBranchCommit)
+	folder, entries, err := actions.ListWorkflows(commit)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, entry := range entries {
 		if entry.Name() == workflowID {
-			return getActionWorkflowEntry(ctx, repo, defaultBranchCommit, repo.DefaultBranch, folder, entry), nil
+			return getActionWorkflowEntry(ctx, repo, commit, ref, folder, entry), nil
 		}
 	}
 

--- a/services/webhook/notifier.go
+++ b/services/webhook/notifier.go
@@ -1032,7 +1032,7 @@ func (*webhookNotifier) WorkflowRunStatusUpdate(ctx context.Context, repo *repo_
 	}
 	defer gitRepo.Close()
 
-	convertedWorkflow, err := convert.GetActionWorkflow(ctx, gitRepo, repo, run.WorkflowID)
+	convertedWorkflow, err := convert.GetActionWorkflow(ctx, gitRepo, repo, run.WorkflowID, run.Ref)
 	if err != nil {
 		log.Error("GetActionWorkflow: %v", err)
 		return


### PR DESCRIPTION
Fixes #37280

## Fix workflow_run webhook not delivered for non-default branches

`GetActionWorkflow()` only searches the default branch for the workflow file. When a workflow YAML (e.g. `.gitea/workflows/build.yaml`) exists only on a non-default branch, `WorkflowRunStatusUpdate` in the webhook notifier fails with:

```
GetActionWorkflow: workflow "build.yaml" not found
```

The `workflow_run` webhook is silently dropped.

### Changes

- Add an optional `fallbackRef` variadic parameter to `GetActionWorkflow()` in `services/convert/convert.go`
- When the workflow is not found on the default branch and a `fallbackRef` is provided, search that ref as well
- Pass `run.Ref` as the fallback from both `services/webhook/notifier.go` and `services/actions/notifier.go`
- Existing callers (API routes) are unchanged — they don't pass a fallback and continue searching only the default branch

### Steps to reproduce

1. Create a repo with default branch `main`
2. Create a branch `dev` with `.gitea/workflows/build.yaml` (do **not** add this file to `main`)
3. Configure a webhook subscribed to `workflow_run` events
4. Push a commit to `dev` — the workflow runs successfully
5. Observe that no `workflow_run` webhook is delivered

Gitea logs show:
```
services/webhook/notifier.go:1037:(*webhookNotifier).WorkflowRunStatusUpdate() [E] GetActionWorkflow: workflow "build.yaml" not found
```

### Tested on

Gitea 1.25.3