### PR TITLE
fix: redirect early CLI console logger to stderr

### DIFF
--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -134,7 +134,7 @@ func PrepareConsoleLoggerLevel(defaultLevel log.Level) func(context.Context, *cl
 		if globalBool(c, "debug") || globalBool(c, "verbose") {
 			level = log.TRACE
 		}
-		log.SetupStderrLogger(log.DEFAULT, "console-default", level)
+		log.SetupStderrLogger(log.DEFAULT, "console-stderr", level)
 		return ctx, nil
 	}
 }

--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -134,7 +134,7 @@ func PrepareConsoleLoggerLevel(defaultLevel log.Level) func(context.Context, *cl
 		if globalBool(c, "debug") || globalBool(c, "verbose") {
 			level = log.TRACE
 		}
-		log.SetConsoleLogger(log.DEFAULT, "console-default", level)
+		log.SetupStderrLogger(log.DEFAULT, "console-default", level)
 		return ctx, nil
 	}
 }

--- a/modules/log/logger_global.go
+++ b/modules/log/logger_global.go
@@ -83,7 +83,7 @@ func SetConsoleLogger(loggerName, writerName string, level Level) {
 		// Stderr must be true: this logger is installed early (app.Before), before subcommands
 		// like "dump" redirect logging to stderr. If set to false, log output goes to stdout and
 		// corrupts any command that writes data to stdout (e.g. "gitea dump --file -").
-		// It is inconsistent with the default console logger (which will be initialized later and use Stdout),
+		// It is inconsistent with the default console logger (which will be initialized later and might use Stdout by default),
 		// but there is no other way than this patch at the moment.
 		WriterOption: WriterConsoleOption{Stderr: true},
 	})

--- a/modules/log/logger_global.go
+++ b/modules/log/logger_global.go
@@ -83,6 +83,8 @@ func SetConsoleLogger(loggerName, writerName string, level Level) {
 		// Stderr must be true: this logger is installed early (app.Before), before subcommands
 		// like "dump" redirect logging to stderr. If set to false, log output goes to stdout and
 		// corrupts any command that writes data to stdout (e.g. "gitea dump --file -").
+		// It is inconsistent with the default console logger (which will be initialized later and use Stdout),
+		// but there is no other way than this patch at the moment.
 		WriterOption: WriterConsoleOption{Stderr: true},
 	})
 	GetManager().GetLogger(loggerName).ReplaceAllWriters(writer)

--- a/modules/log/logger_global.go
+++ b/modules/log/logger_global.go
@@ -80,7 +80,10 @@ func SetConsoleLogger(loggerName, writerName string, level Level) {
 		Level:        level,
 		Flags:        FlagsFromBits(LstdFlags),
 		Colorize:     CanColorStdout,
-		WriterOption: WriterConsoleOption{},
+		// Stderr must be true: this logger is installed early (app.Before), before subcommands
+		// like "dump" redirect logging to stderr. If set to false, log output goes to stdout and
+		// corrupts any command that writes data to stdout (e.g. "gitea dump --file -").
+		WriterOption: WriterConsoleOption{Stderr: true},
 	})
 	GetManager().GetLogger(loggerName).ReplaceAllWriters(writer)
 }

--- a/modules/log/logger_global.go
+++ b/modules/log/logger_global.go
@@ -75,16 +75,21 @@ func IsLoggerEnabled(name string) bool {
 	return GetManager().GetLogger(name).IsEnabled()
 }
 
