### PR TITLE
Add DEFAULT_TITLE_SOURCE setting for pull request title default behavior

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1169,9 +1169,7 @@ LEVEL = Info
 ;; Retarget child pull requests to the parent pull request branch target on merge of parent pull request. It only works on merged PRs where the head and base branch target the same repo.
 ;RETARGET_CHILDREN_ON_MERGE = true
 ;;
-;; Default source for the pull request title when opening a new PR.
-;; - first-commit: use the oldest commit's summary as the default title (default behavior since v1.26)
-;; - auto: use the branch name as the default title for multi-commit PRs, transforming hyphens/underscores to spaces and capitalizing the first letter (closer to GitHub behavior); single-commit PRs always use the commit title
+;; Default source for the pull request title when opening a new PR. "first-commit" uses the oldest commit's summary; "auto" normalizes the branch name for multi-commit PRs (single-commit PRs always use the commit title).
 ;DEFAULT_TITLE_SOURCE = first-commit
 ;;
 ;; Delay mergeable check until page view or API access, for pull requests that have not been updated in the specified days when their base branches get updated.

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1169,6 +1169,12 @@ LEVEL = Info
 ;; Retarget child pull requests to the parent pull request branch target on merge of parent pull request. It only works on merged PRs where the head and base branch target the same repo.
 ;RETARGET_CHILDREN_ON_MERGE = true
 ;;
+;; Default source for the pull request title when opening a new PR.
+;; - first-commit: use the oldest commit's summary as the default title (default behavior since v1.26)
+;; - branch-name: use the branch name as the default title for multi-commit PRs (pre-v1.26 behavior); single-commit PRs always use the commit title
+;; - branch-name-transform: like branch-name but transforms hyphens/underscores to spaces and capitalizes the first letter (closer to GitHub behavior)
+;DEFAULT_PR_TITLE_SOURCE = first-commit
+;;
 ;; Delay mergeable check until page view or API access, for pull requests that have not been updated in the specified days when their base branches get updated.
 ;; Use "-1" to always check all pull requests (old behavior). Use "0" to always delay the checks.
 ;DELAY_CHECK_FOR_INACTIVE_DAYS = 7

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1169,7 +1169,9 @@ LEVEL = Info
 ;; Retarget child pull requests to the parent pull request branch target on merge of parent pull request. It only works on merged PRs where the head and base branch target the same repo.
 ;RETARGET_CHILDREN_ON_MERGE = true
 ;;
-;; Default source for the pull request title when opening a new PR. "first-commit" uses the oldest commit's summary; "auto" normalizes the branch name for multi-commit PRs (single-commit PRs always use the commit title).
+;; Default source for the pull request title when opening a new PR.
+;; "first-commit" uses the oldest commit's summary.
+;; "auto" uses commit's summary if the PR only has one commit, normalizes the branch name if multiple commits.
 ;DEFAULT_TITLE_SOURCE = first-commit
 ;;
 ;; Delay mergeable check until page view or API access, for pull requests that have not been updated in the specified days when their base branches get updated.

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1171,9 +1171,8 @@ LEVEL = Info
 ;;
 ;; Default source for the pull request title when opening a new PR.
 ;; - first-commit: use the oldest commit's summary as the default title (default behavior since v1.26)
-;; - branch-name: use the branch name as the default title for multi-commit PRs (pre-v1.26 behavior); single-commit PRs always use the commit title
-;; - branch-name-transform: like branch-name but transforms hyphens/underscores to spaces and capitalizes the first letter (closer to GitHub behavior)
-;DEFAULT_PR_TITLE_SOURCE = first-commit
+;; - branch-name: use the branch name as the default title for multi-commit PRs, transforming hyphens/underscores to spaces and capitalizing the first letter (closer to GitHub behavior); single-commit PRs always use the commit title
+;DEFAULT_TITLE_SOURCE = first-commit
 ;;
 ;; Delay mergeable check until page view or API access, for pull requests that have not been updated in the specified days when their base branches get updated.
 ;; Use "-1" to always check all pull requests (old behavior). Use "0" to always delay the checks.

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1171,7 +1171,7 @@ LEVEL = Info
 ;;
 ;; Default source for the pull request title when opening a new PR.
 ;; - first-commit: use the oldest commit's summary as the default title (default behavior since v1.26)
-;; - branch-name: use the branch name as the default title for multi-commit PRs, transforming hyphens/underscores to spaces and capitalizing the first letter (closer to GitHub behavior); single-commit PRs always use the commit title
+;; - auto: use the branch name as the default title for multi-commit PRs, transforming hyphens/underscores to spaces and capitalizing the first letter (closer to GitHub behavior); single-commit PRs always use the commit title
 ;DEFAULT_TITLE_SOURCE = first-commit
 ;;
 ;; Delay mergeable check until page view or API access, for pull requests that have not been updated in the specified days when their base branches get updated.

--- a/modules/setting/repository.go
+++ b/modules/setting/repository.go
@@ -89,7 +89,7 @@ var (
 			RetargetChildrenOnMerge                  bool
 			DelayCheckForInactiveDays                int
 			DefaultDeleteBranchAfterMerge            bool
-			DefaultPRTitleSource                     string
+			DefaultTitleSource                       string
 		} `ini:"repository.pull-request"`
 
 		// Issue Setting
