### PR TITLE
build: update pnpm to v11

### DIFF
--- a/.github/workflows/files-changed.yml
+++ b/.github/workflows/files-changed.yml
@@ -71,15 +71,16 @@ jobs:
               - "assets/emoji.json"
               - "package.json"
               - "pnpm-lock.yaml"
+              - "pnpm-workspace.yaml"
               - "Makefile"
               - ".eslintrc.cjs"
-              - ".npmrc"
 
             docs:
               - "**/*.md"
               - ".markdownlint.yaml"
               - "package.json"
               - "pnpm-lock.yaml"
+              - "pnpm-workspace.yaml"
 
             actions:
               - ".github/workflows/*"
@@ -108,6 +109,7 @@ jobs:
               - "Makefile"
               - "package.json"
               - "pnpm-lock.yaml"
+              - "pnpm-workspace.yaml"
               - ".spectral.yaml"
 
             yaml:

--- a/.github/workflows/files-changed.yml
+++ b/.github/workflows/files-changed.yml
@@ -73,7 +73,6 @@ jobs:
               - "pnpm-lock.yaml"
               - "pnpm-workspace.yaml"
               - "Makefile"
-              - ".eslintrc.cjs"
 
             docs:
               - "**/*.md"

--- a/.github/workflows/pull-compliance.yml
+++ b/.github/workflows/pull-compliance.yml
@@ -44,7 +44,7 @@ jobs:
           go-version-file: go.mod
           check-latest: true
           cache: false
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24

--- a/.github/workflows/pull-e2e-tests.yml
+++ b/.github/workflows/pull-e2e-tests.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           cache-name: e2e
           build-cache: "false"
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           go-version-file: go.mod
           check-latest: true
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24

--- a/.github/workflows/release-tag-rc.yml
+++ b/.github/workflows/release-tag-rc.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           go-version-file: go.mod
           check-latest: true
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24

--- a/.github/workflows/release-tag-version.yml
+++ b/.github/workflows/release-tag-version.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           go-version-file: go.mod
           check-latest: true
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24

--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,0 @@
-audit=false
-fund=false
-update-notifier=false
-save-exact=true
-auto-install-peers=true
-dedupe-peer-dependents=false
-enable-pre-post-scripts=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26-alpine3.23 AS frontend-build
 RUN apk --no-cache add build-base git nodejs pnpm
 WORKDIR /src
-COPY package.json pnpm-lock.yaml .npmrc ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm install --frozen-lockfile
 COPY --exclude=.git/ . .
 RUN make frontend

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -3,7 +3,7 @@
 FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.26-alpine3.23 AS frontend-build
 RUN apk --no-cache add build-base git nodejs pnpm
 WORKDIR /src
-COPY package.json pnpm-lock.yaml .npmrc ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm install --frozen-lockfile
 COPY --exclude=.git/ . .
 RUN make frontend

--- a/Makefile
+++ b/Makefile
@@ -613,6 +613,7 @@ update-js: node_modules ## update js dependencies
 .PHONY: nolyfill
 nolyfill: node_modules ## apply nolyfill overrides to package.json and relock
 	pnpm exec nolyfill install
