### PR TITLE
fix(migrations): preserve unique constraints in v334 sync

### DIFF
--- a/models/migrations/v1_27/v334.go
+++ b/models/migrations/v1_27/v334.go
@@ -11,6 +11,7 @@ func AddCancellingSupportToActionRunner(x *xorm.Engine) error {
 	}
 
 	_, err := x.SyncWithOptions(xorm.SyncOptions{
+		IgnoreConstrains:  true,
 		IgnoreDropIndices: true,
 	}, new(ActionRunner))
 	return err


### PR DESCRIPTION
The truncated `ActionRunner` struct in `AddCancellingSupportToActionRunner` declares only the new `HasCancellingSupport` column. When xorm's `SyncWithOptions` compares it against the live `action_runner` table, every index/constraint absent from the local struct is a candidate for removal.

Walking [xorm v1.3.11 sync.go:250-266](https://gitea.com/xorm/xorm/src/tag/v1.3.11/sync.go#L250-L266):

- `IndexType` indices skip the drop when `IgnoreIndices || IgnoreDropIndices` — already covered.
- `UniqueType` indices skip the drop only when `IgnoreConstrains` — **not** set in #37275, so the existing `UNIQUE` on `token_hash` (and any other uniques) would be dropped on upgrade.

Adding `IgnoreConstrains: true` matches v333's pattern and preserves the existing unique constraints. Spotted by @wxiaoguang in https://github.com/go-gitea/gitea/pull/37275#discussion_r3254168680.

---
This PR was written with the help of Claude Opus 4.7