@@ -214,7 +214,7 @@ var (
 			RetargetChildrenOnMerge                  bool
 			DelayCheckForInactiveDays                int
 			DefaultDeleteBranchAfterMerge            bool
-			DefaultPRTitleSource                     string
+			DefaultTitleSource                       string
 		}{
 			WorkInProgressPrefixes: []string{"WIP:", "[WIP]"},
 			// Same as GitHub. See
@@ -231,7 +231,7 @@ var (
 			AddCoCommitterTrailers:                   true,
 			RetargetChildrenOnMerge:                  true,
 			DelayCheckForInactiveDays:                7,
-			DefaultPRTitleSource:                     "first-commit",
+			DefaultTitleSource:                       "first-commit",
 		},
 
 		// Issue settings

--- a/modules/setting/repository.go
+++ b/modules/setting/repository.go
@@ -89,6 +89,7 @@ var (
 			RetargetChildrenOnMerge                  bool
 			DelayCheckForInactiveDays                int
 			DefaultDeleteBranchAfterMerge            bool
+			DefaultPRTitleSource                     string
 		} `ini:"repository.pull-request"`
 
 		// Issue Setting
@@ -213,6 +214,7 @@ var (
 			RetargetChildrenOnMerge                  bool
 			DelayCheckForInactiveDays                int
 			DefaultDeleteBranchAfterMerge            bool
+			DefaultPRTitleSource                     string
 		}{
 			WorkInProgressPrefixes: []string{"WIP:", "[WIP]"},
 			// Same as GitHub. See
@@ -229,6 +231,7 @@ var (
 			AddCoCommitterTrailers:                   true,
 			RetargetChildrenOnMerge:                  true,
 			DelayCheckForInactiveDays:                7,
+			DefaultPRTitleSource:                     "first-commit",
 		},
 
 		// Issue settings

--- a/modules/setting/repository.go
+++ b/modules/setting/repository.go
@@ -18,6 +18,12 @@ const (
 	RepoCreatingPublic             = "public"
 )
 
+// enumerates the values for [repository.pull-request] DEFAULT_TITLE_SOURCE
+const (
+	RepoPRTitleSourceFirstCommit = "first-commit"
+	RepoPRTitleSourceAuto        = "auto"
+)
+
 // ItemsPerPage maximum items per page in forks, watchers and stars of a repo
 const ItemsPerPage = 40
 
@@ -231,7 +237,7 @@ var (
 			AddCoCommitterTrailers:                   true,
 			RetargetChildrenOnMerge:                  true,
 			DelayCheckForInactiveDays:                7,
-			DefaultTitleSource:                       "first-commit",
+			DefaultTitleSource:                       RepoPRTitleSourceFirstCommit,
 		},
 
 		// Issue settings

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -449,16 +449,13 @@ func autoTitleFromBranchName(name string) string {
 }
 
 func prepareNewPullRequestTitleContent(ci *git_service.CompareInfo, commits []*git_model.SignCommitWithStatuses, defaultTitleSource string) (title, content string) {
-	title = ci.HeadRef.ShortName()
-
-	useBranchName := defaultTitleSource == setting.RepoPRTitleSourceAuto && len(commits) != 1
-	if !useBranchName && len(commits) > 0 {
+	useFirstCommitAsTitle := defaultTitleSource == setting.RepoPRTitleSourceFirstCommit && len(commits) > 0
+	if useFirstCommitAsTitle {
 		// the "commits" are from "ShowPrettyFormatLogToList", which is ordered from newest to oldest, here take the oldest one
 		c := commits[len(commits)-1]
 		title = strings.TrimSpace(c.UserCommit.Summary())
-	}
-	if useBranchName {
-		title = autoTitleFromBranchName(title)
+	} else {
+		title = autoTitleFromBranchName(ci.HeadRef.ShortName())
 	}
 
 	if len(commits) == 1 {

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -439,8 +439,9 @@ func autoTitleFromBranchName(name string) string {
 			prevIsSpace = true
 			continue
 		}
-		if i > 0 && unicode.IsUpper(r) && unicode.IsLower(runes[i-1]) {
-			if !prevIsSpace {
+		if !prevIsSpace && unicode.IsUpper(r) {
+			needSpace := i > 0 && unicode.IsLower(runes[i-1]) || i < len(runes)-1 && unicode.IsLower(runes[i+1])
+			if needSpace {
 				buf.WriteRune(' ')
 			}
 		}

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -425,23 +425,22 @@ func ParseCompareInfo(ctx *context.Context) *git_service.CompareInfo {
 	return &compareInfo
 }
 
-func prepareNewPullRequestTitleContent(ci *git_service.CompareInfo, commits []*git_model.SignCommitWithStatuses, defaultPRTitleSource string) (title, content string) {
+func prepareNewPullRequestTitleContent(ci *git_service.CompareInfo, commits []*git_model.SignCommitWithStatuses, defaultTitleSource string) (title, content string) {
 	title = ci.HeadRef.ShortName()
 
 	if len(commits) > 0 {
-		// When defaultPRTitleSource is "branch-name" or "branch-name-transform", keep the branch name for multi-commit PRs (pre-v1.26 behavior).
+		// When defaultTitleSource is "branch-name", keep the branch name for multi-commit PRs.
 		// For single-commit PRs, always use the commit title regardless of the setting.
-		if (defaultPRTitleSource != "branch-name" && defaultPRTitleSource != "branch-name-transform") || len(commits) == 1 {
+		if defaultTitleSource != "branch-name" || len(commits) == 1 {
 			// the "commits" are from "ShowPrettyFormatLogToList", which is ordered from newest to oldest, here take the oldest one
 			c := commits[len(commits)-1]
 			title = strings.TrimSpace(c.UserCommit.Summary())
 		}
 	}
 
-	// For branch-name-transform, apply GitHub-style transformation to the branch name:
-	// replace hyphens and underscores with spaces, capitalize first letter.
+	// For branch-name, apply GitHub-style transformation: replace hyphens and underscores with spaces, capitalize first letter.
 	// Only applies when the branch name is used (not for single-commit PRs which always use the commit title).
-	if defaultPRTitleSource == "branch-name-transform" && len(commits) != 1 {
+	if defaultTitleSource == "branch-name" && len(commits) != 1 {
 		title = strings.NewReplacer("-", " ", "_", " ").Replace(title)
 		if title != "" {
 			runes := []rune(title)
@@ -584,7 +583,7 @@ func PrepareCompareDiff(
 	ctx.Data["Commits"] = commits
 	ctx.Data["CommitCount"] = len(commits)
 
-	ctx.Data["title"], ctx.Data["content"] = prepareNewPullRequestTitleContent(ci, commits, setting.Repository.PullRequest.DefaultPRTitleSource)
+	ctx.Data["title"], ctx.Data["content"] = prepareNewPullRequestTitleContent(ci, commits, setting.Repository.PullRequest.DefaultTitleSource)
 	ctx.Data["Username"] = ci.HeadRepo.OwnerName
 	ctx.Data["Reponame"] = ci.HeadRepo.Name
 

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -429,18 +429,18 @@ func prepareNewPullRequestTitleContent(ci *git_service.CompareInfo, commits []*g
 	title = ci.HeadRef.ShortName()
 
 	if len(commits) > 0 {
-		// When defaultTitleSource is "branch-name", keep the branch name for multi-commit PRs.
+		// When defaultTitleSource is "auto", keep the branch name for multi-commit PRs.
 		// For single-commit PRs, always use the commit title regardless of the setting.
-		if defaultTitleSource != "branch-name" || len(commits) == 1 {
+		if defaultTitleSource != "auto" || len(commits) == 1 {
 			// the "commits" are from "ShowPrettyFormatLogToList", which is ordered from newest to oldest, here take the oldest one
 			c := commits[len(commits)-1]
 			title = strings.TrimSpace(c.UserCommit.Summary())
 		}
 	}
 
-	// For branch-name, apply GitHub-style transformation: replace hyphens and underscores with spaces, capitalize first letter.
+	// For "auto", apply GitHub-style transformation to the branch name: replace hyphens and underscores with spaces, capitalize first letter.
 	// Only applies when the branch name is used (not for single-commit PRs which always use the commit title).
-	if defaultTitleSource == "branch-name" && len(commits) != 1 {
+	if defaultTitleSource == "auto" && len(commits) != 1 {
 		title = strings.NewReplacer("-", " ", "_", " ").Replace(title)
 		if title != "" {
 			runes := []rune(title)

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -425,54 +425,39 @@ func ParseCompareInfo(ctx *context.Context) *git_service.CompareInfo {
 	return &compareInfo
 }
 
-// autoTitleFromBranchName converts a branch name to a PR title following GitHub's algorithm:
-// split camelCase, replace hyphens/underscores with spaces, lowercase everything, left-trim,
-// then capitalize the first letter. Slashes and other characters are preserved as-is.
+// autoTitleFromBranchName humanizes a branch name into a PR title.
 func autoTitleFromBranchName(name string) string {
-	// Step 1: insert a space before each uppercase letter that directly follows a lowercase letter (camelCase split)
 	var buf strings.Builder
 	runes := []rune(name)
 	for i, r := range runes {
 		if i > 0 && unicode.IsUpper(r) && unicode.IsLower(runes[i-1]) {
 			buf.WriteRune(' ')
 		}
-		buf.WriteRune(r)
+		if r == '-' || r == '_' {
+			buf.WriteRune(' ')
+		} else {
+			buf.WriteRune(unicode.ToLower(r))
+		}
 	}
-	name = buf.String()
-
-	// Step 2: replace hyphens and underscores with spaces (consecutive separators stay consecutive)
-	name = strings.NewReplacer("-", " ", "_", " ").Replace(name)
-
-	// Step 3: lowercase everything
-	name = strings.ToLower(name)
-
-	// Step 4: left-trim spaces, then capitalize the first letter
-	name = strings.TrimLeft(name, " ")
-	if name != "" {
-		runes := []rune(name)
-		runes[0] = unicode.ToUpper(runes[0])
-		name = string(runes)
+	out := strings.Trim(buf.String(), " ")
+	if out == "" {
+		return out
 	}
-
-	return name
+	outRunes := []rune(out)
+	outRunes[0] = unicode.ToUpper(outRunes[0])
+	return string(outRunes)
 }
 
 func prepareNewPullRequestTitleContent(ci *git_service.CompareInfo, commits []*git_model.SignCommitWithStatuses, defaultTitleSource string) (title, content string) {
 	title = ci.HeadRef.ShortName()
 
-	if len(commits) > 0 {
-		// When defaultTitleSource is "auto", keep the branch name for multi-commit PRs.
-		// For single-commit PRs, always use the commit title regardless of the setting.
-		if defaultTitleSource != "auto" || len(commits) == 1 {
-			// the "commits" are from "ShowPrettyFormatLogToList", which is ordered from newest to oldest, here take the oldest one
-			c := commits[len(commits)-1]
-			title = strings.TrimSpace(c.UserCommit.Summary())
-		}
+	useBranchName := defaultTitleSource == setting.RepoPRTitleSourceAuto && len(commits) != 1
+	if !useBranchName && len(commits) > 0 {
+		// the "commits" are from "ShowPrettyFormatLogToList", which is ordered from newest to oldest, here take the oldest one
+		c := commits[len(commits)-1]
+		title = strings.TrimSpace(c.UserCommit.Summary())
 	}
-
-	// For "auto", apply GitHub-style transformation to the branch name.
-	// Only applies when the branch name is used (not for single-commit PRs which always use the commit title).
-	if defaultTitleSource == "auto" && len(commits) != 1 {
+	if useBranchName {
 		title = autoTitleFromBranchName(title)
 	}
 

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -428,18 +428,26 @@ func ParseCompareInfo(ctx *context.Context) *git_service.CompareInfo {
 // autoTitleFromBranchName humanizes a branch name into a PR title.
 func autoTitleFromBranchName(name string) string {
 	var buf strings.Builder
+	var prevIsSpace bool
 	runes := []rune(name)
 	for i, r := range runes {
+		isSpace := unicode.IsSpace(r)
+		if r == '-' || r == '_' || isSpace {
+			if !prevIsSpace {
+				buf.WriteRune(' ')
+			}
+			prevIsSpace = true
+			continue
+		}
 		if i > 0 && unicode.IsUpper(r) && unicode.IsLower(runes[i-1]) {
-			buf.WriteRune(' ')
+			if !prevIsSpace {
+				buf.WriteRune(' ')
+			}
 		}
-		if r == '-' || r == '_' {
-			buf.WriteRune(' ')
-		} else {
-			buf.WriteRune(unicode.ToLower(r))
-		}
+		buf.WriteRune(unicode.ToLower(r))
+		prevIsSpace = isSpace
 	}
-	out := strings.Trim(buf.String(), " ")
+	out := strings.TrimSpace(buf.String())
 	if out == "" {
 		return out
 	}

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"unicode"
 
 	"code.gitea.io/gitea/models/db"
 	git_model "code.gitea.io/gitea/models/git"
@@ -424,13 +425,29 @@ func ParseCompareInfo(ctx *context.Context) *git_service.CompareInfo {
 	return &compareInfo
 }
 
-func prepareNewPullRequestTitleContent(ci *git_service.CompareInfo, commits []*git_model.SignCommitWithStatuses) (title, content string) {
+func prepareNewPullRequestTitleContent(ci *git_service.CompareInfo, commits []*git_model.SignCommitWithStatuses, defaultPRTitleSource string) (title, content string) {
 	title = ci.HeadRef.ShortName()
 
 	if len(commits) > 0 {
-		// the "commits" are from "ShowPrettyFormatLogToList", which is ordered from newest to oldest, here take the oldest one
-		c := commits[len(commits)-1]
-		title = strings.TrimSpace(c.UserCommit.Summary())
+		// When defaultPRTitleSource is "branch-name" or "branch-name-transform", keep the branch name for multi-commit PRs (pre-v1.26 behavior).
+		// For single-commit PRs, always use the commit title regardless of the setting.
+		if (defaultPRTitleSource != "branch-name" && defaultPRTitleSource != "branch-name-transform") || len(commits) == 1 {
+			// the "commits" are from "ShowPrettyFormatLogToList", which is ordered from newest to oldest, here take the oldest one
+			c := commits[len(commits)-1]
+			title = strings.TrimSpace(c.UserCommit.Summary())
+		}
+	}
+
+	// For branch-name-transform, apply GitHub-style transformation to the branch name:
+	// replace hyphens and underscores with spaces, capitalize first letter.
+	// Only applies when the branch name is used (not for single-commit PRs which always use the commit title).
+	if defaultPRTitleSource == "branch-name-transform" && len(commits) != 1 {
+		title = strings.NewReplacer("-", " ", "_", " ").Replace(title)
+		if title != "" {
+			runes := []rune(title)
+			runes[0] = unicode.ToUpper(runes[0])
+			title = string(runes)
+		}
 	}
 
 	if len(commits) == 1 {
@@ -567,7 +584,7 @@ func PrepareCompareDiff(
 	ctx.Data["Commits"] = commits
 	ctx.Data["CommitCount"] = len(commits)
 
-	ctx.Data["title"], ctx.Data["content"] = prepareNewPullRequestTitleContent(ci, commits)
+	ctx.Data["title"], ctx.Data["content"] = prepareNewPullRequestTitleContent(ci, commits, setting.Repository.PullRequest.DefaultPRTitleSource)
 	ctx.Data["Username"] = ci.HeadRepo.OwnerName
 	ctx.Data["Reponame"] = ci.HeadRepo.Name
 

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -458,7 +458,7 @@ func autoTitleFromBranchName(name string) string {
 }
 
 func prepareNewPullRequestTitleContent(ci *git_service.CompareInfo, commits []*git_model.SignCommitWithStatuses, defaultTitleSource string) (title, content string) {
-	useFirstCommitAsTitle := defaultTitleSource == setting.RepoPRTitleSourceFirstCommit && len(commits) > 0
+	useFirstCommitAsTitle := len(commits) == 1 || (defaultTitleSource == setting.RepoPRTitleSourceFirstCommit && len(commits) > 0)
 	if useFirstCommitAsTitle {
 		// the "commits" are from "ShowPrettyFormatLogToList", which is ordered from newest to oldest, here take the oldest one
 		c := commits[len(commits)-1]

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -425,6 +425,38 @@ func ParseCompareInfo(ctx *context.Context) *git_service.CompareInfo {
 	return &compareInfo
 }
 
+// autoTitleFromBranchName converts a branch name to a PR title following GitHub's algorithm:
+// split camelCase, replace hyphens/underscores with spaces, lowercase everything, left-trim,
+// then capitalize the first letter. Slashes and other characters are preserved as-is.
+func autoTitleFromBranchName(name string) string {
+	// Step 1: insert a space before each uppercase letter that directly follows a lowercase letter (camelCase split)
+	var buf strings.Builder
+	runes := []rune(name)
+	for i, r := range runes {
+		if i > 0 && unicode.IsUpper(r) && unicode.IsLower(runes[i-1]) {
+			buf.WriteRune(' ')
+		}
+		buf.WriteRune(r)
+	}
+	name = buf.String()
+
+	// Step 2: replace hyphens and underscores with spaces (consecutive separators stay consecutive)
+	name = strings.NewReplacer("-", " ", "_", " ").Replace(name)
+
+	// Step 3: lowercase everything
+	name = strings.ToLower(name)
+
+	// Step 4: left-trim spaces, then capitalize the first letter
+	name = strings.TrimLeft(name, " ")
+	if name != "" {
+		runes := []rune(name)
+		runes[0] = unicode.ToUpper(runes[0])
+		name = string(runes)
+	}
+
+	return name
+}
+
 func prepareNewPullRequestTitleContent(ci *git_service.CompareInfo, commits []*git_model.SignCommitWithStatuses, defaultTitleSource string) (title, content string) {
 	title = ci.HeadRef.ShortName()
 
@@ -438,15 +470,10 @@ func prepareNewPullRequestTitleContent(ci *git_service.CompareInfo, commits []*g
 		}
 	}
 
-	// For "auto", apply GitHub-style transformation to the branch name: replace hyphens and underscores with spaces, capitalize first letter.
+	// For "auto", apply GitHub-style transformation to the branch name.
 	// Only applies when the branch name is used (not for single-commit PRs which always use the commit title).
 	if defaultTitleSource == "auto" && len(commits) != 1 {
-		title = strings.NewReplacer("-", " ", "_", " ").Replace(title)
-		if title != "" {
-			runes := []rune(title)
-			runes[0] = unicode.ToUpper(runes[0])
-			title = string(runes)
-		}
+		title = autoTitleFromBranchName(title)
 	}
 
 	if len(commits) == 1 {

--- a/routers/web/repo/compare_test.go
+++ b/routers/web/repo/compare_test.go
@@ -90,12 +90,12 @@ func TestNewPullRequestTitleContent(t *testing.T) {
 	assert.Equal(t, "title1", title)
 	assert.Empty(t, content)
 
-	// source: "branch-name": multi-commit uses branch name with hyphens/underscores replaced by spaces and first letter capitalized (GitHub behavior); single-commit uses commit title
-	title, content = prepareNewPullRequestTitleContent(ci, nil, "branch-name")
+	// source: "auto": multi-commit uses branch name with hyphens/underscores replaced by spaces and first letter capitalized (GitHub behavior); single-commit uses commit title
+	title, content = prepareNewPullRequestTitleContent(ci, nil, "auto")
 	assert.Equal(t, "Head branch", title)
 	assert.Empty(t, content)
 
-	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("single-commit-title\nbody")}, "branch-name")
+	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("single-commit-title\nbody")}, "auto")
 	assert.Equal(t, "single-commit-title", title)
 	assert.Equal(t, "body", content)
 
@@ -103,7 +103,16 @@ func TestNewPullRequestTitleContent(t *testing.T) {
 		// ordered from newest to oldest; multi-commit should use transformed branch name
 		mockCommit("title2\nbody2"),
 		mockCommit("title1\nbody1"),
-	}, "branch-name")
+	}, "auto")
 	assert.Equal(t, "Head branch", title)
+	assert.Empty(t, content)
+
+	// slashes are preserved; only hyphens and underscores become spaces
+	ciSlash := &git_service.CompareInfo{HeadRef: "refs/heads/fix/the-bug"}
+	title, content = prepareNewPullRequestTitleContent(ciSlash, []*git_model.SignCommitWithStatuses{
+		mockCommit("title2\nbody2"),
+		mockCommit("title1\nbody1"),
+	}, "auto")
+	assert.Equal(t, "Fix/the bug", title)
 	assert.Empty(t, content)
 }

--- a/routers/web/repo/compare_test.go
+++ b/routers/web/repo/compare_test.go
@@ -90,9 +90,9 @@ func TestNewPullRequestTitleContent(t *testing.T) {
 	assert.Equal(t, "title1", title)
 	assert.Empty(t, content)
 
-	// source: "branch-name": multi-commit uses branch name, single-commit uses commit title
+	// source: "branch-name": multi-commit uses branch name with hyphens/underscores replaced by spaces and first letter capitalized (GitHub behavior); single-commit uses commit title
 	title, content = prepareNewPullRequestTitleContent(ci, nil, "branch-name")
-	assert.Equal(t, "head-branch", title)
+	assert.Equal(t, "Head branch", title)
 	assert.Empty(t, content)
 
 	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("single-commit-title\nbody")}, "branch-name")
@@ -100,27 +100,10 @@ func TestNewPullRequestTitleContent(t *testing.T) {
 	assert.Equal(t, "body", content)
 
 	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{
-		// ordered from newest to oldest; multi-commit should use branch name
-		mockCommit("title2\nbody2"),
-		mockCommit("title1\nbody1"),
-	}, "branch-name")
-	assert.Equal(t, "head-branch", title)
-	assert.Empty(t, content)
-
-	// source: "branch-name-transform": multi-commit uses branch name with hyphens/underscores replaced by spaces and first letter capitalized
-	title, content = prepareNewPullRequestTitleContent(ci, nil, "branch-name-transform")
-	assert.Equal(t, "Head branch", title)
-	assert.Empty(t, content)
-
-	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("single-commit-title\nbody")}, "branch-name-transform")
-	assert.Equal(t, "single-commit-title", title)
-	assert.Equal(t, "body", content)
-
-	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{
 		// ordered from newest to oldest; multi-commit should use transformed branch name
 		mockCommit("title2\nbody2"),
 		mockCommit("title1\nbody1"),
-	}, "branch-name-transform")
+	}, "branch-name")
 	assert.Equal(t, "Head branch", title)
 	assert.Empty(t, content)
 }

--- a/routers/web/repo/compare_test.go
+++ b/routers/web/repo/compare_test.go
@@ -61,23 +61,24 @@ func TestNewPullRequestTitleContent(t *testing.T) {
 		}
 	}
 
-	title, content := prepareNewPullRequestTitleContent(ci, nil)
+	// default source: "first-commit"
+	title, content := prepareNewPullRequestTitleContent(ci, nil, "first-commit")
 	assert.Equal(t, "head-branch", title)
 	assert.Empty(t, content)
 
-	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("title-only")})
+	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("title-only")}, "first-commit")
 	assert.Equal(t, "title-only", title)
 	assert.Empty(t, content)
 
-	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("title-" + strings.Repeat("a", 255))})
+	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("title-" + strings.Repeat("a", 255))}, "first-commit")
 	assert.Equal(t, "title-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…", title)
 	assert.Equal(t, "…aaaaaaaaa\n", content)
 
-	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("title\nbody")})
+	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("title\nbody")}, "first-commit")
 	assert.Equal(t, "title", title)
 	assert.Equal(t, "body", content)
 
-	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("a\xf0\xf0\xf0\nb\xf0\xf0\xf0")})
+	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("a\xf0\xf0\xf0\nb\xf0\xf0\xf0")}, "first-commit")
 	assert.Equal(t, "a?", title) // FIXME: GIT-COMMIT-MESSAGE-ENCODING: "title" doesn't use the same charset converting logic as "content"
 	assert.Equal(t, "b"+string(utf8.RuneError)+string(utf8.RuneError), content)
 
@@ -85,7 +86,41 @@ func TestNewPullRequestTitleContent(t *testing.T) {
 		// ordered from newest to oldest
 		mockCommit("title2\nbody2"),
 		mockCommit("title1\nbody1"),
-	})
+	}, "first-commit")
 	assert.Equal(t, "title1", title)
