### PR TITLE
fix(pull): allow internal updates to pull refs

### DIFF
--- a/modules/repository/env.go
+++ b/modules/repository/env.go
@@ -45,9 +45,10 @@ const (
 // or if you absolutely are sure that post-receive and pre-receive will do nothing
 // We provide the full pushing-environment for other hook providers
 func InternalPushingEnvironment(doer *user_model.User, repo *repo_model.Repository) []string {
-	return append(PushingEnvironment(doer, repo),
+	env := append(PushingEnvironment(doer, repo),
 		EnvIsInternal+"=true",
 	)
+	return appendGitConfigEnv(env, "receive.hideRefs", "!refs/pull/")
 }
 
 // PushingEnvironment returns an os environment to allow hooks to work on push
@@ -90,4 +91,28 @@ func FullPushingEnvironment(author, committer *user_model.User, repo *repo_model
 	)
 	environ = append(environ, DoerPushingEnvironment(committer, repo, isWiki)...)
 	return environ
+}
+
+func appendGitConfigEnv(env []string, key, value string) []string {
+	count := 0
+
+	for i, envVar := range env {
+		if !strings.HasPrefix(envVar, "GIT_CONFIG_COUNT=") {
+			continue
+		}
+
+		count, _ = strconv.Atoi(strings.TrimPrefix(envVar, "GIT_CONFIG_COUNT="))
+		env[i] = "GIT_CONFIG_COUNT=" + strconv.Itoa(count+1)
+		env = append(env,
+			"GIT_CONFIG_KEY_"+strconv.Itoa(count)+"="+key,
+			"GIT_CONFIG_VALUE_"+strconv.Itoa(count)+"="+value,
+		)
+		return env
+	}
+
+	return append(env,
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0="+key,
+		"GIT_CONFIG_VALUE_0="+value,
+	)
 }

--- a/modules/repository/env_test.go
+++ b/modules/repository/env_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package repository
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppendGitConfigEnv(t *testing.T) {
+	t.Run("adds first config", func(t *testing.T) {
+		env := appendGitConfigEnv([]string{"A=B"}, "receive.hideRefs", "!refs/pull/")
+
+		assert.Contains(t, env, "A=B")
+		assert.Contains(t, env, "GIT_CONFIG_COUNT=1")
+		assert.Contains(t, env, "GIT_CONFIG_KEY_0=receive.hideRefs")
+		assert.Contains(t, env, "GIT_CONFIG_VALUE_0=!refs/pull/")
+	})
+
+	t.Run("appends after existing config", func(t *testing.T) {
+		env := appendGitConfigEnv([]string{
+			"GIT_CONFIG_COUNT=1",
+			"GIT_CONFIG_KEY_0=core.editor",
+			"GIT_CONFIG_VALUE_0=vim",
+		}, "receive.hideRefs", "!refs/pull/")
+
+		assert.Contains(t, env, "GIT_CONFIG_COUNT=2")
+		assert.Contains(t, env, "GIT_CONFIG_KEY_0=core.editor")
+		assert.Contains(t, env, "GIT_CONFIG_VALUE_0=vim")
+		assert.Contains(t, env, "GIT_CONFIG_KEY_1=receive.hideRefs")
+		assert.Contains(t, env, "GIT_CONFIG_VALUE_1=!refs/pull/")
+	})
+}


### PR DESCRIPTION
Fixes #37699.

Git can reject internal PR ref updates with:

`deny updating a hidden ref`

This change makes Gitea's internal push environment explicitly expose `refs/pull/` to `receive-pack`, so PR creation can continue updating `refs/pull/<id>/head` without weakening normal user push restrictions.

Tests:
- go test -run '^TestAppendGitConfigEnv$' ./modules/repository/