### PR TITLE
Revert "Add WebKit to e2e test matrix (#37298)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -518,7 +518,8 @@ test-mssql-migration: migrations.mssql.test migrations.individual.mssql.test
 
 .PHONY: playwright
 playwright: deps-frontend
-	@pnpm exec playwright install --with-deps chromium firefox webkit $(PLAYWRIGHT_FLAGS)
+	@# on GitHub Actions VMs, playwright's system deps are pre-installed
+	@pnpm exec playwright install $(if $(GITHUB_ACTIONS),,--with-deps) chromium firefox $(PLAYWRIGHT_FLAGS)
 
 .PHONY: test-e2e
 test-e2e: playwright $(EXECUTABLE_E2E)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,11 +36,5 @@ export default defineConfig({
         ...devices['Desktop Firefox'],
       },
     },
-    {
-      name: 'webkit',
-      use: {
-        ...devices['Desktop Safari'],
-      },
-    },
   ],
 });


### PR DESCRIPTION
Reverts: #37298
Ref: https://github.com/go-gitea/gitea/actions/runs/24661464168/job/72108324223?pr=37312

WebKit on Linux has a long history of flakiness in Playwright CI runs, and the exact "WebKit encountered an internal error" class of failures has been reported repeatedly and closed without a real fix (typically stale/no-repro, or worked around by retries):

- https://github.com/microsoft/playwright/issues/34450
- https://github.com/microsoft/playwright/issues/35773
- https://github.com/microsoft/playwright/issues/35870
- https://github.com/microsoft/playwright/issues/35293
- https://github.com/microsoft/playwright/issues/38838

Keeping chromium and firefox in the e2e matrix.

---
This PR was written with the help of Claude Opus 4.7