+	assert.Empty(t, content)
+
+	// source: "branch-name": multi-commit uses branch name, single-commit uses commit title
+	title, content = prepareNewPullRequestTitleContent(ci, nil, "branch-name")
+	assert.Equal(t, "head-branch", title)
+	assert.Empty(t, content)
+
+	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("single-commit-title\nbody")}, "branch-name")
+	assert.Equal(t, "single-commit-title", title)
+	assert.Equal(t, "body", content)
+
+	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{
+		// ordered from newest to oldest; multi-commit should use branch name
+		mockCommit("title2\nbody2"),
+		mockCommit("title1\nbody1"),
+	}, "branch-name")
+	assert.Equal(t, "head-branch", title)
+	assert.Empty(t, content)
+
+	// source: "branch-name-transform": multi-commit uses branch name with hyphens/underscores replaced by spaces and first letter capitalized
+	title, content = prepareNewPullRequestTitleContent(ci, nil, "branch-name-transform")
+	assert.Equal(t, "Head branch", title)
+	assert.Empty(t, content)
+
+	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("single-commit-title\nbody")}, "branch-name-transform")
+	assert.Equal(t, "single-commit-title", title)
+	assert.Equal(t, "body", content)
+
+	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{
+		// ordered from newest to oldest; multi-commit should use transformed branch name
+		mockCommit("title2\nbody2"),
+		mockCommit("title1\nbody1"),
+	}, "branch-name-transform")
+	assert.Equal(t, "Head branch", title)
 	assert.Empty(t, content)
 }

