### PR TITLE
feat(web): also display PR counts in repo list

### DIFF
--- a/templates/shared/repo/list.tmpl
+++ b/templates/shared/repo/list.tmpl
@@ -47,6 +47,10 @@
 								<span {{if ge .NumStars 1000}}data-tooltip-content="{{.NumStars}}"{{end}}>{{CountFmt .NumStars}}</span>
 							</a>
 						{{end}}
+						<a class="flex-text-inline" href="{{.Link}}/pulls">
+							<span class="tw-contents" aria-label="{{ctx.Locale.Tr "repo.pulls"}}">{{svg "octicon-git-pull-request" 16}}</span>
+							<span {{if ge .NumOpenPulls 1000}}data-tooltip-content="{{.NumOpenPulls}}"{{end}}>{{CountFmt .NumOpenPulls}}</span>
+						</a>
 						<a class="flex-text-inline" href="{{.Link}}/forks">
 							<span class="tw-contents" aria-label="{{ctx.Locale.Tr "repo.forks"}}">{{svg "octicon-repo-forked" 16}}</span>
 							<span {{if ge .NumForks 1000}}data-tooltip-content="{{.NumForks}}"{{end}}>{{CountFmt .NumForks}}</span>


### PR DESCRIPTION
This is a follow-up PR of https://github.com/go-gitea/gitea/pull/37731

This patch adds PR count in repo list page, following screenshots are after the patch:

<img width="760" height="450" alt="image" src="https://github.com/user-attachments/assets/376a06d3-7d1c-43b3-8866-9457d1ab0904" />

<img width="782" height="283" alt="image" src="https://github.com/user-attachments/assets/3e4a7b7e-1f1d-47d2-a89c-bb9b66493559" />