### PR TITLE
fix(actions): fix blank lines after `::endgroup::`

### DIFF
--- a/web_src/js/components/ActionRunJobView.vue
+++ b/web_src/js/components/ActionRunJobView.vue
@@ -195,11 +195,12 @@ function beginLogGroup(stepIndex: number, startTime: number, line: LogLine, cmd:
   el._stepLogsActiveContainer = elJobLogList;
 }
 
-// end a log group
-function endLogGroup(stepIndex: number, startTime: number, line: LogLine, cmd: LogLineCommand) {
+// end a log group. The ::endgroup:: marker is purely structural — it closes
+// the active group container — so it is not rendered as its own log line;
+// rendering it produced an empty row between collapsible sections.
+function endLogGroup(stepIndex: number) {
   const el = getJobStepLogsContainer(stepIndex);
   el._stepLogsActiveContainer = undefined;
-  el.append(createLogLine(stepIndex, startTime, line, cmd));
 }
 
 // show/hide the step logs for a step
@@ -253,7 +254,7 @@ function appendLogs(stepIndex: number, startTime: number, logLines: LogLine[]) {
         beginLogGroup(stepIndex, startTime, line, cmd);
         continue;
       case 'endgroup':
-        endLogGroup(stepIndex, startTime, line, cmd);
+        endLogGroup(stepIndex);
         continue;
     }
     // the active logs container may change during the loop, for example: entering and leaving a group

--- a/web_src/js/components/ActionRunJobView.vue
+++ b/web_src/js/components/ActionRunJobView.vue
@@ -195,9 +195,7 @@ function beginLogGroup(stepIndex: number, startTime: number, line: LogLine, cmd:
   el._stepLogsActiveContainer = elJobLogList;
 }
 
-// end a log group. The ::endgroup:: marker is purely structural — it closes
-// the active group container — so it is not rendered as its own log line;
-// rendering it produced an empty row between collapsible sections.
+// end a log group
 function endLogGroup(stepIndex: number) {
   const el = getJobStepLogsContainer(stepIndex);
   el._stepLogsActiveContainer = undefined;


### PR DESCRIPTION
`endLogGroup` was incorrectly appending empty `<div>`s, producing a useless blank line after every group. Before and after:

<img width="250" alt="Screenshot 2026-05-07 at 22 40 40" src="https://github.com/user-attachments/assets/8baf0fd0-99c8-4648-bf3f-edc6c4b197ec" /> <img width="250" alt="Screenshot 2026-05-07 at 22 37 12" src="https://github.com/user-attachments/assets/c45f28ae-1bbf-4b25-9d7b-281c19421f63" />
