### PR TITLE
ci: increase renovate frequency and fix RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS

### DIFF
--- a/.github/workflows/cron-renovate.yml
+++ b/.github/workflows/cron-renovate.yml
@@ -2,7 +2,7 @@ name: cron-renovate
 
 on:
   schedule:
-    - cron: "0 1 * * *" # daily at 01:00 UTC
+    - cron: "23 * * * *" # hourly at :23
   workflow_dispatch:
 
 concurrency:
@@ -28,5 +28,5 @@ jobs:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
           RENOVATE_BINARY_SOURCE: install # auto-install go/node toolchains needed by post-upgrade tasks.
-          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^make (tidy|svg)$"]'
+          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^make (tidy|svg nolyfill)$"]'
           RENOVATE_REPOSITORIES: '["go-gitea/gitea"]'


### PR DESCRIPTION
1. Sync `RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS` with the recent `renovate.json5` change (#37537) — the npm group now runs `make svg nolyfill`, but the workflow allowlist still only matched `^make (tidy|svg)$`, so the post-upgrade task was being rejected.
2. Bump the cron from daily at 01:00 UTC to hourly at :23, matching the cadence of Mend's hosted Renovate App. Hourly gives sub-hour responsiveness to dependency-dashboard checkbox interactions and PR-close reactions; the `:23` offset avoids the GHA scheduler congestion at multiples of 15.

---
This PR was written with the help of Claude Opus 4.7