### PR TITLE
Fix compare dropdown for branches without common history

### DIFF
--- a/modules/gitrepo/compare_test.go
+++ b/modules/gitrepo/compare_test.go
@@ -76,8 +76,9 @@ func TestMergeBaseNoCommonHistory(t *testing.T) {
 	headCommit := commitRootTree(t, repoDir, "head.txt", "head", "head")
 
 	mergeBase, err := MergeBase(t.Context(), &mockRepository{path: repoDir}, baseCommit, headCommit)
+	var noMergeBase ErrNoMergeBase
 	assert.Empty(t, mergeBase)
-	assert.True(t, IsErrNoMergeBase(err), "expected no merge base error, got %v", err)
+	assert.ErrorAs(t, err, &noMergeBase)
 }
 
 func TestRepoGetDivergingCommits(t *testing.T) {

--- a/modules/gitrepo/compare_test.go
+++ b/modules/gitrepo/compare_test.go
@@ -4,9 +4,17 @@
 package gitrepo
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	"code.gitea.io/gitea/modules/git/gitcmd"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockRepository struct {
@@ -15,6 +23,61 @@ type mockRepository struct {
 
 func (r *mockRepository) RelativePath() string {
 	return r.path
+}
+
+func commitRootTree(t *testing.T, repoDir, fileName, content, message string) string {
+	t.Helper()
+
+	require.NoError(t, gitcmd.NewCommand("read-tree", "--empty").WithDir(repoDir).Run(t.Context()))
+
+	stdout, _, err := gitcmd.NewCommand("hash-object", "-w", "--stdin").
+		WithDir(repoDir).
+		WithStdinBytes([]byte(content)).
+		RunStdString(t.Context())
+	require.NoError(t, err)
+	blobSHA := strings.TrimSpace(stdout)
+
+	_, _, err = gitcmd.NewCommand("update-index", "--add", "--replace", "--cacheinfo").
+		AddDynamicArguments("100644", blobSHA, fileName).
+		WithDir(repoDir).
+		RunStdString(t.Context())
+	require.NoError(t, err)
+
+	stdout, _, err = gitcmd.NewCommand("write-tree").WithDir(repoDir).RunStdString(t.Context())
+	require.NoError(t, err)
+	treeSHA := strings.TrimSpace(stdout)
+
+	commitTimeStr := time.Now().Format(time.RFC3339)
+	env := append(os.Environ(),
+		"GIT_AUTHOR_NAME=Test",
+		"GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_AUTHOR_DATE="+commitTimeStr,
+		"GIT_COMMITTER_NAME=Test",
+		"GIT_COMMITTER_EMAIL=test@example.com",
+		"GIT_COMMITTER_DATE="+commitTimeStr,
+	)
+
+	messageBytes := bytes.NewBufferString(message + "\n")
+	stdout, _, err = gitcmd.NewCommand("commit-tree").AddDynamicArguments(treeSHA).
+		WithEnv(env).
+		WithDir(repoDir).
+		WithStdinBytes(messageBytes.Bytes()).
+		RunStdString(t.Context())
+	require.NoError(t, err)
+
+	return strings.TrimSpace(stdout)
+}
+
+func TestMergeBaseNoCommonHistory(t *testing.T) {
+	repoDir := filepath.Join(t.TempDir(), "repo.git")
+	require.NoError(t, gitcmd.NewCommand("init").AddDynamicArguments(repoDir).Run(t.Context()))
+
+	baseCommit := commitRootTree(t, repoDir, "base.txt", "base", "base")
+	headCommit := commitRootTree(t, repoDir, "head.txt", "head", "head")
+
+	mergeBase, err := MergeBase(t.Context(), &mockRepository{path: repoDir}, baseCommit, headCommit)
+	assert.Empty(t, mergeBase)
+	assert.True(t, IsErrNoMergeBase(err), "expected no merge base error, got %v", err)
 }
 
 func TestRepoGetDivergingCommits(t *testing.T) {

--- a/modules/gitrepo/compare_test.go
+++ b/modules/gitrepo/compare_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"code.gitea.io/gitea/modules/git/gitcmd"
+	"code.gitea.io/gitea/modules/util"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -76,9 +77,8 @@ func TestMergeBaseNoCommonHistory(t *testing.T) {
 	headCommit := commitRootTree(t, repoDir, "head.txt", "head", "head")
 
 	mergeBase, err := MergeBase(t.Context(), &mockRepository{path: repoDir}, baseCommit, headCommit)
-	var noMergeBase ErrNoMergeBase
 	assert.Empty(t, mergeBase)
-	assert.ErrorAs(t, err, &noMergeBase)
+	assert.ErrorIs(t, err, util.ErrNotExist)
 }
 
 func TestRepoGetDivergingCommits(t *testing.T) {

--- a/modules/gitrepo/compare_test.go
+++ b/modules/gitrepo/compare_test.go
@@ -4,12 +4,9 @@
 package gitrepo
 
 import (
-	"bytes"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"code.gitea.io/gitea/modules/git/gitcmd"
 	"code.gitea.io/gitea/modules/util"
@@ -26,57 +23,28 @@ func (r *mockRepository) RelativePath() string {
 	return r.path
 }
 
-func commitRootTree(t *testing.T, repoDir, fileName, content, message string) string {
-	t.Helper()
-
-	require.NoError(t, gitcmd.NewCommand("read-tree", "--empty").WithDir(repoDir).Run(t.Context()))
-
-	stdout, _, err := gitcmd.NewCommand("hash-object", "-w", "--stdin").
-		WithDir(repoDir).
-		WithStdinBytes([]byte(content)).
-		RunStdString(t.Context())
-	require.NoError(t, err)
-	blobSHA := strings.TrimSpace(stdout)
-
-	_, _, err = gitcmd.NewCommand("update-index", "--add", "--replace", "--cacheinfo").
-		AddDynamicArguments("100644", blobSHA, fileName).
-		WithDir(repoDir).
-		RunStdString(t.Context())
-	require.NoError(t, err)
-
-	stdout, _, err = gitcmd.NewCommand("write-tree").WithDir(repoDir).RunStdString(t.Context())
-	require.NoError(t, err)
-	treeSHA := strings.TrimSpace(stdout)
-
-	commitTimeStr := time.Now().Format(time.RFC3339)
-	env := append(os.Environ(),
-		"GIT_AUTHOR_NAME=Test",
-		"GIT_AUTHOR_EMAIL=test@example.com",
-		"GIT_AUTHOR_DATE="+commitTimeStr,
-		"GIT_COMMITTER_NAME=Test",
-		"GIT_COMMITTER_EMAIL=test@example.com",
-		"GIT_COMMITTER_DATE="+commitTimeStr,
-	)
-
-	messageBytes := bytes.NewBufferString(message + "\n")
-	stdout, _, err = gitcmd.NewCommand("commit-tree").AddDynamicArguments(treeSHA).
-		WithEnv(env).
-		WithDir(repoDir).
-		WithStdinBytes(messageBytes.Bytes()).
-		RunStdString(t.Context())
-	require.NoError(t, err)
-
-	return strings.TrimSpace(stdout)
-}
-
 func TestMergeBaseNoCommonHistory(t *testing.T) {
 	repoDir := filepath.Join(t.TempDir(), "repo.git")
 	require.NoError(t, gitcmd.NewCommand("init").AddDynamicArguments(repoDir).Run(t.Context()))
+	_, _, runErr := gitcmd.NewCommand("fast-import").WithDir(repoDir).WithStdinBytes([]byte(strings.TrimSpace(`
+commit refs/heads/branch1
+committer User <user@example.com> 1714310400 +0000
+data 12
+First commit
+M 100644 inline file1.txt
+data 12
+Hello from 1
 
-	baseCommit := commitRootTree(t, repoDir, "base.txt", "base", "base")
-	headCommit := commitRootTree(t, repoDir, "head.txt", "head", "head")
-
-	mergeBase, err := MergeBase(t.Context(), &mockRepository{path: repoDir}, baseCommit, headCommit)
+commit refs/heads/branch2
+committer User <user@example.com> 1714310400 +0000
+data 13
+Second commit
+M 100644 inline file2.txt
+data 12
+Hello from 2
+`))).RunStdString(t.Context())
+	require.NoError(t, runErr)
+	mergeBase, err := MergeBase(t.Context(), &mockRepository{path: repoDir}, "branch1", "branch2")
 	assert.Empty(t, mergeBase)
 	assert.ErrorIs(t, err, util.ErrNotExist)
 }

--- a/modules/gitrepo/merge.go
+++ b/modules/gitrepo/merge.go
@@ -5,17 +5,44 @@ package gitrepo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"code.gitea.io/gitea/modules/git/gitcmd"
 )
 
+type ErrNoMergeBase struct {
+	BaseCommitID string
+	HeadCommitID string
+	Err          error
+}
+
+func IsErrNoMergeBase(err error) bool {
+	var noMergeBase ErrNoMergeBase
+	return errors.As(err, &noMergeBase)
+}
+
+func (err ErrNoMergeBase) Error() string {
+	return fmt.Sprintf("get merge-base of %s and %s failed: %v", err.BaseCommitID, err.HeadCommitID, err.Err)
+}
+
+func (err ErrNoMergeBase) Unwrap() error {
+	return err.Err
+}
+
 // MergeBase checks and returns merge base of two commits.
 func MergeBase(ctx context.Context, repo Repository, baseCommitID, headCommitID string) (string, error) {
 	mergeBase, _, err := RunCmdString(ctx, repo, gitcmd.NewCommand("merge-base").
 		AddDashesAndList(baseCommitID, headCommitID))
 	if err != nil {
+		if gitcmd.IsErrorExitCode(err, 1) {
+			return "", ErrNoMergeBase{
+				BaseCommitID: baseCommitID,
+				HeadCommitID: headCommitID,
+				Err:          err,
+			}
+		}
 		return "", fmt.Errorf("get merge-base of %s and %s failed: %w", baseCommitID, headCommitID, err)
 	}
 	return strings.TrimSpace(mergeBase), nil

--- a/modules/gitrepo/merge.go
+++ b/modules/gitrepo/merge.go
@@ -5,7 +5,6 @@ package gitrepo
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -16,11 +15,6 @@ type ErrNoMergeBase struct {
 	BaseCommitID string
 	HeadCommitID string
 	Err          error
-}
-
-func IsErrNoMergeBase(err error) bool {
-	var noMergeBase ErrNoMergeBase
-	return errors.As(err, &noMergeBase)
 }
 
 func (err ErrNoMergeBase) Error() string {

--- a/modules/gitrepo/merge.go
+++ b/modules/gitrepo/merge.go
@@ -9,33 +9,16 @@ import (
 	"strings"
 
 	"code.gitea.io/gitea/modules/git/gitcmd"
+	"code.gitea.io/gitea/modules/util"
 )
-
-type ErrNoMergeBase struct {
-	BaseCommitID string
-	HeadCommitID string
-	Err          error
-}
-
-func (err ErrNoMergeBase) Error() string {
-	return fmt.Sprintf("get merge-base of %s and %s failed: %v", err.BaseCommitID, err.HeadCommitID, err.Err)
-}
-
-func (err ErrNoMergeBase) Unwrap() error {
-	return err.Err
-}
 
 // MergeBase checks and returns merge base of two commits.
 func MergeBase(ctx context.Context, repo Repository, baseCommitID, headCommitID string) (string, error) {
-	mergeBase, _, err := RunCmdString(ctx, repo, gitcmd.NewCommand("merge-base").
+	mergeBase, stderr, err := RunCmdString(ctx, repo, gitcmd.NewCommand("merge-base").
 		AddDashesAndList(baseCommitID, headCommitID))
 	if err != nil {
-		if gitcmd.IsErrorExitCode(err, 1) {
-			return "", ErrNoMergeBase{
-				BaseCommitID: baseCommitID,
-				HeadCommitID: headCommitID,
-				Err:          err,
-			}
+		if gitcmd.IsErrorExitCode(err, 1) && strings.TrimSpace(stderr) == "" {
+			return "", util.NewNotExistErrorf("merge-base for %s and %s doesn't exist", baseCommitID, headCommitID)
 		}
 		return "", fmt.Errorf("get merge-base of %s and %s failed: %w", baseCommitID, headCommitID, err)
 	}

--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -1784,6 +1784,7 @@
   "repo.pulls.review_only_possible_for_full_diff": "Review is only possible when viewing the full diff",
   "repo.pulls.filter_changes_by_commit": "Filter by commit",
   "repo.pulls.nothing_to_compare": "These branches are equal. There is no need to create a pull request.",
+  "repo.pulls.no_common_history": "These branches do not share a common merge base. Select a different base or compare branch.",
   "repo.pulls.nothing_to_compare_have_tag": "The selected branches/tags are equal.",
   "repo.pulls.nothing_to_compare_and_allow_empty_pr": "These branches are equal. This PR will be empty.",
   "repo.pulls.has_pull_request": "A pull request between these branches already exists: <a href=\"%[1]s\">%[2]s#%[3]d</a>",

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -428,12 +428,6 @@ func ParseCompareInfo(ctx *context.Context) (*git_service.CompareInfo, bool) {
 	return &compareInfo, false
 }
 
-func prepareNoMergeBaseCompare(ctx *context.Context) {
-	ctx.Flash.Error(ctx.Tr("repo.pulls.no_common_history"), true)
-	ctx.Data["PageIsComparePull"] = false
-	ctx.Data["CommitCount"] = 0
-}
-
 func prepareNewPullRequestTitleContent(ci *git_service.CompareInfo, commits []*git_model.SignCommitWithStatuses) (title, content string) {
 	title = ci.HeadRef.ShortName()
 
@@ -615,7 +609,9 @@ func CompareDiff(ctx *context.Context) {
 
 	nothingToCompare := true
 	if noMergeBase {
-		prepareNoMergeBaseCompare(ctx)
+		ctx.Flash.Error(ctx.Tr("repo.pulls.no_common_history"), true)
+		ctx.Data["PageIsComparePull"] = false
+		ctx.Data["CommitCount"] = 0
 	} else {
 		nothingToCompare = PrepareCompareDiff(ctx, ci, gitdiff.GetWhitespaceFlag(ctx.Data["WhitespaceBehavior"].(string)))
 		if ctx.Written() {
@@ -636,29 +632,19 @@ func CompareDiff(ctx *context.Context) {
 		return
 	}
 
-	headBranches, err := git_model.FindBranchNames(ctx, git_model.FindBranchOptions{
-		RepoID:          ci.HeadRepo.ID,
-		ListOptions:     db.ListOptionsAll,
-		IsDeletedBranch: optional.Some(false),
-	})
+	headBranches, headTags, err := getBranchesAndTagsForRepo(ctx, ci.HeadRepo)
 	if err != nil {
-		ctx.ServerError("GetBranches", err)
+		ctx.ServerError("GetBranchesAndTagsForRepo", err)
 		return
 	}
 	ctx.Data["HeadBranches"] = headBranches
+	ctx.Data["HeadTags"] = headTags
 
 	// For compare repo branches
 	PrepareBranchList(ctx)
 	if ctx.Written() {
 		return
 	}
-
-	headTags, err := repo_model.GetTagNamesByRepoID(ctx, ci.HeadRepo.ID)
-	if err != nil {
-		ctx.ServerError("GetTagNamesByRepoID", err)
-		return
-	}
-	ctx.Data["HeadTags"] = headTags
 
 	if noMergeBase {
 		ctx.HTML(http.StatusOK, tplCompare)

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -532,6 +532,12 @@ func CompareDiff(ctx *context.Context) {
 	ctx.Data["PullRequestWorkInProgressPrefixes"] = setting.Repository.PullRequest.WorkInProgressPrefixes
 	ctx.Data["CompareInfo"] = ci
 
+	// TODO: need to refactor "prepare compare" related functions together
+	nothingToCompare := prepareCompareDiff(ctx, ci, gitdiff.GetWhitespaceFlag(ctx.Data["WhitespaceBehavior"].(string)))
+	if ctx.Written() {
+		return
+	}
+
 	baseTags, err := repo_model.GetTagNamesByRepoID(ctx, ctx.Repo.Repository.ID)
 	if err != nil {
 		ctx.ServerError("GetTagNamesByRepoID", err)
@@ -560,7 +566,7 @@ func CompareDiff(ctx *context.Context) {
 	}
 
 	if ci.MergeBase != "" {
-		prepareCreatePullRequestPage(ctx, ci)
+		prepareCreatePullRequestPage(ctx, ci, nothingToCompare)
 		if ctx.Written() {
 			return
 		}
@@ -572,13 +578,7 @@ func CompareDiff(ctx *context.Context) {
 	ctx.HTML(http.StatusOK, tplCompare)
 }
 
-func prepareCreatePullRequestPage(ctx *context.Context, ci *git_service.CompareInfo) {
-	// TODO: need to refactor "prepare compare" related functions together
-	nothingToCompare := prepareCompareDiff(ctx, ci, gitdiff.GetWhitespaceFlag(ctx.Data["WhitespaceBehavior"].(string)))
-	if ctx.Written() {
-		return
-	}
-
+func prepareCreatePullRequestPage(ctx *context.Context, ci *git_service.CompareInfo, nothingToCompare bool) {
 	if ctx.Data["PageIsComparePull"] == true {
 		pr, err := issues_model.GetUnmergedPullRequest(ctx, ci.HeadRepo.ID, ctx.Repo.Repository.ID, ci.HeadRef.ShortName(), ci.BaseRef.ShortName(), issues_model.PullRequestFlowGithub)
 		if err != nil {

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -381,6 +381,9 @@ func prepareNewPullRequestTitleContent(ci *git_service.CompareInfo, commits []*g
 
 // prepareCompareDiff renders compare diff page. TODO: need to refactor it and other "compare diff" related functions together
 func prepareCompareDiff(ctx *context.Context, ci *git_service.CompareInfo, whitespaceBehavior gitcmd.TrustedCmdArgs) (nothingToCompare bool) {
+	if ci.MergeBase == "" {
+		return true
+	}
 	repo := ctx.Repo.Repository
 	headCommitID := ci.HeadCommitID
 

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -189,8 +189,8 @@ func setCsvCompareContext(ctx *context.Context) {
 	}
 }
 
-// ParseCompareInfo parse compare info between two commit for preparing comparing references
-func ParseCompareInfo(ctx *context.Context) (*git_service.CompareInfo, bool) {
+// parseCompareInfo parse compare info between two commit for preparing comparing references
+func parseCompareInfo(ctx *context.Context) (*git_service.CompareInfo, error) {
 	baseRepo := ctx.Repo.Repository
 	fileOnly := ctx.FormBool("file-only")
 
@@ -199,47 +199,29 @@ func ParseCompareInfo(ctx *context.Context) (*git_service.CompareInfo, bool) {
 
 	// remove the check when we support compare with carets
 	if compareReq.BaseOriRefSuffix != "" {
-		ctx.HTTPError(http.StatusBadRequest, "Unsupported comparison syntax: ref with suffix")
-		return nil, false
+		return nil, util.NewInvalidArgumentErrorf("unsupported comparison syntax: ref with suffix")
 	}
 
 	// 2 get repository and owner for head
 	headOwner, headRepo, err := common.GetHeadOwnerAndRepo(ctx, baseRepo, compareReq)
-	switch {
-	case errors.Is(err, util.ErrInvalidArgument):
-		ctx.HTTPError(http.StatusBadRequest, err.Error())
-		return nil, false
-	case errors.Is(err, util.ErrNotExist):
-		ctx.NotFound(nil)
-		return nil, false
-	case err != nil:
-		ctx.ServerError("GetHeadOwnerAndRepo", err)
-		return nil, false
+	if err != nil {
+		return nil, err
 	}
-
-	isSameRepo := baseRepo.ID == headRepo.ID
 
 	// 3 permission check
 	// base repository's code unit read permission check has been done on web.go
 	permBase := ctx.Repo.Permission
 
 	// If we're not merging from the same repo:
+	isSameRepo := baseRepo.ID == headRepo.ID
 	if !isSameRepo {
 		// Assert ctx.Doer has permission to read headRepo's codes
 		permHead, err := access_model.GetDoerRepoPermission(ctx, headRepo, ctx.Doer)
 		if err != nil {
-			ctx.ServerError("GetDoerRepoPermission", err)
-			return nil, false
+			return nil, err
 		}
 		if !permHead.CanRead(unit.TypeCode) {
-			if log.IsTrace() {
-				log.Trace("Permission Denied: User: %-v cannot read code in Repo: %-v\nUser in headRepo has Permissions: %-+v",
-					ctx.Doer,
-					headRepo,
-					permHead)
-			}
-			ctx.NotFound(nil)
-			return nil, false
+			return nil, util.NewNotExistErrorf("") // permission: no error message for end users
 		}
 		ctx.Data["CanWriteToHeadRepo"] = permHead.CanWrite(unit.TypeCode)
 	}
@@ -250,24 +232,17 @@ func ParseCompareInfo(ctx *context.Context) (*git_service.CompareInfo, bool) {
 
 	baseRef := ctx.Repo.GitRepo.UnstableGuessRefByShortName(baseRefName)
 	if baseRef == "" {
-		ctx.NotFound(nil)
-		return nil, false
+		return nil, util.NewNotExistErrorf("no base ref: %s", baseRefName)
 	}
-	var headGitRepo *git.Repository
-	if isSameRepo {
-		headGitRepo = ctx.Repo.GitRepo
-	} else {
-		headGitRepo, err = gitrepo.OpenRepository(ctx, headRepo)
-		if err != nil {
-			ctx.ServerError("OpenRepository", err)
-			return nil, false
-		}
-		defer headGitRepo.Close()
+	headGitRepo, err := gitrepo.RepositoryFromRequestContextOrOpen(ctx, headRepo)
+	if err != nil {
+		ctx.ServerError("OpenRepository", err)
+		return nil, err
 	}
+
 	headRef := headGitRepo.UnstableGuessRefByShortName(headRefName)
 	if headRef == "" {
-		ctx.NotFound(nil)
-		return nil, false
+		return nil, util.NewNotExistErrorf("no head ref: %s", headRefName)
 	}
 
 	ctx.Data["BaseName"] = baseRepo.OwnerName
@@ -291,12 +266,9 @@ func ParseCompareInfo(ctx *context.Context) (*git_service.CompareInfo, bool) {
 	var rootRepo *repo_model.Repository
 	if baseRepo.IsFork {
 		err = baseRepo.GetBaseRepo(ctx)
-		if err != nil {
-			if !repo_model.IsErrRepoNotExist(err) {
-				ctx.ServerError("Unable to find root repo", err)
-				return nil, false
-			}
-		} else {
+		if err != nil && !repo_model.IsErrRepoNotExist(err) {
+			return nil, err
+		} else if err == nil {
 			rootRepo = baseRepo.BaseRepo
 		}
 	}
@@ -313,42 +285,10 @@ func ParseCompareInfo(ctx *context.Context) (*git_service.CompareInfo, bool) {
 		}
 	}
 
-	has := headRepo != nil
-	// 3. If the base is a forked from "RootRepo" and the owner of
-	// the "RootRepo" is the :headUser - set headRepo to that
-	if !has && rootRepo != nil && rootRepo.OwnerID == headOwner.ID {
-		headRepo = rootRepo
-		has = true
-	}
-
-	// 4. If the ctx.Doer has their own fork of the baseRepo and the headUser is the ctx.Doer
-	// set the headRepo to the ownFork
-	if !has && ownForkRepo != nil && ownForkRepo.OwnerID == headOwner.ID {
-		headRepo = ownForkRepo
-		has = true
-	}
-
-	// 5. If the headOwner has a fork of the baseRepo - use that
-	if !has {
-		headRepo = repo_model.GetForkedRepo(ctx, headOwner.ID, baseRepo.ID)
-		has = headRepo != nil
-	}
-
-	// 6. If the baseRepo is a fork and the headUser has a fork of that use that
-	if !has && baseRepo.IsFork {
-		headRepo = repo_model.GetForkedRepo(ctx, headOwner.ID, baseRepo.ForkID)
-		has = headRepo != nil
-	}
-
-	// 7. Otherwise if we're not the same repo and haven't found a repo give up
-	if !isSameRepo && !has {
-		ctx.Data["PageIsComparePull"] = false
-	}
-
 	ctx.Data["HeadRepo"] = headRepo
 	ctx.Data["BaseCompareRepo"] = ctx.Repo.Repository
 
-	// If we have a rootRepo and it's different from:
+	// If we have a rootRepo, and it's different from:
 	// 1. the computed base
 	// 2. the computed head
 	// then get the branches of it
@@ -361,17 +301,15 @@ func ParseCompareInfo(ctx *context.Context) (*git_service.CompareInfo, bool) {
 			if !fileOnly {
 				branches, tags, err := getBranchesAndTagsForRepo(ctx, rootRepo)
 				if err != nil {
-					ctx.ServerError("GetBranchesForRepo", err)
-					return nil, false
+					return nil, err
 				}
-
 				ctx.Data["RootRepoBranches"] = branches
 				ctx.Data["RootRepoTags"] = tags
 			}
 		}
 	}
 
-	// If we have a ownForkRepo and it's different from:
+	// If we have a ownForkRepo, and it's different from:
 	// 1. The computed base
 	// 2. The computed head
 	// 3. The rootRepo (if we have one)
@@ -386,8 +324,7 @@ func ParseCompareInfo(ctx *context.Context) (*git_service.CompareInfo, bool) {
 			if !fileOnly {
 				branches, tags, err := getBranchesAndTagsForRepo(ctx, ownForkRepo)
 				if err != nil {
-					ctx.ServerError("GetBranchesForRepo", err)
-					return nil, false
+					return nil, err
 				}
 				ctx.Data["OwnForkRepoBranches"] = branches
 				ctx.Data["OwnForkRepoTags"] = tags
@@ -396,36 +333,24 @@ func ParseCompareInfo(ctx *context.Context) (*git_service.CompareInfo, bool) {
 	}
 
 	// Treat as pull request if both references are branches
-	if ctx.Data["PageIsComparePull"] == nil {
-		ctx.Data["PageIsComparePull"] = baseRef.IsBranch() && headRef.IsBranch() && permBase.CanReadIssuesOrPulls(true)
-	}
-
-	if ctx.Data["PageIsComparePull"] == true && !permBase.CanReadIssuesOrPulls(true) {
-		if log.IsTrace() {
-			log.Trace("Permission Denied: User: %-v cannot create/read pull requests in Repo: %-v\nUser in baseRepo has Permissions: %-+v",
-				ctx.Doer,
-				baseRepo,
-				permBase)
-		}
-		ctx.NotFound(nil)
-		return nil, false
+	willCreatePullRequest := baseRef.IsBranch() && headRef.IsBranch() && permBase.CanReadIssuesOrPulls(true)
+	if willCreatePullRequest && !permBase.CanReadIssuesOrPulls(true) {
+		return nil, util.NewNotExistErrorf("") // permission: no error message for end users
 	}
 
 	compareInfo, err := git_service.GetCompareInfo(ctx, baseRepo, headRepo, headGitRepo, baseRef, headRef, compareReq.DirectComparison(), fileOnly)
 	if err != nil {
-		var noMergeBase gitrepo.ErrNoMergeBase
-		if errors.As(err, &noMergeBase) {
-			return &compareInfo, true
-		}
-		ctx.ServerError("GetCompareInfo", err)
-		return nil, false
+		return nil, err
 	}
+
+	willCreatePullRequest = willCreatePullRequest && compareInfo.MergeBase != ""
+	ctx.Data["PageIsComparePull"] = willCreatePullRequest
 	if compareReq.DirectComparison() {
 		ctx.Data["BeforeCommitID"] = compareInfo.BaseCommitID
 	} else {
 		ctx.Data["BeforeCommitID"] = compareInfo.MergeBase
 	}
-	return &compareInfo, false
+	return &compareInfo, nil
 }
 
 func prepareNewPullRequestTitleContent(ci *git_service.CompareInfo, commits []*git_model.SignCommitWithStatuses) (title, content string) {
@@ -598,8 +523,15 @@ func getBranchesAndTagsForRepo(ctx gocontext.Context, repo *repo_model.Repositor
 
 // CompareDiff show different from one commit to another commit
 func CompareDiff(ctx *context.Context) {
-	ci, noMergeBase := ParseCompareInfo(ctx)
+	ci, err := parseCompareInfo(ctx)
 	if ctx.Written() {
+		return
+	}
+	if errors.Is(err, util.ErrNotExist) || errors.Is(err, util.ErrInvalidArgument) {
+		ctx.NotFound(nil)
+		return
+	} else if err != nil {
+		ctx.ServerError("ParseCompareInfo", err)
 		return
 	}
 
@@ -607,18 +539,20 @@ func CompareDiff(ctx *context.Context) {
 	ctx.Data["PullRequestWorkInProgressPrefixes"] = setting.Repository.PullRequest.WorkInProgressPrefixes
 	ctx.Data["CompareInfo"] = ci
 
-	nothingToCompare := true
-	if noMergeBase {
-		ctx.Flash.Error(ctx.Tr("repo.pulls.no_common_history"), true)
-		ctx.Data["PageIsComparePull"] = false
-		ctx.Data["CommitCount"] = 0
-	} else {
-		nothingToCompare = PrepareCompareDiff(ctx, ci, gitdiff.GetWhitespaceFlag(ctx.Data["WhitespaceBehavior"].(string)))
+	if ci.MergeBase != "" {
+		prepareCreatePullRequestPage(ctx, ci)
 		if ctx.Written() {
 			return
 		}
+	} else {
+		ctx.Flash.Error(ctx.Tr("repo.pulls.no_common_history"), true)
+		ctx.Data["PageIsComparePull"] = false
+		ctx.Data["CommitCount"] = 0
 	}
+	ctx.HTML(http.StatusOK, tplCompare)
+}
 
+func prepareCreatePullRequestPage(ctx *context.Context, ci *git_service.CompareInfo) {
 	baseTags, err := repo_model.GetTagNamesByRepoID(ctx, ctx.Repo.Repository.ID)
 	if err != nil {
 		ctx.ServerError("GetTagNamesByRepoID", err)
@@ -646,8 +580,8 @@ func CompareDiff(ctx *context.Context) {
 		return
 	}
 
-	if noMergeBase {
-		ctx.HTML(http.StatusOK, tplCompare)
+	nothingToCompare := PrepareCompareDiff(ctx, ci, gitdiff.GetWhitespaceFlag(ctx.Data["WhitespaceBehavior"].(string)))
+	if ctx.Written() {
 		return
 	}
 
@@ -691,7 +625,7 @@ func CompareDiff(ctx *context.Context) {
 	if content, ok := ctx.Data["content"].(string); ok && content != "" {
 		// If a template content is set, prepend the "content". In this case that's only
 		// applicable if you have one commit to compare and that commit has a message.
-		// In that case the commit message will be prepend to the template body.
+		// In that case the commit message will be prepended to the template body.
 		if templateContent, ok := ctx.Data[pullRequestTemplateKey].(string); ok && templateContent != "" {
 			// Re-use the same key as that's prioritized over the "content" key.
 			// Add two new lines between the content to ensure there's always at least
@@ -719,14 +653,8 @@ func CompareDiff(ctx *context.Context) {
 
 	ctx.Data["HasIssuesOrPullsWritePermission"] = ctx.Repo.Permission.CanWrite(unit.TypePullRequests)
 
-	if unit, err := ctx.Repo.Repository.GetUnit(ctx, unit.TypePullRequests); err == nil {
-		config := unit.PullRequestsConfig()
-		ctx.Data["AllowMaintainerEdit"] = config.DefaultAllowMaintainerEdit
-	} else {
-		ctx.Data["AllowMaintainerEdit"] = false
-	}
-
-	ctx.HTML(http.StatusOK, tplCompare)
+	prConfig := ctx.Repo.Repository.MustGetUnit(ctx, unit.TypePullRequests).PullRequestsConfig()
+	ctx.Data["AllowMaintainerEdit"] = prConfig.DefaultAllowMaintainerEdit
 }
 
 // attachCommentsToLines attaches comments to their corresponding diff lines

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -332,19 +332,15 @@ func parseCompareInfo(ctx *context.Context) (*git_service.CompareInfo, error) {
 		}
 	}
 
-	// Treat as pull request if both references are branches
-	willCreatePullRequest := baseRef.IsBranch() && headRef.IsBranch() && permBase.CanReadIssuesOrPulls(true)
-	if willCreatePullRequest && !permBase.CanReadIssuesOrPulls(true) {
-		return nil, util.NewNotExistErrorf("") // permission: no error message for end users
-	}
-
 	compareInfo, err := git_service.GetCompareInfo(ctx, baseRepo, headRepo, headGitRepo, baseRef, headRef, compareReq.DirectComparison(), fileOnly)
 	if err != nil {
 		return nil, err
 	}
 
-	willCreatePullRequest = willCreatePullRequest && compareInfo.MergeBase != ""
-	ctx.Data["PageIsComparePull"] = willCreatePullRequest
+	// Treat as pull request if both references are branches
+	allowCreatePullRequest := baseRef.IsBranch() && headRef.IsBranch() && permBase.CanReadIssuesOrPulls(true)
+	allowCreatePullRequest = allowCreatePullRequest && compareInfo.MergeBase != ""
+	ctx.Data["PageIsComparePull"] = allowCreatePullRequest
 	if compareReq.DirectComparison() {
 		ctx.Data["BeforeCommitID"] = compareInfo.BaseCommitID
 	} else {

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -413,6 +413,12 @@ func ParseCompareInfo(ctx *context.Context) *git_service.CompareInfo {
 
 	compareInfo, err := git_service.GetCompareInfo(ctx, baseRepo, headRepo, headGitRepo, baseRef, headRef, compareReq.DirectComparison(), fileOnly)
 	if err != nil {
+		if gitrepo.IsErrNoMergeBase(err) {
+			ctx.Data["NoMergeBase"] = true
+			ctx.Data["BeforeCommitID"] = compareInfo.BaseCommitID
+			ctx.Data["AfterCommitID"] = compareInfo.HeadCommitID
+			return &compareInfo
+		}
 		ctx.ServerError("GetCompareInfo", err)
 		return nil
 	}
@@ -472,6 +478,12 @@ func PrepareCompareDiff(
 	ctx.Data["ExpandNewPrForm"] = ctx.FormBool("expand") || ctx.FormBool("quick_pull") || newPrFormTitle != "" || newPrFormBody != ""
 	ctx.Data["TitleQuery"] = newPrFormTitle
 	ctx.Data["BodyQuery"] = newPrFormBody
+
+	if ctx.Data["NoMergeBase"] == true {
+		ctx.Data["CommitCount"] = 0
+		ctx.Data["Commits"] = []*git_model.SignCommitWithStatuses{}
+		return true
+	}
 
 	if (headCommitID == ci.MergeBase && !ci.DirectComparison()) ||
 		headCommitID == ci.BaseCommitID {

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -413,10 +413,9 @@ func ParseCompareInfo(ctx *context.Context) *git_service.CompareInfo {
 
 	compareInfo, err := git_service.GetCompareInfo(ctx, baseRepo, headRepo, headGitRepo, baseRef, headRef, compareReq.DirectComparison(), fileOnly)
 	if err != nil {
-		if gitrepo.IsErrNoMergeBase(err) {
+		var noMergeBase gitrepo.ErrNoMergeBase
+		if errors.As(err, &noMergeBase) {
 			ctx.Data["NoMergeBase"] = true
-			ctx.Data["BeforeCommitID"] = compareInfo.BaseCommitID
-			ctx.Data["AfterCommitID"] = compareInfo.HeadCommitID
 			return &compareInfo
 		}
 		ctx.ServerError("GetCompareInfo", err)
@@ -428,6 +427,13 @@ func ParseCompareInfo(ctx *context.Context) *git_service.CompareInfo {
 		ctx.Data["BeforeCommitID"] = compareInfo.MergeBase
 	}
 	return &compareInfo
+}
+
+func prepareNoMergeBaseCompare(ctx *context.Context) {
+	ctx.Flash.Error(ctx.Tr("repo.pulls.no_common_history"), true)
+	ctx.Data["PageIsComparePull"] = false
+	ctx.Data["CommitCount"] = 0
+	ctx.Data["HideCompareNothingMessage"] = true
 }
 
 func prepareNewPullRequestTitleContent(ci *git_service.CompareInfo, commits []*git_model.SignCommitWithStatuses) (title, content string) {
@@ -478,12 +484,6 @@ func PrepareCompareDiff(
 	ctx.Data["ExpandNewPrForm"] = ctx.FormBool("expand") || ctx.FormBool("quick_pull") || newPrFormTitle != "" || newPrFormBody != ""
 	ctx.Data["TitleQuery"] = newPrFormTitle
 	ctx.Data["BodyQuery"] = newPrFormBody
-
-	if ctx.Data["NoMergeBase"] == true {
-		ctx.Data["CommitCount"] = 0
-		ctx.Data["Commits"] = []*git_model.SignCommitWithStatuses{}
-		return true
-	}
 
 	if (headCommitID == ci.MergeBase && !ci.DirectComparison()) ||
 		headCommitID == ci.BaseCommitID {
@@ -615,9 +615,14 @@ func CompareDiff(ctx *context.Context) {
 	ctx.Data["PullRequestWorkInProgressPrefixes"] = setting.Repository.PullRequest.WorkInProgressPrefixes
 	ctx.Data["CompareInfo"] = ci
 
-	nothingToCompare := PrepareCompareDiff(ctx, ci, gitdiff.GetWhitespaceFlag(ctx.Data["WhitespaceBehavior"].(string)))
-	if ctx.Written() {
-		return
+	nothingToCompare := true
+	if ctx.Data["NoMergeBase"] == true {
+		prepareNoMergeBaseCompare(ctx)
+	} else {
+		nothingToCompare = PrepareCompareDiff(ctx, ci, gitdiff.GetWhitespaceFlag(ctx.Data["WhitespaceBehavior"].(string)))
+		if ctx.Written() {
+			return
+		}
 	}
 
 	baseTags, err := repo_model.GetTagNamesByRepoID(ctx, ctx.Repo.Repository.ID)
@@ -656,6 +661,11 @@ func CompareDiff(ctx *context.Context) {
 		return
 	}
 	ctx.Data["HeadTags"] = headTags
+
+	if ctx.Data["NoMergeBase"] == true {
+		ctx.HTML(http.StatusOK, tplCompare)
+		return
+	}
 
 	if ctx.Data["PageIsComparePull"] == true {
 		pr, err := issues_model.GetUnmergedPullRequest(ctx, ci.HeadRepo.ID, ctx.Repo.Repository.ID, ci.HeadRef.ShortName(), ci.BaseRef.ShortName(), issues_model.PullRequestFlowGithub)

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -190,7 +190,7 @@ func setCsvCompareContext(ctx *context.Context) {
 }
 
 // ParseCompareInfo parse compare info between two commit for preparing comparing references
-func ParseCompareInfo(ctx *context.Context) *git_service.CompareInfo {
+func ParseCompareInfo(ctx *context.Context) (*git_service.CompareInfo, bool) {
 	baseRepo := ctx.Repo.Repository
 	fileOnly := ctx.FormBool("file-only")
 
@@ -200,7 +200,7 @@ func ParseCompareInfo(ctx *context.Context) *git_service.CompareInfo {
 	// remove the check when we support compare with carets
 	if compareReq.BaseOriRefSuffix != "" {
 		ctx.HTTPError(http.StatusBadRequest, "Unsupported comparison syntax: ref with suffix")
-		return nil
+		return nil, false
 	}
 
 	// 2 get repository and owner for head
@@ -208,13 +208,13 @@ func ParseCompareInfo(ctx *context.Context) *git_service.CompareInfo {
 	switch {
 	case errors.Is(err, util.ErrInvalidArgument):
 		ctx.HTTPError(http.StatusBadRequest, err.Error())
-		return nil
+		return nil, false
 	case errors.Is(err, util.ErrNotExist):
 		ctx.NotFound(nil)
-		return nil
+		return nil, false
 	case err != nil:
 		ctx.ServerError("GetHeadOwnerAndRepo", err)
-		return nil
+		return nil, false
 	}
 
 	isSameRepo := baseRepo.ID == headRepo.ID
@@ -229,7 +229,7 @@ func ParseCompareInfo(ctx *context.Context) *git_service.CompareInfo {
 		permHead, err := access_model.GetDoerRepoPermission(ctx, headRepo, ctx.Doer)
 		if err != nil {
 			ctx.ServerError("GetDoerRepoPermission", err)
-			return nil
+			return nil, false
 		}
 		if !permHead.CanRead(unit.TypeCode) {
 			if log.IsTrace() {
@@ -239,7 +239,7 @@ func ParseCompareInfo(ctx *context.Context) *git_service.CompareInfo {
 					permHead)
 			}
 			ctx.NotFound(nil)
-			return nil
+			return nil, false
 		}
 		ctx.Data["CanWriteToHeadRepo"] = permHead.CanWrite(unit.TypeCode)
 	}
@@ -251,7 +251,7 @@ func ParseCompareInfo(ctx *context.Context) *git_service.CompareInfo {
 	baseRef := ctx.Repo.GitRepo.UnstableGuessRefByShortName(baseRefName)
 	if baseRef == "" {
 		ctx.NotFound(nil)
-		return nil
+		return nil, false
 	}
 	var headGitRepo *git.Repository
 	if isSameRepo {
@@ -260,14 +260,14 @@ func ParseCompareInfo(ctx *context.Context) *git_service.CompareInfo {
 		headGitRepo, err = gitrepo.OpenRepository(ctx, headRepo)
 		if err != nil {
 			ctx.ServerError("OpenRepository", err)
-			return nil
+			return nil, false
 		}
 		defer headGitRepo.Close()
 	}
 	headRef := headGitRepo.UnstableGuessRefByShortName(headRefName)
 	if headRef == "" {
 		ctx.NotFound(nil)
-		return nil
+		return nil, false
 	}
 
 	ctx.Data["BaseName"] = baseRepo.OwnerName
@@ -294,7 +294,7 @@ func ParseCompareInfo(ctx *context.Context) *git_service.CompareInfo {
 		if err != nil {
 			if !repo_model.IsErrRepoNotExist(err) {
 				ctx.ServerError("Unable to find root repo", err)
-				return nil
+				return nil, false
 			}
 		} else {
 			rootRepo = baseRepo.BaseRepo
@@ -362,7 +362,7 @@ func ParseCompareInfo(ctx *context.Context) *git_service.CompareInfo {
 				branches, tags, err := getBranchesAndTagsForRepo(ctx, rootRepo)
 				if err != nil {
 					ctx.ServerError("GetBranchesForRepo", err)
-					return nil
+					return nil, false
 				}
 
 				ctx.Data["RootRepoBranches"] = branches
@@ -387,7 +387,7 @@ func ParseCompareInfo(ctx *context.Context) *git_service.CompareInfo {
 				branches, tags, err := getBranchesAndTagsForRepo(ctx, ownForkRepo)
 				if err != nil {
 					ctx.ServerError("GetBranchesForRepo", err)
-					return nil
+					return nil, false
 				}
 				ctx.Data["OwnForkRepoBranches"] = branches
 				ctx.Data["OwnForkRepoTags"] = tags
@@ -408,32 +408,30 @@ func ParseCompareInfo(ctx *context.Context) *git_service.CompareInfo {
 				permBase)
 		}
 		ctx.NotFound(nil)
-		return nil
+		return nil, false
 	}
 
 	compareInfo, err := git_service.GetCompareInfo(ctx, baseRepo, headRepo, headGitRepo, baseRef, headRef, compareReq.DirectComparison(), fileOnly)
 	if err != nil {
 		var noMergeBase gitrepo.ErrNoMergeBase
 		if errors.As(err, &noMergeBase) {
-			ctx.Data["NoMergeBase"] = true
-			return &compareInfo
+			return &compareInfo, true
 		}
 		ctx.ServerError("GetCompareInfo", err)
-		return nil
+		return nil, false
 	}
 	if compareReq.DirectComparison() {
 		ctx.Data["BeforeCommitID"] = compareInfo.BaseCommitID
 	} else {
 		ctx.Data["BeforeCommitID"] = compareInfo.MergeBase
 	}
-	return &compareInfo
+	return &compareInfo, false
 }
 
 func prepareNoMergeBaseCompare(ctx *context.Context) {
 	ctx.Flash.Error(ctx.Tr("repo.pulls.no_common_history"), true)
 	ctx.Data["PageIsComparePull"] = false
 	ctx.Data["CommitCount"] = 0
-	ctx.Data["HideCompareNothingMessage"] = true
 }
 
 func prepareNewPullRequestTitleContent(ci *git_service.CompareInfo, commits []*git_model.SignCommitWithStatuses) (title, content string) {
@@ -606,7 +604,7 @@ func getBranchesAndTagsForRepo(ctx gocontext.Context, repo *repo_model.Repositor
 
 // CompareDiff show different from one commit to another commit
 func CompareDiff(ctx *context.Context) {
-	ci := ParseCompareInfo(ctx)
+	ci, noMergeBase := ParseCompareInfo(ctx)
 	if ctx.Written() {
 		return
 	}
@@ -616,7 +614,7 @@ func CompareDiff(ctx *context.Context) {
 	ctx.Data["CompareInfo"] = ci
 
 	nothingToCompare := true
-	if ctx.Data["NoMergeBase"] == true {
+	if noMergeBase {
 		prepareNoMergeBaseCompare(ctx)
 	} else {
 		nothingToCompare = PrepareCompareDiff(ctx, ci, gitdiff.GetWhitespaceFlag(ctx.Data["WhitespaceBehavior"].(string)))
@@ -662,7 +660,7 @@ func CompareDiff(ctx *context.Context) {
 	}
 	ctx.Data["HeadTags"] = headTags
 
-	if ctx.Data["NoMergeBase"] == true {
+	if noMergeBase {
 		ctx.HTML(http.StatusOK, tplCompare)
 		return
 	}

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -383,12 +383,8 @@ func prepareNewPullRequestTitleContent(ci *git_service.CompareInfo, commits []*g
 	return title, content
 }
 
-// PrepareCompareDiff renders compare diff page
-func PrepareCompareDiff(
-	ctx *context.Context,
-	ci *git_service.CompareInfo,
-	whitespaceBehavior gitcmd.TrustedCmdArgs,
-) (nothingToCompare bool) {
+// prepareCompareDiff renders compare diff page. TODO: need to refactor it and other "compare diff" related functions together
+func prepareCompareDiff(ctx *context.Context, ci *git_service.CompareInfo, whitespaceBehavior gitcmd.TrustedCmdArgs) (nothingToCompare bool) {
 	repo := ctx.Repo.Repository
 	headCommitID := ci.HeadCommitID
 
@@ -497,9 +493,6 @@ func PrepareCompareDiff(
 	ctx.Data["CommitCount"] = len(commits)
 
 	ctx.Data["title"], ctx.Data["content"] = prepareNewPullRequestTitleContent(ci, commits)
-	ctx.Data["Username"] = ci.HeadRepo.OwnerName
-	ctx.Data["Reponame"] = ci.HeadRepo.Name
-
 	setCompareContext(ctx, beforeCommit, headCommit, ci.HeadRepo.OwnerName, repo.Name)
 
 	return false
@@ -539,20 +532,6 @@ func CompareDiff(ctx *context.Context) {
 	ctx.Data["PullRequestWorkInProgressPrefixes"] = setting.Repository.PullRequest.WorkInProgressPrefixes
 	ctx.Data["CompareInfo"] = ci
 
-	if ci.MergeBase != "" {
-		prepareCreatePullRequestPage(ctx, ci)
-		if ctx.Written() {
-			return
-		}
-	} else {
-		ctx.Flash.Error(ctx.Tr("repo.pulls.no_common_history"), true)
-		ctx.Data["PageIsComparePull"] = false
-		ctx.Data["CommitCount"] = 0
-	}
-	ctx.HTML(http.StatusOK, tplCompare)
-}
-
-func prepareCreatePullRequestPage(ctx *context.Context, ci *git_service.CompareInfo) {
 	baseTags, err := repo_model.GetTagNamesByRepoID(ctx, ctx.Repo.Repository.ID)
 	if err != nil {
 		ctx.ServerError("GetTagNamesByRepoID", err)
@@ -580,7 +559,22 @@ func prepareCreatePullRequestPage(ctx *context.Context, ci *git_service.CompareI
 		return
 	}
 
-	nothingToCompare := PrepareCompareDiff(ctx, ci, gitdiff.GetWhitespaceFlag(ctx.Data["WhitespaceBehavior"].(string)))
+	if ci.MergeBase != "" {
+		prepareCreatePullRequestPage(ctx, ci)
+		if ctx.Written() {
+			return
+		}
+	} else {
+		ctx.Flash.Error(ctx.Tr("repo.pulls.no_common_history"), true)
+		ctx.Data["PageIsComparePull"] = false
+		ctx.Data["CommitCount"] = 0
+	}
+	ctx.HTML(http.StatusOK, tplCompare)
+}
+
+func prepareCreatePullRequestPage(ctx *context.Context, ci *git_service.CompareInfo) {
+	// TODO: need to refactor "prepare compare" related functions together
+	nothingToCompare := prepareCompareDiff(ctx, ci, gitdiff.GetWhitespaceFlag(ctx.Data["WhitespaceBehavior"].(string)))
 	if ctx.Written() {
 		return
 	}

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -1294,7 +1294,10 @@ func CompareAndPullRequestPost(ctx *context.Context) {
 		ctx.ServerError("ParseCompareInfo", err)
 		return
 	}
-
+	if ci.MergeBase == "" {
+		ctx.JSONError(ctx.Tr("repo.pulls.no_common_history"))
+		return
+	}
 	validateRet := ValidateRepoMetasForNewIssue(ctx, *form, true)
 	if ctx.Written() {
 		return

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -1287,7 +1287,10 @@ func CompareAndPullRequestPost(ctx *context.Context) {
 	if ctx.Written() {
 		return
 	}
-	if errors.Is(err, util.ErrNotExist) || errors.Is(err, util.ErrInvalidArgument) {
+	if errors.Is(err, util.ErrNotExist) {
+		ctx.JSONErrorNotFound()
+		return
+	} else if errors.Is(err, util.ErrInvalidArgument) {
 		ctx.JSONError(err.Error())
 		return
 	} else if err != nil {

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -1294,7 +1294,7 @@ func CompareAndPullRequestPost(ctx *context.Context) {
 		attachments []string
 	)
 
-	ci := ParseCompareInfo(ctx)
+	ci, _ := ParseCompareInfo(ctx)
 	if ctx.Written() {
 		return
 	}

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -1281,21 +1281,17 @@ func PullsNewRedirect(ctx *context.Context) {
 // CompareAndPullRequestPost response for creating pull request
 func CompareAndPullRequestPost(ctx *context.Context) {
 	form := web.GetForm(ctx).(*forms.CreateIssueForm)
-	ctx.Data["Title"] = ctx.Tr("repo.pulls.compare_changes")
-	ctx.Data["PageIsComparePull"] = true
-	ctx.Data["IsDiffCompare"] = true
-	ctx.Data["PullRequestWorkInProgressPrefixes"] = setting.Repository.PullRequest.WorkInProgressPrefixes
-	ctx.Data["IsAttachmentEnabled"] = setting.Attachment.Enabled
-	upload.AddUploadContext(ctx, "comment")
-	ctx.Data["HasIssuesOrPullsWritePermission"] = ctx.Repo.Permission.CanWrite(unit.TypePullRequests)
+	repo := ctx.Repo.Repository
 
-	var (
-		repo        = ctx.Repo.Repository
-		attachments []string
-	)
-
-	ci, _ := ParseCompareInfo(ctx)
+	ci, err := parseCompareInfo(ctx)
 	if ctx.Written() {
+		return
+	}
+	if errors.Is(err, util.ErrNotExist) || errors.Is(err, util.ErrInvalidArgument) {
+		ctx.JSONError(err.Error())
+		return
+	} else if err != nil {
+		ctx.ServerError("ParseCompareInfo", err)
 		return
 	}
 
@@ -1306,6 +1302,7 @@ func CompareAndPullRequestPost(ctx *context.Context) {
 
 	labelIDs, assigneeIDs, milestoneID, projectID := validateRet.LabelIDs, validateRet.AssigneeIDs, validateRet.MilestoneID, validateRet.ProjectID
 
+	var attachments []string
 	if setting.Attachment.Enabled {
 		attachments = form.Files
 	}

--- a/services/git/compare.go
+++ b/services/git/compare.go
@@ -45,6 +45,7 @@ func (ci *CompareInfo) DirectComparison() bool {
 
 // GetCompareInfo generates and returns compare information between base and head branches of repositories.
 // It does its best to fill the fields as many as it can.
+// MergeBase can be empty if the base and head are unrelated.
 func GetCompareInfo(ctx context.Context, baseRepo, headRepo *repo_model.Repository, headGitRepo *git.Repository, baseRef, headRef git.RefName, directComparison, fileOnly bool) (compareInfo CompareInfo, err error) {
 	baseCommitID, err1 := gitrepo.GetFullCommitID(ctx, baseRepo, baseRef.String())
 	headCommitID, err2 := gitrepo.GetFullCommitID(ctx, headRepo, headRef.String())
@@ -75,7 +76,7 @@ func GetCompareInfo(ctx context.Context, baseRepo, headRepo *repo_model.Reposito
 
 	if !directComparison {
 		compareInfo.MergeBase, err = gitrepo.MergeBase(ctx, headRepo, compareInfo.BaseCommitID, compareInfo.HeadCommitID)
-		if err != nil {
+		if err != nil && !errors.Is(err, util.ErrNotExist) {
 			return compareInfo, fmt.Errorf("MergeBase: %w", err)
 		}
 	} else {

--- a/services/git/compare.go
+++ b/services/git/compare.go
@@ -83,6 +83,10 @@ func GetCompareInfo(ctx context.Context, baseRepo, headRepo *repo_model.Reposito
 		compareInfo.MergeBase = compareInfo.BaseCommitID
 	}
 
+	if compareInfo.MergeBase == "" {
+		return compareInfo, nil
+	}
+
 	// We have a common base - therefore we know that ... should work
 	if !fileOnly {
 		// In git log/rev-list, the "..." syntax represents the symmetric difference between two references,
@@ -93,12 +97,10 @@ func GetCompareInfo(ctx context.Context, baseRepo, headRepo *repo_model.Reposito
 		if err != nil {
 			return compareInfo, fmt.Errorf("ShowPrettyFormatLogToList: %w", err)
 		}
-	} else {
-		compareInfo.Commits = []*git.Commit{}
 	}
 
 	// Count number of changed files.
-	// This probably should be removed as we need to use shortstat elsewhere
+	// TODO: This probably should be removed as we need to use shortstat elsewhere
 	// Now there is git diff --shortstat but this appears to be slower than simply iterating with --nameonly
 	compareInfo.NumFiles, err = headGitRepo.GetDiffNumChangedFiles(compareInfo.BaseCommitID, compareInfo.HeadCommitID, directComparison)
 	return compareInfo, err

--- a/templates/repo/diff/compare.tmpl
+++ b/templates/repo/diff/compare.tmpl
@@ -168,7 +168,11 @@
 		</div>
 
 		{{$showDiffBox := and .CommitCount (not .IsNothingToCompare)}}
-		{{if and .IsSigned .PageIsComparePull}}
+		{{if .NoMergeBase}}
+			<div class="ui warning message">
+				{{ctx.Locale.Tr "repo.pulls.no_common_history"}}
+			</div>
+		{{else if and .IsSigned .PageIsComparePull}}
 			{{$allowCreatePR := and ($.CompareInfo.BaseRef.IsBranch) ($.CompareInfo.HeadRef.IsBranch) (not $.CompareInfo.DirectComparison) (or $.AllowEmptyPr (not .IsNothingToCompare))}}
 			{{if .IsNothingToCompare}}
 				<div class="ui segment">

--- a/templates/repo/diff/compare.tmpl
+++ b/templates/repo/diff/compare.tmpl
@@ -211,7 +211,7 @@
 				</div>
 			{{end}}
 		{{else}}{{/* not singed-in or not for pull-request */}}
-			{{if and (not .CommitCount) (not .HideCompareNothingMessage)}}
+			{{if not .CommitCount}}
 				<div class="ui segment">{{ctx.Locale.Tr "repo.commits.nothing_to_compare"}}</div>
 			{{end}}
 		{{end}}

--- a/templates/repo/diff/compare.tmpl
+++ b/templates/repo/diff/compare.tmpl
@@ -13,6 +13,7 @@
 				{{ctx.Locale.Tr "action.compare_commits_general"}}
 			{{end}}
 		</h2>
+		{{template "base/alert" .}}
 		{{$BaseCompareName := $.Repository.FullName -}}
 		{{$HeadCompareName := $.HeadRepo.FullName -}}
 		{{$OwnForkCompareName := "" -}}
@@ -168,11 +169,7 @@
 		</div>
 
 		{{$showDiffBox := and .CommitCount (not .IsNothingToCompare)}}
-		{{if .NoMergeBase}}
-			<div class="ui warning message">
-				{{ctx.Locale.Tr "repo.pulls.no_common_history"}}
-			</div>
-		{{else if and .IsSigned .PageIsComparePull}}
+		{{if and .IsSigned .PageIsComparePull}}
 			{{$allowCreatePR := and ($.CompareInfo.BaseRef.IsBranch) ($.CompareInfo.HeadRef.IsBranch) (not $.CompareInfo.DirectComparison) (or $.AllowEmptyPr (not .IsNothingToCompare))}}
 			{{if .IsNothingToCompare}}
 				<div class="ui segment">
@@ -214,7 +211,7 @@
 				</div>
 			{{end}}
 		{{else}}{{/* not singed-in or not for pull-request */}}
-			{{if not .CommitCount}}
+			{{if and (not .CommitCount) (not .HideCompareNothingMessage)}}
 				<div class="ui segment">{{ctx.Locale.Tr "repo.commits.nothing_to_compare"}}</div>
 			{{end}}
 		{{end}}

--- a/tests/integration/compare_test.go
+++ b/tests/integration/compare_test.go
@@ -4,19 +4,25 @@
 package integration
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
+	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unittest"
 	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/git/gitcmd"
 	"code.gitea.io/gitea/modules/test"
 	repo_service "code.gitea.io/gitea/services/repository"
 	"code.gitea.io/gitea/tests"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCompareTag(t *testing.T) {
@@ -122,6 +128,76 @@ func TestCompareBranches(t *testing.T) {
 	diffChanges = []string{"test.txt"}
 
 	inspectCompare(t, htmlDoc, diffCount, diffChanges)
+}
+
+func createUnrelatedBranch(t *testing.T, repo *repo_model.Repository, user *user_model.User, branchName string) {
+	t.Helper()
+
+	repoPath := repo_model.RepoPath(user.Name, repo.Name)
+	require.NoError(t, gitcmd.NewCommand("read-tree", "--empty").WithDir(repoPath).Run(t.Context()))
+
+	stdout, _, err := gitcmd.NewCommand("hash-object", "-w", "--stdin").
+		WithDir(repoPath).
+		WithStdinBytes([]byte("Unrelated File")).
+		RunStdString(t.Context())
+	require.NoError(t, err)
+	blobSHA := strings.TrimSpace(stdout)
+
+	_, _, err = gitcmd.NewCommand("update-index", "--add", "--replace", "--cacheinfo").
+		AddDynamicArguments("100644", blobSHA, "unrelated.txt").
+		WithDir(repoPath).
+		RunStdString(t.Context())
+	require.NoError(t, err)
+
+	stdout, _, err = gitcmd.NewCommand("write-tree").WithDir(repoPath).RunStdString(t.Context())
+	require.NoError(t, err)
+	treeSHA := strings.TrimSpace(stdout)
+
+	commitTimeStr := time.Now().Format(time.RFC3339)
+	doerSig := user.NewGitSig()
+	env := append(os.Environ(),
+		"GIT_AUTHOR_NAME="+doerSig.Name,
+		"GIT_AUTHOR_EMAIL="+doerSig.Email,
+		"GIT_AUTHOR_DATE="+commitTimeStr,
+		"GIT_COMMITTER_NAME="+doerSig.Name,
+		"GIT_COMMITTER_EMAIL="+doerSig.Email,
+		"GIT_COMMITTER_DATE="+commitTimeStr,
+	)
+
+	messageBytes := bytes.NewBufferString("Unrelated\n")
+	stdout, _, err = gitcmd.NewCommand("commit-tree").AddDynamicArguments(treeSHA).
+		WithEnv(env).
+		WithDir(repoPath).
+		WithStdinBytes(messageBytes.Bytes()).
+		RunStdString(t.Context())
+	require.NoError(t, err)
+	commitSHA := strings.TrimSpace(stdout)
+
+	_, _, err = gitcmd.NewCommand("branch").AddDynamicArguments(branchName, commitSHA).
+		WithDir(repoPath).
+		RunStdString(t.Context())
+	require.NoError(t, err)
+}
+
+func TestCompareBranchesNoCommonMergeBase(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user2"})
+	repo1 := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{OwnerID: user2.ID, Name: "repo1"})
+	createUnrelatedBranch(t, repo1, user2, "unrelated-history")
+
+	session := loginUser(t, "user2")
+	req := NewRequest(t, "GET", "/user2/repo1/compare/master...unrelated-history")
+	resp := session.MakeRequest(t, req, http.StatusOK)
+	body := resp.Body.String()
+	htmlDoc := NewHTMLParser(t, resp.Body)
+
+	selection := htmlDoc.doc.Find(".ui.dropdown.select-branch")
+	assert.Lenf(t, selection.Nodes, 2, "The template has changed")
+	assert.Contains(t, body, "These branches do not share a common merge base")
+	assert.Equal(t, 1, htmlDoc.doc.Find(`a.item[href="/user2/repo1/compare/master...unrelated-history"]`).Length())
+	assert.Equal(t, 1, htmlDoc.doc.Find(`a.item[href="/user2/repo1/compare/master...master"]`).Length())
+	assert.Equal(t, 0, htmlDoc.doc.Find(".pullrequest-form").Length())
 }
 
 func TestCompareCodeExpand(t *testing.T) {

--- a/tests/integration/compare_test.go
+++ b/tests/integration/compare_test.go
@@ -4,14 +4,11 @@
 package integration
 
 import (
-	"bytes"
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"testing"
-	"time"
 
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unittest"
@@ -20,9 +17,9 @@ import (
 	"code.gitea.io/gitea/modules/test"
 	repo_service "code.gitea.io/gitea/services/repository"
 	"code.gitea.io/gitea/tests"
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCompareTag(t *testing.T) {
@@ -130,61 +127,23 @@ func TestCompareBranches(t *testing.T) {
 	inspectCompare(t, htmlDoc, diffCount, diffChanges)
 }
 
-func createUnrelatedBranch(t *testing.T, repo *repo_model.Repository, user *user_model.User, branchName string) {
-	t.Helper()
-
-	repoPath := repo_model.RepoPath(user.Name, repo.Name)
-	require.NoError(t, gitcmd.NewCommand("read-tree", "--empty").WithDir(repoPath).Run(t.Context()))
-
-	stdout, _, err := gitcmd.NewCommand("hash-object", "-w", "--stdin").
-		WithDir(repoPath).
-		WithStdinBytes([]byte("Unrelated File")).
-		RunStdString(t.Context())
-	require.NoError(t, err)
-	blobSHA := strings.TrimSpace(stdout)
-
-	_, _, err = gitcmd.NewCommand("update-index", "--add", "--replace", "--cacheinfo").
-		AddDynamicArguments("100644", blobSHA, "unrelated.txt").
-		WithDir(repoPath).
-		RunStdString(t.Context())
-	require.NoError(t, err)
-
-	stdout, _, err = gitcmd.NewCommand("write-tree").WithDir(repoPath).RunStdString(t.Context())
-	require.NoError(t, err)
-	treeSHA := strings.TrimSpace(stdout)
-
-	commitTimeStr := time.Now().Format(time.RFC3339)
-	doerSig := user.NewGitSig()
-	env := append(os.Environ(),
-		"GIT_AUTHOR_NAME="+doerSig.Name,
-		"GIT_AUTHOR_EMAIL="+doerSig.Email,
-		"GIT_AUTHOR_DATE="+commitTimeStr,
-		"GIT_COMMITTER_NAME="+doerSig.Name,
-		"GIT_COMMITTER_EMAIL="+doerSig.Email,
-		"GIT_COMMITTER_DATE="+commitTimeStr,
-	)
-
-	messageBytes := bytes.NewBufferString("Unrelated\n")
-	stdout, _, err = gitcmd.NewCommand("commit-tree").AddDynamicArguments(treeSHA).
-		WithEnv(env).
-		WithDir(repoPath).
-		WithStdinBytes(messageBytes.Bytes()).
-		RunStdString(t.Context())
-	require.NoError(t, err)
-	commitSHA := strings.TrimSpace(stdout)
-
-	_, _, err = gitcmd.NewCommand("branch").AddDynamicArguments(branchName, commitSHA).
-		WithDir(repoPath).
-		RunStdString(t.Context())
-	require.NoError(t, err)
-}
-
 func TestCompareBranchesNoCommonMergeBase(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
 
 	user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user2"})
 	repo1 := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{OwnerID: user2.ID, Name: "repo1"})
-	createUnrelatedBranch(t, repo1, user2, "unrelated-history")
+
+	repoPath := repo_model.RepoPath(user2.Name, repo1.Name)
+	_, _, runErr := gitcmd.NewCommand("fast-import").WithDir(repoPath).WithStdinBytes([]byte(strings.TrimSpace(`
+commit refs/heads/unrelated-history
+committer User <user@example.com> 1714310400 +0000
+data 13
+Second commit
+M 100644 inline file2.txt
+data 12
+Hello from 2
+`))).RunStdString(t.Context())
+	require.NoError(t, runErr)
 
 	session := loginUser(t, "user2")
 	req := NewRequest(t, "GET", "/user2/repo1/compare/master...unrelated-history")

--- a/tests/integration/compare_test.go
+++ b/tests/integration/compare_test.go
@@ -17,9 +17,9 @@ import (
 	"code.gitea.io/gitea/modules/test"
 	repo_service "code.gitea.io/gitea/services/repository"
 	"code.gitea.io/gitea/tests"
-	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCompareTag(t *testing.T) {


### PR DESCRIPTION
## Summary

- handle compare requests where base and head refs have no common merge base without returning 500
- keep the compare branch selectors usable and show a clear warning message
- add regression coverage for unrelated-history compare selection and merge-base error detection
- refactor legacy code, remove dead code and fix incorrect logic

Fixes #37469 