### PR TITLE
fix(actions): report individual step status in workflow job API response

### DIFF
--- a/services/convert/action_test.go
+++ b/services/convert/action_test.go
@@ -135,41 +135,35 @@ func TestToActionWorkflowJob_StepStatusIsIndependentOfJobStatus(t *testing.T) {
 		RepoID:        2,
 		TriggerUserID: 1,
 		WorkflowID:    "test.yaml",
-		Index:         9001,
+		Index:         12345,
 		Ref:           "refs/heads/main",
-		CommitSHA:     "c2d72f548424103f01ee1dc02889c1e2bff816b0",
-		Event:         "push",
-		TriggerEvent:  "push",
 		Status:        actions_model.StatusFailure,
 	}
 	require.NoError(t, db.Insert(ctx, run))
 
 	task := &actions_model.ActionTask{
-		ID:             9001,
-		JobID:          9001,
-		RepoID:         2,
-		Status:         actions_model.StatusFailure,
-		TokenHash:      "test_token_hash_9001_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-		TokenSalt:      "testsalt",
-		TokenLastEight: "testlst1",
+		ID:     900102,
+		JobID:  9001,
+		RepoID: 2,
+		Status: actions_model.StatusFailure,
 	}
 	require.NoError(t, db.Insert(ctx, task))
 
 	job := &actions_model.ActionRunJob{
-		ID:      9001,
+		ID:      90010203,
 		RunID:   9001,
+		TaskID:  900102,
 		RepoID:  2,
-		Name:    "test-job",
+		Name:    "test-job-name",
 		Attempt: 1,
-		JobID:   "test-job",
-		TaskID:  9001,
+		JobID:   "test-job-id",
 		Status:  actions_model.StatusFailure,
 	}
 	require.NoError(t, db.Insert(ctx, job))
 
 	require.NoError(t, db.Insert(ctx,
-		&actions_model.ActionTaskStep{TaskID: 9001, RepoID: 2, Index: 0, Name: "step-success", Status: actions_model.StatusSuccess},
-		&actions_model.ActionTaskStep{TaskID: 9001, RepoID: 2, Index: 1, Name: "step-failure", Status: actions_model.StatusFailure},
+		&actions_model.ActionTaskStep{TaskID: task.ID, RepoID: 2, Index: 0, Name: "step-success", Status: actions_model.StatusSuccess},
+		&actions_model.ActionTaskStep{TaskID: task.ID, RepoID: 2, Index: 1, Name: "step-failure", Status: actions_model.StatusFailure},
 	))
 
 	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 2})

--- a/services/convert/action_test.go
+++ b/services/convert/action_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	actions_model "code.gitea.io/gitea/models/actions"
+	db "code.gitea.io/gitea/models/db"
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unit"
 	"code.gitea.io/gitea/models/unittest"
@@ -123,4 +124,62 @@ func TestToActionWorkflowRun_UsesTriggerEvent(t *testing.T) {
 	apiRun, err := ToActionWorkflowRun(t.Context(), run, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "schedule", apiRun.Event)
+}
+
+func TestToActionWorkflowJob_StepStatusIsIndependentOfJobStatus(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+	ctx := t.Context()
+
+	run := &actions_model.ActionRun{
+		ID:            9001,
+		RepoID:        2,
+		TriggerUserID: 1,
+		WorkflowID:    "test.yaml",
+		Index:         9001,
+		Ref:           "refs/heads/main",
+		CommitSHA:     "c2d72f548424103f01ee1dc02889c1e2bff816b0",
+		Event:         "push",
+		TriggerEvent:  "push",
+		Status:        actions_model.StatusFailure,
+	}
+	require.NoError(t, db.Insert(ctx, run))
+
+	task := &actions_model.ActionTask{
+		ID:             9001,
+		JobID:          9001,
+		RepoID:         2,
+		Status:         actions_model.StatusFailure,
+		TokenHash:      "test_token_hash_9001_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		TokenSalt:      "testsalt",
+		TokenLastEight: "testlst1",
+	}
+	require.NoError(t, db.Insert(ctx, task))
+
+	job := &actions_model.ActionRunJob{
+		ID:      9001,
+		RunID:   9001,
+		RepoID:  2,
+		Name:    "test-job",
+		Attempt: 1,
+		JobID:   "test-job",
+		TaskID:  9001,
+		Status:  actions_model.StatusFailure,
+	}
+	require.NoError(t, db.Insert(ctx, job))
+
+	require.NoError(t, db.Insert(ctx,
+		&actions_model.ActionTaskStep{TaskID: 9001, RepoID: 2, Index: 0, Name: "step-success", Status: actions_model.StatusSuccess},
+		&actions_model.ActionTaskStep{TaskID: 9001, RepoID: 2, Index: 1, Name: "step-failure", Status: actions_model.StatusFailure},
+	))
+
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 2})
+
+	apiJob, err := ToActionWorkflowJob(ctx, repo, task, job)
+	require.NoError(t, err)
+	require.Len(t, apiJob.Steps, 2)
+
+	assert.Equal(t, "completed", apiJob.Steps[0].Status, "step 0 status")
+	assert.Equal(t, "success", apiJob.Steps[0].Conclusion, "step 0 conclusion (succeeded before the failure)")
+	assert.Equal(t, "completed", apiJob.Steps[1].Status, "step 1 status")
+	assert.Equal(t, "failure", apiJob.Steps[1].Conclusion, "step 1 conclusion")
 }

