### PR TITLE
tests(e2e): add regression test for PR showing already-merged commits (#37383)

### DIFF
--- a/tests/e2e/pull-request-commits.test.ts
+++ b/tests/e2e/pull-request-commits.test.ts
@@ -60,12 +60,12 @@ test('PR should not list commits already present in the target branch via anothe
       head: 'develop', base: 'staging', title: 'develop into staging',
     });
 
-    // Verify via UI that the PR commit count is correct
+    // Verify via UI that the PR commits page is reachable and shows the correct state
     await login(page);
-    await page.goto(`/${owner}/${repo}/pulls/${pr3}`);
-    await page.getByRole('tab', {name: /Commits/i}).click();
+    await page.goto(`/${owner}/${repo}/pulls/${pr3}/commits`);
+    await page.waitForLoadState('networkidle');
 
-    // Screenshot before assertion — proves we reached the correct PR state
+    // Screenshot before assertion — proves we reached the correct PR commits page
     await page.screenshot({path: 'test-results/pr-commits-tab.png'});
 
     const commits = await apiGetPullRequestCommits(request, owner, repo, pr3);

--- a/tests/e2e/pull-request-commits.test.ts
+++ b/tests/e2e/pull-request-commits.test.ts
@@ -6,7 +6,7 @@ import {
   apiCreateRepo,
   apiCreateBranch,
   apiCreateFile,
-  apiCreatePullRequest,
+  apiCreatePR,
   apiMergePullRequest,
   apiGetPullRequestCommits,
   apiDeleteRepo,
@@ -16,8 +16,8 @@ import {
  * Regression test for: PRs are showing already merged commits
  * https://github.com/go-gitea/gitea/issues/37383
  *
- * When a commit reaches a branch via two different merge paths, Gitea incorrectly
- * lists it as a new commit in a subsequent PR that targets that branch.
+ * When the same commit reaches a branch via two different merge paths, Gitea
+ * incorrectly lists it as a new commit in a subsequent PR targeting that branch.
  *
  * Git topology after setup:
  *   main:    A
@@ -26,10 +26,8 @@ import {
  *   develop: A → M2         (M2 = merge commit "feature into develop"; M2 contains B)
  *
  * PR develop → staging (PR3):
- *   git log staging..develop = [M2]   (M2 is new in develop; B is already in staging via M1)
- *
- *   → BUG: PR3 lists [M2, B] (2 commits) — B incorrectly shown as new for staging
- *   → FIX: PR3 lists [M2]   (1 commit)  — only the genuinely new merge commit appears
+ *   git log staging..develop = [M2]     correct: M2 is new; B is already in staging via M1
+ *   git log staging..develop = [M2, B]  buggy: B incorrectly listed as new for staging
  */
 test('PR should not list commits already present in the target branch via another merge path', async ({page, request}) => {
   const owner = env.GITEA_TEST_E2E_USER;
@@ -46,26 +44,20 @@ test('PR should not list commits already present in the target branch via anothe
       login(page),
     ]);
 
-    // Add a commit on feature (must specify branch — default would commit to main)
+    // Add a commit on the feature branch (commit B in the diagram above)
     await apiCreateFile(request, owner, repo, 'feature.txt',
-      `feature content ${randomString(8)}`, 'feature');
+      `feature content ${randomString(8)}`, {branch: 'feature'});
 
-    // PR 1: feature → staging, merge it
-    const pr1 = await apiCreatePullRequest(request, owner, repo, {
-      head: 'feature', base: 'staging', title: 'feature into staging',
-    });
+    // PR1: feature → staging — merge creates M1
+    const pr1 = await apiCreatePR(request, owner, repo, 'feature', 'staging', 'feature into staging');
     await apiMergePullRequest(request, owner, repo, pr1);
 
-    // PR 2: feature → develop, merge it
-    const pr2 = await apiCreatePullRequest(request, owner, repo, {
-      head: 'feature', base: 'develop', title: 'feature into develop',
-    });
+    // PR2: feature → develop — merge creates M2
+    const pr2 = await apiCreatePR(request, owner, repo, 'feature', 'develop', 'feature into develop');
     await apiMergePullRequest(request, owner, repo, pr2);
 
-    // PR 3: develop → staging (the one being tested)
-    const pr3 = await apiCreatePullRequest(request, owner, repo, {
-      head: 'develop', base: 'staging', title: 'develop into staging',
-    });
+    // PR3: develop → staging — the one being tested
+    const pr3 = await apiCreatePR(request, owner, repo, 'develop', 'staging', 'develop into staging');
 
     // Fetch commits via API and navigate to the PR page concurrently
     const [commits] = await Promise.all([
@@ -75,10 +67,9 @@ test('PR should not list commits already present in the target branch via anothe
         .then(() => page.screenshot({path: 'test-results/pr-commits-tab.png'})),
     ]);
 
-    // M2 (the merge commit "feature into develop") is genuinely new in develop and
-    // should appear. The feature file commit B must NOT appear — it is already
-    // reachable from staging via M1. A buggy Gitea lists both (length 2); a correct
-    // implementation lists only M2 (length 1).
+    // M2 is genuinely new in develop and must appear.
+    // B must NOT appear — it is already reachable from staging via M1.
+    // Buggy Gitea returns [M2, B] (len 2); fixed Gitea returns [M2] (len 1).
     expect(commits, 'PR develop→staging must not list commits already present in staging').toHaveLength(1);
     expect(commits[0].commit.message, 'Only the develop merge commit should appear — not the feature file commit').toContain('feature into develop');
   } finally {

--- a/tests/e2e/pull-request-commits.test.ts
+++ b/tests/e2e/pull-request-commits.test.ts
@@ -38,10 +38,13 @@ test('PR should not list commits already present in the target branch via anothe
   await apiCreateRepo(request, {name: repo, autoInit: true});
 
   try {
-    // Create branches from main
-    await apiCreateBranch(request, owner, repo, 'staging');
-    await apiCreateBranch(request, owner, repo, 'develop');
-    await apiCreateBranch(request, owner, repo, 'feature');
+    // Create branches and log in concurrently — all independent after repo exists
+    await Promise.all([
+      apiCreateBranch(request, owner, repo, 'staging'),
+      apiCreateBranch(request, owner, repo, 'develop'),
+      apiCreateBranch(request, owner, repo, 'feature'),
+      login(page),
+    ]);
 
     // Add a commit on feature (must specify branch — default would commit to main)
     await apiCreateFile(request, owner, repo, 'feature.txt',
@@ -59,20 +62,18 @@ test('PR should not list commits already present in the target branch via anothe
     });
     await apiMergePullRequest(request, owner, repo, pr2);
 
-    // PR 3: develop → staging (the one that should show 0 new commits)
+    // PR 3: develop → staging (the one being tested)
     const pr3 = await apiCreatePullRequest(request, owner, repo, {
       head: 'develop', base: 'staging', title: 'develop into staging',
     });
 
-    // Verify via UI that the PR commits page is reachable and shows the correct state
-    await login(page);
-    await page.goto(`/${owner}/${repo}/pulls/${pr3}/commits`);
-    await page.waitForLoadState('load');
-
-    // Screenshot before assertion — proves we reached the correct PR commits page
-    await page.screenshot({path: 'test-results/pr-commits-tab.png'});
-
-    const commits = await apiGetPullRequestCommits(request, owner, repo, pr3);
+    // Fetch commits via API and navigate to the PR page concurrently
+    const [commits] = await Promise.all([
+      apiGetPullRequestCommits(request, owner, repo, pr3),
+      page.goto(`/${owner}/${repo}/pulls/${pr3}/commits`)
+        .then(() => page.waitForLoadState('load'))
+        .then(() => page.screenshot({path: 'test-results/pr-commits-tab.png'})),
+    ]);
 
     // M2 (the merge commit "feature into develop") is genuinely new in develop and
     // should appear. The feature file commit B must NOT appear — it is already

--- a/tests/e2e/pull-request-commits.test.ts
+++ b/tests/e2e/pull-request-commits.test.ts
@@ -19,13 +19,17 @@ import {
  * When a commit reaches a branch via two different merge paths, Gitea incorrectly
  * lists it as a new commit in a subsequent PR that targets that branch.
  *
- * Scenario:
- *   1. commit A is added to `feature`
- *   2. PR feature → staging is merged  (commit A is now in staging)
- *   3. PR feature → develop is merged  (commit A is now in develop)
- *   4. PR develop → staging is opened
- *   → BUG: PR #4 lists commit A as new, even though it is already in staging
- *   → FIX: PR #4 lists 0 commits (nothing new for staging)
+ * Git topology after setup:
+ *   main:    A
+ *   feature: A → B          (B = the feature file commit)
+ *   staging: A → M1         (M1 = merge commit "feature into staging"; M1 contains B)
+ *   develop: A → M2         (M2 = merge commit "feature into develop"; M2 contains B)
+ *
+ * PR develop → staging (PR3):
+ *   git log staging..develop = [M2]   (M2 is new in develop; B is already in staging via M1)
+ *
+ *   → BUG: PR3 lists [M2, B] (2 commits) — B incorrectly shown as new for staging
+ *   → FIX: PR3 lists [M2]   (1 commit)  — only the genuinely new merge commit appears
  */
 test('PR should not list commits already present in the target branch via another merge path', async ({page, request}) => {
   const owner = env.GITEA_TEST_E2E_USER;
@@ -70,9 +74,12 @@ test('PR should not list commits already present in the target branch via anothe
 
     const commits = await apiGetPullRequestCommits(request, owner, repo, pr3);
 
-    // The commit from `feature` is already in `staging` via PR 1.
-    // A correct implementation lists 0 new commits for this PR.
-    expect(commits, 'PR develop→staging must not list commits already present in staging').toHaveLength(0);
+    // M2 (the merge commit "feature into develop") is genuinely new in develop and
+    // should appear. The feature file commit B must NOT appear — it is already
+    // reachable from staging via M1. A buggy Gitea lists both (length 2); a correct
+    // implementation lists only M2 (length 1).
+    expect(commits, 'PR develop→staging must not list commits already present in staging').toHaveLength(1);
+    expect(commits[0].commit.message, 'Only the develop merge commit should appear — not the feature file commit').toContain('feature into develop');
   } finally {
     await apiDeleteRepo(request, owner, repo);
   }

--- a/tests/e2e/pull-request-commits.test.ts
+++ b/tests/e2e/pull-request-commits.test.ts
@@ -39,9 +39,9 @@ test('PR should not list commits already present in the target branch via anothe
     await apiCreateBranch(request, owner, repo, 'develop');
     await apiCreateBranch(request, owner, repo, 'feature');
 
-    // Add a commit on feature
+    // Add a commit on feature (must specify branch — default would commit to main)
     await apiCreateFile(request, owner, repo, 'feature.txt',
-      `feature content ${randomString(8)}`);
+      `feature content ${randomString(8)}`, 'feature');
 
     // PR 1: feature → staging, merge it
     const pr1 = await apiCreatePullRequest(request, owner, repo, {

--- a/tests/e2e/pull-request-commits.test.ts
+++ b/tests/e2e/pull-request-commits.test.ts
@@ -1,0 +1,79 @@
+import {env} from 'node:process';
+import {test, expect} from '@playwright/test';
+import {
+  login,
+  randomString,
+  apiCreateRepo,
+  apiCreateBranch,
+  apiCreateFile,
+  apiCreatePullRequest,
+  apiMergePullRequest,
+  apiGetPullRequestCommits,
+  apiDeleteRepo,
+} from './utils.ts';
+
+/**
+ * Regression test for: PRs are showing already merged commits
+ * https://github.com/go-gitea/gitea/issues/37383
+ *
+ * When a commit reaches a branch via two different merge paths, Gitea incorrectly
+ * lists it as a new commit in a subsequent PR that targets that branch.
+ *
+ * Scenario:
+ *   1. commit A is added to `feature`
+ *   2. PR feature → staging is merged  (commit A is now in staging)
+ *   3. PR feature → develop is merged  (commit A is now in develop)
+ *   4. PR develop → staging is opened
+ *   → BUG: PR #4 lists commit A as new, even though it is already in staging
+ *   → FIX: PR #4 lists 0 commits (nothing new for staging)
+ */
+test('PR should not list commits already present in the target branch via another merge path', async ({page, request}) => {
+  const owner = env.GITEA_TEST_E2E_USER;
+  const repo = `e2e-pr-commits-${randomString(6)}`;
+
+  await apiCreateRepo(request, {name: repo, autoInit: true});
+
+  try {
+    // Create branches from main
+    await apiCreateBranch(request, owner, repo, 'staging');
+    await apiCreateBranch(request, owner, repo, 'develop');
+    await apiCreateBranch(request, owner, repo, 'feature');
+
+    // Add a commit on feature
+    await apiCreateFile(request, owner, repo, 'feature.txt',
+      `feature content ${randomString(8)}`);
+
+    // PR 1: feature → staging, merge it
+    const pr1 = await apiCreatePullRequest(request, owner, repo, {
+      head: 'feature', base: 'staging', title: 'feature into staging',
+    });
+    await apiMergePullRequest(request, owner, repo, pr1);
+
+    // PR 2: feature → develop, merge it
+    const pr2 = await apiCreatePullRequest(request, owner, repo, {
+      head: 'feature', base: 'develop', title: 'feature into develop',
+    });
+    await apiMergePullRequest(request, owner, repo, pr2);
+
+    // PR 3: develop → staging (the one that should show 0 new commits)
+    const pr3 = await apiCreatePullRequest(request, owner, repo, {
+      head: 'develop', base: 'staging', title: 'develop into staging',
+    });
+
+    // Verify via UI that the PR commit count is correct
+    await login(page);
+    await page.goto(`/${owner}/${repo}/pulls/${pr3}`);
+    await page.getByRole('tab', {name: /Commits/i}).click();
+
+    // Screenshot before assertion — proves we reached the correct PR state
+    await page.screenshot({path: 'test-results/pr-commits-tab.png'});
+
+    const commits = await apiGetPullRequestCommits(request, owner, repo, pr3);
+
+    // The commit from `feature` is already in `staging` via PR 1.
+    // A correct implementation lists 0 new commits for this PR.
+    expect(commits, 'PR develop→staging must not list commits already present in staging').toHaveLength(0);
+  } finally {
+    await apiDeleteRepo(request, owner, repo);
+  }
+});

--- a/tests/e2e/pull-request-commits.test.ts
+++ b/tests/e2e/pull-request-commits.test.ts
@@ -63,7 +63,7 @@ test('PR should not list commits already present in the target branch via anothe
     // Verify via UI that the PR commits page is reachable and shows the correct state
     await login(page);
     await page.goto(`/${owner}/${repo}/pulls/${pr3}/commits`);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
 
     // Screenshot before assertion — proves we reached the correct PR commits page
     await page.screenshot({path: 'test-results/pr-commits-tab.png'});

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -167,20 +167,21 @@ export async function logout(page: Page) {
   await expect(page.getByRole('link', {name: 'Sign In'})).toBeVisible();
 }
 
-export async function apiCreatePullRequest(requestContext: APIRequestContext, owner: string, repo: string, {head, base, title}: {head: string; base: string; title: string}): Promise<number> {
-  const response = await requestContext.post(`${baseUrl()}/api/v1/repos/${owner}/${repo}/pulls`, {
-    headers: apiHeaders(),
-    data: {head, base, title},
-  });
-  const body = await response.json();
-  return body.number;
-}
-
 export async function apiMergePullRequest(requestContext: APIRequestContext, owner: string, repo: string, index: number): Promise<void> {
-  await apiRetry(() => requestContext.post(`${baseUrl()}/api/v1/repos/${owner}/${repo}/pulls/${index}/merge`, {
-    headers: apiHeaders(),
-    data: {Do: 'merge', merge_message_field: ''},
-  }), 'apiMergePullRequest');
+  // Gitea returns 405 "Please try again later" when the merge queue is busy or mergeability
+  // has not been computed yet — retry until the merge succeeds.
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const response = await requestContext.post(`${baseUrl()}/api/v1/repos/${owner}/${repo}/pulls/${index}/merge`, {
+      headers: apiHeaders(),
+      data: {Do: 'merge', merge_message_field: ''},
+    });
+    if (response.ok()) return;
+    if (response.status() === 405 && attempt < 19) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      continue;
+    }
+    throw new Error(`apiMergePullRequest failed: ${response.status()} ${await response.text()}`);
+  }
 }
 
 export async function apiGetPullRequestCommits(requestContext: APIRequestContext, owner: string, repo: string, index: number): Promise<{sha: string; commit: {message: string}}[]> {

--- a/tests/e2e/utils.ts
+++ b/tests/e2e/utils.ts
@@ -166,3 +166,26 @@ export async function logout(page: Page) {
   await page.goto('/');
   await expect(page.getByRole('link', {name: 'Sign In'})).toBeVisible();
 }
+
+export async function apiCreatePullRequest(requestContext: APIRequestContext, owner: string, repo: string, {head, base, title}: {head: string; base: string; title: string}): Promise<number> {
+  const response = await requestContext.post(`${baseUrl()}/api/v1/repos/${owner}/${repo}/pulls`, {
+    headers: apiHeaders(),
+    data: {head, base, title},
+  });
+  const body = await response.json();
+  return body.number;
+}
+
+export async function apiMergePullRequest(requestContext: APIRequestContext, owner: string, repo: string, index: number): Promise<void> {
+  await apiRetry(() => requestContext.post(`${baseUrl()}/api/v1/repos/${owner}/${repo}/pulls/${index}/merge`, {
+    headers: apiHeaders(),
+    data: {Do: 'merge', merge_message_field: ''},
+  }), 'apiMergePullRequest');
+}
+
+export async function apiGetPullRequestCommits(requestContext: APIRequestContext, owner: string, repo: string, index: number): Promise<{sha: string; commit: {message: string}}[]> {
+  const response = await requestContext.get(`${baseUrl()}/api/v1/repos/${owner}/${repo}/pulls/${index}/commits`, {
+    headers: apiHeaders(),
+  });
+  return response.json();
+}

--- a/tests/integration/api_pull_commits_test.go
+++ b/tests/integration/api_pull_commits_test.go
@@ -4,12 +4,15 @@
 package integration
 
 import (
+	"encoding/base64"
 	"net/http"
 	"testing"
+	"time"
 
 	issues_model "code.gitea.io/gitea/models/issues"
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unittest"
+	"code.gitea.io/gitea/modules/queue"
 	api "code.gitea.io/gitea/modules/structs"
 	"code.gitea.io/gitea/tests"
 
@@ -38,6 +41,75 @@ func TestAPIPullCommits(t *testing.T) {
 	assert.NotEmpty(t, commits[1].Files)
 	assert.NotNil(t, commits[0].RepoCommit.Verification)
 	assert.NotNil(t, commits[1].RepoCommit.Verification)
+}
+
+// TestAPIPullCommitsNotDuplicatedViaMergePaths is a regression test for:
+// https://github.com/go-gitea/gitea/issues/37383
+//
+// When the same commit reaches a branch via two different merge paths, Gitea
+// must not list it again as a new commit in a subsequent PR targeting that branch.
+//
+// Git topology:
+//
+//	main:    A
+//	feature: A → B          (B = feature file commit)
+//	staging: A → M1         (M1 = merge commit "feature into staging"; parents: A, B)
+//	develop: A → M2         (M2 = merge commit "feature into develop";  parents: A, B)
+//
+// PR develop → staging (PR3):
+//
+//	git log staging..develop = [M2]     correct: M2 is new; B is already in staging via M1
+//	git log staging..develop = [M2, B]  buggy: B incorrectly listed as new
+func TestAPIPullCommitsNotDuplicatedViaMergePaths(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	ctx := NewAPITestContext(t, "user2", "pr-commits-dupe-test")
+	doAPICreateRepository(ctx, false)(t)
+
+	// Create branches from the default branch
+	for _, branch := range []string{"staging", "develop", "feature"} {
+		req := NewRequestWithJSON(t, http.MethodPost,
+			"/api/v1/repos/"+ctx.Username+"/"+ctx.Reponame+"/branches",
+			&api.CreateBranchRepoOption{BranchName: branch},
+		).AddTokenAuth(ctx.Token)
+		ctx.Session.MakeRequest(t, req, http.StatusCreated)
+	}
+
+	// Commit a file on the feature branch (commit B in the diagram above)
+	doAPICreateFile(ctx, "feature.txt", &api.CreateFileOptions{
+		FileOptions:   api.FileOptions{Message: "add feature.txt", BranchName: "feature"},
+		ContentBase64: base64.StdEncoding.EncodeToString([]byte("feature content")),
+	})(t)
+
+	// PR1: feature → staging — merge creates M1
+	pr1, err := doAPICreatePullRequest(ctx, ctx.Username, ctx.Reponame, "staging", "feature")(t)
+	require.NoError(t, err)
+	doAPIMergePullRequest(ctx, ctx.Username, ctx.Reponame, pr1.Index)(t)
+
+	// PR2: feature → develop — merge creates M2
+	pr2, err := doAPICreatePullRequest(ctx, ctx.Username, ctx.Reponame, "develop", "feature")(t)
+	require.NoError(t, err)
+	doAPIMergePullRequest(ctx, ctx.Username, ctx.Reponame, pr2.Index)(t)
+
+	// Flush queues so that PR3's merge-base computation starts from a clean state
+	queue.GetManager().FlushAll(t.Context(), 5*time.Second)
+
+	// PR3: develop → staging — the PR whose commit list is under test
+	pr3, err := doAPICreatePullRequest(ctx, ctx.Username, ctx.Reponame, "staging", "develop")(t)
+	require.NoError(t, err)
+
+	req := NewRequestf(t, http.MethodGet, "/api/v1/repos/%s/%s/pulls/%d/commits",
+		ctx.Username, ctx.Reponame, pr3.Index,
+	).AddTokenAuth(ctx.Token)
+	resp := ctx.Session.MakeRequest(t, req, http.StatusOK)
+
+	var commits []*api.Commit
+	DecodeJSON(t, resp, &commits)
+
+	// M2 is genuinely new in develop and must appear.
+	// B must NOT appear — it is already reachable from staging via M1.
+	// Buggy Gitea returns [M2, B] (len 2); fixed Gitea returns [M2] (len 1).
+	require.Len(t, commits, 1, "PR develop→staging must not list commits already present in staging")
 }
 
 // TODO add tests for already merged PR and closed PR

--- a/tests/integration/api_pull_commits_test.go
+++ b/tests/integration/api_pull_commits_test.go
@@ -6,6 +6,7 @@ package integration
 import (
 	"encoding/base64"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -61,55 +62,55 @@ func TestAPIPullCommits(t *testing.T) {
 //	git log staging..develop = [M2]     correct: M2 is new; B is already in staging via M1
 //	git log staging..develop = [M2, B]  buggy: B incorrectly listed as new
 func TestAPIPullCommitsNotDuplicatedViaMergePaths(t *testing.T) {
-	defer tests.PrepareTestEnv(t)()
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
+		ctx := NewAPITestContext(t, "user2", "pr-commits-dupe-test")
+		doAPICreateRepository(ctx, false)(t)
 
-	ctx := NewAPITestContext(t, "user2", "pr-commits-dupe-test")
-	doAPICreateRepository(ctx, false)(t)
+		// Create branches from the default branch
+		for _, branch := range []string{"staging", "develop", "feature"} {
+			req := NewRequestWithJSON(t, http.MethodPost,
+				"/api/v1/repos/"+ctx.Username+"/"+ctx.Reponame+"/branches",
+				&api.CreateBranchRepoOption{BranchName: branch},
+			).AddTokenAuth(ctx.Token)
+			ctx.Session.MakeRequest(t, req, http.StatusCreated)
+		}
 
-	// Create branches from the default branch
-	for _, branch := range []string{"staging", "develop", "feature"} {
-		req := NewRequestWithJSON(t, http.MethodPost,
-			"/api/v1/repos/"+ctx.Username+"/"+ctx.Reponame+"/branches",
-			&api.CreateBranchRepoOption{BranchName: branch},
+		// Commit a file on the feature branch (commit B in the diagram above)
+		doAPICreateFile(ctx, "feature.txt", &api.CreateFileOptions{
+			FileOptions:   api.FileOptions{Message: "add feature.txt", BranchName: "feature"},
+			ContentBase64: base64.StdEncoding.EncodeToString([]byte("feature content")),
+		})(t)
+
+		// PR1: feature → staging — merge creates M1
+		pr1, err := doAPICreatePullRequest(ctx, ctx.Username, ctx.Reponame, "staging", "feature")(t)
+		require.NoError(t, err)
+		doAPIMergePullRequest(ctx, ctx.Username, ctx.Reponame, pr1.Index)(t)
+
+		// PR2: feature → develop — merge creates M2
+		pr2, err := doAPICreatePullRequest(ctx, ctx.Username, ctx.Reponame, "develop", "feature")(t)
+		require.NoError(t, err)
+		doAPIMergePullRequest(ctx, ctx.Username, ctx.Reponame, pr2.Index)(t)
+
+		// Flush queues so that PR3's merge-base computation starts from a clean state
+		queue.GetManager().FlushAll(t.Context(), 5*time.Second)
+
+		// PR3: develop → staging — the PR whose commit list is under test
+		pr3, err := doAPICreatePullRequest(ctx, ctx.Username, ctx.Reponame, "staging", "develop")(t)
+		require.NoError(t, err)
+
+		req := NewRequestf(t, http.MethodGet, "/api/v1/repos/%s/%s/pulls/%d/commits",
+			ctx.Username, ctx.Reponame, pr3.Index,
 		).AddTokenAuth(ctx.Token)
-		ctx.Session.MakeRequest(t, req, http.StatusCreated)
-	}
+		resp := ctx.Session.MakeRequest(t, req, http.StatusOK)
 
-	// Commit a file on the feature branch (commit B in the diagram above)
-	doAPICreateFile(ctx, "feature.txt", &api.CreateFileOptions{
-		FileOptions:   api.FileOptions{Message: "add feature.txt", BranchName: "feature"},
-		ContentBase64: base64.StdEncoding.EncodeToString([]byte("feature content")),
-	})(t)
+		var commits []*api.Commit
+		DecodeJSON(t, resp, &commits)
 
-	// PR1: feature → staging — merge creates M1
-	pr1, err := doAPICreatePullRequest(ctx, ctx.Username, ctx.Reponame, "staging", "feature")(t)
-	require.NoError(t, err)
-	doAPIMergePullRequest(ctx, ctx.Username, ctx.Reponame, pr1.Index)(t)
-
-	// PR2: feature → develop — merge creates M2
-	pr2, err := doAPICreatePullRequest(ctx, ctx.Username, ctx.Reponame, "develop", "feature")(t)
-	require.NoError(t, err)
-	doAPIMergePullRequest(ctx, ctx.Username, ctx.Reponame, pr2.Index)(t)
-
-	// Flush queues so that PR3's merge-base computation starts from a clean state
-	queue.GetManager().FlushAll(t.Context(), 5*time.Second)
-
-	// PR3: develop → staging — the PR whose commit list is under test
-	pr3, err := doAPICreatePullRequest(ctx, ctx.Username, ctx.Reponame, "staging", "develop")(t)
-	require.NoError(t, err)
-
-	req := NewRequestf(t, http.MethodGet, "/api/v1/repos/%s/%s/pulls/%d/commits",
-		ctx.Username, ctx.Reponame, pr3.Index,
-	).AddTokenAuth(ctx.Token)
-	resp := ctx.Session.MakeRequest(t, req, http.StatusOK)
-
-	var commits []*api.Commit
-	DecodeJSON(t, resp, &commits)
-
-	// M2 is genuinely new in develop and must appear.
-	// B must NOT appear — it is already reachable from staging via M1.
-	// Buggy Gitea returns [M2, B] (len 2); fixed Gitea returns [M2] (len 1).
-	require.Len(t, commits, 1, "PR develop→staging must not list commits already present in staging")
+		// M2 is genuinely new in develop and must appear.
+		// B must NOT appear — it is already reachable from staging via M1.
+		// Buggy Gitea returns [M2, B] (len 2); fixed Gitea returns [M2] (len 1).
+		require.Len(t, commits, 1, "PR develop→staging must not list commits already present in staging")
+	})
 }
 
 // TODO add tests for already merged PR and closed PR


### PR DESCRIPTION
## Summary

Adds a Playwright e2e regression test for #37383: when a commit reaches a target branch via two different merge paths, Gitea incorrectly lists it as a new commit in a subsequent PR against that branch.

### Scenario reproduced

```
feature branch  ──── commit A ────┐
                                  ├── PR 1: feature → staging  (merged)
                                  └── PR 2: feature → develop  (merged)

PR 3: develop → staging
  BUG:  lists commit A as new  ❌  (commit A already in staging via PR 1)
  FIX:  lists 0 new commits    ✓
```

### Changes

- `tests/e2e/pull-request-commits.test.ts` — new regression test covering the four-step merge scenario
- `tests/e2e/utils.ts` — three new API helpers plus fixes:
  - `apiCreatePullRequest`
  - `apiMergePullRequest` (with mergeability polling)
  - `apiGetPullRequestCommits`
  - `apiCreateFile`: optional `branch` parameter

### Test assertion

```typescript
const commits = await apiGetPullRequestCommits(request, owner, repo, pr3);
expect(commits, 'PR develop→staging must not list commits already present in staging').toHaveLength(0);
```

Ref #37383