### PR TITLE
fix(actions): support package scopes for task tokens

### DIFF
--- a/services/auth/action_token_scope.go
+++ b/services/auth/action_token_scope.go
@@ -1,0 +1,52 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"context"
+
+	actions_model "code.gitea.io/gitea/models/actions"
+	auth_model "code.gitea.io/gitea/models/auth"
+	"code.gitea.io/gitea/models/perm"
+	"code.gitea.io/gitea/models/unit"
+)
+
+func setActionTokenScope(ctx context.Context, store DataStore, task *actions_model.ActionTask) error {
+	store.GetData()["LoginMethod"] = ActionTokenMethodName
+
+	if err := task.LoadJob(ctx); err != nil {
+		return err
+	}
+	if err := task.Job.LoadRepo(ctx); err != nil {
+		return err
+	}
+
+	tokenPerms, err := actions_model.ComputeTaskTokenPermissions(ctx, task, task.Job.Repo)
+	if err != nil {
+		return err
+	}
+
+	var scope auth_model.AccessTokenScope
+	packageAccess := tokenPerms.UnitAccessModes[unit.TypePackages]
+	switch {
+	case packageAccess >= perm.AccessModeWrite:
+		scope = auth_model.AccessTokenScopeWritePackage
+	case packageAccess >= perm.AccessModeRead:
+		scope = auth_model.AccessTokenScopeReadPackage
+	default:
+		return nil
+	}
+
+	store.GetData()["IsApiToken"] = true
+	store.GetData()["ApiTokenScope"] = scope
+	return nil
+}
+
+func setActionTokenScopeByTaskID(ctx context.Context, store DataStore, taskID int64) error {
+	task, err := actions_model.GetTaskByID(ctx, taskID)
+	if err != nil {
+		return err
+	}
+	return setActionTokenScope(ctx, store, task)
+}

--- a/services/auth/action_token_scope_test.go
+++ b/services/auth/action_token_scope_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"testing"
+
+	actions_model "code.gitea.io/gitea/models/actions"
+	auth_model "code.gitea.io/gitea/models/auth"
+	"code.gitea.io/gitea/models/db"
+	"code.gitea.io/gitea/models/perm"
+	repo_model "code.gitea.io/gitea/models/repo"
+	"code.gitea.io/gitea/models/unit"
+	"code.gitea.io/gitea/models/unittest"
+	"code.gitea.io/gitea/modules/reqctx"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetActionTokenScope(t *testing.T) {
+	require.NoError(t, unittest.PrepareTestDatabase())
+	ctx := t.Context()
+
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 2})
+	require.NoError(t, db.Insert(ctx, &repo_model.RepoUnit{
+		RepoID: repo.ID,
+		Type:   unit.TypeActions,
+		Config: &repo_model.ActionsConfig{},
+	}))
+
+	task := unittest.AssertExistsAndLoadBean(t, &actions_model.ActionTask{ID: 53})
+	require.NoError(t, task.LoadJob(ctx))
+
+	perms := repo_model.MakeActionsTokenPermissions(perm.AccessModeNone)
+	perms.UnitAccessModes[unit.TypePackages] = perm.AccessModeRead
+	task.Job.TokenPermissions = &perms
+	_, err := actions_model.UpdateRunJob(ctx, task.Job, nil, "token_permissions")
+	require.NoError(t, err)
+
+	store := reqctx.ContextData{}
+	require.NoError(t, setActionTokenScope(ctx, store, task))
+
+	assert.Equal(t, ActionTokenMethodName, store["LoginMethod"])
+	assert.True(t, store["IsApiToken"].(bool))
+	assert.Equal(t, auth_model.AccessTokenScopeReadPackage, store["ApiTokenScope"])
+}