--- a/routers/web/repo/compare_test.go
+++ b/routers/web/repo/compare_test.go
@@ -114,6 +114,7 @@ func TestAutoTitleFromBranchName(t *testing.T) {
 		{"fix/the-bug", "Fix/the bug"},
 		{"Already-Capitalized", "Already capitalized"},
 		{"ALL-CAPS-BRANCH", "All caps branch"},
+		{"FixHTMLBug", "Fix html bug"},
 		{"MixedCase-Name", "Mixed case name"},
 		{"fooBar-baz", "Foo bar baz"},
 		{"foo/BAR", "Foo/bar"},

--- a/routers/web/repo/compare_test.go
+++ b/routers/web/repo/compare_test.go
@@ -73,7 +73,7 @@ func TestNewPullRequestTitleContent(t *testing.T) {
 
 	// single commit
 	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("single-commit-title\nbody")}, setting.RepoPRTitleSourceAuto)
-	assert.Equal(t, "Head branch", title)
+	assert.Equal(t, "single-commit-title", title)
 	assert.Equal(t, "body", content)
 
 	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("single-commit-title\nbody")}, setting.RepoPRTitleSourceFirstCommit)

--- a/routers/web/repo/compare_test.go
+++ b/routers/web/repo/compare_test.go
@@ -119,7 +119,7 @@ func TestAutoTitleFromBranchName(t *testing.T) {
 		{"foo/BAR", "Foo/bar"},
 		{"_leading-underscore", "Leading underscore"},
 		{"CamelCase", "Camel case"},
-		{"foo--double-dash", "Foo  double dash"},
+		{"foo--double-dash", "Foo double dash"},
 		{"123-fix", "123 fix"},
 	}
 	for _, c := range cases {

--- a/routers/web/repo/compare_test.go
+++ b/routers/web/repo/compare_test.go
@@ -13,6 +13,7 @@ import (
 	issues_model "code.gitea.io/gitea/models/issues"
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/git"
+	"code.gitea.io/gitea/modules/setting"
 	git_service "code.gitea.io/gitea/services/git"
 	"code.gitea.io/gitea/services/gitdiff"
 
@@ -61,24 +62,23 @@ func TestNewPullRequestTitleContent(t *testing.T) {
 		}
 	}
 
-	// default source: "first-commit"
-	title, content := prepareNewPullRequestTitleContent(ci, nil, "first-commit")
+	title, content := prepareNewPullRequestTitleContent(ci, nil, setting.RepoPRTitleSourceFirstCommit)
 	assert.Equal(t, "head-branch", title)
 	assert.Empty(t, content)
 
-	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("title-only")}, "first-commit")
+	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("title-only")}, setting.RepoPRTitleSourceFirstCommit)
 	assert.Equal(t, "title-only", title)
 	assert.Empty(t, content)
 