+	node tools/migrate-nolyfills.ts
 	pnpm install
 	@touch node_modules
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "packageManager": "pnpm@11.0.8",
   "engines": {
     "node": ">= 22.18.0",
-    "pnpm": ">= 10.0.0"
+    "pnpm": ">= 11.0.0"
   },
   "dependencies": {
     "@citation-js/core": "0.7.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@11.0.8",
   "engines": {
     "node": ">= 22.18.0",
     "pnpm": ">= 10.0.0"
@@ -124,34 +124,5 @@
     "updates": "17.16.8",
     "vitest": "4.1.5",
     "vue-tsc": "3.2.8"
-  },
-  "pnpm": {
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "eslint-plugin-github>eslint": ">=9"
-      }
-    },
-    "overrides": {
-      "array-includes": "npm:@nolyfill/array-includes@^1",
-      "array.prototype.findlastindex": "npm:@nolyfill/array.prototype.findlastindex@^1",
-      "array.prototype.flat": "npm:@nolyfill/array.prototype.flat@^1",
-      "array.prototype.flatmap": "npm:@nolyfill/array.prototype.flatmap@^1",
-      "es-aggregate-error": "npm:@nolyfill/es-aggregate-error@^1",
-      "hasown": "npm:@nolyfill/hasown@^1",
-      "is-core-module": "npm:@nolyfill/is-core-module@^1",
-      "object.assign": "npm:@nolyfill/object.assign@^1",
-      "object.fromentries": "npm:@nolyfill/object.fromentries@^1",
-      "object.groupby": "npm:@nolyfill/object.groupby@^1",
-      "object.values": "npm:@nolyfill/object.values@^1",
-      "safe-buffer": "npm:@nolyfill/safe-buffer@^1",
-      "safe-regex-test": "npm:@nolyfill/safe-regex-test@^1",
-      "safer-buffer": "npm:@nolyfill/safer-buffer@^1",
-      "string.prototype.includes": "npm:@nolyfill/string.prototype.includes@^1",
-      "string.prototype.trimend": "npm:@nolyfill/string.prototype.trimend@^1",
-      "object-keys": "npm:@nolyfill/object-keys@^1",
-      "object.entries": "npm:@nolyfill/object.entries@^1",
-      "abab": "npm:@nolyfill/abab@^1",
-      "es-set-tostringtag": "npm:@nolyfill/es-set-tostringtag@^1"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,4 @@
-# nolyfill 1.0.44 requires `packages` to be set (SukkaW/nolyfill#119); pnpm itself does not.
-packages: [.]
+packages: [.] # worarkound for https://github.com/SukkaW/nolyfill/issues/119
 savePrefix: ''
 dedupePeerDependents: false
 updateNotifier: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,9 @@
-packages:
-  - .
-
+# nolyfill 1.0.44 requires `packages` to be set (SukkaW/nolyfill#119); pnpm itself does not.
+packages: [.]
 savePrefix: ''
 dedupePeerDependents: false
 updateNotifier: false
+minimumReleaseAge: 0
 
 peerDependencyRules:
   allowedVersions:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
-packages: [.] # worarkound for https://github.com/SukkaW/nolyfill/issues/119
+packages: [.] # workaround for https://github.com/SukkaW/nolyfill/issues/119
 savePrefix: ''
 dedupePeerDependents: false
 updateNotifier: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages: [.] # worarkound for https://github.com/SukkaW/nolyfill/issues/119
 savePrefix: ''
 dedupePeerDependents: false
 updateNotifier: false
+strictDepBuilds: false
 minimumReleaseAge: 0
 
 peerDependencyRules:
@@ -29,9 +30,3 @@ overrides:
   object.entries: npm:@nolyfill/object.entries@^1
   abab: npm:@nolyfill/abab@^1
   es-set-tostringtag: npm:@nolyfill/es-set-tostringtag@^1
-
-allowBuilds:
-  '@scarf/scarf': false
-  'core-js': false
-  'esbuild': false
-  'unrs-resolver': false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,38 @@
+packages:
+  - .
+
+savePrefix: ''
+dedupePeerDependents: false
+updateNotifier: false
+
+peerDependencyRules:
+  allowedVersions:
+    eslint-plugin-github>eslint: '>=9'
+
+overrides:
+  array-includes: npm:@nolyfill/array-includes@^1
+  array.prototype.findlastindex: npm:@nolyfill/array.prototype.findlastindex@^1
+  array.prototype.flat: npm:@nolyfill/array.prototype.flat@^1
+  array.prototype.flatmap: npm:@nolyfill/array.prototype.flatmap@^1
+  es-aggregate-error: npm:@nolyfill/es-aggregate-error@^1
+  hasown: npm:@nolyfill/hasown@^1
+  is-core-module: npm:@nolyfill/is-core-module@^1
+  object.assign: npm:@nolyfill/object.assign@^1
+  object.fromentries: npm:@nolyfill/object.fromentries@^1
+  object.groupby: npm:@nolyfill/object.groupby@^1
+  object.values: npm:@nolyfill/object.values@^1
+  safe-buffer: npm:@nolyfill/safe-buffer@^1
+  safe-regex-test: npm:@nolyfill/safe-regex-test@^1
+  safer-buffer: npm:@nolyfill/safer-buffer@^1
+  string.prototype.includes: npm:@nolyfill/string.prototype.includes@^1
+  string.prototype.trimend: npm:@nolyfill/string.prototype.trimend@^1
+  object-keys: npm:@nolyfill/object-keys@^1
+  object.entries: npm:@nolyfill/object.entries@^1
+  abab: npm:@nolyfill/abab@^1
+  es-set-tostringtag: npm:@nolyfill/es-set-tostringtag@^1
+
+allowBuilds:
+  '@scarf/scarf': false
+  'core-js': false
+  'esbuild': false
+  'unrs-resolver': false

--- a/renovate.json5
+++ b/renovate.json5
@@ -72,7 +72,7 @@
       "matchManagers": ["npm"],
       "postUpgradeTasks": {
         "commands": ["make svg nolyfill"],
-        "fileFilters": ["package.json", "pnpm-lock.yaml", "public/assets/img/svg/**"],
+        "fileFilters": ["package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml", "public/assets/img/svg/**"],
         "executionMode": "branch",
       },
     },