--- a/services/auth/basic.go
+++ b/services/auth/basic.go
@@ -112,7 +112,9 @@ func (b *Basic) VerifyAuthToken(req *http.Request, w http.ResponseWriter, store 
 	task, err := actions_model.GetRunningTaskByToken(req.Context(), authToken)
 	if err == nil && task != nil {
 		log.Trace("Basic Authorization: Valid AccessToken for task[%d]", task.ID)
-		store.GetData()["LoginMethod"] = ActionTokenMethodName
+		if err := setActionTokenScope(req.Context(), store, task); err != nil {
+			return nil, err
+		}
 		return user_model.NewActionsUserWithTaskID(task.ID), nil
 	}
 	return nil, nil //nolint:nilnil // the auth method is not applicable

--- a/services/auth/oauth2.go
+++ b/services/auth/oauth2.go
@@ -114,6 +114,9 @@ func (o *OAuth2) userFromToken(ctx context.Context, tokenSHA string, store DataS
 		// First attempt to decode an actions JWT, returning the actions user
 		if taskID, err := actions.TokenToTaskID(tokenSHA); err == nil {
 			if CheckTaskIsRunning(ctx, taskID) {
+				if err := setActionTokenScopeByTaskID(ctx, store, taskID); err != nil {
+					return nil, err
+				}
 				return user_model.NewActionsUserWithTaskID(taskID), nil
 			}
 		}
@@ -132,6 +135,9 @@ func (o *OAuth2) userFromToken(ctx context.Context, tokenSHA string, store DataS
 			// check task token
 			if task, err := actions_model.GetRunningTaskByToken(ctx, tokenSHA); err == nil {
 				log.Trace("Basic Authorization: Valid AccessToken for task[%d]", task.ID)
+				if err := setActionTokenScope(ctx, store, task); err != nil {
+					return nil, err
+				}
 				return user_model.NewActionsUserWithTaskID(task.ID), nil
 			}
 		}

--- a/services/context/main_test.go
+++ b/services/context/main_test.go
@@ -1,0 +1,14 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package context
+
+import (
+	"testing"
+
+	"code.gitea.io/gitea/models/unittest"
+)
+
+func TestMain(m *testing.M) {
+	unittest.MainTest(m)
+}

--- a/services/context/package.go
+++ b/services/context/package.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"net/http"
 
+	actions_model "code.gitea.io/gitea/models/actions"
 	"code.gitea.io/gitea/models/organization"
 	packages_model "code.gitea.io/gitea/models/packages"
 	"code.gitea.io/gitea/models/perm"
+	access_model "code.gitea.io/gitea/models/perm/access"
 	"code.gitea.io/gitea/models/unit"
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/setting"
@@ -122,7 +124,16 @@ func determineAccessMode(ctx *Base, pkgOwner, doer *user_model.User) (perm.Acces
 		return perm.AccessModeNone, nil
 	}
 
-	// TODO: ActionUser permission check
+	if taskID, ok := user_model.GetActionsUserTaskID(doer); ok {
+		actionAccessMode, err := determineActionsPackageAccessMode(ctx, pkgOwner, doer, taskID)
+		if err != nil {
+			return perm.AccessModeNone, err
+		}
+		if actionAccessMode != perm.AccessModeNone {
+			return actionAccessMode, nil
+		}
+	}
+
 	accessMode := perm.AccessModeNone
 	if pkgOwner.IsOrganization() {
 		org := organization.OrgFromUser(pkgOwner)
@@ -167,6 +178,28 @@ func determineAccessMode(ctx *Base, pkgOwner, doer *user_model.User) (perm.Acces
 	}
 
 	return accessMode, nil
+}
+
+func determineActionsPackageAccessMode(ctx *Base, pkgOwner, doer *user_model.User, taskID int64) (perm.AccessMode, error) {
+	task, err := actions_model.GetTaskByID(ctx, taskID)
+	if err != nil {
+		return perm.AccessModeNone, err
+	}
+	if err := task.LoadJob(ctx); err != nil {
+		return perm.AccessModeNone, err
+	}
+	if err := task.Job.LoadRepo(ctx); err != nil {
+		return perm.AccessModeNone, err
+	}
+	if task.Job.Repo.OwnerID != pkgOwner.ID {
+		return perm.AccessModeNone, nil
+	}
+
+	repoPerm, err := access_model.GetActionsUserRepoPermission(ctx, task.Job.Repo, doer, taskID)
+	if err != nil {
+		return perm.AccessModeNone, err
+	}
+	return repoPerm.UnitAccessMode(unit.TypePackages), nil
 }
 
 // PackageContexter initializes a package context for a request.

--- a/services/context/package_test.go
+++ b/services/context/package_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package context
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	actions_model "code.gitea.io/gitea/models/actions"
+	"code.gitea.io/gitea/models/db"
+	"code.gitea.io/gitea/models/perm"
+	repo_model "code.gitea.io/gitea/models/repo"
+	"code.gitea.io/gitea/models/unit"
+	"code.gitea.io/gitea/models/unittest"
+	user_model "code.gitea.io/gitea/models/user"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetermineAccessModeActionsUser(t *testing.T) {
+	require.NoError(t, unittest.PrepareTestDatabase())
+	ctx := t.Context()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/packages/user2/generic/pkg/1/file", nil)
+	base := NewBaseContextForTest(httptest.NewRecorder(), req)
+
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 2})
+	require.NoError(t, db.Insert(ctx, &repo_model.RepoUnit{
+		RepoID: repo.ID,
+		Type:   unit.TypeActions,
+		Config: &repo_model.ActionsConfig{},
+	}))
+
+	owner := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	otherOwner := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 31})
+	doer := user_model.NewActionsUserWithTaskID(53)
+	task := unittest.AssertExistsAndLoadBean(t, &actions_model.ActionTask{ID: 53})
+	require.NoError(t, task.LoadJob(ctx))
+
+	perms := repo_model.MakeActionsTokenPermissions(perm.AccessModeNone)
+	perms.UnitAccessModes[unit.TypePackages] = perm.AccessModeRead
+	task.Job.TokenPermissions = &perms
+	_, err := actions_model.UpdateRunJob(ctx, task.Job, nil, "token_permissions")
+	require.NoError(t, err)
+
+	mode, err := determineAccessMode(base, owner, doer)
+	require.NoError(t, err)
+	assert.Equal(t, perm.AccessModeRead, mode)
+
+	mode, err = determineAccessMode(base, otherOwner, doer)
+	require.NoError(t, err)
+	assert.Equal(t, perm.AccessModeNone, mode)
+
+	perms.UnitAccessModes[unit.TypePackages] = perm.AccessModeWrite
+	task.Job.TokenPermissions = &perms
+	_, err = actions_model.UpdateRunJob(ctx, task.Job, nil, "token_permissions")
+	require.NoError(t, err)
+
+	mode, err = determineAccessMode(base, owner, doer)
+	require.NoError(t, err)
+	assert.Equal(t, perm.AccessModeWrite, mode)
+}


### PR DESCRIPTION
Fixes #23642.

The Actions token already carries per-job package permissions, but the package auth path did not expose those permissions as package scopes. It also treated `gitea-actions` like a normal user when resolving package owner access.

This maps the job's `packages` permission to a read/write package scope during auth, then uses the Actions repo permission when the package owner matches the run repo owner.

Tests:
- `go test ./services/auth ./services/context`