-	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("title-" + strings.Repeat("a", 255))}, "first-commit")
+	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("title-" + strings.Repeat("a", 255))}, setting.RepoPRTitleSourceFirstCommit)
 	assert.Equal(t, "title-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…", title)
 	assert.Equal(t, "…aaaaaaaaa\n", content)
 
-	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("title\nbody")}, "first-commit")
+	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("title\nbody")}, setting.RepoPRTitleSourceFirstCommit)
 	assert.Equal(t, "title", title)
 	assert.Equal(t, "body", content)
 
-	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("a\xf0\xf0\xf0\nb\xf0\xf0\xf0")}, "first-commit")
+	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("a\xf0\xf0\xf0\nb\xf0\xf0\xf0")}, setting.RepoPRTitleSourceFirstCommit)
 	assert.Equal(t, "a?", title) // FIXME: GIT-COMMIT-MESSAGE-ENCODING: "title" doesn't use the same charset converting logic as "content"
 	assert.Equal(t, "b"+string(utf8.RuneError)+string(utf8.RuneError), content)
 
@@ -86,23 +86,22 @@ func TestNewPullRequestTitleContent(t *testing.T) {
 		// ordered from newest to oldest
 		mockCommit("title2\nbody2"),
 		mockCommit("title1\nbody1"),
-	}, "first-commit")
+	}, setting.RepoPRTitleSourceFirstCommit)
 	assert.Equal(t, "title1", title)
 	assert.Empty(t, content)
 