-func SetConsoleLogger(loggerName, writerName string, level Level) {
+func SetupStderrLogger(loggerName, writerName string, level Level) {
 	writer := NewEventWriterConsole(writerName, WriterMode{
 		Level:    level,
 		Flags:    FlagsFromBits(LstdFlags),
 		Colorize: CanColorStderr,
-		// Stderr must be true: this logger is installed early (app.Before), before subcommands
-		// like "dump" redirect logging to stderr. If set to false, log output goes to stdout and
-		// corrupts any command that writes data to stdout (e.g. "gitea dump --file -").
-		// It is inconsistent with the default console logger (which will be initialized later and might use Stdout by default),
-		// but there is no other way than this patch at the moment.
+
+		// For most CLI commands, it's better to use Stderr as log output:
+		// this logger is installed early (app.Before), before subcommands like "dump" redirect logging to stderr.
+		// If Stdout, early log output (e.g.: warning during config loading) goes to stdout
+		// and corrupts any command that writes data to stdout (e.g. "gitea dump --file -").
+		//
+		// It is inconsistent with the web server's default console logger from config
+		// (which will be initialized later and use Stdout by default), but there is no other way at the moment:
+		// and many existing users depend on such behavior to collect web logs (e.g. fail2ban).
+		// Maybe need to refactor the logger system again in the future.
 		WriterOption: WriterConsoleOption{Stderr: true},
 	})
 	GetManager().GetLogger(loggerName).ReplaceAllWriters(writer)

--- a/modules/log/logger_global.go
+++ b/modules/log/logger_global.go
@@ -88,7 +88,8 @@ func SetupStderrLogger(loggerName, writerName string, level Level) {
 		//
 		// It is inconsistent with the web server's default console logger from config
 		// (which will be initialized later and use Stdout by default), but there is no other way at the moment:
-		// and many existing users depend on such behavior to collect web logs (e.g. fail2ban).
+		// many existing users depend on such behavior to collect web logs (e.g. fail2ban).
+		//
 		// Maybe need to refactor the logger system again in the future.
 		WriterOption: WriterConsoleOption{Stderr: true},
 	})

--- a/modules/log/logger_global.go
+++ b/modules/log/logger_global.go
@@ -77,9 +77,9 @@ func IsLoggerEnabled(name string) bool {
 
 func SetConsoleLogger(loggerName, writerName string, level Level) {
 	writer := NewEventWriterConsole(writerName, WriterMode{
-		Level:        level,
-		Flags:        FlagsFromBits(LstdFlags),
-		Colorize:     CanColorStdout,
+		Level:    level,
+		Flags:    FlagsFromBits(LstdFlags),
+		Colorize: CanColorStderr,
 		// Stderr must be true: this logger is installed early (app.Before), before subcommands
 		// like "dump" redirect logging to stderr. If set to false, log output goes to stdout and
 		// corrupts any command that writes data to stdout (e.g. "gitea dump --file -").

--- a/modules/setting/log.go
+++ b/modules/setting/log.go
@@ -256,7 +256,7 @@ func initLoggerByName(manager *log.LoggerManager, rootCfg ConfigProvider, logger
 }
 
 func InitSQLLoggersForCli(level log.Level) {
-	log.SetupStderrLogger("xorm", "console", level)
+	log.SetupStderrLogger("xorm", "console-stderr", level)
 }
 
 func IsAccessLogEnabled() bool {

--- a/modules/setting/log.go
+++ b/modules/setting/log.go
@@ -256,7 +256,7 @@ func initLoggerByName(manager *log.LoggerManager, rootCfg ConfigProvider, logger
 }
 
 func InitSQLLoggersForCli(level log.Level) {
-	log.SetConsoleLogger("xorm", "console", level)
+	log.SetupStderrLogger("xorm", "console", level)
 }
 
 func IsAccessLogEnabled() bool {

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -43,7 +43,7 @@ func init() {
 
 	// FIXME: the logger shouldn't be initialized here, the app entry should initialize the logger
 	// By default set this logger at Info - we'll change it later, but we need to start with something.
-	log.SetupStderrLogger(log.DEFAULT, "console", log.INFO)
+	log.SetupStderrLogger(log.DEFAULT, "console-stderr", log.INFO)
 }
 
 // IsRunUserMatchCurrentUser returns false if configured run user does not match

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -41,9 +41,9 @@ func init() {
 		AppVer = "dev"
 	}
 
-	// We can rely on log.CanColorStdout being set properly because modules/log/console_windows.go comes before modules/setting/setting.go lexicographically
+	// FIXME: the logger shouldn't be initialized here, the app entry should initialize the logger
 	// By default set this logger at Info - we'll change it later, but we need to start with something.
-	log.SetConsoleLogger(log.DEFAULT, "console", log.INFO)
+	log.SetupStderrLogger(log.DEFAULT, "console", log.INFO)
 }
 
 // IsRunUserMatchCurrentUser returns false if configured run user does not match


### PR DESCRIPTION
When running `gitea dump` with output routed to stdout (--file -), deprecation warnings from loadAvatarsFrom were written to stdout, corrupting the archive stream.

Root cause: PrepareConsoleLoggerLevel (called in app.Before) sets up a console logger via SetConsoleLogger, which used WriterConsoleOption{} defaulting Stderr to false (i.e. stdout). This logger is installed before the dump subcommand can redirect logging to stderr in runDump.

Fix: use WriterConsoleOption{Stderr: true} in SetConsoleLogger so all early CLI diagnostic output goes to stderr from the start. This is correct for all subcommands — diagnostic/log output should never pollute stdout.

