### PR TITLE
fix(build): fix snap release

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -75,6 +75,7 @@ parts:
       set -x
       sed -i 's/os.Getuid()/1/g' modules/setting/setting.go
       npm install -g pnpm
+      # The release will always read main branch's file
       TAGS="bindata sqlite sqlite_unlock_notify pam cert" make build
       install -D gitea "${SNAPCRAFT_PART_INSTALL}/gitea"
       cp -r options "${SNAPCRAFT_PART_INSTALL}/"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -75,7 +75,7 @@ parts:
       set -x
       sed -i 's/os.Getuid()/1/g' modules/setting/setting.go
       npm install -g pnpm
-      TAGS="bindata pam cert" make build
+      TAGS="bindata sqlite sqlite_unlock_notify pam cert" make build
       install -D gitea "${SNAPCRAFT_PART_INSTALL}/gitea"
       cp -r options "${SNAPCRAFT_PART_INSTALL}/"
 


### PR DESCRIPTION
Fix #37593 
The stable version release of snap will read the main branch's snap file. So that we cannot remove the sqlite tags at the moment.