-	// source: "auto": multi-commit uses transformed branch name; single-commit uses commit title
-	title, content = prepareNewPullRequestTitleContent(ci, nil, "auto")
+	title, content = prepareNewPullRequestTitleContent(ci, nil, setting.RepoPRTitleSourceAuto)
 	assert.Equal(t, "Head branch", title)
 	assert.Empty(t, content)
 
-	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("single-commit-title\nbody")}, "auto")
+	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("single-commit-title\nbody")}, setting.RepoPRTitleSourceAuto)
 	assert.Equal(t, "single-commit-title", title)
 	assert.Equal(t, "body", content)
 
 	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{
 		mockCommit("title2\nbody2"),
 		mockCommit("title1\nbody1"),
-	}, "auto")
+	}, setting.RepoPRTitleSourceAuto)
 	assert.Equal(t, "Head branch", title)
 	assert.Empty(t, content)
 }
@@ -112,29 +111,16 @@ func TestAutoTitleFromBranchName(t *testing.T) {
 		branch string
 		want   string
 	}{
-		// basic hyphen/underscore replacement
 		{"fix/the-bug", "Fix/the bug"},
-		{"head-branch", "Head branch"},
-		// already-capitalized letters are lowercased
 		{"Already-Capitalized", "Already capitalized"},
-		// all-caps words are lowercased
 		{"ALL-CAPS-BRANCH", "All caps branch"},
-		// mixed case with hyphen separator
 		{"MixedCase-Name", "Mixed case name"},
-		// camelCase within a segment
 		{"fooBar-baz", "Foo bar baz"},
-		// slash preserved; uppercase after slash is lowercased
 		{"foo/BAR", "Foo/bar"},
-		// leading underscore is trimmed
 		{"_leading-underscore", "Leading underscore"},
-		// leading hyphen is trimmed
-		{"-leading-hyphen", "Leading hyphen"},
-		// PascalCase without separators
 		{"CamelCase", "Camel case"},
-		// consecutive separators produce consecutive spaces (not collapsed)
-		{"foo--bar", "Foo  bar"},
-		// trailing separator preserved (not right-trimmed)
-		{"trailing-", "Trailing "},
+		{"foo--double-dash", "Foo  double dash"},
+		{"123-fix", "123 fix"},
 	}
 	for _, c := range cases {
 		assert.Equal(t, c.want, autoTitleFromBranchName(c.branch), "branch: %q", c.branch)

--- a/routers/web/repo/compare_test.go
+++ b/routers/web/repo/compare_test.go
@@ -90,7 +90,7 @@ func TestNewPullRequestTitleContent(t *testing.T) {
 	assert.Equal(t, "title1", title)
 	assert.Empty(t, content)
 
-	// source: "auto": multi-commit uses branch name with hyphens/underscores replaced by spaces and first letter capitalized (GitHub behavior); single-commit uses commit title
+	// source: "auto": multi-commit uses transformed branch name; single-commit uses commit title
 	title, content = prepareNewPullRequestTitleContent(ci, nil, "auto")
 	assert.Equal(t, "Head branch", title)
 	assert.Empty(t, content)
@@ -100,19 +100,43 @@ func TestNewPullRequestTitleContent(t *testing.T) {
 	assert.Equal(t, "body", content)
 
 	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{
-		// ordered from newest to oldest; multi-commit should use transformed branch name
 		mockCommit("title2\nbody2"),
 		mockCommit("title1\nbody1"),
 	}, "auto")
 	assert.Equal(t, "Head branch", title)
 	assert.Empty(t, content)
+}
 
-	// slashes are preserved; only hyphens and underscores become spaces
-	ciSlash := &git_service.CompareInfo{HeadRef: "refs/heads/fix/the-bug"}
-	title, content = prepareNewPullRequestTitleContent(ciSlash, []*git_model.SignCommitWithStatuses{
-		mockCommit("title2\nbody2"),
-		mockCommit("title1\nbody1"),
-	}, "auto")
-	assert.Equal(t, "Fix/the bug", title)
-	assert.Empty(t, content)
+func TestAutoTitleFromBranchName(t *testing.T) {
+	cases := []struct {
+		branch string
+		want   string
+	}{
+		// basic hyphen/underscore replacement
+		{"fix/the-bug", "Fix/the bug"},
+		{"head-branch", "Head branch"},
+		// already-capitalized letters are lowercased
+		{"Already-Capitalized", "Already capitalized"},
+		// all-caps words are lowercased
+		{"ALL-CAPS-BRANCH", "All caps branch"},
+		// mixed case with hyphen separator
+		{"MixedCase-Name", "Mixed case name"},
+		// camelCase within a segment
+		{"fooBar-baz", "Foo bar baz"},
+		// slash preserved; uppercase after slash is lowercased
+		{"foo/BAR", "Foo/bar"},
+		// leading underscore is trimmed
+		{"_leading-underscore", "Leading underscore"},
+		// leading hyphen is trimmed
+		{"-leading-hyphen", "Leading hyphen"},
+		// PascalCase without separators
+		{"CamelCase", "Camel case"},
+		// consecutive separators produce consecutive spaces (not collapsed)
+		{"foo--bar", "Foo  bar"},
+		// trailing separator preserved (not right-trimmed)
+		{"trailing-", "Trailing "},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, autoTitleFromBranchName(c.branch), "branch: %q", c.branch)
+	}
 }

