### PR TITLE
Refactor CheckIfPRContentChanged

### DIFF
--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -510,14 +510,29 @@ func AddTestPullRequestTask(opts TestPullRequestOptions) {
 // checkIfPRContentChanged checks if diff to target branch has changed by push
 // A commit can be considered to leave the PR untouched if the patch/diff with its merge base is unchanged
 func checkIfPRContentChanged(ctx context.Context, pr *issues_model.PullRequest, oldCommitID, newCommitID string) (hasChanged bool, mergeBase string, err error) {
-	prCtx, cancel, err := createTemporaryRepoForPR(ctx, pr) // FIXME: why it still needs to create a temp repo, since the alongside calls like GetDiverging doesn't do so anymore
-	if err != nil {
-		log.Error("CreateTemporaryRepoForPR %-v: %v", pr, err)
-		return false, "", err
+	if err := pr.LoadHeadRepo(ctx); err != nil {
+		return false, "", fmt.Errorf("LoadHeadRepo: %w", err)
+	} else if pr.HeadRepo == nil {
+		return false, "", &repo_model.ErrRepoNotExist{ID: pr.HeadRepoID}
 	}
-	defer cancel()
+	if err := pr.LoadBaseRepo(ctx); err != nil {
+		return false, "", fmt.Errorf("LoadBaseRepo: %w", err)
+	} else if pr.BaseRepo == nil {
+		return false, "", &repo_model.ErrRepoNotExist{ID: pr.BaseRepoID}
+	}
 
-	mergeBase, err = gitrepo.MergeBase(ctx, pr.BaseRepo, pr.BaseBranch, pr.GetGitHeadRefName())
+	baseCommitID, err := gitrepo.GetFullCommitID(ctx, pr.BaseRepo, pr.BaseBranch)
+	if err != nil {
+		return false, "", fmt.Errorf("GetFullCommitID[%s]: %w", pr.BaseBranch, err)
+	}
+
+	if pr.BaseRepo.ID != pr.HeadRepo.ID && !gitrepo.IsReferenceExist(ctx, pr.HeadRepo, baseCommitID) {
+		if err := gitrepo.FetchRemoteCommit(ctx, pr.HeadRepo, pr.BaseRepo, baseCommitID); err != nil {
+			return false, "", fmt.Errorf("FetchRemoteCommit: %w", err)
+		}
+	}
+
+	mergeBase, err = gitrepo.MergeBase(ctx, pr.HeadRepo, baseCommitID, newCommitID)
 	if err != nil {
 		return false, "", fmt.Errorf("GetMergeBase: %w", err)
 	}
@@ -526,16 +541,14 @@ func checkIfPRContentChanged(ctx context.Context, pr *issues_model.PullRequest, 
 
 	stdoutReader, stdoutReaderClose := cmd.MakeStdoutPipe()
 	defer stdoutReaderClose()
-	if err := cmd.WithDir(prCtx.tmpBasePath).
-		WithPipelineFunc(func(ctx gitcmd.Context) error {
-			return util.IsEmptyReader(stdoutReader)
-		}).
-		RunWithStderr(ctx); err != nil {
+	if err := gitrepo.RunCmdWithStderr(ctx, pr.HeadRepo, cmd.WithPipelineFunc(func(ctx gitcmd.Context) error {
+		return util.IsEmptyReader(stdoutReader)
+	})); err != nil {
 		if errors.Is(err, util.ErrNotEmpty) {
 			return true, mergeBase, nil
 		}
 
-		log.Error("Unable to run diff on %s %s %s in tempRepo for PR[%d]%s/%s...%s/%s: Error: %v",
+		log.Error("Unable to run diff on %s %s %s in head repo for PR[%d]%s/%s...%s/%s: Error: %v",
 			newCommitID, oldCommitID, mergeBase,
 			pr.ID, pr.BaseRepo.FullName(), pr.BaseBranch, pr.HeadRepo.FullName(), pr.HeadBranch,
 			err)

--- a/services/pull/pull_test.go
+++ b/services/pull/pull_test.go
@@ -5,6 +5,9 @@
 package pull
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	issues_model "code.gitea.io/gitea/models/issues"
@@ -14,6 +17,7 @@ import (
 	"code.gitea.io/gitea/modules/gitrepo"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TODO TestPullRequest_PushToBaseRepo
@@ -87,4 +91,68 @@ func TestPullRequest_GetDefaultMergeMessage_ExternalTracker(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "Merge pull request 'issue3' (#3) from user2/repo2:branch2 into master", mergeMessage)
+}
+
+func TestCheckIfPRContentChanged_ForkPR(t *testing.T) {
+	require.NoError(t, unittest.PrepareTestDatabase())
+
+	pr := unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{ID: 3})
+	require.NoError(t, pr.LoadBaseRepo(t.Context()))
+	require.NoError(t, pr.LoadHeadRepo(t.Context()))
+
+	oldBaseCommitID, err := gitrepo.GetFullCommitID(t.Context(), pr.BaseRepo, pr.BaseBranch)
+	require.NoError(t, err)
+	oldHeadCommitID, err := gitrepo.GetFullCommitID(t.Context(), pr.HeadRepo, pr.HeadBranch)
+	require.NoError(t, err)
+
+	baseWorktreePath := filepath.Join(t.TempDir(), "base-worktree")
+	runGitCommand(t, "clone", pr.BaseRepo.RepoPath(), baseWorktreePath)
+	runGitCommand(t, "-C", baseWorktreePath, "config", "user.name", "Gitea Tests")
+	runGitCommand(t, "-C", baseWorktreePath, "config", "user.email", "tests@gitea.io")
+
+	regressionFilePath := filepath.Join(baseWorktreePath, "fork-pr-regression.txt")
+	require.NoError(t, os.WriteFile(regressionFilePath, []byte("fork PR regression\n"), 0o644))
+	runGitCommand(t, "-C", baseWorktreePath, "add", filepath.Base(regressionFilePath))
+	runGitCommand(t, "-C", baseWorktreePath, "commit", "-m", "Advance base branch for fork PR regression test")
+	runGitCommand(t, "--git-dir", pr.BaseRepo.RepoPath(), "fetch", baseWorktreePath, "HEAD:refs/heads/"+pr.BaseBranch)
+
+	newBaseCommitID, err := gitrepo.GetFullCommitID(t.Context(), pr.BaseRepo, pr.BaseBranch)
+	require.NoError(t, err)
+	require.NotEqual(t, oldBaseCommitID, newBaseCommitID)
+
+	headWorktreePath := filepath.Join(t.TempDir(), "head-worktree")
+	runGitCommand(t, "clone", pr.HeadRepo.RepoPath(), headWorktreePath)
+	runGitCommand(t, "-C", headWorktreePath, "checkout", pr.HeadBranch)
+	runGitCommand(t, "-C", headWorktreePath, "config", "user.name", "Gitea Tests")
+	runGitCommand(t, "-C", headWorktreePath, "config", "user.email", "tests@gitea.io")
+
+	headChangePath := filepath.Join(headWorktreePath, "fork-pr-head-change.txt")
+	require.NoError(t, os.WriteFile(headChangePath, []byte("new head content\n"), 0o644))
+	runGitCommand(t, "-C", headWorktreePath, "add", filepath.Base(headChangePath))
+	runGitCommand(t, "-C", headWorktreePath, "commit", "-m", "Add head change for fork PR regression test")
+	runGitCommand(t, "--git-dir", pr.HeadRepo.RepoPath(), "fetch", headWorktreePath, "HEAD:refs/heads/"+pr.HeadBranch)
+
+	newHeadCommitID, err := gitrepo.GetFullCommitID(t.Context(), pr.HeadRepo, pr.HeadBranch)
+	require.NoError(t, err)
+	require.NotEqual(t, oldHeadCommitID, newHeadCommitID)
+
+	_, err = gitrepo.MergeBase(t.Context(), pr.HeadRepo, newBaseCommitID, newHeadCommitID)
+	require.Error(t, err)
+
+	changed, mergeBase, err := checkIfPRContentChanged(t.Context(), pr, oldHeadCommitID, newHeadCommitID)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Equal(t, oldBaseCommitID, mergeBase)
+
+	mergeBaseAfterFetch, err := gitrepo.MergeBase(t.Context(), pr.HeadRepo, newBaseCommitID, newHeadCommitID)
+	require.NoError(t, err)
+	assert.Equal(t, oldBaseCommitID, mergeBaseAfterFetch)
+}
+
+func runGitCommand(t *testing.T, args ...string) {
+	t.Helper()
+
+	cmd := exec.CommandContext(t.Context(), "git", args...)
+	output, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %v failed: %s", args, output)
 }


### PR DESCRIPTION
It’s unnecessary for CheckIfPRContentChanged to create a temporary Git repository.