### PR TITLE
chore(renovate): detect Makefile tools, enable `go` bumps

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,11 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests", "customManagers:githubActionsVersions"],
   "configMigration": true,
-  "enabledManagers": ["github-actions", "gomod", "npm", "pep621", "nix"],
+  "enabledManagers": ["github-actions", "gomod", "npm", "pep621", "nix", "custom.regex"],
   "labels": ["dependencies"],
   "branchPrefix": "renovate/",
   "schedule": ["* * * * 1"], // dependency update PRs weekly, vulnerabilityAlerts bypasses this
-  "minimumReleaseAge": "5 days",
+  "minimumReleaseAge": "3 days",
   "semanticCommits": "enabled",
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {
@@ -60,12 +60,24 @@
     },
     {
       "groupName": "go dependencies",
-      "matchDatasources": ["go"], // covers gomod manager + Makefile go-tool customManager
+      "matchManagers": ["gomod"],
       "postUpgradeTasks": {
         "commands": ["make tidy"],
         "fileFilters": ["go.mod", "go.sum", "assets/go-licenses.json"],
         "executionMode": "branch",
       },
+    },
+    {
+      "groupName": "tool dependencies",
+      "matchManagers": ["custom.regex"],
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go"],
+      "matchDepTypes": ["golang"], // bump go.mod go directive
+      "rangeStrategy": "bump",
+      "schedule": ["at any time"],
+      "minimumReleaseAge": "0",
     },
     {
       "groupName": "npm dependencies",

--- a/renovate.json5
+++ b/renovate.json5
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests", "customManagers:githubActionsVersions"],
   "configMigration": true,
-  "enabledManagers": ["github-actions", "gomod", "npm", "pep621", "nix", "custom.makeTools"],
+  "enabledManagers": ["github-actions", "gomod", "npm", "pep621", "nix", "custom.regex"],
   "labels": ["dependencies"],
   "branchPrefix": "renovate/",
   "schedule": ["* * * * 1"], // dependency update PRs weekly, vulnerabilityAlerts bypasses this
@@ -14,7 +14,7 @@
   },
   "customManagers": [
     {
-      "customType": "makeTools",
+      "customType": "regex",
       "managerFilePatterns": ["/(^|/)Makefile$/"],
       "matchStrings": [
         "[A-Z_]+_PACKAGE\\s*\\?=\\s*(?<depName>[^@\\s]+?)(?:/cmd/[^@/\\s]+)?@(?<currentValue>\\S+)\\s+# renovate: datasource=(?<datasource>\\S+)",
@@ -69,7 +69,8 @@
     },
     {
       "groupName": "tool dependencies",
-      "matchManagers": ["custom.makeTools"],
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["**/Makefile"],
     },
     {
       "matchManagers": ["gomod"],

--- a/renovate.json5
+++ b/renovate.json5
@@ -14,7 +14,7 @@
   },
   "customManagers": [
     {
-      "customType": "regex",
+      "customType": "makeTools",
       "managerFilePatterns": ["/(^|/)Makefile$/"],
       "matchStrings": [
         "[A-Z_]+_PACKAGE\\s*\\?=\\s*(?<depName>[^@\\s]+?)(?:/cmd/[^@/\\s]+)?@(?<currentValue>\\S+)\\s+# renovate: datasource=(?<datasource>\\S+)",

--- a/renovate.json5
+++ b/renovate.json5
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests", "customManagers:githubActionsVersions"],
   "configMigration": true,
-  "enabledManagers": ["github-actions", "gomod", "npm", "pep621", "nix", "custom.regex"],
+  "enabledManagers": ["github-actions", "gomod", "npm", "pep621", "nix", "custom.makeTools"],
   "labels": ["dependencies"],
   "branchPrefix": "renovate/",
   "schedule": ["* * * * 1"], // dependency update PRs weekly, vulnerabilityAlerts bypasses this

--- a/renovate.json5
+++ b/renovate.json5
@@ -69,7 +69,7 @@
     },
     {
       "groupName": "tool dependencies",
-      "matchManagers": ["custom.regex"],
+      "matchManagers": ["custom.makeTools"],
     },
     {
       "matchManagers": ["gomod"],

--- a/renovate.json5
+++ b/renovate.json5
@@ -74,7 +74,7 @@
     {
       "matchManagers": ["gomod"],
       "matchDepNames": ["go"],
-      "matchDepTypes": ["golang"], // bump go.mod go directive
+      "matchDepTypes": ["golang"],
       "rangeStrategy": "bump",
       "schedule": ["at any time"],
       "minimumReleaseAge": "0",

--- a/renovate.json5
+++ b/renovate.json5
@@ -6,7 +6,7 @@
   "labels": ["dependencies"],
   "branchPrefix": "renovate/",
   "schedule": ["* * * * 1"], // dependency update PRs weekly, vulnerabilityAlerts bypasses this
-  "minimumReleaseAge": "3 days",
+  "minimumReleaseAge": "5 days",
   "semanticCommits": "enabled",
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {


### PR DESCRIPTION
- fix detection of Makefile tools and group them separately
- Enable `go.mod` `go` directive bumps, schedule it at any time and exempt it from the release-age delay

---
This PR was written with the help of Claude Opus 4.7