### PR TITLE
fix(config): Enable lfs cleanup #37671

### DIFF
--- a/services/cron/tasks_extended.go
+++ b/services/cron/tasks_extended.go
@@ -186,7 +186,7 @@ func registerGCLFS() {
 
 	RegisterTaskFatal("gc_lfs", &GCLFSConfig{
 		BaseConfig: BaseConfig{
-			Enabled:    false,
+			Enabled:    true,
 			RunAtStart: false,
 			Schedule:   "@every 24h",
 		},
@@ -207,9 +207,11 @@ func registerGCLFS() {
 	}, func(ctx context.Context, _ *user_model.User, config Config) error {
 		gcLFSConfig := config.(*GCLFSConfig)
 		return repo_service.GarbageCollectLFSMetaObjects(ctx, repo_service.GarbageCollectLFSMetaObjectsOptions{
-			AutoFix:                 true,
-			OlderThan:               time.Now().Add(-gcLFSConfig.OlderThan),
-			UpdatedLessRecentlyThan: time.Now().Add(-gcLFSConfig.LastUpdatedMoreThanAgo),
+			AutoFix:                  true,
+			OlderThan:                time.Now().Add(-gcLFSConfig.OlderThan),
+			UpdatedLessRecentlyThan:  time.Now().Add(-gcLFSConfig.LastUpdatedMoreThanAgo),
+			NumberToCheckPerRepo:     gcLFSConfig.NumberToCheckPerRepo,
+			ProportionToCheckPerRepo: gcLFSConfig.ProportionToCheckPerRepo,
 		})
 	})
 }


### PR DESCRIPTION
## Summary

The `gc_lfs` cron task is only registered when LFS is enabled, but it defaulted to `Enabled: false`, so LFS orphan cleanup never ran unless an admin enabled it. `NumberToCheckPerRepo` and `ProportionToCheckPerRepo` were defined on `GCLFSConfig` but were not passed into `GarbageCollectLFSMetaObjectsOptions`, so the intended per-repo sampling limits had no effect.

## Changes

- Set `gc_lfs` `BaseConfig.Enabled` to `true` so scheduled LFS meta-object GC runs by default when the LFS server is on.
- Forward `NumberToCheckPerRepo` and `ProportionToCheckPerRepo` from the cron config into `repository.GarbageCollectLFSMetaObjects`.

## Notes

- `git gc` still does not remove LFS blobs; `gc_lfs` remains the mechanism that removes orphaned `lfs_meta_object` rows and storage entries after pointer blobs are gone from git.
- This fixes cron defaults and config wiring only; it does not implement full reachability-based LFS cleanup.

Fixes: #37671 

------------------------------
Using AI Opus 4.7 