### PR TITLE
CI: drop -coverprofile from unit-tests to enable Go test result cache

### DIFF
--- a/.github/workflows/pull-db-tests.yml
+++ b/.github/workflows/pull-db-tests.yml
@@ -142,16 +142,18 @@ jobs:
         env:
           TAGS: bindata
       - name: unit-tests
-        run: make unit-test-coverage test-check
+        run: make test-backend test-check
         env:
           TAGS: bindata
           RACE_ENABLED: true
+          GOTESTFLAGS: -timeout=20m
           GITHUB_READ_TOKEN: ${{ secrets.GITHUB_READ_TOKEN }}
       - name: unit-tests-gogit
-        run: GOEXPERIMENT='' make unit-test-coverage test-check
+        run: GOEXPERIMENT='' make test-backend test-check
         env:
           TAGS: bindata gogit
           RACE_ENABLED: true
+          GOTESTFLAGS: -timeout=20m
           GITHUB_READ_TOKEN: ${{ secrets.GITHUB_READ_TOKEN }}
 
   test-mysql:


### PR DESCRIPTION
The `test-unit` job invokes `make unit-test-coverage`, which passes `-coverprofile` to `go test`. That flag is **not** in Go's cacheable-flags allowlist ([docs](https://pkg.go.dev/cmd/go#hdr-Testing_flags)), so it silently disables the test result cache for every unit-test package on every run.

**`coverage.out` is unused.** I verified:
- The only consumer is `make coverage` (Makefile:405–409), which merges it into `coverage.all`.
- `make coverage` is never called by any workflow, shell script, or CI config in the repo.
- `coverage.all` is never uploaded or consumed anywhere.
- No codecov/coveralls integration exists (only two archived CHANGELOG mentions from years ago).
- The comment already present in `test-mysql` at line 202 — `# run: make integration-test-coverage (at the moment, no coverage is really handled)` — confirms coverage has been knowingly dead for some time; this PR applies the same cleanup to `test-unit`.

Switch to `make test-backend`, preserving the 20m timeout via `GOTESTFLAGS`. On warm runs with an intact build cache, unchanged unit-test packages are now skipped entirely rather than re-executed.

### Dependency

The practical benefit requires the build cache to persist across runs. On current `main` the cache is ineffective (see #37387, which fixes the cache key collision). Landing this PR on its own gives no real speedup; landing it after #37387 unlocks genuine test-result caching for unit tests.

---
This PR was written with the help of Claude Opus 4.7