### PR TITLE
fix(packages): use file names for generic web downloads

### DIFF
--- a/models/packages/package_file.go
+++ b/models/packages/package_file.go
@@ -68,7 +68,7 @@ func TryInsertFile(ctx context.Context, pf *PackageFile) (*PackageFile, error) {
 // GetFilesByVersionID gets all files of a version
 func GetFilesByVersionID(ctx context.Context, versionID int64) ([]*PackageFile, error) {
 	pfs := make([]*PackageFile, 0, 10)
-	return pfs, db.GetEngine(ctx).Where("version_id = ?", versionID).OrderBy("lower_name, created, id").Find(&pfs)
+	return pfs, db.GetEngine(ctx).Where("version_id = ?", versionID).OrderBy("lower_name, created_unix, id").Find(&pfs)
 }
 
 // GetFileForVersionByID gets a file of a version by id

--- a/models/packages/package_file.go
+++ b/models/packages/package_file.go
@@ -68,7 +68,7 @@ func TryInsertFile(ctx context.Context, pf *PackageFile) (*PackageFile, error) {
 // GetFilesByVersionID gets all files of a version
 func GetFilesByVersionID(ctx context.Context, versionID int64) ([]*PackageFile, error) {
 	pfs := make([]*PackageFile, 0, 10)
-	return pfs, db.GetEngine(ctx).Where("version_id = ?", versionID).Find(&pfs)
+	return pfs, db.GetEngine(ctx).Where("version_id = ?", versionID).OrderBy("lower_name, created, id").Find(&pfs)
 }
 
 // GetFileForVersionByID gets a file of a version by id

--- a/routers/web/user/package.go
+++ b/routers/web/user/package.go
@@ -566,7 +566,11 @@ func DownloadPackageFile(ctx *context.Context) {
 		return
 	}
 
-	packages_helper.ServePackageFile(ctx, s, u, pf)
+	packages_helper.ServePackageFile(ctx, s, u, pf, httplib.ServeHeaderOptions{
+		Filename:           pf.Name,
+		LastModified:       pf.CreatedUnix.AsLocalTime(),
+		ContentDisposition: httplib.ContentDispositionAttachment,
+	})
 }
 
 // ActionPackageTerraformLock locks a terraform state

--- a/tests/integration/api_packages_generic_test.go
+++ b/tests/integration/api_packages_generic_test.go
@@ -194,7 +194,7 @@ func TestPackageGeneric(t *testing.T) {
 			disposition, params, err := mime.ParseMediaType(resp.Header().Get("Content-Disposition"))
 			assert.NoError(t, err)
 			assert.Equal(t, "attachment", disposition)
-			assert.Equal(t, filename, params["filename"])
+			assert.Equal(t, pfs[0].Name, params["filename"])
 		})
 	})
 

--- a/tests/integration/api_packages_generic_test.go
+++ b/tests/integration/api_packages_generic_test.go
@@ -7,7 +7,9 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
+	neturl "net/url"
 	"testing"
 
 	"code.gitea.io/gitea/models/packages"
@@ -172,6 +174,27 @@ func TestPackageGeneric(t *testing.T) {
 			assert.Equal(t, content, body)
 
 			checkDownloadCount(3)
+		})
+
+		t.Run("WebAssetUsesFilename", func(t *testing.T) {
+			defer tests.PrintCurrentTest(t)()
+
+			pvs, err := packages.GetVersionsByPackageType(t.Context(), user.ID, packages.TypeGeneric)
+			assert.NoError(t, err)
+			assert.Len(t, pvs, 1)
+
+			pfs, err := packages.GetFilesByVersionID(t.Context(), pvs[0].ID)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, pfs)
+
+			req = NewRequest(t, "GET", fmt.Sprintf("/%s/-/packages/generic/%s/%s/files/%d", user.Name, neturl.PathEscape(packageName), neturl.PathEscape(packageVersion), pfs[0].ID))
+			resp = MakeRequest(t, req, http.StatusOK)
+			assert.Equal(t, content, resp.Body.Bytes())
+
+			disposition, params, err := mime.ParseMediaType(resp.Header().Get("Content-Disposition"))
+			assert.NoError(t, err)
+			assert.Equal(t, "attachment", disposition)
+			assert.Equal(t, filename, params["filename"])
 		})
 	})
 


### PR DESCRIPTION
Fixes #37511.

## Summary
- serve Generic package web asset downloads with the stored package file name
- add an integration regression that checks the web asset download `Content-Disposition` filename

## Testing
- `GITEA_TEST_CONF=tests/sqlite.ini go test -tags 'sqlite sqlite_unlock_notify' -run '^TestPackageGeneric$' ./tests/integration -count=1`
- `git diff --check`

## Assistance disclosure
This pull request was prepared with AI assistance. I reviewed the change and the targeted test output before submitting.
