### PR TITLE
fix: snap build (main branch)

### DIFF
--- a/snap/part-gitea-build.sh
+++ b/snap/part-gitea-build.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+if [ ! -f go.mod -o ! -d snap ]; then
+  echo "This script should be run from the root of the gitea repository"
+  exit 1
+fi
+
+if [ -z "$SNAPCRAFT_PART_INSTALL" ]; then
+  SNAPCRAFT_PART_INSTALL="./dist/snap"
+  echo "* using mock install path: $SNAPCRAFT_PART_INSTALL"
+fi
+
+command -v pnpm >/dev/null 2>&1 || npm install -g pnpm
+
+# build tags for 1.26: "bindata sqlite sqlite_unlock_notify pam cert"
+# for 1.27: sqlite is not needed, "cert" seems doing nothing
+TAGS="bindata pam" make build
+
+install -D gitea "${SNAPCRAFT_PART_INSTALL}/gitea"
+cp -r options "${SNAPCRAFT_PART_INSTALL}/"

--- a/snap/part-gitea-build.sh
+++ b/snap/part-gitea-build.sh
@@ -1,12 +1,12 @@
-#!/bin/sh
-set -e
+#!/bin/bash
+set -euo pipefail
 
-if [ ! -f go.mod -o ! -d snap ]; then
+if [ ! -f go.mod ] || [ ! -d snap ]; then
   echo "This script should be run from the root of the gitea repository"
   exit 1
 fi
 
-if [ -z "$SNAPCRAFT_PART_INSTALL" ]; then
+if [ -z "${SNAPCRAFT_PART_INSTALL:-}" ]; then
   SNAPCRAFT_PART_INSTALL="./dist/snap"
   echo "* using mock install path: $SNAPCRAFT_PART_INSTALL"
 fi

--- a/snap/part-gitea-pull.sh
+++ b/snap/part-gitea-pull.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -e
+
+if [ ! -f go.mod -o ! -d snap ]; then
+  echo "This script should be run from the root of the gitea repository"
+  exit 1
+fi
+
+if [ -z "$SNAPCRAFT_PROJECT_NAME" ]; then
+  echo "No snapcraft build env, continue with mocking ...."
+  craftctl() { echo "* mocking craftctl: $*"; }
+  snap() { echo "* mocking snap: $*"; }
+else
+  echo "Add working directory to git safe.directory ..."
+  git config --global --add safe.directory "$PWD"
+fi
+
+# How it works:
+# * snapcraft.io checks out the default branch (e.g.: main during 1.27 dev period)
+# * "override-pull" step gets the latest tag by date (e.g.: v1.26.1)
+# * use "snap info gitea" to get the latest released tag
+#   * if the latest tag is not released to stable, checkout that tag and build it for "stable"
+#   * otherwise, build the main branch for "devel"
+# * "override-build" step uses build script from the checked out commit to build
+# This approach highly depends on the "main" branch's push.
+
+# To debug the logic:
+# * last_committed_tag=v1.26.1 last_released_tag=v1.26.0 ./snap/part-gitea-pull.sh
+#   it will checkout tag v1.26.1, and build that for "stable"
+# * last_committed_tag=v1.26.1 last_released_tag=v1.26.1 recent_tag=v1.27.0-dev-205 ./snap/part-gitea-pull.sh
+#   it will still use the current branch, and build it for "devel"
+
+[ -z "$last_committed_tag" ] && last_committed_tag="$(git for-each-ref --sort=taggerdate --format '%(tag)' refs/tags | tail -n 1)"
+[ -z "$last_released_tag" ] && last_released_tag="$(snap info gitea | awk '$1 == "latest/candidate:" { print $2 }')"
+
+if [ "${last_committed_tag}" != "${last_released_tag}" ]; then
+  # if the latest tag has not been released to stable, build that tag instead of default branch.
+  echo "Build last committed tag ${last_committed_tag} for new release, fetching and checking out ..."
+  git fetch --quiet
+  git checkout --quiet "${last_committed_tag}"
+  # HINT: after this, the "build" step will use that commit's "part-gitea-build.sh", but not this one's
+else
+  echo "Build current branch $(git branch --show-current) @ $(git rev-parse HEAD)"
+fi
+
+# possible tag names:
+# * v1.27.0-dev-205-gce089f498b
+# * v1.26.1
+# * v1.22.0-rc1-2816-gce089f498b
+# then normalize it to semver format: v1.2.3+dev.205.gce089f498b
+[ -z "$recent_tag" ] && recent_tag="$(git describe --always --tags)"
+echo "Use recent tag $recent_tag to determine version and grade"
+
+version_main="$(echo "$recent_tag" | cut -d'-' -f1)"
+version_ext="$(echo "$recent_tag" | cut -d'-' -s -f2- | sed -e 'y/-/./')"
+[ -n "$version_ext" ] && grade=devel || grade=stable
+
+version="${version_main}"
+[ -n "$version_ext" ] && version="${version}+${version_ext}"
+
+craftctl set version="$version"
+craftctl set grade="$grade"

--- a/snap/part-gitea-pull.sh
+++ b/snap/part-gitea-pull.sh
@@ -1,12 +1,12 @@
-#!/bin/sh
-set -e
+#!/bin/bash
+set -euo pipefail
 
