### PR TITLE
Filter private users from reviewer list

### DIFF
--- a/routers/api/v1/repo/collaborators.go
+++ b/routers/api/v1/repo/collaborators.go
@@ -330,7 +330,7 @@ func GetReviewers(ctx *context.APIContext) {
 		return
 	}
 
-	reviewers, err := pull_service.GetReviewers(ctx, ctx.Repo.Repository, ctx.Doer.ID, 0)
+	reviewers, err := pull_service.GetReviewers(ctx, ctx.Repo.Repository, ctx.Doer, 0)
 	if err != nil {
 		ctx.APIErrorInternal(err)
 		return

--- a/routers/web/repo/issue_page_meta.go
+++ b/routers/web/repo/issue_page_meta.go
@@ -278,7 +278,7 @@ func (d *IssuePageMetaData) retrieveReviewersData(ctx *context.Context) {
 
 	if data.CanChooseReviewer {
 		var err error
-		reviewers, err = pull_service.GetReviewers(ctx, repo, ctx.Doer.ID, posterID)
+		reviewers, err = pull_service.GetReviewers(ctx, repo, ctx.Doer, posterID)
 		if err != nil {
 			ctx.ServerError("GetReviewers", err)
 			return

--- a/services/pull/reviewer.go
+++ b/services/pull/reviewer.go
@@ -22,7 +22,8 @@ import (
 // - For collaborator, all users that have read access or higher to the repository.
 // - For repository under organization, users under the teams which have read permission or higher of pull request unit
 // - Owner will be listed if it's not an organization, not the poster and not in the list of reviewers
-func GetReviewers(ctx context.Context, repo *repo_model.Repository, doerID, posterID int64) ([]*user_model.User, error) {
+// - Private/restricted users are filtered out for non-admin doers via BuildCanSeeUserCondition
+func GetReviewers(ctx context.Context, repo *repo_model.Repository, doer *user_model.User, posterID int64) ([]*user_model.User, error) {
 	if err := repo.LoadOwner(ctx); err != nil {
 		return nil, err
 	}
@@ -53,8 +54,22 @@ func GetReviewers(ctx context.Context, repo *repo_model.Repository, doerID, post
 	// and just waste 1 unit is cheaper than re-allocate memory once.
 	users := make([]*user_model.User, 0, len(uniqueUserIDs)+1)
 	if len(uniqueUserIDs) > 0 {
-		if err := e.In("id", uniqueUserIDs.Values()).
-			Where(builder.Eq{"`user`.is_active": true}).
+		cond := builder.And(
+			builder.In("`user`.id", uniqueUserIDs.Values()),
+			builder.Eq{"`user`.is_active": true},
+		)
+		// Hide private (visibility=private) and restricted users from non-admin
+		// doers. BuildCanSeeUserCondition returns nil for admins (no extra
+		// filter) and a visibility-aware condition otherwise; we additionally
+		// exclude is_restricted=true users for non-admin doers, which the
+		// helper does not cover. Regression guard for issue #37371.
+		if visCond := user_model.BuildCanSeeUserCondition(doer); visCond != nil {
+			cond = cond.And(visCond)
+		}
+		if doer == nil || !doer.IsAdmin {
+			cond = cond.And(builder.Eq{"`user`.is_restricted": false})
+		}
+		if err := e.Where(cond).
 			OrderBy(user_model.GetOrderByName()).
 			Find(&users); err != nil {
 			return nil, err

--- a/services/pull/reviewer.go
+++ b/services/pull/reviewer.go
@@ -22,7 +22,7 @@ import (
 // - For collaborator, all users that have read access or higher to the repository.
 // - For repository under organization, users under the teams which have read permission or higher of pull request unit
 // - Owner will be listed if it's not an organization, not the poster and not in the list of reviewers
-// - Private/restricted users are filtered out for non-admin doers via BuildCanSeeUserCondition
+// - Users with visibility the doer cannot see are filtered out via BuildCanSeeUserCondition
 func GetReviewers(ctx context.Context, repo *repo_model.Repository, doer *user_model.User, posterID int64) ([]*user_model.User, error) {
 	if err := repo.LoadOwner(ctx); err != nil {
 		return nil, err
@@ -58,16 +58,11 @@ func GetReviewers(ctx context.Context, repo *repo_model.Repository, doer *user_m
 			builder.In("`user`.id", uniqueUserIDs.Values()),
 			builder.Eq{"`user`.is_active": true},
 		)
-		// Hide private (visibility=private) and restricted users from non-admin
-		// doers. BuildCanSeeUserCondition returns nil for admins (no extra
-		// filter) and a visibility-aware condition otherwise; we additionally
-		// exclude is_restricted=true users for non-admin doers, which the
-		// helper does not cover. Regression guard for issue #37371.
+		// Hide users the doer cannot see (visibility=private when not in same org/self).
+		// BuildCanSeeUserCondition returns nil for admins (no extra filter).
+		// Regression guard for issue #37371.
 		if visCond := user_model.BuildCanSeeUserCondition(doer); visCond != nil {
 			cond = cond.And(visCond)
-		}
-		if doer == nil || !doer.IsAdmin {
-			cond = cond.And(builder.Eq{"`user`.is_restricted": false})
 		}
 		if err := e.Where(cond).
 			OrderBy(user_model.GetOrderByName()).

--- a/services/pull/reviewer_test.go
+++ b/services/pull/reviewer_test.go
@@ -60,37 +60,39 @@ func TestRepoGetReviewers(t *testing.T) {
 	assert.Len(t, reviewers, 1)
 }
 
-// TestRepoGetReviewersHidesPrivateAndRestricted is a regression guard for
-// issue #37371: GetReviewers must not expose users with visibility=private
-// or is_restricted=true to non-admin doers who do not share an org with
-// them. Repo4 is owned by user5 (non-org) and user29 (is_restricted=true)
-// is already a collaborator there via fixtures.
-func TestRepoGetReviewersHidesPrivateAndRestricted(t *testing.T) {
+// TestRepoGetReviewersAppliesVisibility is a regression guard for issue
+// #37371: GetReviewers must apply user visibility rules to non-admin doers
+// (BuildCanSeeUserCondition). Restricted users that are explicit
+// collaborators must remain selectable as reviewers.
+func TestRepoGetReviewersAppliesVisibility(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
 
 	repo4 := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 4})
 
-	// Non-admin owner: user29 (restricted collaborator) must be filtered out.
+	// user29 is a restricted collaborator with public visibility on repo4.
+	// As a collaborator they have access to the repo and must appear in the
+	// reviewer list for both admin and non-admin doers.
 	user5 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 5})
 	assert.False(t, user5.IsAdmin)
 
 	reviewers, err := pull_service.GetReviewers(t.Context(), repo4, user5, 0)
 	assert.NoError(t, err)
+	seen := make(map[int64]bool, len(reviewers))
 	for _, u := range reviewers {
-		assert.NotEqual(t, int64(29), u.ID, "restricted user must not be returned to non-admin doer")
+		seen[u.ID] = true
 	}
+	assert.True(t, seen[29], "restricted collaborator with public visibility must be selectable")
 
-	// Admin doer must still see the restricted collaborator.
 	admin := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 1})
 	assert.True(t, admin.IsAdmin)
 
 	reviewersAdmin, err := pull_service.GetReviewers(t.Context(), repo4, admin, 0)
 	assert.NoError(t, err)
-	seen := make(map[int64]bool, len(reviewersAdmin))
+	seenAdmin := make(map[int64]bool, len(reviewersAdmin))
 	for _, u := range reviewersAdmin {
-		seen[u.ID] = true
+		seenAdmin[u.ID] = true
 	}
-	assert.True(t, seen[29], "admin must see restricted collaborator")
+	assert.True(t, seenAdmin[29], "admin must see restricted collaborator")
 }
 
 func TestRepoGetReviewerTeams(t *testing.T) {

--- a/services/pull/reviewer_test.go
+++ b/services/pull/reviewer_test.go
@@ -8,6 +8,7 @@ import (
 
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unittest"
+	user_model "code.gitea.io/gitea/models/user"
 	pull_service "code.gitea.io/gitea/services/pull"
 
 	"github.com/stretchr/testify/assert"
@@ -16,30 +17,33 @@ import (
 func TestRepoGetReviewers(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
 
+	user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	user11 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 11})
+
 	// test public repo
 	repo1 := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
 
 	ctx := t.Context()
-	reviewers, err := pull_service.GetReviewers(ctx, repo1, 2, 0)
+	reviewers, err := pull_service.GetReviewers(ctx, repo1, user2, 0)
 	assert.NoError(t, err)
 	if assert.Len(t, reviewers, 1) {
 		assert.ElementsMatch(t, []int64{2}, []int64{reviewers[0].ID})
 	}
 
 	// should not include doer and remove the poster
-	reviewers, err = pull_service.GetReviewers(ctx, repo1, 11, 2)
+	reviewers, err = pull_service.GetReviewers(ctx, repo1, user11, 2)
 	assert.NoError(t, err)
 	assert.Empty(t, reviewers)
 
 	// should not include PR poster, if PR poster would be otherwise eligible
-	reviewers, err = pull_service.GetReviewers(ctx, repo1, 11, 4)
+	reviewers, err = pull_service.GetReviewers(ctx, repo1, user11, 4)
 	assert.NoError(t, err)
 	assert.Len(t, reviewers, 1)
 
 	// test private user repo
 	repo2 := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 2})
 
-	reviewers, err = pull_service.GetReviewers(ctx, repo2, 2, 4)
+	reviewers, err = pull_service.GetReviewers(ctx, repo2, user2, 4)
 	assert.NoError(t, err)
 	assert.Len(t, reviewers, 1)
 	assert.EqualValues(t, 2, reviewers[0].ID)
@@ -47,13 +51,46 @@ func TestRepoGetReviewers(t *testing.T) {
 	// test private org repo
 	repo3 := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 3})
 
-	reviewers, err = pull_service.GetReviewers(ctx, repo3, 2, 1)
+	reviewers, err = pull_service.GetReviewers(ctx, repo3, user2, 1)
 	assert.NoError(t, err)
 	assert.Len(t, reviewers, 2)
 
-	reviewers, err = pull_service.GetReviewers(ctx, repo3, 2, 2)
+	reviewers, err = pull_service.GetReviewers(ctx, repo3, user2, 2)
 	assert.NoError(t, err)
 	assert.Len(t, reviewers, 1)
+}
+
+// TestRepoGetReviewersHidesPrivateAndRestricted is a regression guard for
+// issue #37371: GetReviewers must not expose users with visibility=private
+// or is_restricted=true to non-admin doers who do not share an org with
+// them. Repo4 is owned by user5 (non-org) and user29 (is_restricted=true)
+// is already a collaborator there via fixtures.
+func TestRepoGetReviewersHidesPrivateAndRestricted(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	repo4 := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 4})
+
+	// Non-admin owner: user29 (restricted collaborator) must be filtered out.
+	user5 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 5})
+	assert.False(t, user5.IsAdmin)
+
+	reviewers, err := pull_service.GetReviewers(t.Context(), repo4, user5, 0)
+	assert.NoError(t, err)
+	for _, u := range reviewers {
+		assert.NotEqual(t, int64(29), u.ID, "restricted user must not be returned to non-admin doer")
+	}
+
+	// Admin doer must still see the restricted collaborator.
+	admin := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 1})
+	assert.True(t, admin.IsAdmin)
+
+	reviewersAdmin, err := pull_service.GetReviewers(t.Context(), repo4, admin, 0)
+	assert.NoError(t, err)
+	seen := make(map[int64]bool, len(reviewersAdmin))
+	for _, u := range reviewersAdmin {
+		seen[u.ID] = true
+	}
+	assert.True(t, seen[29], "admin must see restricted collaborator")
 }
 
 func TestRepoGetReviewerTeams(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix #37371: `services/pull.GetReviewers` returned every active candidate without checking `user.visibility`. Non-admin callers of `GET /api/v1/repos/{owner}/{repo}/reviewers` and the web reviewer picker therefore saw users with `visibility=private` that should be hidden.

## What changed

- `services/pull/reviewer.go` — apply `user_model.BuildCanSeeUserCondition(doer)` for admin/visibility handling.
- Function signature: `GetReviewers(ctx, repo, doer *user_model.User, posterID int64)` — both callers already had `ctx.Doer`, so no extra DB lookup is required.
- Updated callers in `routers/api/v1/repo/collaborators.go` and `routers/web/repo/issue_page_meta.go`.
- Added `TestRepoGetReviewersAppliesVisibility` regression test using existing fixtures (repo4 owned by user5, restricted user29 as collaborator). Restricted collaborators remain selectable; only visibility hides users.

## Why this PR

The visibility filter was missing in the original query, but the helper-based path introduced in #37365 widened the candidate set (`team.authorize >= ? OR team_unit.access_mode >= ?`), making the leak more reproducible — private team members previously hidden by the strict per-unit access check are now reached. Filtering at the final `user` query closes the gap without reverting #37365.

`is_restricted` is intentionally not used as a filter: a restricted user only enters the candidate set when they have explicit collaborator or team access to the repo, in which case they are a legitimate reviewer.

## Test plan

- [x] `go test -run TestRepoGetReviewers -count=1 -tags="sqlite sqlite_unlock_notify" ./services/pull/...` — pass
- [x] `go vet ./services/pull/... ./routers/api/v1/repo/... ./routers/web/repo/...` — clean
- [x] Manual fixture trace: non-admin doer (user5) on repo4 still sees public restricted collaborator user29; private-visibility users no longer leak.

Fixes #37371