### PR TITLE
feat(migrations): support SSH clone addresses

### DIFF
--- a/modules/git/remote.go
+++ b/modules/git/remote.go
@@ -79,11 +79,33 @@ func IsRemoteNotExistError(err error) bool {
 	return gitcmd.StderrHasPrefix(err, prefix1) || gitcmd.StderrHasPrefix(err, prefix2)
 }
 
+// IsSSHRemoteAddr reports whether remoteAddr looks like an SSH remote.
+// It matches both the URL form (ssh://user@host[:port]/path) and the
+// SCP-like short form (user@host:path) commonly used by Git hosts.
+func IsSSHRemoteAddr(remoteAddr string) bool {
+	remoteAddr = strings.TrimSpace(remoteAddr)
+	if strings.HasPrefix(remoteAddr, "ssh://") || strings.HasPrefix(remoteAddr, "git+ssh://") {
+		return true
+	}
+	// SCP-like short syntax: [user@]host:path. The first ':' must come before the first '/'
+	// (otherwise it's a URL or a path containing a colon).
+	at := strings.Index(remoteAddr, "@")
+	colon := strings.Index(remoteAddr, ":")
+	slash := strings.Index(remoteAddr, "/")
+	if at <= 0 || colon <= at {
+		return false
+	}
+	if slash >= 0 && slash < colon {
+		return false
+	}
+	return true
+}
+
 // ParseRemoteAddr checks if given remote address is valid,
 // and returns composed URL with needed username and password.
 func ParseRemoteAddr(remoteAddr, authUsername, authPassword string) (string, error) {
 	remoteAddr = strings.TrimSpace(remoteAddr)
-	// Remote address can be HTTP/HTTPS/Git URL or local path.
+	// Remote address can be HTTP/HTTPS/Git/SSH URL, SCP-like short SSH syntax or local path.
 	if strings.HasPrefix(remoteAddr, "http://") ||
 		strings.HasPrefix(remoteAddr, "https://") ||
 		strings.HasPrefix(remoteAddr, "git://") {
@@ -96,6 +118,10 @@ func ParseRemoteAddr(remoteAddr, authUsername, authPassword string) (string, err
 		}
 		remoteAddr = u.String()
 	}
+
+	// SSH addresses (ssh:// URL form or SCP-like git@host:path form) authenticate
+	// with a key/agent at clone time, so we don't embed username/password in the URL.
+	// We keep the raw address as-is so that git understands the SCP form.
 
 	return remoteAddr, nil
 }

--- a/modules/git/remote_test.go
+++ b/modules/git/remote_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package git
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSSHRemoteAddr(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected bool
+	}{
+		// SSH URL form
+		{"ssh://git@github.com/go-gitea/gitea.git", true},
+		{"ssh://git@host:22/path", true},
+		{"git+ssh://git@github.com/go-gitea/gitea.git", true},
+		{"  ssh://git@github.com/go-gitea/gitea.git  ", true}, // trims whitespace
+
+		// SCP-like short form
+		{"git@github.com:go-gitea/gitea.git", true},
+		{"user@host:path/to/repo", true},
+		{"git@host:/absolute/path/repo.git", true},
+
+		// Not SSH
+		{"https://github.com/go-gitea/gitea.git", false},
+		{"http://github.com/go-gitea/gitea.git", false},
+		{"git://github.com/go-gitea/gitea.git", false},
+		{"/local/path/repo.git", false},
+		{"file:///tmp/repo.git", false},
+		{"", false},
+
+		// Edge cases that look SCP-ish but aren't
+		{"host:path", false},               // no '@'
+		{"@host:path", false},              // '@' at start, no user
+		{"git@host", false},                // no ':'
+		{"http://user@host/path", false},   // '/' before ':' (after scheme)
+		{"user@host/path:branch", false},   // '/' before ':' — looks like a URL path, not SCP
+		{":git@host:path", false},          // ':' before '@'
+	}
+	for _, c := range cases {
+		t.Run(c.input, func(t *testing.T) {
+			assert.Equal(t, c.expected, IsSSHRemoteAddr(c.input))
+		})
+	}
+}

