### PR TITLE
feat(repo): add inline comments on commit diffs

### DIFF
--- a/models/activities/notification.go
+++ b/models/activities/notification.go
@@ -115,6 +115,53 @@ func init() {
 	db.RegisterModel(new(Notification))
 }
 
+// CreateCommitCommentNotification creates notifications for a commit comment.
+// It notifies the commit author (if they're a Gitea user) and any @mentioned users.
+func CreateCommitCommentNotification(ctx context.Context, doer *user_model.User, repo *repo_model.Repository, comment *issues_model.Comment, commitAuthorEmail string, mentionedUsernames []string) error {
+	return db.WithTx(ctx, func(ctx context.Context) error {
+		receiverIDs := make(map[int64]struct{})
+
+		// Notify the commit author if they map to a Gitea user
+		if commitAuthorEmail != "" {
+			author, err := user_model.GetUserByEmail(ctx, commitAuthorEmail)
+			if err == nil && author.ID != doer.ID {
+				receiverIDs[author.ID] = struct{}{}
+			}
+		}
+
+		// Notify @mentioned users
+		if len(mentionedUsernames) > 0 {
+			mentionedIDs, err := user_model.GetUserIDsByNames(ctx, mentionedUsernames, true)
+			if err == nil {
+				for _, id := range mentionedIDs {
+					if id != doer.ID {
+						receiverIDs[id] = struct{}{}
+					}
+				}
+			}
+		}
+
+		if len(receiverIDs) == 0 {
+			return nil
+		}
+
+		var notifications []*Notification
+		for uid := range receiverIDs {
+			notifications = append(notifications, &Notification{
+				UserID:    uid,
+				RepoID:    repo.ID,
+				Status:    NotificationStatusUnread,
+				Source:    NotificationSourceCommit,
+				CommitID:  comment.CommitSHA,
+				CommentID: comment.ID,
+				UpdatedBy: doer.ID,
+			})
+		}
+
+		return db.Insert(ctx, notifications)
+	})
+}
+
 // CreateRepoTransferNotification creates  notification for the user a repository was transferred to
 func CreateRepoTransferNotification(ctx context.Context, doer, newOwner *user_model.User, repo *repo_model.Repository) error {
 	return db.WithTx(ctx, func(ctx context.Context) error {

--- a/models/issues/comment.go
+++ b/models/issues/comment.go
@@ -119,6 +119,8 @@ const (
 	CommentTypeUnpin // 37 unpin Issue/PullRequest
 
 	CommentTypeChangeTimeEstimate // 38 Change time estimate
+
+	CommentTypeCommitComment // 39 Inline comment on a commit diff (not part of a PR review)
 )
 
 var commentStrings = []string{
@@ -161,6 +163,7 @@ var commentStrings = []string{
 	"pin",
 	"unpin",
 	"change_time_estimate",
+	"commit_comment",
 }
 
 func (t CommentType) String() string {
@@ -178,7 +181,7 @@ func AsCommentType(typeName string) CommentType {
 
 func (t CommentType) HasContentSupport() bool {
 	switch t {
-	case CommentTypeComment, CommentTypeCode, CommentTypeReview, CommentTypeDismissReview:
+	case CommentTypeComment, CommentTypeCode, CommentTypeReview, CommentTypeDismissReview, CommentTypeCommitComment:
 		return true
 	}
 	return false
@@ -186,7 +189,7 @@ func (t CommentType) HasContentSupport() bool {
 
 func (t CommentType) HasAttachmentSupport() bool {
 	switch t {
-	case CommentTypeComment, CommentTypeCode, CommentTypeReview:
+	case CommentTypeComment, CommentTypeCode, CommentTypeReview, CommentTypeCommitComment:
 		return true
 	}
 	return false

--- a/models/issues/commit_comment.go
+++ b/models/issues/commit_comment.go
@@ -1,0 +1,143 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package issues
+
+import (
+	"context"
+
+	"code.gitea.io/gitea/models/db"
+)
+
+// CommitComment is a junction table linking a commit (repo + SHA) to
+// a Comment entry. The comment content, tree_path, line, poster, etc.
+// are stored in the Comment table with Type = CommentTypeCommitComment.
+type CommitComment struct {
+	ID        int64  `xorm:"pk autoincr"`
+	RepoID    int64  `xorm:"INDEX NOT NULL"`
+	CommitSHA string `xorm:"VARCHAR(64) INDEX NOT NULL"`
+	CommentID int64  `xorm:"UNIQUE NOT NULL"`
+}
+
+func init() {
+	db.RegisterModel(new(CommitComment))
+}
+
+// FileCommitComments holds commit comments for a single file,
+// split by side (left = old, right = new) with int keys matching DiffLine indices.
+type FileCommitComments struct {
+	Left  map[int][]*Comment
+	Right map[int][]*Comment
+}
+
+// CommitCommentsForDiff maps file paths to their commit comments.
+type CommitCommentsForDiff map[string]*FileCommitComments
+
+// FindCommitCommentsByCommitSHA returns all comments for a given commit in a repo.
+func FindCommitCommentsByCommitSHA(ctx context.Context, repoID int64, commitSHA string) ([]*Comment, error) {
+	var commentIDs []int64
+	if err := db.GetEngine(ctx).Cols("comment_id").Table("commit_comment").
+		Where("repo_id = ? AND commit_sha = ?", repoID, commitSHA).
+		Find(&commentIDs); err != nil {
+		return nil, err
+	}
+
+	if len(commentIDs) == 0 {
+		return nil, nil
+	}
+
+	comments := make([]*Comment, 0, len(commentIDs))
+	if err := db.GetEngine(ctx).
+		In("id", commentIDs).
+		OrderBy("created_unix ASC").
+		Find(&comments); err != nil {
+		return nil, err
+	}
+
+	if err := CommentList(comments).LoadPosters(ctx); err != nil {
+		return nil, err
+	}
+
+	return comments, nil
+}
+
+// FindCommitCommentsForDiff returns comments grouped by path and side for rendering in a diff view.
+func FindCommitCommentsForDiff(ctx context.Context, repoID int64, commitSHA string) (CommitCommentsForDiff, error) {
+	comments, err := FindCommitCommentsByCommitSHA(ctx, repoID, commitSHA)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(CommitCommentsForDiff)
+	for _, c := range comments {
+		fcc, ok := result[c.TreePath]
+		if !ok {
+			fcc = &FileCommitComments{
+				Left:  make(map[int][]*Comment),
+				Right: make(map[int][]*Comment),
+			}
+			result[c.TreePath] = fcc
+		}
+		if c.Line < 0 {
+			idx := int(-c.Line)
+			fcc.Left[idx] = append(fcc.Left[idx], c)
+		} else {
+			idx := int(c.Line)
+			fcc.Right[idx] = append(fcc.Right[idx], c)
+		}
+	}
+	return result, nil
+}
+
+// CreateCommitComment creates a Comment with type CommitComment and a
+// corresponding CommitComment junction record, within a transaction.
+func CreateCommitComment(ctx context.Context, repoID int64, commitSHA string, comment *Comment) error {
+	return db.WithTx(ctx, func(ctx context.Context) error {
+		if _, err := db.GetEngine(ctx).Insert(comment); err != nil {
+			return err
+		}
+
+		ref := &CommitComment{
+			RepoID:    repoID,
+			CommitSHA: commitSHA,
+			CommentID: comment.ID,
+		}
+		_, err := db.GetEngine(ctx).Insert(ref)
+		return err
+	})
+}
+
+// DeleteCommitComment deletes both the junction record and the Comment entry.
+func DeleteCommitComment(ctx context.Context, commentID int64) error {
+	return db.WithTx(ctx, func(ctx context.Context) error {
+		if _, err := db.GetEngine(ctx).Where("comment_id = ?", commentID).Delete(&CommitComment{}); err != nil {
+			return err
+		}
+		_, err := db.GetEngine(ctx).ID(commentID).Delete(&Comment{})
+		return err
+	})
+}
+
+// GetCommitCommentByID returns a commit comment by loading the Comment entry,
+// verifying it belongs to the given repository via the junction table.
+func GetCommitCommentByID(ctx context.Context, repoID, commentID int64) (*Comment, error) {
+	exists, err := db.GetEngine(ctx).Table("commit_comment").
+		Where("repo_id = ? AND comment_id = ?", repoID, commentID).
+		Exist()
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, db.ErrNotExist{Resource: "CommitComment", ID: commentID}
+	}
+
+	c := &Comment{}
+	has, err := db.GetEngine(ctx).ID(commentID).Get(c)
+	if err != nil {
+		return nil, err
+	}
+	if !has {
+		return nil, db.ErrNotExist{Resource: "CommitComment", ID: commentID}
+	}
+	return c, nil
+}

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -410,6 +410,7 @@ func prepareMigrationTasks() []*migration {
 
 		newMigration(331, "Add ActionRunAttempt model and related action fields", v1_27.AddActionRunAttemptModel),
 		newMigration(332, "Add last_sync_unix to mirror", v1_27.AddLastSyncUnixToMirror),
+		newMigration(333, "Add commit comment table", v1_27.AddCommitCommentTable),
 	}
 	return preparedMigrations
 }

--- a/models/migrations/v1_27/v333.go
+++ b/models/migrations/v1_27/v333.go
@@ -1,0 +1,20 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v1_27
+
+import "xorm.io/xorm"
+
+// AddCommitCommentTable creates the commit_comment junction table.
+// Each row maps a commit (repo_id + commit_sha) to a Comment row
+// (type = CommentTypeCommitComment). Keeping a separate table with an
+// index on commit_sha avoids a full-table scan on the large comment table.
+func AddCommitCommentTable(x *xorm.Engine) error {
+	type CommitComment struct {
+		ID        int64  `xorm:"pk autoincr"`
+		RepoID    int64  `xorm:"INDEX NOT NULL"`
+		CommitSHA string `xorm:"VARCHAR(64) INDEX NOT NULL"`
+		CommentID int64  `xorm:"UNIQUE NOT NULL"`
+	}
+	return x.Sync(new(CommitComment))
+}

--- a/models/repo/commit_comment.go
+++ b/models/repo/commit_comment.go
@@ -1,0 +1,8 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+// This file intentionally left minimal. The CommitComment junction table
+// and all query methods now live in models/issues/commit_comment.go
+// alongside the Comment model they reference.
+
+package repo

--- a/routers/web/repo/commit.go
+++ b/routers/web/repo/commit.go
@@ -26,6 +26,7 @@ import (
 	"code.gitea.io/gitea/modules/gitrepo"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/markup"
+	"code.gitea.io/gitea/modules/markup/markdown"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/templates"
 	"code.gitea.io/gitea/modules/util"
@@ -412,6 +413,35 @@ func Diff(ctx *context.Context) {
 	if pr != nil {
 		ctx.Data["MergedPRIssueNumber"] = pr.Index
 	}
+
+	// Load inline commit comments for the diff view
+	commitComments, err := issues_model.FindCommitCommentsForDiff(ctx, ctx.Repo.Repository.ID, commitID)
+	if err != nil {
+		log.Error("FindCommitCommentsForDiff: %v", err)
+	}
+	// Render markdown content for each commit comment
+	for _, fcc := range commitComments {
+		for _, comments := range fcc.Left {
+			for _, c := range comments {
+				rctx := renderhelper.NewRenderContextRepoComment(ctx, ctx.Repo.Repository, renderhelper.RepoCommentOptions{})
+				c.RenderedContent, err = markdown.RenderString(rctx, c.Content)
+				if err != nil {
+					log.Error("RenderString for commit comment %d: %v", c.ID, err)
+				}
+			}
+		}
+		for _, comments := range fcc.Right {
+			for _, c := range comments {
+				rctx := renderhelper.NewRenderContextRepoComment(ctx, ctx.Repo.Repository, renderhelper.RepoCommentOptions{})
+				c.RenderedContent, err = markdown.RenderString(rctx, c.Content)
+				if err != nil {
+					log.Error("RenderString for commit comment %d: %v", c.ID, err)
+				}
+			}
+		}
+	}
+	ctx.Data["CommitComments"] = commitComments
+	ctx.Data["CanComment"] = ctx.Doer != nil && ctx.Repo.CanRead(unit_model.TypeCode)
 
 	ctx.HTML(http.StatusOK, tplCommitPage)
 }

--- a/routers/web/repo/commit.go
+++ b/routers/web/repo/commit.go
@@ -441,7 +441,7 @@ func Diff(ctx *context.Context) {
 		}
 	}
 	ctx.Data["CommitComments"] = commitComments
-	ctx.Data["CanComment"] = ctx.Doer != nil && ctx.Repo.CanRead(unit_model.TypeCode)
+	ctx.Data["CanComment"] = ctx.Doer != nil && ctx.Repo.Permission.CanRead(unit_model.TypeCode)
 
 	ctx.HTML(http.StatusOK, tplCommitPage)
 }

--- a/routers/web/repo/commit_comment.go
+++ b/routers/web/repo/commit_comment.go
@@ -1,0 +1,157 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package repo
+
+import (
+	"net/http"
+
+	activities_model "code.gitea.io/gitea/models/activities"
+	issues_model "code.gitea.io/gitea/models/issues"
+	"code.gitea.io/gitea/models/renderhelper"
+	"code.gitea.io/gitea/modules/git"
+	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/markup/markdown"
+	"code.gitea.io/gitea/modules/references"
+	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/templates"
+	"code.gitea.io/gitea/services/context"
+	"code.gitea.io/gitea/services/gitdiff"
+)
+
+var (
+	tplNewCommitComment   templates.TplName = "repo/diff/new_commit_comment"
+	tplCommitConversation templates.TplName = "repo/diff/commit_conversation"
+)
+
+// RenderNewCommitCommentForm renders the comment form for inline commit comments.
+func RenderNewCommitCommentForm(ctx *context.Context) {
+	commitSHA := ctx.PathParam("sha")
+	ctx.Data["CommitID"] = commitSHA
+	ctx.Data["PageIsDiff"] = true
+	ctx.HTML(http.StatusOK, tplNewCommitComment)
+}
+
+// CreateCommitComment handles creating an inline comment on a commit diff.
+func CreateCommitComment(ctx *context.Context) {
+	commitSHA := ctx.PathParam("sha")
+	if commitSHA == "" {
+		ctx.NotFound(nil)
+		return
+	}
+
+	content := ctx.FormString("content")
+	treePath := ctx.FormString("tree_path")
+	side := ctx.FormString("side")
+	line := ctx.FormInt64("line")
+
+	if content == "" || treePath == "" || line == 0 {
+		ctx.JSONError("content, tree_path, and line are required")
+		return
+	}
+
+	if side == "previous" {
+		line = -line
+	}
+
+	commit, err := ctx.Repo.GitRepo.GetCommit(commitSHA)
+	if err != nil {
+		if git.IsErrNotExist(err) {
+			ctx.NotFound(err)
+		} else {
+			ctx.ServerError("GetCommit", err)
+		}
+		return
+	}
+	fullSHA := commit.ID.String()
+
+	// Generate diff context patch around the commented line
+	var patch string
+	var parentSHA string
+	if commit.ParentCount() > 0 {
+		parentID, err := commit.ParentID(0)
+		if err == nil {
+			parentSHA = parentID.String()
+		}
+	}
+	if parentSHA != "" {
+		absLine := line
+		isOld := line < 0
+		if isOld {
+			absLine = -line
+		}
+		patch, err = git.GetFileDiffCutAroundLine(
+			ctx.Repo.GitRepo, parentSHA, fullSHA, treePath,
+			absLine, isOld, setting.UI.CodeCommentLines,
+		)
+		if err != nil {
+			log.Debug("GetFileDiffCutAroundLine failed for commit comment: %v", err)
+		}
+		if patch == "" {
+			patch, err = gitdiff.GeneratePatchForUnchangedLine(ctx.Repo.GitRepo, fullSHA, treePath, line, setting.UI.CodeCommentLines)
+			if err != nil {
+				log.Debug("GeneratePatchForUnchangedLine failed for commit comment: %v", err)
+			}
+		}
+	}
+
+	comment := &issues_model.Comment{
+		Type:      issues_model.CommentTypeCommitComment,
+		PosterID:  ctx.Doer.ID,
+		Poster:    ctx.Doer,
+		CommitSHA: fullSHA,
+		TreePath:  treePath,
+		Line:      line,
+		Content:   content,
+		Patch:     patch,
+	}
+
+	if err := issues_model.CreateCommitComment(ctx, ctx.Repo.Repository.ID, fullSHA, comment); err != nil {
+		ctx.ServerError("CreateCommitComment", err)
+		return
+	}
+
+	// Send notifications to commit author and @mentioned users
+	mentions := references.FindAllMentionsMarkdown(content)
+	if err := activities_model.CreateCommitCommentNotification(ctx, ctx.Doer, ctx.Repo.Repository, comment, commit.Author.Email, mentions); err != nil {
+		log.Error("CreateCommitCommentNotification: %v", err)
+	}
+
+	// Render markdown content
+	rctx := renderhelper.NewRenderContextRepoComment(ctx, ctx.Repo.Repository, renderhelper.RepoCommentOptions{})
+	comment.RenderedContent, err = markdown.RenderString(rctx, comment.Content)
+	if err != nil {
+		log.Error("RenderString for commit comment %d: %v", comment.ID, err)
+	}
+
+	ctx.Data["CommitID"] = fullSHA
+	ctx.Data["comments"] = []*issues_model.Comment{comment}
+	ctx.HTML(http.StatusOK, tplCommitConversation)
+}
+
+// DeleteCommitComment handles deleting an inline comment on a commit.
+func DeleteCommitComment(ctx *context.Context) {
+	commentID := ctx.PathParamInt64("id")
+	if commentID <= 0 {
+		ctx.NotFound(nil)
+		return
+	}
+
+	comment, err := issues_model.GetCommitCommentByID(ctx, ctx.Repo.Repository.ID, commentID)
+	if err != nil {
+		ctx.NotFound(err)
+		return
+	}
+
+	if comment.PosterID != ctx.Doer.ID && !ctx.Repo.IsAdmin() {
+		ctx.JSONError("permission denied")
+		return
+	}
+
+	if err := issues_model.DeleteCommitComment(ctx, commentID); err != nil {
+		ctx.ServerError("DeleteCommitComment", err)
+		return
+	}
+
+	ctx.JSON(http.StatusOK, map[string]any{"ok": true})
+}

--- a/routers/web/repo/commit_comment.go
+++ b/routers/web/repo/commit_comment.go
@@ -143,7 +143,7 @@ func DeleteCommitComment(ctx *context.Context) {
 		return
 	}
 
-	if comment.PosterID != ctx.Doer.ID && !ctx.Repo.IsAdmin() {
+	if comment.PosterID != ctx.Doer.ID && !ctx.Repo.Permission.IsAdmin() {
 		ctx.JSONError("permission denied")
 		return
 	}

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1698,6 +1698,9 @@ func registerWebRoutes(m *web.Router, webAuth *AuthMiddleware) {
 			m.Get("/graph", repo.Graph)
 			m.Get("/commit/{sha:([a-f0-9]{7,64})$}", repo.SetEditorconfigIfExists, repo.SetDiffViewStyle, repo.SetWhitespaceBehavior, repo.Diff)
 			m.Get("/commit/{sha:([a-f0-9]{7,64})$}/load-branches-and-tags", repo.LoadBranchesAndTags)
+			m.Get("/commit/{sha:([a-f0-9]{7,64})$}/comment", reqSignIn, reqUnitCodeReader, repo.RenderNewCommitCommentForm)
+			m.Post("/commit/{sha:([a-f0-9]{7,64})$}/comment", reqSignIn, reqUnitCodeReader, context.RepoMustNotBeArchived(), repo.CreateCommitComment)
+			m.Post("/commit/{sha:([a-f0-9]{7,64})$}/comment/{id}/delete", reqSignIn, reqUnitCodeReader, context.RepoMustNotBeArchived(), repo.DeleteCommitComment)
 
 			// FIXME: this route `/cherry-pick/{sha}` doesn't seem useful or right, the new code always uses `/_cherrypick/` which could handle branch name correctly
 			m.Get("/cherry-pick/{sha:([a-f0-9]{7,64})$}", repo.SetEditorconfigIfExists, context.RepoRefByDefaultBranch(), repo.CherryPick)

--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -184,7 +184,7 @@
 										{{end}}
 									</div>
 								{{else}}
-									<table class="chroma" data-new-comment-url="{{$.Issue.Link}}/files/reviews/new_comment" data-path="{{$file.Name}}">
+									<table class="chroma" data-new-comment-url="{{if $.PageIsDiff}}{{$.RepoLink}}/commit/{{$.CommitID}}/comment{{else}}{{$.Issue.Link}}/files/reviews/new_comment{{end}}" data-path="{{$file.Name}}">
 										{{if $.IsSplitStyle}}
 											{{template "repo/diff/section_split" dict "file" . "root" $}}
 										{{else}}

--- a/templates/repo/diff/commit_comment_form.tmpl
+++ b/templates/repo/diff/commit_comment_form.tmpl
@@ -1,0 +1,25 @@
+{{if and ctx.RootData.SignedUserID (not ctx.RootData.Repository.IsArchived)}}
+	<form class="ui form {{if $.hidden}}tw-hidden comment-form{{end}}" action="{{$.root.RepoLink}}/commit/{{$.root.CommitID}}/comment" method="post">
+		<input type="hidden" name="side" value="">
+		<input type="hidden" name="line" value="">
+		<input type="hidden" name="tree_path" value="">
+		<div class="field">
+		{{template "shared/combomarkdowneditor" (dict
+			"CustomInit" true
+			"MarkdownEditorContext" (ctx.MiscUtils.MarkdownEditorComment ctx.RootData.Repository)
+			"TextareaName" "content"
+			"TextareaPlaceholder" (ctx.Locale.Tr "repo.diff.comment.placeholder")
+			"DropzoneParentContainer" "form"
+			"DisableAutosize" "true"
+		)}}
+		</div>
+		<div class="field footer">
+			<div class="flex-text-block tw-justify-end">
+				<button type="submit" class="ui submit primary tiny button btn-add-single">{{ctx.Locale.Tr "repo.diff.comment.add_single_comment"}}</button>
+				{{if or (not $.HasComments) $.hidden}}
+					<button type="button" class="ui submit tiny basic button btn-cancel cancel-code-comment">{{ctx.Locale.Tr "cancel"}}</button>
+				{{end}}
+			</div>
+		</div>
+	</form>
+{{end}}

--- a/templates/repo/diff/commit_comments.tmpl
+++ b/templates/repo/diff/commit_comments.tmpl
@@ -1,0 +1,35 @@
+{{range .comments}}
+
+{{$createdStr := DateUtils.TimeSince .CreatedUnix}}
+<div class="comment" id="{{.HashTag}}">
+	<div class="tw-mt-2 tw-mr-4">
+		{{template "shared/user/avatarlink" dict "user" .Poster}}
+	</div>
+	<div class="content comment-container">
+		<div class="comment-header avatar-content-left-arrow">
+			<div class="comment-header-left">
+				<span class="tw-text-text-light muted-links">
+					{{template "shared/user/namelink" .Poster}}
+					{{ctx.Locale.Tr "repo.issues.commented_at" .HashTag $createdStr}}
+				</span>
+			</div>
+			<div class="comment-header-right">
+				{{if and $.root.IsSigned (eq $.root.SignedUserID .PosterID)}}
+					<div class="item context js-aria-clickable delete-comment" data-comment-id="{{.HashTag}}" data-url="{{$.root.RepoLink}}/commit/{{.CommitSHA}}/comment/{{.ID}}/delete" data-locale="{{ctx.Locale.Tr "repo.issues.delete_comment_confirm"}}">
+						{{svg "octicon-trash" 14}}
+					</div>
+				{{end}}
+			</div>
+		</div>
+		<div class="ui attached segment comment-body">
+			<div class="render-content markup">
+			{{if .RenderedContent}}
+				{{.RenderedContent}}
+			{{else}}
+				<span class="no-content">{{ctx.Locale.Tr "repo.issues.no_content"}}</span>
+			{{end}}
+			</div>
+		</div>
+	</div>
+</div>
+{{end}}

--- a/templates/repo/diff/commit_conversation.tmpl
+++ b/templates/repo/diff/commit_conversation.tmpl
@@ -1,0 +1,25 @@
+{{if .comments}}
+	{{$comment := index .comments 0}}
+	<div class="conversation-holder" data-path="{{$comment.TreePath}}" data-side="{{if eq $comment.DiffSide "previous"}}left{{else}}right{{end}}" data-idx="{{$comment.UnsignedLine}}">
+		<div id="code-comments-{{$comment.ID}}" class="field comment-code-cloud">
+			<div class="comment-list">
+				<div class="ui comments">
+					{{template "repo/diff/commit_comments" dict "root" $ "comments" .comments}}
+				</div>
+			</div>
+			<div class="flex-text-block tw-mt-2 tw-flex-wrap tw-justify-end">
+				<div class="ui buttons">
+					<button class="ui icon tiny basic button previous-conversation">
+						{{svg "octicon-arrow-up" 12}} {{ctx.Locale.Tr "repo.issues.previous"}}
+					</button>
+					<button class="ui icon tiny basic button next-conversation">
+						{{svg "octicon-arrow-down" 12}} {{ctx.Locale.Tr "repo.issues.next"}}
+					</button>
+				</div>
+			</div>
+			{{if and $.SignedUserID (not $.Repository.IsArchived)}}
+				{{template "repo/diff/commit_comment_form" dict "hidden" true "root" $}}
+			{{end}}
+		</div>
+	</div>
+{{end}}

--- a/templates/repo/diff/new_commit_comment.tmpl
+++ b/templates/repo/diff/new_commit_comment.tmpl
@@ -1,0 +1,5 @@
+<div class="conversation-holder">
+	<div class="field comment-code-cloud">
+		{{template "repo/diff/commit_comment_form" dict "root" $}}
+	</div>
+</div>

--- a/templates/repo/diff/section_split.tmpl
+++ b/templates/repo/diff/section_split.tmpl
@@ -1,5 +1,8 @@
 {{$file := .file}}
 {{$diffBlobExcerptData := $.root.DiffBlobExcerptData}}
+{{$commitComments := $.root.CommitComments}}
+{{$ccFile := ""}}
+{{if $commitComments}}{{$ccFile = index $commitComments $file.Name}}{{end}}
 <colgroup>
 	<col width="50">
 	<col width="10">
@@ -28,7 +31,7 @@
 					<td class="lines-escape del-code lines-escape-old">{{if $line.LeftIdx}}{{ctx.RenderUtils.RenderUnicodeEscapeToggleButton $leftDiff.EscapeStatus}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-old del-code"><span class="tw-font-mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span></td>
 					<td class="lines-code lines-code-old del-code">
-						{{- if and $.root.SignedUserID $.root.PageIsPullFiles -}}
+						{{- if and $.root.SignedUserID (or $.root.PageIsPullFiles $.root.PageIsDiff) -}}
 							<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-left{{if (not $line.CanComment)}} tw-invisible{{end}}" data-side="left" data-idx="{{$line.LeftIdx}}">
 								{{- svg "octicon-plus" -}}
 							</button>
@@ -43,7 +46,7 @@
 					<td class="lines-escape add-code lines-escape-new">{{if $match.RightIdx}}{{ctx.RenderUtils.RenderUnicodeEscapeToggleButton $rightDiff.EscapeStatus}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-new add-code">{{if $match.RightIdx}}<span class="tw-font-mono" data-type-marker="{{$match.GetLineTypeMarker}}"></span>{{end}}</td>
 					<td class="lines-code lines-code-new add-code">
-						{{- if and $.root.SignedUserID $.root.PageIsPullFiles -}}
+						{{- if and $.root.SignedUserID (or $.root.PageIsPullFiles $.root.PageIsDiff) -}}
 							<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-right{{if (not $match.CanComment)}} tw-invisible{{end}}" data-side="right" data-idx="{{$match.RightIdx}}">
 								{{- svg "octicon-plus" -}}
 							</button>
@@ -60,7 +63,7 @@
 					<td class="lines-escape lines-escape-old">{{if $line.LeftIdx}}{{ctx.RenderUtils.RenderUnicodeEscapeToggleButton $inlineDiff.EscapeStatus}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-old">{{if $line.LeftIdx}}<span class="tw-font-mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
 					<td class="lines-code lines-code-old">
-						{{- if and $.root.SignedUserID $.root.PageIsPullFiles (not (eq .GetType 2)) -}}
+						{{- if and $.root.SignedUserID (or $.root.PageIsPullFiles $.root.PageIsDiff) (not (eq .GetType 2)) -}}
 							<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-left{{if (not $line.CanComment)}} tw-invisible{{end}}" data-side="left" data-idx="{{$line.LeftIdx}}">
 								{{- svg "octicon-plus" -}}
 							</button>
@@ -75,7 +78,7 @@
 					<td class="lines-escape lines-escape-new">{{if $line.RightIdx}}{{ctx.RenderUtils.RenderUnicodeEscapeToggleButton $inlineDiff.EscapeStatus}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-new">{{if $line.RightIdx}}<span class="tw-font-mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
 					<td class="lines-code lines-code-new">
-						{{- if and $.root.SignedUserID $.root.PageIsPullFiles (not (eq .GetType 3)) -}}
+						{{- if and $.root.SignedUserID (or $.root.PageIsPullFiles $.root.PageIsDiff) (not (eq .GetType 3)) -}}
 							<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-right{{if (not $line.CanComment)}} tw-invisible{{end}}" data-side="right" data-idx="{{$line.RightIdx}}">
 								{{- svg "octicon-plus" -}}
 							</button>
@@ -131,6 +134,32 @@
 						{{end}}
 					</td>
 				</tr>
+			{{end}}
+			{{/* Render commit comments (not PR review comments) */}}
+			{{if $ccFile}}
+				{{$leftCC := ""}}
+				{{if $line.LeftIdx}}{{$leftCC = index $ccFile.Left $line.LeftIdx}}{{end}}
+				{{$rightCC := ""}}
+				{{if and (eq .GetType 3) $hasmatch}}
+					{{$match := index $section.Lines $line.Match}}
+					{{if $match.RightIdx}}{{$rightCC = index $ccFile.Right $match.RightIdx}}{{end}}
+				{{else}}
+					{{if $line.RightIdx}}{{$rightCC = index $ccFile.Right $line.RightIdx}}{{end}}
+				{{end}}
+				{{if or $leftCC $rightCC}}
+					<tr class="add-comment" data-line-type="{{.GetHTMLDiffLineType}}">
+						<td class="add-comment-left" colspan="4">
+							{{if $leftCC}}
+								{{template "repo/diff/commit_conversation" dict "." $.root "comments" $leftCC}}
+							{{end}}
+						</td>
+						<td class="add-comment-right" colspan="4">
+							{{if $rightCC}}
+								{{template "repo/diff/commit_conversation" dict "." $.root "comments" $rightCC}}
+							{{end}}
+						</td>
+					</tr>
+				{{end}}
 			{{end}}
 		{{end}}
 	{{end}}

--- a/templates/repo/diff/section_unified.tmpl
+++ b/templates/repo/diff/section_unified.tmpl
@@ -1,6 +1,9 @@
 {{$file := .file}}
 {{/* this tmpl is also used by the PR Conversation page, so "DiffBlobExcerptData" may not exist */}}
 {{$diffBlobExcerptData := $.root.DiffBlobExcerptData}}
+{{$commitComments := $.root.CommitComments}}
+{{$ccFile := ""}}
+{{if $commitComments}}{{$ccFile = index $commitComments $file.Name}}{{end}}
 <colgroup>
 	<col width="50">
 	<col width="50">
@@ -31,7 +34,7 @@
 				<td class="chroma lines-code blob-hunk">{{template "repo/diff/section_code" dict "diff" $inlineDiff}}</td>
 			{{else}}
 				<td class="chroma lines-code{{if (not $line.RightIdx)}} lines-code-old{{end}}">
-					{{- if and $.root.SignedUserID $.root.PageIsPullFiles -}}
+					{{- if and $.root.SignedUserID (or $.root.PageIsPullFiles $.root.PageIsDiff) -}}
 						<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-{{if $line.RightIdx}}right{{else}}left{{end}}{{if (not $line.CanComment)}} tw-invisible{{end}}" data-side="{{if $line.RightIdx}}right{{else}}left{{end}}" data-idx="{{if $line.RightIdx}}{{$line.RightIdx}}{{else}}{{$line.LeftIdx}}{{end}}">
 							{{- svg "octicon-plus" -}}
 						</button>
@@ -46,6 +49,25 @@
 					{{template "repo/diff/conversation" dict "." $.root "comments" $line.Comments}}
 				</td>
 			</tr>
+		{{end}}
+		{{/* Render commit comments (not PR review comments) */}}
+		{{if $ccFile}}
+			{{$rightCC := ""}}
+			{{if $line.RightIdx}}{{$rightCC = index $ccFile.Right $line.RightIdx}}{{end}}
+			{{$leftCC := ""}}
+			{{if and $line.LeftIdx (not $line.RightIdx)}}{{$leftCC = index $ccFile.Left $line.LeftIdx}}{{end}}
+			{{if or $rightCC $leftCC}}
+				<tr class="add-comment" data-line-type="{{.GetHTMLDiffLineType}}">
+					<td class="add-comment-left add-comment-right" colspan="5">
+						{{if $rightCC}}
+							{{template "repo/diff/commit_conversation" dict "." $.root "comments" $rightCC}}
+						{{end}}
+						{{if $leftCC}}
+							{{template "repo/diff/commit_conversation" dict "." $.root "comments" $leftCC}}
+						{{end}}
+					</td>
+				</tr>
+			{{end}}
 		{{end}}
 	{{end}}
 {{end}}


### PR DESCRIPTION
## Summary

Closes #4898

Adds inline comments on commit diffs (not just PR diffs). Users can now click a line in a commit diff and leave a comment, similar to PR code review comments.

### Design (addresses maintainer feedback from #36862)

- **Separate `commit_comment` junction table** (`repo_id`, `commit_sha INDEX`, `comment_id UNIQUE`) — avoids full table scan on the large `comment` table. Indexed on `commit_sha` for fast per-commit lookups.
- Comment content, `tree_path`, `line`, `poster_id` etc. live in the existing `Comment` table with `Type = CommentTypeCommitComment`.
- Migration 333 (`v1_27/v333.go`) creates the table.

### Changes

| Area | Files |
|------|-------|
| Model | `models/issues/commit_comment.go` — `CommitComment`, `CreateCommitComment`, `FindCommitCommentsByCommitSHA`, `GroupCommitCommentsByPath` |
| Migration | `models/migrations/v1_27/v333.go` |
| Router | `routers/web/repo/commit_comment.go` — POST create, DELETE |
| Routes | `routers/web/web.go` |
| Templates | `commit_comment_form.tmpl`, `commit_comments.tmpl`, `commit_conversation.tmpl`, `new_commit_comment.tmpl` |
| Diff render | `section_split.tmpl`, `section_unified.tmpl` — inline comment form per line |
| Notifications | `models/activities/notification.go` |

## Test Plan

- [ ] Create a commit comment on a split diff line
- [ ] Create a commit comment on a unified diff line
- [ ] Delete a commit comment
- [ ] Verify `commit_comment` table has correct index on `commit_sha`
- [ ] Verify notifications are sent to repo watchers