--- a/routers/web/repo/compare_test.go
+++ b/routers/web/repo/compare_test.go
@@ -62,48 +62,46 @@ func TestNewPullRequestTitleContent(t *testing.T) {
 		}
 	}
 
-	title, content := prepareNewPullRequestTitleContent(ci, nil, setting.RepoPRTitleSourceFirstCommit)
-	assert.Equal(t, "head-branch", title)
+	// no commit
+	title, content := prepareNewPullRequestTitleContent(ci, nil, setting.RepoPRTitleSourceAuto)
+	assert.Equal(t, "Head branch", title)
 	assert.Empty(t, content)
 
-	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("title-only")}, setting.RepoPRTitleSourceFirstCommit)
-	assert.Equal(t, "title-only", title)
+	title, content = prepareNewPullRequestTitleContent(ci, nil, setting.RepoPRTitleSourceFirstCommit)
+	assert.Equal(t, "Head branch", title)
 	assert.Empty(t, content)
 
+	// single commit
+	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("single-commit-title\nbody")}, setting.RepoPRTitleSourceAuto)
+	assert.Equal(t, "Head branch", title)
+	assert.Equal(t, "body", content)
+
+	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("single-commit-title\nbody")}, setting.RepoPRTitleSourceFirstCommit)
+	assert.Equal(t, "single-commit-title", title)
+	assert.Equal(t, "body", content)
+
+	// multiple commits
+	commits := []*git_model.SignCommitWithStatuses{
+		// ordered from newest to oldest
+		mockCommit("title2\nbody2"),
+		mockCommit("title1\nbody1"),
+	}
+	title, content = prepareNewPullRequestTitleContent(ci, commits, setting.RepoPRTitleSourceAuto)
+	assert.Equal(t, "Head branch", title)
+	assert.Empty(t, content)
+
+	title, content = prepareNewPullRequestTitleContent(ci, commits, setting.RepoPRTitleSourceFirstCommit)
+	assert.Equal(t, "title1", title)
+	assert.Empty(t, content)
+
+	// title string handling
 	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("title-" + strings.Repeat("a", 255))}, setting.RepoPRTitleSourceFirstCommit)
 	assert.Equal(t, "title-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…", title)
 	assert.Equal(t, "…aaaaaaaaa\n", content)
 
