### PR TITLE
Use modern "git update-index --cacheinfo" syntax to support more file names

### DIFF
--- a/services/repository/files/temp_repo.go
+++ b/services/repository/files/temp_repo.go
@@ -178,8 +178,9 @@ func (t *TemporaryUploadRepository) HashObjectAndWrite(ctx context.Context, cont
 
 // AddObjectToIndex adds the provided object hash to the index with the provided mode and path
 func (t *TemporaryUploadRepository) AddObjectToIndex(ctx context.Context, mode, objectHash, objectPath string) error {
-	if err := gitcmd.NewCommand("update-index", "--add", "--replace", "--cacheinfo").
-		AddDynamicArguments(mode, objectHash, objectPath).WithDir(t.basePath).RunWithStderr(ctx); err != nil {
+	cmd := gitcmd.NewCommand("update-index", "--add", "--replace", "--cacheinfo").
+		AddDynamicArguments(mode + "," + objectHash + "," + objectPath).WithDir(t.basePath)
+	if err := cmd.RunWithStderr(ctx); err != nil {
 		if matched, _ := regexp.MatchString(".*Invalid path '.*", err.Stderr()); matched {
 			return ErrFilePathInvalid{
 				Message: objectPath,

--- a/services/repository/files/temp_repo_test.go
+++ b/services/repository/files/temp_repo_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package files
+
+import (
+	"bytes"
+	"testing"
+
+	repo_model "code.gitea.io/gitea/models/repo"
+	"code.gitea.io/gitea/modules/git"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemporaryUploadRepository(t *testing.T) {
+	mockedRepo := &repo_model.Repository{Name: "mocked-repo-name", OwnerName: "mocked-owner-name"}
+	tmpGitRepo, err := NewTemporaryUploadRepository(mockedRepo)
+	require.NoError(t, err)
+	defer tmpGitRepo.Close()
+
+	require.NoError(t, tmpGitRepo.Init(t.Context(), git.Sha256ObjectFormat.Name()))
+
+	require.NoError(t, tmpGitRepo.RemoveFilesFromIndex(t.Context(), "any-file-name"))
+	require.NoError(t, tmpGitRepo.RemoveFilesFromIndex(t.Context(), "--any-file-name"))
+
+	objID, err := tmpGitRepo.HashObjectAndWrite(t.Context(), bytes.NewReader(nil))
+	require.NoError(t, err)
+	require.NoError(t, tmpGitRepo.AddObjectToIndex(t.Context(), "100644", objID, "any-file-name"))
+	require.NoError(t, tmpGitRepo.AddObjectToIndex(t.Context(), "100644", objID, "--any-file-name"))
+}

--- a/services/repository/files/temp_repo_test.go
+++ b/services/repository/files/temp_repo_test.go
@@ -15,17 +15,31 @@ import (
 
 func TestTemporaryUploadRepository(t *testing.T) {
 	mockedRepo := &repo_model.Repository{Name: "mocked-repo-name", OwnerName: "mocked-owner-name"}
-	tmpGitRepo, err := NewTemporaryUploadRepository(mockedRepo)
-	require.NoError(t, err)
-	defer tmpGitRepo.Close()
 
-	require.NoError(t, tmpGitRepo.Init(t.Context(), git.Sha256ObjectFormat.Name()))
+	doTest := func(t *testing.T, objectFormatName string) {
+		tmpGitRepo, err := NewTemporaryUploadRepository(mockedRepo)
+		require.NoError(t, err)
+		defer tmpGitRepo.Close()
 
-	require.NoError(t, tmpGitRepo.RemoveFilesFromIndex(t.Context(), "any-file-name"))
-	require.NoError(t, tmpGitRepo.RemoveFilesFromIndex(t.Context(), "--any-file-name"))
+		require.NoError(t, tmpGitRepo.Init(t.Context(), objectFormatName))
 
-	objID, err := tmpGitRepo.HashObjectAndWrite(t.Context(), bytes.NewReader(nil))
-	require.NoError(t, err)
-	require.NoError(t, tmpGitRepo.AddObjectToIndex(t.Context(), "100644", objID, "any-file-name"))
-	require.NoError(t, tmpGitRepo.AddObjectToIndex(t.Context(), "100644", objID, "--any-file-name"))
+		require.NoError(t, tmpGitRepo.RemoveFilesFromIndex(t.Context(), "any-file-name"))
+		require.NoError(t, tmpGitRepo.RemoveFilesFromIndex(t.Context(), "--any-file-name"))
+
+		objID, err := tmpGitRepo.HashObjectAndWrite(t.Context(), bytes.NewReader(nil))
+		require.NoError(t, err)
+		require.NoError(t, tmpGitRepo.AddObjectToIndex(t.Context(), "100644", objID, "any-file-name"))
+		require.NoError(t, tmpGitRepo.AddObjectToIndex(t.Context(), "100644", objID, "--any-file-name"))
+	}
+
+	t.Run("sha1", func(t *testing.T) {
+		doTest(t, git.Sha1ObjectFormat.Name())
+	})
+
+	t.Run("sha256", func(t *testing.T) {
+		if !git.DefaultFeatures().SupportHashSha256 {
+			t.Skip("sha256 is not supported")
+		}
+		doTest(t, git.Sha256ObjectFormat.Name())
+	})
 }


### PR DESCRIPTION
Modern syntax was added in git 2.0

And add more tests