### PR TITLE
Workflow: Close Stale Issues

### DIFF
--- a/.github/workflows/cron-stale.yml
+++ b/.github/workflows/cron-stale.yml
@@ -19,6 +19,6 @@ jobs:
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. This issue will be closed if no further activity occurs during the next 2 weeks. If the issue is still valid just add a comment or remove `issue/stale` label to keep it alive.'
           stale-issue-label: 'issue/stale'
           days-before-issue-stale: 120
-          days-before-isseu-close: 14
+          days-before-issue-close: 14
           days-before-pr-stale: -1
           days-before-pr-close: -1

--- a/.github/workflows/cron-stale.yml
+++ b/.github/workflows/cron-stale.yml
@@ -17,7 +17,7 @@ jobs:
           repo-token: ${{ secrets.GITEABOT_TOKEN }}
           debug-only: true
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. This issue will be closed if no further activity occurs during the next 2 weeks. If the issue is still valid just add a comment or remove `issue/stale` label to keep it alive.'
-          stale-issue-label: issue/stale
+          stale-issue-label: 'issue/stale'
           days-before-issue-stale: 120
           days-before-isseu-close: 14
           days-before-pr-stale: -1

--- a/.github/workflows/cron-stale.yml
+++ b/.github/workflows/cron-stale.yml
@@ -1,0 +1,24 @@
+name: cron-stale
+
+on:
+  schedule:
+    - cron: '30 1 * * *' # every day at 01:30 UTC
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    if: github.repository == 'go-gitea/gitea'
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITEABOT_TOKEN }}
+          debug-only: true
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. This issue will be closed if no further activity occurs during the next 2 weeks. If the issue is still valid just add a comment or remove `issue/stale` label to keep it alive.'
+          stale-issue-label: issue/stale
+          days-before-issue-stale: 120
+          days-before-isseu-close: 14
+          days-before-pr-stale: -1
+          days-before-pr-close: -1


### PR DESCRIPTION
### Why manage stale issues?
- **Reduce Signal Noise (Signal vs. Noise)**
In an active project, hundreds of issues accumulate. Many of these are "one-hit wonders": Someone reports a bug but then never responds to follow-up questions. Without automation, these dead issues remain open indefinitely. Stale filters these out so you and your collaborators can focus on what's relevant now.
- **Expectation Management**
Nothing is more frustrating for users than an issue remaining open for two years without any response. The Action communicates transparently: "Hey, nothing's happened here in a while. If this is still important, let us know, otherwise we'll clean this up soon." This comes across as more professional than dead silence.
- **Focus for Maintainers**
As a maintainer, you have limited energy. A list of ~2500 open issues is mentally taxing (risk of burnout). When the Action automatically marks or closes the "junk," the list shrinks to the actual issues. This gives you the feeling of regaining control of the project.
- **Community Reactivation**
Sometimes people simply forget they still have an open pull request. The "stale" warning serves as a gentle nudge. Users often write, "Oh sorry, totally forgot, I'll fix it tomorrow!" – and just like that, an old problem is solved.
- **Cleanliness without being the "bad guy"**
It's unpleasant for a human to manually close hundreds of issues and tell people, "We're no longer interested in this." When a bot does this according to established rules, it's less personal and more readily accepted by the community as a necessary rule.

### How does the process work?
1. **Tagging:** After 120 days of inactivity, a bot adds the label `issue/stale` and comments on the issue.
2. **Warning:** The bot often prompts you to refresh the issue to keep it open.
3. **Closing:** If there is no activity after another 14 days, the issue is automatically closed.
4. **Activity:** If a response is received, the `issue/stale` status is removed.

### There are currently ~2500 open issues:

| Filter | Open Issues |
| --- | --- |
| `is:issue state:open updated:<@today-8y` | 5 |
| `is:issue state:open updated:<@today-7y` | 38 |
| `is:issue state:open updated:<@today-6y` | 122 |
| `is:issue state:open updated:<@today-5y` | 246 |
| `is:issue state:open updated:<@today-4y` | 396 |
| `is:issue state:open updated:<@today-3y` | 676 |
| `is:issue state:open updated:<@today-2y` | 1177 |
| `is:issue state:open updated:<@today-1y` | 1621 |
| `is:issue state:open updated:<@today-180d` | 1923 |
| `is:issue state:open updated:<@today-120d` | 2017 |
| `is:issue state:open updated:<@today-90d` | 2055 |
| `is:issue state:open updated:<@today-60d` | 2200 |
| `is:issue state:open updated:<@today-30d` | 2302 |

### Note:
If the PR is accepted, the line `debug-only: true` should be deleted after the first successful dry run.