### PR TITLE
Add ICS calendar feed for issue dashboard searches

### DIFF
--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -75,6 +75,7 @@
   "activities": "Activities",
   "pull_requests": "Pull Requests",
   "issues": "Issues",
+  "issues.calendar": "Subscribe to calendar",
   "milestones": "Milestones",
   "ok": "OK",
   "cancel": "Cancel",

--- a/routers/web/user/home.go
+++ b/routers/web/user/home.go
@@ -357,7 +357,19 @@ func Issues(ctx *context.Context) {
 // Regexp for repos query
 var issueReposQueryPattern = regexp.MustCompile(`^\[\d+(,\d+)*,?\]$`)
 
-func buildIssueOverview(ctx *context.Context, unitType unit.Type) {
+type issueOverviewQuery struct {
+	ctxUser      *user_model.User
+	viewType     string
+	filterMode   int
+	sortType     string
+	searchMode   string
+	keyword      string
+	isShowClosed bool
+	page         int
+	opts         *issues_model.IssuesOptions
+}
+
+func buildIssueOverviewQuery(ctx *context.Context, unitType unit.Type) (*issueOverviewQuery, bool) {
 	// ----------------------------------------------------
 	// Determine user; can be either user or organization.
 	// Return with NotFound or ServerError if unsuccessful.
@@ -365,7 +377,7 @@ func buildIssueOverview(ctx *context.Context, unitType unit.Type) {
 
 	ctxUser := prepareDashboardContextUserOrgTeams(ctx)
 	if ctx.Written() {
-		return
+		return nil, false
 	}
 
 	// Default to recently updated, unlike repository issues list
@@ -426,7 +438,7 @@ func buildIssueOverview(ctx *context.Context, unitType unit.Type) {
 
 		issue.PrepareFilterIssueLabels(ctx, 0, ctx.Org.Organization.AsUser())
 		if ctx.Written() {
-			return
+			return nil, false
 		}
 	}
 	// Get filter by author id & assignee id
@@ -466,14 +478,12 @@ func buildIssueOverview(ctx *context.Context, unitType unit.Type) {
 	if opts.Team != nil {
 		repoOpts.TeamID = opts.Team.ID
 	}
-	accessibleRepos := container.Set[int64]{}
 	{
 		ids, _, err := repo_model.SearchRepositoryIDs(ctx, repoOpts)
 		if err != nil {
 			ctx.ServerError("SearchRepositoryIDs", err)
-			return
+			return nil, false
 		}
-		accessibleRepos.AddMultiple(ids...)
 		opts.RepoIDs = ids
 		if len(opts.RepoIDs) == 0 {
 			// no repos found, don't let the indexer return all repos
@@ -528,6 +538,35 @@ func buildIssueOverview(ctx *context.Context, unitType unit.Type) {
 			ctx.Flash.Error(ctx.Tr("invalid_data", selectedLabels), true)
 		}
 	}
+
+	return &issueOverviewQuery{
+		ctxUser:      ctxUser,
+		viewType:     viewType,
+		filterMode:   filterMode,
+		sortType:     sortType,
+		searchMode:   searchMode,
+		keyword:      keyword,
+		isShowClosed: isShowClosed,
+		page:         page,
+		opts:         opts,
+	}, true
+}
+
+func buildIssueOverview(ctx *context.Context, unitType unit.Type) {
+	query, ok := buildIssueOverviewQuery(ctx, unitType)
+	if !ok {
+		return
+	}
+
+	ctxUser := query.ctxUser
+	filterMode := query.filterMode
+	searchMode := query.searchMode
+	keyword := query.keyword
+	opts := query.opts
+	sortType := query.sortType
+	viewType := query.viewType
+	isShowClosed := query.isShowClosed
+	page := query.page
 
 	// ------------------------------
 	// Get issues as defined by opts.
@@ -627,6 +666,9 @@ func buildIssueOverview(ctx *context.Context, unitType unit.Type) {
 	ctx.Data["IsShowClosed"] = isShowClosed
 	ctx.Data["SearchModes"] = issue_indexer.SupportedSearchModes()
 	ctx.Data["SelectedSearchMode"] = ctx.FormTrim("search_mode")
+	if unitType == unit.TypeIssues {
+		ctx.Data["IssueCalendarURL"] = ctx.Req.URL.Path + ".ics"
+	}
 
 	if isShowClosed {
 		ctx.Data["State"] = "closed"
@@ -639,6 +681,48 @@ func buildIssueOverview(ctx *context.Context, unitType unit.Type) {
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplIssues)
+}
+
+// IssuesICS renders the issue search as an iCalendar feed.
+func IssuesICS(ctx *context.Context) {
+	if unit.TypeIssues.UnitGlobalDisabled() {
+		log.Debug("Issues calendar not available as it is globally disabled.")
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+
+	query, ok := buildIssueOverviewQuery(ctx, unit.TypeIssues)
+	if !ok {
+		return
+	}
+
+	query.opts.Paginator = &db.ListOptions{ListAll: true, PageSize: setting.API.DefaultPagingNum}
+	issueIDs, _, err := issue_indexer.SearchIssues(ctx, issue_indexer.ToSearchOptions(query.keyword, query.opts).Copy(
+		func(o *issue_indexer.SearchOptions) {
+			o.SearchMode = indexer.SearchModeType(query.searchMode)
+		},
+	))
+	if err != nil {
+		ctx.ServerError("issueIDsFromSearch", err)
+		return
+	}
+	issues, err := issues_model.GetIssuesByIDs(ctx, issueIDs, true)
+	if err != nil {
+		ctx.ServerError("GetIssuesByIDs", err)
+		return
+	}
+
+	calendar, err := issue_service.BuildIssuesCalendar(ctx, issues, ctx.Locale.TrString("issues"))
+	if err != nil {
+		ctx.ServerError("BuildIssuesCalendar", err)
+		return
+	}
+
+	ctx.Resp.Header().Set("Content-Type", "text/calendar; charset=utf-8")
+	ctx.Resp.WriteHeader(http.StatusOK)
+	if _, err := ctx.Resp.Write(calendar); err != nil {
+		ctx.ServerError("WriteIssuesCalendar", err)
+	}
 }
 
 // ShowSSHKeys output all the ssh keys of user by uid

--- a/routers/web/user/home_test.go
+++ b/routers/web/user/home_test.go
@@ -4,9 +4,11 @@
 package user
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
+	issues_model "code.gitea.io/gitea/models/issues"
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unittest"
 	"code.gitea.io/gitea/modules/setting"
@@ -61,6 +63,28 @@ func TestIssues(t *testing.T) {
 
 	assert.EqualValues(t, true, ctx.Data["IsShowClosed"])
 	assert.Len(t, ctx.Data["Issues"], 1)
+}
+
+func TestIssuesICS(t *testing.T) {
+	assert.NoError(t, unittest.LoadFixtures())
+
+	ctx, resp := contexttest.MockContext(t, "issues.ics")
+	contexttest.LoadUser(t, ctx, 2)
+
+	IssuesICS(ctx)
+	assert.Equal(t, http.StatusOK, ctx.Resp.WrittenStatus())
+	assert.Contains(t, resp.Header().Get("Content-Type"), "text/calendar")
+
+	body := resp.Body.String()
+	assert.Contains(t, body, "BEGIN:VCALENDAR")
+
+	issue := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{ID: 10})
+	assert.NoError(t, issue.LoadRepo(ctx))
+
+	expectedDate := issue.DeadlineUnix.AsTime().Format("20060102")
+	assert.Contains(t, body, "DTSTART;VALUE=DATE:"+expectedDate)
+	assert.Contains(t, body, fmt.Sprintf("SUMMARY:%s (%s)", issue.Title, issue.Repo.FullName()))
+	assert.Contains(t, body, "URL:"+issue.HTMLURL(ctx))
 }
 
 func TestPulls(t *testing.T) {

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -543,6 +543,7 @@ func registerWebRoutes(m *web.Router, webAuth *AuthMiddleware) {
 		m.Get("", user.Issues)
 		m.Get("/search", repo.SearchIssues)
 	}, reqSignIn)
+	m.Get("/issues.ics", reqSignIn, user.IssuesICS)
 
 	m.Get("/pulls", reqSignIn, user.Pulls)
 	m.Get("/milestones", reqSignIn, reqMilestonesDashboardPageEnabled, user.Milestones)
@@ -944,6 +945,8 @@ func registerWebRoutes(m *web.Router, webAuth *AuthMiddleware) {
 			m.Get("/dashboard/-/heatmap", user.DashboardHeatmap)
 			m.Get("/dashboard/-/heatmap/{team}", user.DashboardHeatmap)
 			m.Get("/issues", user.Issues)
+			m.Get("/issues.ics", user.IssuesICS)
+			m.Get("/issues/{team}.ics", user.IssuesICS)
 			m.Get("/issues/{team}", user.Issues)
 			m.Get("/pulls", user.Pulls)
 			m.Get("/pulls/{team}", user.Pulls)

--- a/services/issue/calendar.go
+++ b/services/issue/calendar.go
@@ -1,0 +1,85 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package issue
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	issues_model "code.gitea.io/gitea/models/issues"
+	"code.gitea.io/gitea/modules/setting"
+)
+
+func buildIssuesCalendarUID(issueID int64) string {
+	host := setting.Domain
+	if host == "" {
+		if parsed, err := url.Parse(setting.AppURL); err == nil {
+			host = parsed.Host
+		}
+	}
+	if host == "" {
+		host = "localhost"
+	}
+	return fmt.Sprintf("issue-%d@%s", issueID, host)
+}
+
+func escapeCalendarText(value string) string {
+	replacer := strings.NewReplacer(
+		"\\", "\\\\",
+		";", "\\;",
+		",", "\\,",
+		"\r\n", "\\n",
+		"\n", "\\n",
+		"\r", "\\n",
+	)
+	return replacer.Replace(value)
+}
+
+// BuildIssuesCalendar creates an iCalendar payload for issues that have due dates.
+func BuildIssuesCalendar(ctx context.Context, issues issues_model.IssueList, calendarName string) ([]byte, error) {
+	var buf bytes.Buffer
+	now := time.Now().UTC()
+	writeLine := func(line string) {
+		buf.WriteString(line)
+		buf.WriteString("\r\n")
+	}
+
+	writeLine("BEGIN:VCALENDAR")
+	writeLine("VERSION:2.0")
+	writeLine("PRODID:-//Gitea//NONSGML Gitea//EN")
+	writeLine("CALSCALE:GREGORIAN")
+	if calendarName != "" {
+		writeLine("X-WR-CALNAME:" + escapeCalendarText(calendarName))
+	}
+
+	for _, issue := range issues {
+		if issue.DeadlineUnix.IsZero() {
+			continue
+		}
+		if err := issue.LoadRepo(ctx); err != nil {
+			return nil, err
+		}
+
+		issueURL := issue.HTMLURL(ctx)
+		summary := fmt.Sprintf("%s (%s)", issue.Title, issue.Repo.FullName())
+		description := "Find out more at " + issueURL
+
+		writeLine("BEGIN:VEVENT")
+		writeLine("DTSTAMP:" + now.Format("20060102T150405Z"))
+		writeLine("UID:" + buildIssuesCalendarUID(issue.ID))
+		writeLine("DTSTART;VALUE=DATE:" + issue.DeadlineUnix.AsTime().Format("20060102"))
+		writeLine("SUMMARY:" + escapeCalendarText(summary))
+		writeLine("DESCRIPTION:" + escapeCalendarText(description))
+		writeLine("TRANSP:TRANSPARENT")
+		writeLine("URL:" + escapeCalendarText(issueURL))
+		writeLine("END:VEVENT")
+	}
+
+	writeLine("END:VCALENDAR")
+	return buf.Bytes(), nil
+}

--- a/templates/user/dashboard/issues.tmpl
+++ b/templates/user/dashboard/issues.tmpl
@@ -37,6 +37,7 @@
 			</div>
 
 			{{$queryLinkWithFilter := QueryBuild $queryLink "poster" $.FilterPosterUsername "assignee" $.FilterAssigneeUsername}}
+			{{$calendarLink := QueryBuild $.IssueCalendarURL "type" $.ViewType "sort" $.SortType "state" $.State "q" $.Keyword "labels" .SelectLabels "search_mode" $.SelectedSearchMode "poster" $.FilterPosterUsername "assignee" $.FilterAssigneeUsername}}
 			<div class="flex-container-main content">
 				<div class="list-header">
 					<div class="small-menu-items ui compact tiny menu list-header-toggle flex-items-block">
@@ -65,6 +66,12 @@
 					<div class="list-header-filters ui secondary menu tw-m-0">
 						{{if $.Labels}}
 							{{template "repo/issue/filter_item_label" dict "Labels" .Labels "QueryLink" $queryLinkWithFilter "SupportArchivedLabel" true}}
+						{{end}}
+
+						{{if $.IssueCalendarURL}}
+							<a class="item" href="{{$calendarLink}}" data-tooltip-content="{{ctx.Locale.Tr "issues.calendar"}}">
+								{{svg "octicon-calendar" 14}}
+							</a>
 						{{end}}
 
 						{{/* at the moment there is no easy way to get poster candidates on this page, so only show a username input, search for what the end user enters */}}


### PR DESCRIPTION
Resolve #13659 

- add an iCalendar generator for issues with due dates
- expose /issues.ics (including org/team dashboards) and a calendar link in the issues dashboard
- reuse dashboard query filters to keep ICS results consistent with the UI
- add a web test covering ICS output content

---
Generated by a coding agent with Codex