-if [ ! -f go.mod -o ! -d snap ]; then
+if [ ! -f go.mod ] || [ ! -d snap ]; then
   echo "This script should be run from the root of the gitea repository"
   exit 1
 fi
 
-if [ -z "$SNAPCRAFT_PROJECT_NAME" ]; then
+if [ -z "${SNAPCRAFT_PROJECT_NAME:-}" ]; then
   echo "No snapcraft build env, continue with mocking ...."
   craftctl() { echo "* mocking craftctl: $*"; }
   snap() { echo "* mocking snap: $*"; }
@@ -30,8 +30,8 @@ fi
 # * last_committed_tag=v1.26.1 last_released_tag=v1.26.1 recent_tag=v1.27.0-dev-205 ./snap/part-gitea-pull.sh
 #   it will still use the current branch, and build it for "devel"
 
-[ -z "$last_committed_tag" ] && last_committed_tag="$(git for-each-ref --sort=taggerdate --format '%(tag)' refs/tags | tail -n 1)"
-[ -z "$last_released_tag" ] && last_released_tag="$(snap info gitea | awk '$1 == "latest/candidate:" { print $2 }')"
+last_committed_tag="${last_committed_tag:-$(git for-each-ref --sort=taggerdate --format '%(tag)' refs/tags | tail -n 1)}"
+last_released_tag="${last_released_tag:-$(snap info gitea | awk '$1 == "latest/candidate:" { print $2 }')}"
 
 if [ "${last_committed_tag}" != "${last_released_tag}" ]; then
   # if the latest tag has not been released to stable, build that tag instead of default branch.
@@ -48,15 +48,18 @@ fi
 # * v1.26.1
 # * v1.22.0-rc1-2816-gce089f498b
 # then normalize it to semver format: v1.2.3+dev.205.gce089f498b
-[ -z "$recent_tag" ] && recent_tag="$(git describe --always --tags)"
+recent_tag="${recent_tag:-$(git describe --always --tags)}"
 echo "Use recent tag $recent_tag to determine version and grade"
 
 version_main="$(echo "$recent_tag" | cut -d'-' -f1)"
 version_ext="$(echo "$recent_tag" | cut -d'-' -s -f2- | sed -e 'y/-/./')"
-[ -n "$version_ext" ] && grade=devel || grade=stable
-
-version="${version_main}"
-[ -n "$version_ext" ] && version="${version}+${version_ext}"
+if [ -n "$version_ext" ]; then
+  grade=devel
+  version="${version_main}+${version_ext}"
+else
+  grade=stable
+  version="${version_main}"
+fi
 
 craftctl set version="$version"
 craftctl set grade="$grade"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -2,9 +2,9 @@ name: gitea
 summary: Gitea - A painless self-hosted Git service
 description: |
   The goal of this project is to make the easiest, fastest, and most painless
-  way of setting up a self-hosted Git service. With Go, this can be done with
-  an independent binary distribution across ALL platforms that Go supports,
-  including Linux, Mac OS X, Windows and ARM.
+  way of setting up a self-hosted Git service with GitHub-like experiences,
+  including issue tracking, code review, project management, wikis, packages registry,
+  GitHub Actions and more.
 
 icon: public/assets/img/logo.png
 confinement: strict
@@ -53,31 +53,8 @@ parts:
     build-snaps: [ go/1.26/stable, node/24/stable ]
     build-environment:
       - LDFLAGS: ""
-    override-pull: |
-      craftctl default
-
-      git config --global --add safe.directory /root/parts/gitea/src
-      last_committed_tag="$(git for-each-ref --sort=taggerdate --format '%(tag)' refs/tags | tail -n 1)"
-      last_released_tag="$(snap info gitea | awk '$1 == "latest/candidate:" { print $2 }')"
-      # If the latest tag from the upstream project has not been released to
-      # stable, build that tag instead of master.
-      if [ "${last_committed_tag}" != "${last_released_tag}" ]; then
-        git fetch
-        git checkout "${last_committed_tag}"
-      fi
-
-      version="$(git describe --always | sed -e 's/-/+git/;y/-/./')"
-      [ -n "$(echo $version | grep "+git")" ] && grade=devel || grade=stable
-      craftctl set version="$version"
-      craftctl set grade="$grade"
-
-    override-build: |
-      set -x
-      npm install -g pnpm
-      TAGS="bindata pam cert" make build
-      install -D gitea "${SNAPCRAFT_PART_INSTALL}/gitea"
-      cp -r options "${SNAPCRAFT_PART_INSTALL}/"
-
+    override-pull: craftctl default && ./snap/part-gitea-pull.sh
+    override-build: ./snap/part-gitea-build.sh
     prime:
       - -etc
       - -usr/lib/systemd


### PR DESCRIPTION
1. make "pull" and "build" testable and debuggable
2. add more comments for how the build works
3. separate 1.26 and main build tags
4. fix incorrect tag describe (the current `snap info gitea` outputs version 1.22)

Legacy logic is kept as is although some of them don't seem good (e.g.: snap version grep, tag finding, etc)

ATTENTION:

* merge 1.26 change first https://github.com/go-gitea/gitea/pull/37646
* after this one merges, owners need to confirm the snap build works as expected