### PR TITLE
Fix button layout shift when collapsing file tree in editor

### DIFF
--- a/web_src/css/modules/breadcrumb.css
+++ b/web_src/css/modules/breadcrumb.css
@@ -1,6 +1,7 @@
 .breadcrumb {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 3px;
   overflow-wrap: anywhere;
 }

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -200,6 +200,7 @@ td .commit-summary {
 
 .repo-editor-header {
   display: flex;
+  /* margin-top and align-items must match .repo-button-row so the file tree toggle button sits at the same y position in both states */
   margin: 8px 0 1rem;
   width: 100%;
   gap: 0.5em;

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -206,10 +206,6 @@ td .commit-summary {
   width: 100%;
 }
 
-.repo-editor-header .breadcrumb {
-  flex-wrap: wrap;
-}
-
 .repo-editor-header input {
   vertical-align: middle !important;
   width: auto !important;

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -199,11 +199,12 @@ td .commit-summary {
 }
 
 .repo-editor-header {
+  margin: 8px 0;
   display: flex;
-  margin: 8px 0 1rem; /* match .repo-button-row so the tree toggle button stays put */
-  width: 100%;
-  gap: 0.5em;
   align-items: flex-start;
+  gap: 8px;
+  flex-wrap: wrap;
+  width: 100%;
 }
 
 .repo-editor-header input {

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -200,8 +200,7 @@ td .commit-summary {
 
 .repo-editor-header {
   display: flex;
-  margin: 1rem 0;
-  padding: 3px 0;
+  margin: 5px 0 1rem;
   width: 100%;
   gap: 0.5em;
   align-items: center;

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -201,7 +201,7 @@ td .commit-summary {
 .repo-editor-header {
   margin: 8px 0;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 8px;
   flex-wrap: wrap;
   width: 100%;
@@ -210,7 +210,8 @@ td .commit-summary {
 .repo-editor-header input {
   vertical-align: middle !important;
   width: auto !important;
-  padding: 7px 8px !important;
+  height: 30px !important;
+  padding: 5px 8px !important;
   margin-right: 5px !important;
 }
 

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -200,8 +200,7 @@ td .commit-summary {
 
 .repo-editor-header {
   display: flex;
-  /* margin-top and align-items must match .repo-button-row so the file tree toggle button sits at the same y position in both states */
-  margin: 8px 0 1rem;
+  margin: 8px 0 1rem; /* match .repo-button-row so the tree toggle button stays put */
   width: 100%;
   gap: 0.5em;
   align-items: flex-start;

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -199,6 +199,7 @@ td .commit-summary {
 }
 
 .repo-editor-header {
+  /* it should match ".repo-button-row" so the tree toggle button stays aligned */
   margin: 8px 0;
   display: flex;
   align-items: center;

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -200,10 +200,10 @@ td .commit-summary {
 
 .repo-editor-header {
   display: flex;
-  margin: 5px 0 1rem;
+  margin: 8px 0 1rem;
   width: 100%;
   gap: 0.5em;
-  align-items: center;
+  align-items: flex-start;
 }
 
 .repo-editor-header input {

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -203,8 +203,11 @@ td .commit-summary {
   display: flex;
   align-items: center;
   gap: 8px;
-  flex-wrap: wrap;
   width: 100%;
+}
+
+.repo-editor-header .breadcrumb {
+  flex-wrap: wrap;
 }
 
 .repo-editor-header input {


### PR DESCRIPTION
---
old:

https://github.com/user-attachments/assets/136a9ce8-f229-4583-bf19-75258d085513

new:

https://github.com/user-attachments/assets/21b7c885-00f4-4295-9191-07b66ca58b64

