### PR TITLE
Stabilize e2e logout propagation test

### DIFF
--- a/tests/e2e/events.test.ts
+++ b/tests/e2e/events.test.ts
@@ -68,6 +68,13 @@ test.describe('events', () => {
     // Verify page2 is logged in
     await expect(page2.getByRole('link', {name: 'Sign In'})).toBeHidden();
 
+    // Give page2's SharedWorker time to register its SSE connection on the
+    // server — otherwise the logout event can race the connection and be
+    // silently dropped. See https://github.com/go-gitea/gitea/pull/37403
+    // In the future, we can set an attribute to HTML page when the connection is established,
+    // then here we can just wait for that attribute (it should also work for the planned WebSocket SharedWorker)
+    await page2.waitForTimeout(500); // eslint-disable-line playwright/no-wait-for-timeout
+
     // Logout from page1 — this sends a logout event to all tabs
     await page1.goto('/user/logout');
 


### PR DESCRIPTION
Backport of #37403 to `release/v1.26`.

The `events › logout propagation` e2e test was racing the SSE connection setup: if page2's SharedWorker had not finished registering its messenger by the time page1 triggered logout, the event was silently dropped and page2 stayed on the authenticated page.

Wait 500ms after verifying page2 is signed in, before triggering the logout from page1, so the SharedWorker has time to register. Comment points at a cleaner future fix (expose a ready attribute on the page) that will also work for the planned WebSocket SharedWorker.

---
This PR was written with the help of Claude Opus 4.7