-	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("title\nbody")}, setting.RepoPRTitleSourceFirstCommit)
-	assert.Equal(t, "title", title)
-	assert.Equal(t, "body", content)
-
 	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("a\xf0\xf0\xf0\nb\xf0\xf0\xf0")}, setting.RepoPRTitleSourceFirstCommit)
 	assert.Equal(t, "a?", title) // FIXME: GIT-COMMIT-MESSAGE-ENCODING: "title" doesn't use the same charset converting logic as "content"
 	assert.Equal(t, "b"+string(utf8.RuneError)+string(utf8.RuneError), content)
-
-	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{
-		// ordered from newest to oldest
-		mockCommit("title2\nbody2"),
-		mockCommit("title1\nbody1"),
-	}, setting.RepoPRTitleSourceFirstCommit)
-	assert.Equal(t, "title1", title)
-	assert.Empty(t, content)
-
-	title, content = prepareNewPullRequestTitleContent(ci, nil, setting.RepoPRTitleSourceAuto)
-	assert.Equal(t, "Head branch", title)
-	assert.Empty(t, content)
-
-	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{mockCommit("single-commit-title\nbody")}, setting.RepoPRTitleSourceAuto)
-	assert.Equal(t, "single-commit-title", title)
-	assert.Equal(t, "body", content)
-
-	title, content = prepareNewPullRequestTitleContent(ci, []*git_model.SignCommitWithStatuses{
-		mockCommit("title2\nbody2"),
-		mockCommit("title1\nbody1"),
-	}, setting.RepoPRTitleSourceAuto)
-	assert.Equal(t, "Head branch", title)
-	assert.Empty(t, content)
 }
 
 func TestAutoTitleFromBranchName(t *testing.T) {


### PR DESCRIPTION
Adds a new `DEFAULT_TITLE_SOURCE` option under `[repository.pull-request]` with three values:

- `first-commit` (default): uses the oldest commit summary, current behavior since v1.26
- `auto`: normalizes branch name as title for multi-commit PRs (just like GitHub), use commit summary for single-commit PRs

Closes #37463
