### PR TITLE
Set Renovate `gitAuthor` to `GiteaBot`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,6 +5,7 @@
   "enabledManagers": ["github-actions", "gomod", "npm", "pep621", "nix"],
   "labels": ["dependencies"],
   "branchPrefix": "renovate/",
+  "gitAuthor": "GiteaBot <teabot@gitea.io>",
   "schedule": ["* * * * 1"], // dependency update PRs weekly, vulnerabilityAlerts bypasses this
   "minimumReleaseAge": "5 days",
   "semanticCommits": "enabled",


### PR DESCRIPTION
Fixes warning seen on https://github.com/go-gitea/gitea/actions/runs/25296832559/job/74156959338#step:3:88. Note that these commits will be unsigned, could be fixed via adding another secret RENOVATE_GIT_PRIVATE_KEY which holds the gpg private key of the bot.

To acutally have the bot working the permissions on RENOVATE_TOKEN (pat token created on the bot account) still need to configured as per [this](https://github.com/go-gitea/gitea/pull/37050#:~:text=Admin%20steps%20before%2Fafter%20merge). @lunny can you fix those permissions on the token? And if the renovate app is still enabled on the repo, disable/remove it.

---
This PR was written with the help of Claude Opus 4.7