### PR TITLE
chore: upgrade Go version in devcontainer image to 1.26

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Gitea DevContainer",
-  "image": "mcr.microsoft.com/devcontainers/go:1.25-trixie",
+  "image": "mcr.microsoft.com/devcontainers/go:1.26-trixie",
   "containerEnv": {
     // override "local" from packaged version
     "GOTOOLCHAIN": "auto"


### PR DESCRIPTION
Upgrade the base devcontainer image to prevent the in-container toolchain upgrade from breaking `make build`.

Solves #37373
