### PR TITLE
Fix label key in locale_en-US.json

### DIFF
--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -1402,7 +1402,7 @@
   "repo.issues.new": "New Issue",
   "repo.issues.new.title_empty": "Title cannot be empty",
   "repo.issues.new.labels": "Labels",
-  "repo.issues.new.no_labels": "No labels",
+  "repo.issues.new.no_label": "No labels",
   "repo.issues.new.clear_labels": "Clear labels",
   "repo.issues.new.projects": "Projects",
   "repo.issues.new.clear_projects": "Clear projects",


### PR DESCRIPTION
The english locale has the wrong key for the no_label text. it should be singular. The other locales are correct. Currently this is what displays instead of No labels: 

<img width="329" height="93" alt="image" src="https://github.com/user-attachments/assets/70f34eaa-22ce-426e-b229-89e4bf280220" />

This PR simply corrects the key to repo.issues.new.no_label