### PR TITLE
Make ServeSetHeaders default to download attachment if filename exists

### DIFF
--- a/modules/httplib/serve.go
+++ b/modules/httplib/serve.go
@@ -87,8 +87,9 @@ func ServeSetHeaders(w http.ResponseWriter, opts ServeHeaderOptions) {
 	if opts.ContentLength != nil {
 		header.Set("Content-Length", strconv.FormatInt(*opts.ContentLength, 10))
 	}
-	if opts.Filename != "" && opts.ContentDisposition != "" {
-		header.Set("Content-Disposition", encodeContentDisposition(opts.ContentDisposition, path.Base(opts.Filename)))
+	if opts.Filename != "" {
+		contentDisposition := util.IfZero(opts.ContentDisposition, ContentDispositionAttachment)
+		header.Set("Content-Disposition", encodeContentDisposition(contentDisposition, path.Base(opts.Filename)))
 		header.Set("Access-Control-Expose-Headers", "Content-Disposition")
 	}
 

--- a/modules/httplib/serve_test.go
+++ b/modules/httplib/serve_test.go
@@ -133,3 +133,11 @@ func TestServeSetHeaderContentRelated(t *testing.T) {
 	// make sure sandboxed
 	require.Contains(t, serveHeaderCspDefault, "; sandbox")
 }
+
+func TestServeSetHeaders(t *testing.T) {
+	w := httptest.NewRecorder()
+	ServeSetHeaders(w, ServeHeaderOptions{Filename: "foo.zip"})
+	assert.Equal(t, "attachment; filename=foo.zip", w.Header().Get("Content-Disposition"))
+	ServeSetHeaders(w, ServeHeaderOptions{Filename: "foo.zip", ContentDisposition: ContentDispositionInline})
+	assert.Equal(t, "inline; filename=foo.zip", w.Header().Get("Content-Disposition"))
+}


### PR DESCRIPTION
Fix #37550