--- a/services/convert/convert.go
+++ b/services/convert/convert.go
@@ -390,7 +390,7 @@ func ToActionWorkflowJob(ctx context.Context, repo *repo_model.Repository, task 
 				runnerName = runner.Name
 			}
 			for i, step := range task.Steps {
-				stepStatus, stepConclusion := ToActionsStatus(job.Status)
+				stepStatus, stepConclusion := ToActionsStatus(step.Status)
 				steps = append(steps, &api.ActionWorkflowStep{
 					Name:        step.Name,
 					Number:      int64(i),

--- a/services/convert/convert.go
+++ b/services/convert/convert.go
@@ -330,7 +330,7 @@ func ToWorkflowRunAction(status actions_model.Status) (action string) {
 	return action
 }
 
-func ToActionsStatus(status actions_model.Status) (action string, conclusion string) {
+func ToActionsStatus(status actions_model.Status) (action, conclusion string) {
 	switch status {
 	case actions_model.StatusWaiting:
 		action = "queued" // "waiting" is a naming conflict of the webhook between Gitea and GitHub Actions

--- a/services/convert/convert.go
+++ b/services/convert/convert.go
@@ -314,33 +314,31 @@ func ToActionWorkflowRun(ctx context.Context, run *actions_model.ActionRun, atte
 	}, nil
 }
 
-func ToWorkflowRunAction(status actions_model.Status) string {
-	var action string
+func ToWorkflowRunAction(status actions_model.Status) (action string) {
 	switch status {
 	case actions_model.StatusWaiting, actions_model.StatusBlocked:
 		action = "requested"
 	case actions_model.StatusRunning:
 		action = "in_progress"
-	}
-	if status.IsDone() {
-		action = "completed"
+	default:
+		if status.IsDone() {
+			action = "completed"
+		} else {
+			setting.PanicInDevOrTesting("unknown action status: %v", status)
+		}
 	}
 	return action
 }
 
-func ToActionsStatus(status actions_model.Status) (string, string) {
-	var action string
-	var conclusion string
+func ToActionsStatus(status actions_model.Status) (action string, conclusion string) {
 	switch status {
-	// This is a naming conflict of the webhook between Gitea and GitHub Actions
 	case actions_model.StatusWaiting:
-		action = "queued"
+		action = "queued" // "waiting" is a naming conflict of the webhook between Gitea and GitHub Actions
 	case actions_model.StatusBlocked:
-		action = "waiting"
+		action = "waiting" // naming conflict (as above)
 	case actions_model.StatusRunning:
 		action = "in_progress"
-	}
-	if status.IsDone() {
+	default:
 		action = "completed"
 		switch status {
 		case actions_model.StatusSuccess:
@@ -351,6 +349,8 @@ func ToActionsStatus(status actions_model.Status) (string, string) {
 			conclusion = "failure"
 		case actions_model.StatusSkipped:
 			conclusion = "skipped"
+		default:
+			setting.PanicInDevOrTesting("unknown action status: %v", status)
 		}
 	}
 	return action, conclusion


### PR DESCRIPTION
When a workflow job failed, the API response reported all steps as failed — even steps that had completed successfully before the failing step. `ToActionWorkflowJob` was calling `ToActionsStatus(job.Status)` for every step instead of `ToActionsStatus(step.Status)`, so the job's overall conclusion was propagated to each step.

Each `ActionTaskStep` has its own `Status` field that tracks the actual outcome of that step independently of the job result.
