### PR TITLE
fix(pulls): fallback fork PR target when upstream is archived

### DIFF
--- a/models/repo/pull_request_default.go
+++ b/models/repo/pull_request_default.go
@@ -14,3 +14,22 @@ func (repo *Repository) GetPullRequestTargetBranch(ctx context.Context) string {
 	unitPRConfig := repo.MustGetUnit(ctx, unit.TypePullRequests).PullRequestsConfig()
 	return util.IfZero(unitPRConfig.DefaultTargetBranch, repo.DefaultBranch)
 }
+
+// GetPullRequestDefaultBaseRepo returns the repository that should be used as
+// the default base repository when creating a new pull request from repo.
+func (repo *Repository) GetPullRequestDefaultBaseRepo(ctx context.Context) (*Repository, error) {
+	if repo.IsFork {
+		if err := repo.GetBaseRepo(ctx); err != nil {
+			return nil, err
+		}
+		if repo.BaseRepo != nil && repo.BaseRepo.AllowsPulls(ctx) && repo.BaseRepo.CanContentChange() {
+			return repo.BaseRepo, nil
+		}
+	}
+
+	if repo.AllowsPulls(ctx) {
+		return repo, nil
+	}
+
+	return nil, nil
+}

--- a/models/repo/pull_request_default_test.go
+++ b/models/repo/pull_request_default_test.go
@@ -4,12 +4,15 @@
 package repo
 
 import (
+	"context"
 	"testing"
 
+	"code.gitea.io/gitea/models/db"
 	"code.gitea.io/gitea/models/unit"
 	"code.gitea.io/gitea/models/unittest"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultTargetBranchSelection(t *testing.T) {
@@ -29,4 +32,30 @@ func TestDefaultTargetBranchSelection(t *testing.T) {
 	assert.NoError(t, UpdateRepoUnitConfig(ctx, prUnit))
 	repo.Units = nil
 	assert.Equal(t, "branch2", repo.GetPullRequestTargetBranch(ctx))
+}
+
+func TestDefaultBaseRepoSelection(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	ctx := t.Context()
+	forkRepo := unittest.AssertExistsAndLoadBean(t, &Repository{ID: 11})
+	baseRepo := unittest.AssertExistsAndLoadBean(t, &Repository{ID: 10})
+	require.NoError(t, db.Insert(ctx, &RepoUnit{RepoID: forkRepo.ID, Type: unit.TypePullRequests, Config: DefaultPullRequestsConfig()}))
+	forkRepo.Units = nil
+
+	defaultBaseRepo, err := forkRepo.GetPullRequestDefaultBaseRepo(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, defaultBaseRepo)
+	assert.Equal(t, baseRepo.ID, defaultBaseRepo.ID)
+
+	require.NoError(t, SetArchiveRepoState(ctx, baseRepo, true))
+	t.Cleanup(func() {
+		assert.NoError(t, SetArchiveRepoState(context.Background(), baseRepo, false))
+	})
+
+	forkRepo.BaseRepo = nil
+	defaultBaseRepo, err = forkRepo.GetPullRequestDefaultBaseRepo(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, defaultBaseRepo)
+	assert.Equal(t, forkRepo.ID, defaultBaseRepo.ID)
 }

--- a/routers/private/hook_post_receive.go
+++ b/routers/private/hook_post_receive.go
@@ -229,6 +229,7 @@ func HookPostReceive(ctx *gitea_context.PrivateContext) {
 	// We have to reload the repo in case its state is changed above
 	repo = nil
 	var baseRepo *repo_model.Repository
+	var err error
 
 	// Now handle the pull request notification trailers
 	for i := range opts.OldCommitIDs {
@@ -244,20 +245,17 @@ func HookPostReceive(ctx *gitea_context.PrivateContext) {
 					return
 				}
 
-				baseRepo = repo
-
-				if repo.IsFork {
-					if err := repo.GetBaseRepo(ctx); err != nil {
-						log.Error("Failed to get Base Repository of Forked repository: %-v Error: %v", repo, err)
-						ctx.JSON(http.StatusInternalServerError, private.HookPostReceiveResult{
-							Err:          fmt.Sprintf("Failed to get Base Repository of Forked repository: %-v Error: %v", repo, err),
-							RepoWasEmpty: wasEmpty,
-						})
-						return
-					}
-					if repo.BaseRepo.AllowsPulls(ctx) {
-						baseRepo = repo.BaseRepo
-					}
+				baseRepo, err = repo.GetPullRequestDefaultBaseRepo(ctx)
+				if err != nil {
+					log.Error("Failed to get default pull request base repository: %-v Error: %v", repo, err)
+					ctx.JSON(http.StatusInternalServerError, private.HookPostReceiveResult{
+						Err:          fmt.Sprintf("Failed to get default pull request base repository: %-v Error: %v", repo, err),
+						RepoWasEmpty: wasEmpty,
+					})
+					return
+				}
+				if baseRepo == nil {
+					baseRepo = repo
 				}
 
 				if !baseRepo.AllowsPulls(ctx) {

--- a/routers/web/repo/common_recentbranches.go
+++ b/routers/web/repo/common_recentbranches.go
@@ -20,17 +20,18 @@ func prepareRecentlyPushedNewBranches(ctx *context.Context) {
 	if ctx.Doer == nil {
 		return
 	}
-	if err := ctx.Repo.Repository.GetBaseRepo(ctx); err != nil {
-		log.Error("GetBaseRepo: %v", err)
+	baseRepo, err := ctx.Repo.Repository.GetPullRequestDefaultBaseRepo(ctx)
+	if err != nil {
+		log.Error("GetPullRequestDefaultBaseRepo: %v", err)
+		return
+	}
+	if baseRepo == nil {
 		return
 	}
 
 	opts := git_model.FindRecentlyPushedNewBranchesOptions{
 		Repo:     ctx.Repo.Repository,
-		BaseRepo: ctx.Repo.Repository,
-	}
-	if ctx.Repo.Repository.IsFork {
-		opts.BaseRepo = ctx.Repo.Repository.BaseRepo
+		BaseRepo: baseRepo,
 	}
 
 	baseRepoPerm, err := access_model.GetDoerRepoPermission(ctx, opts.BaseRepo, ctx.Doer)

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -1281,14 +1281,16 @@ func stopTimerIfAvailable(ctx *context.Context, user *user_model.User, issue *is
 
 func PullsNewRedirect(ctx *context.Context) {
 	branch := ctx.PathParam("*")
-	redirectRepo := ctx.Repo.Repository
 	repo := ctx.Repo.Repository
-	if repo.IsFork {
-		if err := repo.GetBaseRepo(ctx); err != nil {
-			ctx.ServerError("GetBaseRepo", err)
-			return
-		}
-		redirectRepo = repo.BaseRepo
+	redirectRepo, err := repo.GetPullRequestDefaultBaseRepo(ctx)
+	if err != nil {
+		ctx.ServerError("GetPullRequestDefaultBaseRepo", err)
+		return
+	}
+	if redirectRepo == nil {
+		redirectRepo = repo
+	}
+	if redirectRepo.ID != repo.ID {
 		branch = fmt.Sprintf("%s:%s", repo.OwnerName, branch)
 	}
 	ctx.Redirect(fmt.Sprintf("%s/compare/%s...%s?expand=1", redirectRepo.Link(), util.PathEscapeSegments(redirectRepo.DefaultBranch), util.PathEscapeSegments(branch)))

--- a/services/context/repo.go
+++ b/services/context/repo.go
@@ -738,15 +738,15 @@ func repoAssignmentPreparePullRequests(ctx *Context, data *repoAssignmentPrepare
 	if repo.IsEmpty {
 		return
 	}
-	// Pull request is allowed if this is a fork repository, and base repository accepts pull requests.
-	if repo.BaseRepo != nil && repo.BaseRepo.AllowsPulls(ctx) {
+	baseRepo, err := repo.GetPullRequestDefaultBaseRepo(ctx)
+	if err != nil {
+		ctx.ServerError("GetPullRequestDefaultBaseRepo", err)
+		return
+	}
+	if baseRepo != nil {
 		// TODO: this (and below) "BaseRepo" var is not clear and should be removed in the future
-		ctx.Data["BaseRepo"] = repo.BaseRepo
-		InitRepoPullRequestCtx(ctx, repo.BaseRepo, repo)
-	} else if repo.AllowsPulls(ctx) {
-		// Or, this is repository accepts pull requests between branches.
-		ctx.Data["BaseRepo"] = repo
-		InitRepoPullRequestCtx(ctx, repo, repo)
+		ctx.Data["BaseRepo"] = baseRepo
+		InitRepoPullRequestCtx(ctx, baseRepo, repo)
 	}
 }
 

--- a/tests/integration/pull_compare_test.go
+++ b/tests/integration/pull_compare_test.go
@@ -4,19 +4,23 @@
 package integration
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
 
+	"code.gitea.io/gitea/models/db"
 	issues_model "code.gitea.io/gitea/models/issues"
 	repo_model "code.gitea.io/gitea/models/repo"
+	"code.gitea.io/gitea/models/unit"
 	"code.gitea.io/gitea/models/unittest"
 	"code.gitea.io/gitea/modules/test"
 	repo_service "code.gitea.io/gitea/services/repository"
 	"code.gitea.io/gitea/tests"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPullCompare(t *testing.T) {
@@ -32,6 +36,50 @@ func TestPullCompare(t *testing.T) {
 		resp = MakeRequest(t, req, http.StatusSeeOther)
 		redirect = test.RedirectURL(resp)
 		assert.Equal(t, "/user12/repo10/compare/master...user13:foo?expand=1", redirect)
+	})
+
+	t.Run("ArchivedForkBaseUsesSelfAsDefaultTarget", func(t *testing.T) {
+		require.NoError(t, db.Insert(t.Context(), &repo_model.RepoUnit{RepoID: 11, Type: unit.TypePullRequests, Config: repo_model.DefaultPullRequestsConfig()}))
+
+		baseRepo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 10})
+		require.NoError(t, repo_model.SetArchiveRepoState(t.Context(), baseRepo, true))
+		t.Cleanup(func() {
+			assert.NoError(t, repo_model.SetArchiveRepoState(context.Background(), baseRepo, false))
+		})
+
+		session := loginUser(t, "user13")
+
+		req := NewRequest(t, "GET", "/user13/repo11/pulls/new/foo")
+		resp := session.MakeRequest(t, req, http.StatusSeeOther)
+		assert.Equal(t, "/user13/repo11/compare/master...foo?expand=1", test.RedirectURL(resp))
+
+		req = NewRequest(t, "GET", "/user13/repo11/pulls")
+		resp = session.MakeRequest(t, req, http.StatusOK)
+		htmlDoc := NewHTMLParser(t, resp.Body)
+		newPRButton := htmlDoc.doc.Find(".new-pr-button")
+		if assert.Equal(t, 1, newPRButton.Length()) {
+			href, exists := newPRButton.Attr("href")
+			if assert.True(t, exists) {
+				assert.Equal(t, "/user13/repo11/compare/master...master", href)
+			}
+			className, exists := newPRButton.Attr("class")
+			if assert.True(t, exists) {
+				assert.NotContains(t, className, "disabled")
+			}
+		}
+
+		req = NewRequest(t, "GET", "/user13/repo11")
+		resp = session.MakeRequest(t, req, http.StatusOK)
+		htmlDoc = NewHTMLParser(t, resp.Body)
+		codeButton := htmlDoc.doc.Find("#new-pull-request")
+		if assert.Equal(t, 1, codeButton.Length()) {
+			href, exists := codeButton.Attr("href")
+			if assert.True(t, exists) {
+				assert.Equal(t, "/user13/repo11/compare/master...master?expand=1", href)
+				resp = session.MakeRequest(t, NewRequest(t, "GET", href), http.StatusOK)
+				assert.Equal(t, http.StatusOK, resp.Code)
+			}
+		}
 	})
 
 	t.Run("ButtonsExist", func(t *testing.T) {


### PR DESCRIPTION
Closes #37649

Fix pull request target selection for forked repositories when the upstream repository is archived.

When a fork's upstream repository is archived, Gitea should no longer treat the archived upstream as the default PR base. Instead, it now falls back to the fork itself, so users can still open pull requests between branches in the fork.

## What changed

- add a shared helper to determine the default base repository for new pull requests
- prefer the upstream repository only when it still allows pull requests and content changes
- fall back to the fork itself when the upstream repository is archived
- reuse the same logic for:
  - repository pull request context initialization
  - `/pulls/new/*` redirects
  - recently pushed branch prompts
  - post-receive pull request base selection