--- a/modules/git/remote_test.go
+++ b/modules/git/remote_test.go
@@ -34,12 +34,12 @@ func TestIsSSHRemoteAddr(t *testing.T) {
 		{"", false},
 
 		// Edge cases that look SCP-ish but aren't
-		{"host:path", false},               // no '@'
-		{"@host:path", false},              // '@' at start, no user
-		{"git@host", false},                // no ':'
-		{"http://user@host/path", false},   // '/' before ':' (after scheme)
-		{"user@host/path:branch", false},   // '/' before ':' — looks like a URL path, not SCP
-		{":git@host:path", false},          // ':' before '@'
+		{"host:path", false},             // no '@'
+		{"@host:path", false},            // '@' at start, no user
+		{"git@host", false},              // no ':'
+		{"http://user@host/path", false}, // '/' before ':' (after scheme)
+		{"user@host/path:branch", false}, // '/' before ':' — looks like a URL path, not SCP
+		{":git@host:path", false},        // ':' before '@'
 	}
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {

--- a/modules/migration/null_downloader.go
+++ b/modules/migration/null_downloader.go
@@ -6,6 +6,9 @@ package migration
 import (
 	"context"
 	"net/url"
+
+	"code.gitea.io/gitea/modules/git"
+	"code.gitea.io/gitea/modules/log"
 )
 
 // NullDownloader implements a blank downloader
@@ -66,6 +69,12 @@ func (n NullDownloader) GetReviews(_ context.Context, reviewable Reviewable) ([]
 // FormatCloneURL add authentication into remote URLs
 func (n NullDownloader) FormatCloneURL(opts MigrateOptions, remoteAddr string) (string, error) {
 	if len(opts.AuthToken) > 0 || len(opts.AuthUsername) > 0 {
+		// SSH addresses authenticate via key/agent, not via embedded credentials.
+		// Returning them as-is also avoids url.Parse mangling the SCP-like short form.
+		if git.IsSSHRemoteAddr(remoteAddr) {
+			log.Warn("auth_username/auth_token supplied with SSH clone address %q; ignored — SSH uses the keys/agent of the Gitea process", remoteAddr)
+			return remoteAddr, nil
+		}
 		u, err := url.Parse(remoteAddr)
 		if err != nil {
 			return "", err

--- a/modules/structs/repo.go
+++ b/modules/structs/repo.go
@@ -384,6 +384,12 @@ func (gt GitServiceType) Title() string {
 // MigrateRepoOptions options for migrating repository's
 // this is used to interact with api v1
 type MigrateRepoOptions struct {
+	// CloneAddr is the source URL. Supported forms: HTTP(S) URLs (https://host/owner/repo.git),
+	// Git URLs (git://host/path), SSH URLs (ssh://user@host[:port]/path) and the
+	// SCP-like SSH short syntax (user@host:owner/repo.git). When using an SSH address,
+	// authentication relies on the keys/configuration available to the Gitea server
+	// process (for example via the GIT_SSH_COMMAND environment variable);
+	// auth_username/auth_password are ignored for SSH addresses.
 	// required: true
 	CloneAddr string `json:"clone_addr" binding:"Required"`
 	// deprecated (only for backwards compatibility, use repo_owner instead)

--- a/modules/util/url.go
+++ b/modules/util/url.go
@@ -19,6 +19,18 @@ func PathEscapeSegments(path string) string {
 }
 
 func SanitizeURL(s string) (string, error) {
+	// SCP-like SSH short syntax (e.g. git@host:owner/repo.git) is not a valid URL,
+	// so url.Parse mangles it. Detect and return as-is — there are no embedded
+	// credentials in this form to sanitize.
+	trimmed := strings.TrimSpace(s)
+	if !strings.Contains(trimmed, "://") {
+		at := strings.Index(trimmed, "@")
+		colon := strings.Index(trimmed, ":")
+		slash := strings.Index(trimmed, "/")
+		if at > 0 && colon > at && (slash < 0 || slash > colon) {
+			return trimmed, nil
+		}
+	}
 	u, err := url.Parse(s)
 	if err != nil {
 		return "", err

--- a/modules/util/url_test.go
+++ b/modules/util/url_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "strips userinfo from https URL",
+			input:    "https://user:secret@host.example.com/owner/repo.git",
+			expected: "https://host.example.com/owner/repo.git",
+		},
+		{
+			name:     "https without credentials is unchanged",
+			input:    "https://host.example.com/owner/repo.git",
+			expected: "https://host.example.com/owner/repo.git",
+		},
+		{
+			name:     "scp-like SSH short form is returned as-is",
+			input:    "git@github.com:go-gitea/gitea.git",
+			expected: "git@github.com:go-gitea/gitea.git",
+		},
+		{
+			name:     "scp-like SSH short form with whitespace is trimmed",
+			input:    "  git@github.com:go-gitea/gitea.git  ",
+			expected: "git@github.com:go-gitea/gitea.git",
+		},
+		{
+			name:     "ssh:// URL strips userinfo like other URLs",
+			input:    "ssh://git@github.com/go-gitea/gitea.git",
+			expected: "ssh://github.com/go-gitea/gitea.git",
+		},
+		{
+			name:     "local path is unchanged",
+			input:    "/tmp/repo.git",
+			expected: "/tmp/repo.git",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := SanitizeURL(c.input)
+			if c.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, c.expected, got)
+		})
+	}
+}

--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -1106,7 +1106,7 @@
   "repo.migrate_items_releases": "Releases",
   "repo.migrate_repo": "Migrate Repository",
   "repo.migrate.clone_address": "Migrate / Clone From URL",
-  "repo.migrate.clone_address_desc": "The HTTP(S) or Git 'clone' URL of an existing repository",
+  "repo.migrate.clone_address_desc": "The HTTP(S), SSH or Git 'clone' URL of an existing repository",
   "repo.migrate.github_token_desc": "You can put one or more tokens here, separated by commas, to make migrating faster by circumventing the GitHub API rate limit. WARNING: Abusing this feature may violate the service provider's policy and may lead to getting your account(s) blocked.",
   "repo.migrate.clone_local_path": "or a local server path",
   "repo.migrate.permission_denied": "You are not allowed to import local repositories.",

--- a/services/migrations/migrate.go
+++ b/services/migrations/migrate.go
@@ -18,6 +18,7 @@ import (
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/container"
 	"code.gitea.io/gitea/modules/git"
+	giturl "code.gitea.io/gitea/modules/git/url"
 	"code.gitea.io/gitea/modules/hostmatcher"
 	"code.gitea.io/gitea/modules/log"
 	base "code.gitea.io/gitea/modules/migration"
@@ -42,7 +43,23 @@ func RegisterDownloaderFactory(factory base.DownloaderFactory) {
 
 // IsMigrateURLAllowed checks if an URL is allowed to be migrated from
 func IsMigrateURLAllowed(remoteURL string, doer *user_model.User) error {
-	// Remote address can be HTTP/HTTPS/Git URL or local path.
+	// Remote address can be HTTP/HTTPS/Git/SSH URL, SCP-like SSH short form or local path.
+	if git.IsSSHRemoteAddr(remoteURL) {
+		gitURL, err := giturl.ParseGitURL(remoteURL)
+		if err != nil {
+			return &git.ErrInvalidCloneAddr{IsURLError: true, Host: remoteURL}
+		}
+		hostName, _, errIgnored := net.SplitHostPort(gitURL.Host)
+		if errIgnored != nil {
+			hostName = gitURL.Host
+		}
+		if hostName == "" {
+			return &git.ErrInvalidCloneAddr{IsURLError: true, Host: remoteURL}
+		}
+		addrList, _ := net.LookupIP(hostName)
+		return checkByAllowBlockList(hostName, addrList)
+	}
+
 	u, err := url.Parse(remoteURL)
 	if err != nil {
 		return &git.ErrInvalidCloneAddr{IsURLError: true, Host: remoteURL}
@@ -204,10 +221,17 @@ func migrateRepository(ctx context.Context, doer *user_model.User, downloader ba
 			return err
 		}
 
-		// SECURITY: Ensure that we haven't been redirected from an external to a local filesystem
-		// Now we know all of these must parse
-		cloneAddrURL, _ := url.Parse(opts.CloneAddr)
-		cloneURL, _ := url.Parse(repo.CloneURL)
+		// SECURITY: Ensure that we haven't been redirected from an external to a local filesystem.
+		// Use giturl.ParseGitURL so SCP-like SSH addresses (git@host:owner/repo.git) parse
+		// without erroring; net/url.Parse rejects them as "first path segment cannot contain colon".
+		cloneAddrURL, err := giturl.ParseGitURL(opts.CloneAddr)
+		if err != nil {
+			return err
+		}
+		cloneURL, err := giturl.ParseGitURL(repo.CloneURL)
+		if err != nil {
+			return err
+		}
 
 		if cloneURL.Scheme == "file" || cloneURL.Scheme == "" {
 			if cloneAddrURL.Scheme != "file" && cloneAddrURL.Scheme != "" {

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -27245,6 +27245,7 @@
           "x-go-name": "AWSSecretAccessKey"
         },
         "clone_addr": {
+          "description": "CloneAddr is the source URL. Supported forms: HTTP(S) URLs (https://host/owner/repo.git),\nGit URLs (git://host/path), SSH URLs (ssh://user@host[:port]/path) and the\nSCP-like SSH short syntax (user@host:owner/repo.git). When using an SSH address,\nauthentication relies on the keys/configuration available to the Gitea server\nprocess (for example via the GIT_SSH_COMMAND environment variable);\nauth_username/auth_password are ignored for SSH addresses.",
           "type": "string",
           "x-go-name": "CloneAddr"
         },

--- a/templates/swagger/v1_openapi3_json.tmpl
+++ b/templates/swagger/v1_openapi3_json.tmpl
@@ -7409,6 +7409,7 @@
             "x-go-name": "AWSSecretAccessKey"
           },
           "clone_addr": {
+            "description": "CloneAddr is the source URL. Supported forms: HTTP(S) URLs (https://host/owner/repo.git),\nGit URLs (git://host/path), SSH URLs (ssh://user@host[:port]/path) and the\nSCP-like SSH short syntax (user@host:owner/repo.git). When using an SSH address,\nauthentication relies on the keys/configuration available to the Gitea server\nprocess (for example via the GIT_SSH_COMMAND environment variable);\nauth_username/auth_password are ignored for SSH addresses.",
             "type": "string",
             "x-go-name": "CloneAddr"
           },


### PR DESCRIPTION
## Summary

- Accept SSH clone addresses (`ssh://...` and SCP form `git@host:owner/repo.git`) in repository migration; previously rejected at URL validation.
- Enables migrating from SSH-only hosts and private repos **without storing PATs** — auth is delegated to the Gitea process's SSH keys.
- Allow/block-list is enforced for SSH hosts; `auth_username`/`auth_token` are ignored for SSH with a warning log.

Repository migration currently only accepts HTTP(S) and `git://` URLs. SSH addresses — both `ssh://...` and the SCP short form `git@host:owner/repo.git` — are rejected at URL validation, even though the underlying `git clone` handles them natively.

This is a real gap:
- Mirroring from hosts that only offer SSH (internal GitLab, Gerrit, corporate Git).
- Migrating private repos **without storing PATs** — auth is delegated to the keys of the Gitea process, credentials never touch Gitea's DB.
- Users pasting the "Clone with SSH" button output get a confusing "invalid path" error.

<img width="764" height="113" alt="Screenshot 2026-05-14 133318" src="https://github.com/user-attachments/assets/f0ea829b-9bb8-49d4-bd59-7c4df3b9a4b5" />
<img width="1755" height="914" alt="Screenshot 2026-05-14 133542" src="https://github.com/user-attachments/assets/afec194b-9ca3-4928-9b1b-18fe652d095d" />
<img width="1952" height="1190" alt="Screenshot 2026-05-14 133744" src="https://github.com/user-attachments/assets/c39498f1-0c90-4203-bcce-40be24497a22" />