--- a/tools/migrate-nolyfills.ts
+++ b/tools/migrate-nolyfills.ts
@@ -18,7 +18,7 @@ if (!overrides || !Object.keys(overrides).length) {
 
 const block = dump({overrides}, {lineWidth: -1, quotingType: "'"});
 const workspace = readFileSync(workspacePath, 'utf8');
-const overridesRegex = /^overrides:[^\n]*(?:\n[ \t][^\n]*)*\n?/m;
+const overridesRegex = /^overrides:[^\n]*(?:\n(?:[ \t][^\n]*|[ \t]*(?=\n[ \t])))*\n?/m;
 
 if (!overridesRegex.test(workspace)) {
   console.error(`No 'overrides:' block found in pnpm-workspace.yaml`);

--- a/tools/migrate-nolyfills.ts
+++ b/tools/migrate-nolyfills.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 // nolyfill writes overrides to package.json#pnpm.overrides which pnpm v11 ignores.
 // This moves them to pnpm-workspace.yaml until SukkaW/nolyfill#119 is fixed.
-
 import {readFileSync, writeFileSync} from 'node:fs';
 import {exit} from 'node:process';
 import {fileURLToPath} from 'node:url';

--- a/tools/migrate-nolyfills.ts
+++ b/tools/migrate-nolyfills.ts
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+// nolyfill writes overrides to package.json#pnpm.overrides which pnpm v11 ignores.
+// This moves them to pnpm-workspace.yaml until SukkaW/nolyfill#119 is fixed.
+
+import {readFileSync, writeFileSync} from 'node:fs';
+import {exit} from 'node:process';
+import {fileURLToPath} from 'node:url';
+import {dump} from 'js-yaml';
+
+const packagePath = fileURLToPath(new URL('../package.json', import.meta.url));
+const workspacePath = fileURLToPath(new URL('../pnpm-workspace.yaml', import.meta.url));
+
+const packageJson: {pnpm?: {overrides?: Record<string, string>}} = JSON.parse(readFileSync(packagePath, 'utf8'));
+const overrides = packageJson.pnpm?.overrides;
+
+if (!overrides || !Object.keys(overrides).length) {
+  exit(0);
+}
+
+const block = dump({overrides}, {lineWidth: -1, quotingType: "'"});
+const workspace = readFileSync(workspacePath, 'utf8');
+const overridesRegex = /^overrides:[^\n]*(?:\n[ \t][^\n]*)*\n?/m;
+
+if (!overridesRegex.test(workspace)) {
+  console.error(`No 'overrides:' block found in pnpm-workspace.yaml`);
+  exit(1);
+}
+
+writeFileSync(workspacePath, workspace.replace(overridesRegex, block));
+
+const pnpm = packageJson.pnpm!;
+delete pnpm.overrides;
+if (!Object.keys(pnpm).length) delete packageJson.pnpm;
+writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);


### PR DESCRIPTION
Update to https://github.com/pnpm/pnpm/releases/tag/v11.0.0

- move all pnpm settings to `pnpm-workspace.yaml`, pnpm v11 only reads that file
- drop redundant or no-op settings
- disable `strictDepBuilds` to avoid having to manually specify deps with build scripts, this is equivalent to v10 where it will not execute and warn.
- add workarounds for https://github.com/SukkaW/nolyfill/issues/119
- remove dead eslintrc entry

---
This PR was written with the help of Claude Opus 4.7