### PR TITLE
fix(api): add default sort order for action job queries

### DIFF
--- a/models/actions/run_job_list.go
+++ b/models/actions/run_job_list.go
@@ -124,7 +124,10 @@ func (opts FindRunJobOptions) ToJoins() []db.JoinFunc {
 }
 
 func (opts FindRunJobOptions) ToOrders() string {
-	return "`action_run_job`.`id` DESC"
+	if opts.PageSize > 0 || opts.Page > 0 {
+		return "`action_run_job`.`id` DESC"
+	}
+	return ""
 }
 
 var _ db.FindOptionsOrder = (*FindRunJobOptions)(nil)

--- a/models/actions/run_job_list.go
+++ b/models/actions/run_job_list.go
@@ -122,3 +122,9 @@ func (opts FindRunJobOptions) ToJoins() []db.JoinFunc {
 	}
 	return nil
 }
+
+func (opts FindRunJobOptions) ToOrders() string {
+	return "`action_run_job`.`id` DESC"
+}
+
+var _ db.FindOptionsOrder = (*FindRunJobOptions)(nil)

--- a/tests/integration/api_actions_run_test.go
+++ b/tests/integration/api_actions_run_test.go
@@ -327,6 +327,18 @@ func testAPIActionsListUserWorkflows(t *testing.T) {
 			assert.NotEmpty(t, job.HTMLURL, "html_url should be populated via batch-loaded repo")
 		}
 	})
+
+	t.Run("JobsOrderedByIDDesc", func(t *testing.T) {
+		req := NewRequest(t, "GET", "/api/v1/user/actions/jobs").AddTokenAuth(token)
+		resp := MakeRequest(t, req, http.StatusOK)
+		jobs := DecodeJSON(t, resp, &api.ActionWorkflowJobsResponse{})
+
+		assert.GreaterOrEqual(t, len(jobs.Entries), 2, "need at least 2 jobs to verify ordering")
+		for i := 1; i < len(jobs.Entries); i++ {
+			assert.Greater(t, jobs.Entries[i-1].ID, jobs.Entries[i].ID,
+				"jobs should be ordered by ID descending")
+		}
+	})
 }
 
 func testAPIActionsListRepoWorkflows(t *testing.T) {


### PR DESCRIPTION
`FindRunJobOptions` does not implement `ToOrders()`, so action job API endpoints return results in ascending primary-key order (oldest first). Paginated queries like `?status=success&limit=20` return the 20 oldest jobs rather than the 20 most recent.

Add `ToOrders()` returning `` `action_run_job`.`id` DESC `` and a compile-time interface assertion, matching the existing `FindRunOptions.ToOrders()` from #28084 and the artifact ordering fix pattern from #33569.

Fixes #37666

---
Built with Claude Code.