### PR TITLE
Fix Mermaid diagrams failing when node labels contain line breaks

### DIFF
--- a/web_src/js/features/repo-issue-pull.ts
+++ b/web_src/js/features/repo-issue-pull.ts
@@ -68,7 +68,7 @@ async function initRepoPullRequestMergeForm(box: HTMLElement) {
   view.mount(el);
 }
 
-function executeScripts(elem: HTMLElement) {
+function executeScripts(elem: Element) {
   // find any existing nonce value from the current page and apply it to the new script
   const scriptNonce = document.querySelector('script[nonce]')!.getAttribute('nonce')!;
   for (const oldScript of elem.querySelectorAll('script')) {

--- a/web_src/js/markup/mermaid.ts
+++ b/web_src/js/markup/mermaid.ts
@@ -1,4 +1,4 @@
-import {isDarkTheme, parseDom} from '../utils.ts';
+import {isDarkTheme} from '../utils.ts';
 import {displayError} from './common.ts';
 import {createElementFromAttrs, createElementFromHTML, queryElems} from '../utils/dom.ts';
 import {html, htmlRaw} from '../utils/html.ts';
@@ -180,9 +180,6 @@ export async function initMarkupCodeMermaid(elMarkup: HTMLElement): Promise<void
     theme: isDarkTheme() ? 'dark' : 'neutral', // TODO: maybe it should use "darkMode" to adopt more user-specified theme instead of just "dark" or "neutral"
     securityLevel: 'strict',
     suppressErrorRendering: true,
-    // HTML labels embed foreignObject content (e.g. <br> for line breaks) that is not well-formed XML;
-    // we parse the SVG string with DOMParser as image/svg+xml before inserting it (see #37295, mermaid-js/mermaid#1766).
-    htmlLabels: false,
   });
 
   const iframeStyleText = getIframeCss();
@@ -204,8 +201,7 @@ export async function initMarkupCodeMermaid(elMarkup: HTMLElement): Promise<void
     try {
       // render the mermaid diagram to svg text, and parse it to a DOM node
       const {svg: svgText, bindFunctions} = await mermaid.render('mermaid', source, parentContainer);
-      const svgDoc = parseDom(svgText, 'image/svg+xml');
-      const svgNode = (svgDoc.documentElement as unknown) as SVGSVGElement;
+      const svgNode = createElementFromHTML<SVGSVGElement>(svgText);
 
       const viewControllerHtml = html`
         <div class="view-controller auto-hide-control flex-text-block">

--- a/web_src/js/markup/mermaid.ts
+++ b/web_src/js/markup/mermaid.ts
@@ -180,6 +180,9 @@ export async function initMarkupCodeMermaid(elMarkup: HTMLElement): Promise<void
     theme: isDarkTheme() ? 'dark' : 'neutral', // TODO: maybe it should use "darkMode" to adopt more user-specified theme instead of just "dark" or "neutral"
     securityLevel: 'strict',
     suppressErrorRendering: true,
+    // HTML labels embed foreignObject content (e.g. <br> for line breaks) that is not well-formed XML;
+    // we parse the SVG string with DOMParser as image/svg+xml before inserting it (see #37295, mermaid-js/mermaid#1766).
+    htmlLabels: false,
   });
 
   const iframeStyleText = getIframeCss();

--- a/web_src/js/markup/mermaid.ts
+++ b/web_src/js/markup/mermaid.ts
@@ -81,7 +81,7 @@ async function loadMermaid(needElkRender: boolean) {
   };
 }
 
-function initMermaidViewController(viewController: HTMLElement, dragElement: SVGSVGElement) {
+function initMermaidViewController(viewController: Element, dragElement: SVGSVGElement) {
   let inited = false, isDragging = false;
   let currentScale = 1, initLeft = 0, lastLeft = 0, lastTop = 0, lastPageX = 0, lastPageY = 0;
 

--- a/web_src/js/utils/dom.ts
+++ b/web_src/js/utils/dom.ts
@@ -265,7 +265,7 @@ export function isElemVisible(el: HTMLElement): boolean {
   return Boolean(!el.classList.contains('tw-hidden') && (el.offsetWidth || el.offsetHeight || el.getClientRects().length) && el.style.display !== 'none');
 }
 
-export function createElementFromHTML<T extends HTMLElement>(htmlString: string): T {
+export function createElementFromHTML<T extends Element>(htmlString: string): T {
   htmlString = htmlString.trim();
   // There is no way to create some elements without a proper parent, jQuery's approach: https://github.com/jquery/jquery/blob/main/src/manipulation/wrapMap.js
   // eslint-disable-next-line github/unescaped-html-literal


### PR DESCRIPTION
Mermaid code blocks that use line breaks inside node labels (for example `A["line1\nline2"]` or labels that resolve to multi-line text) could fail to render in Gitea. This change fixes that by disabling Mermaid’s HTML-based labels so the generated SVG stays well-formed XML for our client-side pipeline.
- Fixes [#37295](https://github.com/go-gitea/gitea/issues/37295)


## Root cause

Gitea renders Mermaid in the browser, then parses the returned SVG string with `DOMParser` using the `image/svg+xml` type before inserting it into the page. With Mermaid’s default **`htmlLabels: true`**, labels with line breaks are often emitted as HTML inside a `foreignObject`, including tags like `<br>` that are valid in HTML but **not** valid in XML. That output can break strict XML parsing of the SVG string (see [mermaid-js/mermaid#1766](https://github.com/mermaid-js/mermaid/issues/1766)).

## What we changed

Set **`htmlLabels: false`** in `mermaid.initialize()` so labels are drawn with SVG text instead of HTML in `foreignObject`, producing SVG that parses cleanly as `image/svg+xml`.

## Trade-offs

- **Pros:** Restores reliable rendering for diagrams with line breaks in labels; aligns with **`securityLevel: 'strict'`** (less reliance on HTML inside diagrams).
- **Cons:** Node/edge labels are no longer rendered via the HTML/foreignObject path, so **rich HTML inside quoted label text** may not behave like before; layout/wrapping of long labels may differ slightly.