### PR TITLE
feat(actions): support dynamic matrix strategies that depend on upstream job outputs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -221,6 +221,7 @@ require (
 	github.com/kevinburke/ssh_config v1.6.0 // indirect
 	github.com/klauspost/crc32 v1.3.0 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/libdns/libdns v1.1.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/markbates/going v1.0.3 // indirect

--- a/models/actions/run_job.go
+++ b/models/actions/run_job.go
@@ -95,6 +95,16 @@ func init() {
 	db.RegisterModel(new(ActionRunJob))
 }
 
+// InsertActionRunJobs bulk-inserts a batch of ActionRunJob records. Used by
+// the job emitter when expanding a deferred-matrix placeholder into N child
+// rows so the children land in a single round-trip.
+func InsertActionRunJobs(ctx context.Context, jobs []*ActionRunJob) error {
+	if len(jobs) == 0 {
+		return nil
+	}
+	return db.Insert(ctx, jobs)
+}
+
 func (job *ActionRunJob) Duration() time.Duration {
 	return calculateDuration(job.Started, job.Stopped, job.Status, job.Updated)
 }

--- a/models/actions/run_job.go
+++ b/models/actions/run_job.go
@@ -47,6 +47,16 @@ type ActionRunJob struct {
 	Needs  []string `xorm:"JSON TEXT"`
 	RunsOn []string `xorm:"JSON TEXT"`
 
+	// RawMatrix holds the unevaluated strategy.matrix YAML for jobs whose matrix
+	// references upstream job outputs (e.g. ${{ fromJSON(needs.X.outputs.Y) }}).
+	// Such jobs are persisted as a single placeholder RunJob at submission time;
+	// the job emitter expands them into N child RunJobs once all "needs:" finish.
+	// Empty for non-matrix jobs and for already-expanded matrix children.
+	RawMatrix string `xorm:"TEXT"`
+	// MatrixValues stores the concrete matrix combination for an expanded job
+	// (static or dynamic). Nil for non-matrix jobs and placeholders.
+	MatrixValues map[string]any `xorm:"JSON TEXT"`
+
 	TaskID       int64 // the task created by this job in its own attempt
 	SourceTaskID int64 `xorm:"NOT NULL DEFAULT 0"` // SourceTaskID points to a historical task when this job reuses an earlier attempt's result.
 

--- a/models/actions/run_test.go
+++ b/models/actions/run_test.go
@@ -44,3 +44,32 @@ func TestActionRun_Duration_NonNegative(t *testing.T) {
 	}
 	assert.Equal(t, time.Duration(0), run.Duration())
 }
+
+func TestInsertActionRunJobs(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	t.Run("empty slice is a no-op", func(t *testing.T) {
+		assert.NoError(t, InsertActionRunJobs(t.Context(), nil))
+		assert.NoError(t, InsertActionRunJobs(t.Context(), []*ActionRunJob{}))
+	})
+
+	t.Run("bulk-insert multiple rows", func(t *testing.T) {
+		// Use distinct, non-colliding RunID/Repo so we don't tangle with fixtures.
+		const runID = int64(987654)
+		batch := []*ActionRunJob{
+			{RunID: runID, RepoID: 1, OwnerID: 1, Name: "batch-a", JobID: "j", Status: StatusWaiting, MatrixValues: map[string]any{"k": "a"}},
+			{RunID: runID, RepoID: 1, OwnerID: 1, Name: "batch-b", JobID: "j", Status: StatusWaiting, MatrixValues: map[string]any{"k": "b"}},
+			{RunID: runID, RepoID: 1, OwnerID: 1, Name: "batch-c", JobID: "j", Status: StatusWaiting, MatrixValues: map[string]any{"k": "c"}},
+		}
+		assert.NoError(t, InsertActionRunJobs(t.Context(), batch))
+
+		var loaded []*ActionRunJob
+		assert.NoError(t, db.GetEngine(t.Context()).Where("run_id = ?", runID).OrderBy("id").Find(&loaded))
+		assert.Len(t, loaded, 3)
+		assert.Equal(t, "batch-a", loaded[0].Name)
+		assert.Equal(t, "batch-c", loaded[2].Name)
+		// MatrixValues round-trip through the JSON column.
+		assert.Equal(t, "a", loaded[0].MatrixValues["k"])
+		assert.Equal(t, "c", loaded[2].MatrixValues["k"])
+	})
+}

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -412,6 +412,7 @@ func prepareMigrationTasks() []*migration {
 		newMigration(332, "Add last_sync_unix to mirror", v1_27.AddLastSyncUnixToMirror),
 		newMigration(333, "Add bypass allowlist to branch protection", v1_27.AddBranchProtectionBypassAllowlist),
 		newMigration(334, "Add cancelling support to action runners", v1_27.AddCancellingSupportToActionRunner),
+		newMigration(335, "Add matrix fields to ActionRunJob for deferred matrix expansion", v1_27.AddMatrixFieldsToActionRunJob),
 	}
 	return preparedMigrations
 }

--- a/models/migrations/v1_27/v335.go
+++ b/models/migrations/v1_27/v335.go
@@ -1,0 +1,18 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v1_27
+
+import "xorm.io/xorm"
+
+func AddMatrixFieldsToActionRunJob(x *xorm.Engine) error {
+	type ActionRunJob struct {
+		RawMatrix    string         `xorm:"TEXT"`
+		MatrixValues map[string]any `xorm:"JSON TEXT"`
+	}
+
+	_, err := x.SyncWithOptions(xorm.SyncOptions{
+		IgnoreDropIndices: true,
+	}, new(ActionRunJob))
+	return err
+}

--- a/models/migrations/v1_27/v335_test.go
+++ b/models/migrations/v1_27/v335_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v1_27
+
+import (
+	"testing"
+
+	"code.gitea.io/gitea/models/migrations/migrationtest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddMatrixFieldsToActionRunJob(t *testing.T) {
+	type ActionRunJob struct {
+		ID   int64 `xorm:"pk autoincr"`
+		Name string
+	}
+
+	x, deferable := migrationtest.PrepareTestEnv(t, 0, new(ActionRunJob))
+	defer deferable()
+	if x == nil || t.Failed() {
+		return
+	}
+
+	_, err := x.Insert(&ActionRunJob{Name: "legacy"})
+	require.NoError(t, err)
+
+	require.NoError(t, AddMatrixFieldsToActionRunJob(x))
+
+	// New columns must exist; existing rows default to empty / NULL.
+	var rawMatrix string
+	has, err := x.SQL("SELECT raw_matrix FROM action_run_job WHERE id = ?", 1).Get(&rawMatrix)
+	require.NoError(t, err)
+	require.True(t, has)
+	require.Empty(t, rawMatrix)
+
+	var matrixValues string
+	has, err = x.SQL("SELECT COALESCE(matrix_values, '') FROM action_run_job WHERE id = ?", 1).Get(&matrixValues)
+	require.NoError(t, err)
+	require.True(t, has)
+	require.Empty(t, matrixValues)
+}

--- a/modules/actions/jobparser/deferred_matrix_test.go
+++ b/modules/actions/jobparser/deferred_matrix_test.go
@@ -120,6 +120,84 @@ func TestExpandDeferredMatrix(t *testing.T) {
 	assert.ElementsMatch(t, []string{"a", "b"}, got)
 }
 
+func TestExpandDeferredMatrixInterpolatesStepNames(t *testing.T) {
+	wf := []byte(`name: deferred-with-step-name
+on: push
+jobs:
+  prep:
+    runs-on: ubuntu-latest
+    outputs:
+      list: ${{ steps.s.outputs.list }}
+    steps:
+      - id: s
+        run: echo 'list=["alpha","beta"]' >> $GITHUB_OUTPUT
+  fan-out:
+    needs: prep
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        thing: ${{ fromJSON(needs.prep.outputs.list) }}
+    steps:
+      - name: Process ${{ matrix.thing }}
+        run: echo ${{ matrix.thing }}
+`)
+	parsed, err := Parse(wf)
+	require.NoError(t, err)
+	var placeholder *SingleWorkflow
+	for _, w := range parsed {
+		if id, _ := w.Job(); id == "fan-out" {
+			placeholder = w
+		}
+	}
+	require.NotNil(t, placeholder)
+	payload, err := placeholder.Marshal()
+	require.NoError(t, err)
+
+	expanded, err := ExpandDeferredMatrix(
+		payload,
+		[]string{"prep"},
+		map[string]map[string]string{"prep": {"list": `["alpha","beta"]`}},
+	)
+	require.NoError(t, err)
+	require.Len(t, expanded, 2)
+	got := map[string]bool{}
+	for _, w := range expanded {
+		_, job := w.Job()
+		require.NotNil(t, job)
+		require.Len(t, job.Steps, 1)
+		got[job.Steps[0].Name] = true
+	}
+	assert.True(t, got["Process alpha"], "step name for iteration alpha must be interpolated")
+	assert.True(t, got["Process beta"], "step name for iteration beta must be interpolated")
+}
+
+func TestParseStaticMatrixInterpolatesStepNames(t *testing.T) {
+	wf := []byte(`name: static-matrix
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [linux, darwin]
+    steps:
+      - name: Building on ${{ matrix.os }}
+        run: echo ${{ matrix.os }}
+`)
+	parsed, err := Parse(wf)
+	require.NoError(t, err)
+	require.Len(t, parsed, 2)
+	got := map[string]bool{}
+	for _, w := range parsed {
+		_, job := w.Job()
+		require.NotNil(t, job)
+		require.Len(t, job.Steps, 1)
+		got[job.Steps[0].Name] = true
+	}
+	assert.True(t, got["Building on linux"])
+	assert.True(t, got["Building on darwin"])
+}
+
 func TestExpandDeferredMatrixRequiresSingleJob(t *testing.T) {
 	// A workflow with two jobs in the payload should be rejected — the
 	// emitter only calls ExpandDeferredMatrix on a placeholder, which is

--- a/modules/actions/jobparser/deferred_matrix_test.go
+++ b/modules/actions/jobparser/deferred_matrix_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package jobparser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v4"
+)
+
+func TestMatrixDependsOnNeedsOutputs(t *testing.T) {
+	t.Run("zero node returns false", func(t *testing.T) {
+		assert.False(t, MatrixDependsOnNeedsOutputs(yaml.Node{}))
+	})
+
+	cases := []struct {
+		name   string
+		input  string
+		expect bool
+	}{
+		{"static matrix", "os:\n  - linux\n  - windows\n", false},
+		{"matrix references inputs only", "thing: ${{ inputs.what }}\n", false},
+		{"matrix references vars", "thing: ${{ vars.LIST }}\n", false},
+		{"matrix references needs.result (not outputs)", "thing: ${{ needs.job1.result }}\n", false},
+		{"matrix references needs.outputs directly", "manifest: ${{ fromJSON(needs.job1.outputs.matrix) }}\n", true},
+		{"matrix references needs.outputs nested", "key: ${{ needs.upstream-job.outputs.list }}\n", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var node yaml.Node
+			require.NoError(t, yaml.Unmarshal([]byte(c.input), &node))
+			// yaml.Unmarshal produces a DocumentNode wrapping the actual content;
+			// MatrixDependsOnNeedsOutputs works on either since Marshal round-trips
+			// the original text. Use the content node for fidelity with the actual
+			// callers, which read job.Strategy.RawMatrix (mapping/scalar nodes).
+			require.NotEmpty(t, node.Content)
+			assert.Equal(t, c.expect, MatrixDependsOnNeedsOutputs(*node.Content[0]))
+		})
+	}
+}
+
+const deferredMatrixWorkflow = `name: deferred-matrix
+on: push
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      manifest: ${{ steps.set.outputs.manifest }}
+    steps:
+      - id: set
+        run: echo "manifest=[\"a\",\"b\"]" >> $GITHUB_OUTPUT
+  build:
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        manifest: ${{ fromJSON(needs.prepare.outputs.manifest) }}
+    steps:
+      - run: echo ${{ matrix.manifest }}
+`
+
+func TestParseEmitsPlaceholderForDeferredMatrix(t *testing.T) {
+	workflows, err := Parse([]byte(deferredMatrixWorkflow))
+	require.NoError(t, err)
+	// One SingleWorkflow for `prepare` (no matrix), one PLACEHOLDER for `build`.
+	require.Len(t, workflows, 2)
+
+	var build *SingleWorkflow
+	for _, w := range workflows {
+		id, _ := w.Job()
+		if id == "build" {
+			build = w
+		}
+	}
+	require.NotNil(t, build, "build job must be emitted as a placeholder")
+
+	_, buildJob := build.Job()
+	require.NotNil(t, buildJob)
+	// Placeholder preserves needs (the job emitter uses them later).
+	assert.Equal(t, []string{"prepare"}, buildJob.Needs())
+	// Placeholder retains the raw matrix expression for later evaluation.
+	assert.True(t, MatrixDependsOnNeedsOutputs(buildJob.Strategy.RawMatrix))
+}
+
+func TestExpandDeferredMatrix(t *testing.T) {
+	parsed, err := Parse([]byte(deferredMatrixWorkflow))
+	require.NoError(t, err)
+
+	var placeholder *SingleWorkflow
+	for _, w := range parsed {
+		id, _ := w.Job()
+		if id == "build" {
+			placeholder = w
+		}
+	}
+	require.NotNil(t, placeholder)
+	payload, err := placeholder.Marshal()
+	require.NoError(t, err)
+
+	outputs := map[string]map[string]string{
+		"prepare": {"manifest": `["a","b"]`},
+	}
+	expanded, err := ExpandDeferredMatrix(payload, []string{"prepare"}, outputs)
+	require.NoError(t, err)
+	require.Len(t, expanded, 2, "matrix produced two iterations")
+
+	got := make([]string, 0, len(expanded))
+	for _, w := range expanded {
+		_, job := w.Job()
+		require.NotNil(t, job)
+		// Each expanded iteration's matrix is pinned to a single value.
+		var pinned map[string][]any
+		require.NoError(t, job.Strategy.RawMatrix.Decode(&pinned))
+		require.Len(t, pinned["manifest"], 1)
+		got = append(got, pinned["manifest"][0].(string))
+	}
+	assert.ElementsMatch(t, []string{"a", "b"}, got)
+}
+
+func TestExpandDeferredMatrixRequiresSingleJob(t *testing.T) {
+	// A workflow with two jobs in the payload should be rejected — the
+	// emitter only calls ExpandDeferredMatrix on a placeholder, which is
+	// always a single-job SingleWorkflow.
+	multiJob := []byte("name: x\non: push\njobs:\n  a:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo a\n  b:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo b\n")
+	_, err := ExpandDeferredMatrix(multiJob, nil, nil)
+	require.Error(t, err)
+}

--- a/modules/actions/jobparser/jobparser.go
+++ b/modules/actions/jobparser/jobparser.go
@@ -91,6 +91,7 @@ func Parse(content []byte, options ...ParseOption) ([]*SingleWorkflow, error) {
 				runsOn[i] = evaluator.Interpolate(v)
 			}
 			job.RawRunsOn = encodeRunsOn(runsOn)
+			interpolateStepNames(job, evaluator)
 			swf := &SingleWorkflow{
 				Name:           workflow.Name,
 				RawOn:          workflow.RawOn,
@@ -237,6 +238,7 @@ func ExpandDeferredMatrix(content []byte, needs []string, outputs map[string]map
 			runsOn[i] = iterEval.Interpolate(v)
 		}
 		clonedJob.RawRunsOn = encodeRunsOn(runsOn)
+		interpolateStepNames(clonedJob, iterEval)
 		swf := &SingleWorkflow{
 			Name:           workflow.Name,
 			RawOn:          workflow.RawOn,
@@ -251,6 +253,31 @@ func ExpandDeferredMatrix(content []byte, needs []string, outputs map[string]map
 		ret = append(ret, swf)
 	}
 	return ret, nil
+}
+
+// interpolateStepNames resolves `${{ ... }}` expressions in each step's
+// `name:` against the per-iteration evaluator (matrix + vars + inputs + needs).
+// Job.Clone shares the Steps slice's backing array, so we allocate a fresh
+// slice with copied *Step values before mutating — otherwise per-iteration
+// changes bleed back to every clone (the last write wins for all of them).
+// Empty names are left untouched; step `run:` content is interpolated later
+// at execution time by the runner.
+func interpolateStepNames(job *Job, evaluator *ExpressionEvaluator) {
+	if len(job.Steps) == 0 {
+		return
+	}
+	out := make([]*Step, len(job.Steps))
+	for i, step := range job.Steps {
+		if step == nil {
+			continue
+		}
+		clone := *step
+		if step.Name != "" {
+			clone.Name = evaluator.Interpolate(step.Name)
+		}
+		out[i] = &clone
+	}
+	job.Steps = out
 }
 
 // matrixOutputsRefRegex matches `${{ ... needs.<id>.outputs.<key> ... }}`

--- a/modules/actions/jobparser/jobparser.go
+++ b/modules/actions/jobparser/jobparser.go
@@ -6,6 +6,7 @@ package jobparser
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -52,6 +53,27 @@ func Parse(content []byte, options ...ParseOption) ([]*SingleWorkflow, error) {
 
 	for i, id := range ids {
 		job := jobs[i]
+
+		// Deferred matrix expansion: if strategy.matrix references upstream
+		// `needs.<id>.outputs.<key>`, the value isn't known at submission time.
+		// Emit a single placeholder SingleWorkflow carrying the un-evaluated
+		// matrix. The job emitter re-runs expansion once the needs jobs finish.
+		if MatrixDependsOnNeedsOutputs(job.Strategy.RawMatrix) {
+			swf := &SingleWorkflow{
+				Name:           workflow.Name,
+				RawOn:          workflow.RawOn,
+				Env:            workflow.Env,
+				Defaults:       workflow.Defaults,
+				RawPermissions: workflow.RawPermissions,
+				RunName:        workflow.RunName,
+			}
+			if err := swf.SetJob(id, job.Clone()); err != nil {
+				return nil, fmt.Errorf("SetJob: %w", err)
+			}
+			ret = append(ret, swf)
+			continue
+		}
+
 		matricxes, err := getMatrixes(origin.GetJob(id))
 		if err != nil {
 			return nil, fmt.Errorf("getMatrixes: %w", err)
@@ -112,6 +134,143 @@ type parseContext struct {
 }
 
 type ParseOption func(c *parseContext)
+
+// ExpandDeferredMatrix re-parses a placeholder SingleWorkflow (as emitted
+// by Parse when strategy.matrix references upstream job outputs) and expands
+// it into N concrete iterations, using the provided upstream needs outputs
+// to resolve `${{ ... needs.<id>.outputs.<key> ... }}` references inside the
+// matrix YAML.
+//
+// `content` is the placeholder's serialized SingleWorkflow (the value stored
+// in ActionRunJob.WorkflowPayload). `needs` lists the placeholder job's
+// upstream job IDs; `outputs` maps each upstream job ID to its merged outputs.
+// Pass any GitHub/vars/inputs context via the option helpers.
+func ExpandDeferredMatrix(content []byte, needs []string, outputs map[string]map[string]string, options ...ParseOption) ([]*SingleWorkflow, error) {
+	workflow := &SingleWorkflow{}
+	if err := yaml.Unmarshal(content, workflow); err != nil {
+		return nil, fmt.Errorf("yaml.Unmarshal: %w", err)
+	}
+
+	pc := &parseContext{}
+	for _, o := range options {
+		o(pc)
+	}
+
+	ids, jobs, err := workflow.jobs()
+	if err != nil {
+		return nil, fmt.Errorf("invalid jobs: %w", err)
+	}
+	if len(ids) != 1 {
+		return nil, fmt.Errorf("ExpandDeferredMatrix: expected single job, got %d", len(ids))
+	}
+	id, job := ids[0], jobs[0]
+
+	results := map[string]*JobResult{}
+	// NewInterpeter expects the placeholder's own JobID to be present in the
+	// run's workflow.Jobs map (it reads run.Job().Needs() to filter the
+	// available `needs.*` context). Add a stub entry for the placeholder
+	// itself before the upstream needs.
+	results[id] = &JobResult{Needs: needs}
+	for _, needID := range needs {
+		needOutputs := outputs[needID]
+		if needOutputs == nil {
+			needOutputs = map[string]string{}
+		}
+		results[needID] = &JobResult{
+			Needs:   nil,
+			Result:  "success",
+			Outputs: needOutputs,
+		}
+	}
+
+	// Build a model.Job to feed into the interpreter / matrix-expansion helpers.
+	// RawNeeds must reflect the placeholder's needs list so the interpreter
+	// populates the `needs.*` context for the matrix expression.
+	var rawNeeds yaml.Node
+	if len(needs) > 0 {
+		if err := rawNeeds.Encode(needs); err != nil {
+			return nil, fmt.Errorf("encode needs: %w", err)
+		}
+	}
+	actJob := &model.Job{
+		Name:      job.Name,
+		RawNeeds:  rawNeeds,
+		RawRunsOn: job.RawRunsOn,
+		Env:       job.Env,
+		If:        job.If,
+		Strategy: &model.Strategy{
+			FailFastString:    job.Strategy.FailFastString,
+			MaxParallelString: job.Strategy.MaxParallelString,
+			RawMatrix:         job.Strategy.RawMatrix,
+		},
+	}
+
+	// Resolve ${{ ... }} expressions inside the matrix YAML using the needs
+	// outputs context. After this, the matrix node holds concrete values.
+	evaluator := NewExpressionEvaluator(NewInterpeter(id, actJob, nil, pc.gitContext, results, pc.vars, pc.inputs))
+	if err := evaluator.EvaluateYamlNode(&actJob.Strategy.RawMatrix); err != nil {
+		return nil, fmt.Errorf("evaluate matrix YAML: %w", err)
+	}
+	// Mirror the evaluated matrix back onto the parsed SingleWorkflow's Job
+	// so the per-iteration clones below carry the resolved values.
+	job.Strategy.RawMatrix = actJob.Strategy.RawMatrix
+
+	matrixes, err := getMatrixes(actJob)
+	if err != nil {
+		return nil, fmt.Errorf("getMatrixes: %w", err)
+	}
+	if len(matrixes) == 0 {
+		return nil, fmt.Errorf("matrix expansion produced no combinations for job %q", id)
+	}
+
+	var ret []*SingleWorkflow
+	for _, matrix := range matrixes {
+		clonedJob := job.Clone()
+		if clonedJob.Name == "" {
+			clonedJob.Name = id
+		}
+		clonedJob.Strategy.RawMatrix = encodeMatrix(matrix)
+		iterEval := NewExpressionEvaluator(NewInterpeter(id, actJob, matrix, pc.gitContext, results, pc.vars, pc.inputs))
+		clonedJob.Name = nameWithMatrix(clonedJob.Name, matrix, iterEval)
+		runsOn := actJob.RunsOn()
+		for i, v := range runsOn {
+			runsOn[i] = iterEval.Interpolate(v)
+		}
+		clonedJob.RawRunsOn = encodeRunsOn(runsOn)
+		swf := &SingleWorkflow{
+			Name:           workflow.Name,
+			RawOn:          workflow.RawOn,
+			Env:            workflow.Env,
+			Defaults:       workflow.Defaults,
+			RawPermissions: workflow.RawPermissions,
+			RunName:        workflow.RunName,
+		}
+		if err := swf.SetJob(id, clonedJob); err != nil {
+			return nil, fmt.Errorf("SetJob: %w", err)
+		}
+		ret = append(ret, swf)
+	}
+	return ret, nil
+}
+
+// matrixOutputsRefRegex matches `${{ ... needs.<id>.outputs.<key> ... }}`
+// inside a matrix YAML node. Such expressions cannot be evaluated at
+// submission time and force deferred matrix expansion.
+var matrixOutputsRefRegex = regexp.MustCompile(`\$\{\{[^}]*\bneeds\.[a-zA-Z0-9_-]+\.outputs\.`)
+
+// MatrixDependsOnNeedsOutputs reports whether the given strategy.matrix YAML
+// node references `needs.<id>.outputs.<key>` and therefore needs to be
+// expanded after the upstream jobs finish.
+func MatrixDependsOnNeedsOutputs(node yaml.Node) bool {
+	if node.Kind == 0 {
+		return false
+	}
+	buf, err := yaml.Marshal(&node)
+	if err != nil {
+		return false
+	}
+	return matrixOutputsRefRegex.Match(buf)
+}
 
 func getMatrixes(job *model.Job) ([]map[string]any, error) {
 	ret, err := job.GetMatrixes()

--- a/routers/web/repo/actions/actions.go
+++ b/routers/web/repo/actions/actions.go
@@ -180,6 +180,19 @@ func prepareWorkflowTemplate(ctx *context.Context, commit *git.Commit) (workflow
 	}
 
 	ctx.Data["workflows"] = workflows
+	// WorkflowDisplayNames maps each workflow filename (the WorkflowID stored
+	// on ActionRun) to the human-friendly `name:` from the YAML, falling back
+	// to the filename when YAML doesn't declare one. Used by runs_list.tmpl
+	// so each run shows the configured workflow name instead of the file.
+	displayNames := make(map[string]string, len(workflows))
+	for _, w := range workflows {
+		name := w.Entry.Name()
+		if w.Workflow != nil && w.Workflow.Name != "" {
+			name = w.Workflow.Name
+		}
+		displayNames[w.Entry.Name()] = name
+	}
+	ctx.Data["WorkflowDisplayNames"] = displayNames
 	ctx.Data["RepoLink"] = ctx.Repo.Repository.Link()
 	ctx.Data["AllowDisableOrEnableWorkflow"] = ctx.Repo.Permission.IsAdmin()
 	actionsConfig := ctx.Repo.Repository.MustGetUnit(ctx, unit.TypeActions).ActionsConfig()

--- a/routers/web/repo/actions/actions.go
+++ b/routers/web/repo/actions/actions.go
@@ -44,6 +44,31 @@ type WorkflowInfo struct {
 	Workflow *act_model.Workflow
 }
 
+// WorkflowDisplayName returns the human-friendly `name:` from the parsed
+// workflow YAML when present, otherwise falls back to the filename. Kept as
+// a small standalone function so the fallback rule is easy to test (the
+// surrounding BuildWorkflowDisplayNames takes WorkflowInfo values whose
+// Entry field is a git.TreeEntry that's awkward to construct in unit tests).
+func WorkflowDisplayName(filename string, wf *act_model.Workflow) string {
+	if wf != nil && wf.Name != "" {
+		return wf.Name
+	}
+	return filename
+}
+
+// BuildWorkflowDisplayNames maps each workflow filename (the WorkflowID
+// stored on ActionRun) to the human-friendly `name:` from the YAML, falling
+// back to the filename when YAML doesn't declare one. Used by runs_list.tmpl
+// so each run shows the configured workflow name instead of the file.
+func BuildWorkflowDisplayNames(workflows []WorkflowInfo) map[string]string {
+	out := make(map[string]string, len(workflows))
+	for _, w := range workflows {
+		filename := w.Entry.Name()
+		out[filename] = WorkflowDisplayName(filename, w.Workflow)
+	}
+	return out
+}
+
 // MustEnableActions check if actions are enabled in settings
 func MustEnableActions(ctx *context.Context) {
 	if !setting.Actions.Enabled {
@@ -180,19 +205,7 @@ func prepareWorkflowTemplate(ctx *context.Context, commit *git.Commit) (workflow
 	}
 
 	ctx.Data["workflows"] = workflows
-	// WorkflowDisplayNames maps each workflow filename (the WorkflowID stored
-	// on ActionRun) to the human-friendly `name:` from the YAML, falling back
-	// to the filename when YAML doesn't declare one. Used by runs_list.tmpl
-	// so each run shows the configured workflow name instead of the file.
-	displayNames := make(map[string]string, len(workflows))
-	for _, w := range workflows {
-		name := w.Entry.Name()
-		if w.Workflow != nil && w.Workflow.Name != "" {
-			name = w.Workflow.Name
-		}
-		displayNames[w.Entry.Name()] = name
-	}
-	ctx.Data["WorkflowDisplayNames"] = displayNames
+	ctx.Data["WorkflowDisplayNames"] = BuildWorkflowDisplayNames(workflows)
 	ctx.Data["RepoLink"] = ctx.Repo.Repository.Link()
 	ctx.Data["AllowDisableOrEnableWorkflow"] = ctx.Repo.Permission.IsAdmin()
 	actionsConfig := ctx.Repo.Repository.MustGetUnit(ctx, unit.TypeActions).ActionsConfig()

--- a/routers/web/repo/actions/actions_test.go
+++ b/routers/web/repo/actions/actions_test.go
@@ -159,6 +159,26 @@ func TestReadWorkflow_WorkflowDispatchConfig(t *testing.T) {
 	}, workflowDispatch.Inputs[2])
 }
 
+func TestWorkflowDisplayName(t *testing.T) {
+	t.Run("falls back to filename when workflow is nil", func(t *testing.T) {
+		assert.Equal(t, "ci.yml", WorkflowDisplayName("ci.yml", nil))
+	})
+
+	t.Run("falls back to filename when YAML has no name", func(t *testing.T) {
+		assert.Equal(t, "ci.yml", WorkflowDisplayName("ci.yml", &act_model.Workflow{}))
+	})
+
+	t.Run("uses YAML name when present", func(t *testing.T) {
+		wf := &act_model.Workflow{Name: "Continuous Integration"}
+		assert.Equal(t, "Continuous Integration", WorkflowDisplayName("ci.yml", wf))
+	})
+
+	t.Run("YAML name with whitespace is preserved verbatim", func(t *testing.T) {
+		wf := &act_model.Workflow{Name: "  Deploy  "}
+		assert.Equal(t, "  Deploy  ", WorkflowDisplayName("d.yml", wf))
+	})
+}
+
 func Test_loadIsRefDeleted(t *testing.T) {
 	unittest.PrepareTestEnv(t)
 

--- a/services/actions/job_emitter.go
+++ b/services/actions/job_emitter.go
@@ -523,14 +523,21 @@ func expandOnePlaceholder(ctx context.Context, run *actions_model.ActionRun, pla
 	}
 
 	giteaCtx := GenerateGiteaContext(ctx, run, runAttempt, nil)
+	cacheKey := computeMatrixCacheKey(placeholder.WorkflowPayload, placeholder.Needs, needsOutputs)
 	timings.startParse()
-	expanded, err := jobparser.ExpandDeferredMatrix(
-		placeholder.WorkflowPayload,
-		placeholder.Needs,
-		needsOutputs,
-		jobparser.WithVars(vars),
-		jobparser.WithGitContext(giteaCtx.ToGitHubContext()),
-	)
+	expanded, cacheHit := matrixCacheGet(cacheKey)
+	if !cacheHit {
+		expanded, err = jobparser.ExpandDeferredMatrix(
+			placeholder.WorkflowPayload,
+			placeholder.Needs,
+			needsOutputs,
+			jobparser.WithVars(vars),
+			jobparser.WithGitContext(giteaCtx.ToGitHubContext()),
+		)
+		if err == nil {
+			matrixCachePut(cacheKey, expanded)
+		}
+	}
 	timings.endParse()
 	if err != nil {
 		return fmt.Errorf("ExpandDeferredMatrix: %w", err)

--- a/services/actions/job_emitter.go
+++ b/services/actions/job_emitter.go
@@ -437,9 +437,14 @@ func expandDeferredMatrixPlaceholders(ctx context.Context, run *actions_model.Ac
 			continue
 		}
 		allDone, allSucceed := needsReadyForExpansion(placeholder, byJobID)
-		if !allDone || !allSucceed {
-			// Either not yet ready, or an upstream failure: leave for the
-			// resolver to handle (it will keep blocked or skip).
+		if !allDone {
+			observeDeferredCheck()
+			continue
+		}
+		if !allSucceed {
+			// An upstream failure: leave for the resolver, which will skip
+			// the placeholder. No metric counter — that's a workflow
+			// outcome, not a matrix-expansion outcome.
 			continue
 		}
 		if err := expandOnePlaceholder(ctx, run, placeholder); err != nil {
@@ -478,7 +483,17 @@ func needsReadyForExpansion(placeholder *actions_model.ActionRunJob, byJobID map
 // expandOnePlaceholder builds the upstream needs-outputs map, calls
 // jobparser.ExpandDeferredMatrix, inserts N child RunJobs, and deletes the
 // placeholder row. All operations run in the caller's transaction.
-func expandOnePlaceholder(ctx context.Context, run *actions_model.ActionRun, placeholder *actions_model.ActionRunJob) error {
+func expandOnePlaceholder(ctx context.Context, run *actions_model.ActionRun, placeholder *actions_model.ActionRunJob) (err error) {
+	timings := newMatrixTimings()
+	childrenCount := 0
+	defer func() {
+		outcome := "success"
+		if err != nil {
+			outcome = "failure"
+		}
+		timings.end(outcome, childrenCount)
+	}()
+
 	taskNeeds, err := FindTaskNeeds(ctx, placeholder)
 	if err != nil {
 		return fmt.Errorf("FindTaskNeeds: %w", err)
@@ -508,6 +523,7 @@ func expandOnePlaceholder(ctx context.Context, run *actions_model.ActionRun, pla
 	}
 
 	giteaCtx := GenerateGiteaContext(ctx, run, runAttempt, nil)
+	timings.startParse()
 	expanded, err := jobparser.ExpandDeferredMatrix(
 		placeholder.WorkflowPayload,
 		placeholder.Needs,
@@ -515,6 +531,7 @@ func expandOnePlaceholder(ctx context.Context, run *actions_model.ActionRun, pla
 		jobparser.WithVars(vars),
 		jobparser.WithGitContext(giteaCtx.ToGitHubContext()),
 	)
+	timings.endParse()
 	if err != nil {
 		return fmt.Errorf("ExpandDeferredMatrix: %w", err)
 	}
@@ -569,9 +586,12 @@ func expandOnePlaceholder(ctx context.Context, run *actions_model.ActionRun, pla
 			MatrixValues:      matrixValues,
 		})
 	}
+	timings.startInsert()
 	if err := actions_model.InsertActionRunJobs(ctx, children); err != nil {
 		return fmt.Errorf("InsertActionRunJobs: %w", err)
 	}
+	timings.endInsert()
+	childrenCount = len(children)
 
 	if _, err := db.GetEngine(ctx).ID(placeholder.ID).Delete(&actions_model.ActionRunJob{}); err != nil {
 		return fmt.Errorf("delete placeholder %d: %w", placeholder.ID, err)

--- a/services/actions/job_emitter.go
+++ b/services/actions/job_emitter.go
@@ -10,6 +10,7 @@ import (
 
 	actions_model "code.gitea.io/gitea/models/actions"
 	"code.gitea.io/gitea/models/db"
+	"code.gitea.io/gitea/modules/actions/jobparser"
 	"code.gitea.io/gitea/modules/container"
 	"code.gitea.io/gitea/modules/graceful"
 	"code.gitea.io/gitea/modules/log"
@@ -253,6 +254,21 @@ func checkJobsOfCurrentRunAttempt(ctx context.Context, run *actions_model.Action
 	resolver := newJobStatusResolver(jobs, vars)
 
 	if err = db.WithTx(ctx, func(ctx context.Context) error {
+		// Expand any deferred-matrix placeholders whose `needs` are now done
+		// and all succeeded. This must happen inside the transaction so the
+		// resolver below sees the newly created children atomically.
+		expanded, err := expandDeferredMatrixPlaceholders(ctx, run, jobs)
+		if err != nil {
+			return fmt.Errorf("expandDeferredMatrixPlaceholders: %w", err)
+		}
+		if expanded {
+			jobs, err = actions_model.GetRunJobsByRunAndAttemptID(ctx, run.ID, run.LatestAttemptID)
+			if err != nil {
+				return fmt.Errorf("reload jobs after matrix expansion: %w", err)
+			}
+			resolver = newJobStatusResolver(jobs, vars)
+		}
+
 		for _, job := range jobs {
 			job.Run = run
 		}
@@ -395,6 +411,183 @@ func (r *jobStatusResolver) resolve(ctx context.Context) map[int64]actions_model
 		}
 	}
 	return ret
+}
+
+// expandDeferredMatrixPlaceholders finds any deferred-matrix placeholder
+// jobs (RawMatrix != "") whose `needs:` are all done and all succeeded, and
+// expands them into N concrete child RunJobs — one per matrix combination.
+// The placeholder row is deleted; new child rows replace it.
+//
+// Placeholders whose needs aren't all done yet, or whose needs include a
+// failure/cancelled/skipped, are left untouched: the resolver downstream
+// either keeps them blocked or transitions them to Skipped via the standard
+// flow.
+//
+// Returns true if any placeholder was expanded (caller should reload jobs).
+func expandDeferredMatrixPlaceholders(ctx context.Context, run *actions_model.ActionRun, jobs []*actions_model.ActionRunJob) (bool, error) {
+	// Index jobs by JobID for the readiness check.
+	byJobID := make(map[string][]*actions_model.ActionRunJob, len(jobs))
+	for _, j := range jobs {
+		byJobID[j.JobID] = append(byJobID[j.JobID], j)
+	}
+
+	expanded := false
+	for _, placeholder := range jobs {
+		if placeholder.RawMatrix == "" || placeholder.Status != actions_model.StatusBlocked {
+			continue
+		}
+		allDone, allSucceed := needsReadyForExpansion(placeholder, byJobID)
+		if !allDone || !allSucceed {
+			// Either not yet ready, or an upstream failure: leave for the
+			// resolver to handle (it will keep blocked or skip).
+			continue
+		}
+		if err := expandOnePlaceholder(ctx, run, placeholder); err != nil {
+			return expanded, fmt.Errorf("expand placeholder job %d: %w", placeholder.ID, err)
+		}
+		expanded = true
+	}
+	return expanded, nil
+}
+
+// needsReadyForExpansion returns whether all of placeholder.Needs are present
+// and done in the snapshot, and whether they all succeeded (or were skipped,
+// which we treat as success for the purpose of expansion — same as the
+// resolver's standard `allSucceed` check).
+func needsReadyForExpansion(placeholder *actions_model.ActionRunJob, byJobID map[string][]*actions_model.ActionRunJob) (allDone, allSucceed bool) {
+	allDone, allSucceed = true, true
+	for _, needID := range placeholder.Needs {
+		siblings := byJobID[needID]
+		if len(siblings) == 0 {
+			// Need not present in this snapshot — treat as not done.
+			allDone = false
+			continue
+		}
+		for _, s := range siblings {
+			if !s.Status.IsDone() {
+				allDone = false
+			}
+			if s.Status.In(actions_model.StatusFailure, actions_model.StatusCancelled, actions_model.StatusSkipped) {
+				allSucceed = false
+			}
+		}
+	}
+	return allDone, allSucceed
+}
+
+// expandOnePlaceholder builds the upstream needs-outputs map, calls
+// jobparser.ExpandDeferredMatrix, inserts N child RunJobs, and deletes the
+// placeholder row. All operations run in the caller's transaction.
+func expandOnePlaceholder(ctx context.Context, run *actions_model.ActionRun, placeholder *actions_model.ActionRunJob) error {
+	taskNeeds, err := FindTaskNeeds(ctx, placeholder)
+	if err != nil {
+		return fmt.Errorf("FindTaskNeeds: %w", err)
+	}
+	needsOutputs := make(map[string]map[string]string, len(taskNeeds))
+	for needID, tn := range taskNeeds {
+		needsOutputs[needID] = tn.Outputs
+	}
+
+	vars, err := actions_model.GetVariablesOfRun(ctx, run)
+	if err != nil {
+		return fmt.Errorf("GetVariablesOfRun: %w", err)
+	}
+
+	runAttempt, has, err := run.GetLatestAttempt(ctx)
+	if err != nil {
+		return fmt.Errorf("GetLatestAttempt: %w", err)
+	}
+	if !has {
+		return fmt.Errorf("no latest attempt for run %d", run.ID)
+	}
+
+	giteaCtx := GenerateGiteaContext(ctx, run, runAttempt, nil)
+	expanded, err := jobparser.ExpandDeferredMatrix(
+		placeholder.WorkflowPayload,
+		placeholder.Needs,
+		needsOutputs,
+		jobparser.WithVars(vars),
+		jobparser.WithGitContext(giteaCtx.ToGitHubContext()),
+	)
+	if err != nil {
+		return fmt.Errorf("ExpandDeferredMatrix: %w", err)
+	}
+
+	// Allocate child AttemptJobIDs starting after the maximum currently in
+	// use within this attempt — keeps the (run_id, attempt_id, attempt_job_id)
+	// uniqueness invariant from migration v331.
+	maxAttemptJobID, err := maxAttemptJobIDForAttempt(ctx, run.ID, placeholder.RunAttemptID)
+	if err != nil {
+		return fmt.Errorf("maxAttemptJobIDForAttempt: %w", err)
+	}
+
+	for i, swf := range expanded {
+		id, job := swf.Job()
+		// Mirror InsertRun's payload contract: children are dispatched to
+		// runners, so their needs must be erased from the serialized payload.
+		job.EraseNeeds()
+		if err := swf.SetJob(id, job); err != nil {
+			return fmt.Errorf("SetJob: %w", err)
+		}
+		payload, err := swf.Marshal()
+		if err != nil {
+			return fmt.Errorf("marshal expanded SingleWorkflow: %w", err)
+		}
+
+		var pinned map[string][]any
+		_ = job.Strategy.RawMatrix.Decode(&pinned)
+		matrixValues := make(map[string]any, len(pinned))
+		for k, v := range pinned {
+			if len(v) == 1 {
+				matrixValues[k] = v[0]
+			}
+		}
+
+		child := &actions_model.ActionRunJob{
+			RunID:             placeholder.RunID,
+			RunAttemptID:      placeholder.RunAttemptID,
+			RepoID:            placeholder.RepoID,
+			OwnerID:           placeholder.OwnerID,
+			CommitSHA:         placeholder.CommitSHA,
+			IsForkPullRequest: placeholder.IsForkPullRequest,
+			Name:              util.EllipsisDisplayString(job.Name, 255),
+			Attempt:           placeholder.Attempt,
+			WorkflowPayload:   payload,
+			JobID:             id,
+			AttemptJobID:      maxAttemptJobID + int64(i+1),
+			Needs:             placeholder.Needs,
+			RunsOn:            job.RunsOn(),
+			Status:            actions_model.StatusWaiting,
+			TokenPermissions:  placeholder.TokenPermissions,
+			MatrixValues:      matrixValues,
+		}
+		if err := db.Insert(ctx, child); err != nil {
+			return fmt.Errorf("insert expanded child: %w", err)
+		}
+	}
+
+	if _, err := db.GetEngine(ctx).ID(placeholder.ID).Delete(&actions_model.ActionRunJob{}); err != nil {
+		return fmt.Errorf("delete placeholder %d: %w", placeholder.ID, err)
+	}
+
+	if err := actions_model.IncreaseTaskVersion(ctx, placeholder.OwnerID, placeholder.RepoID); err != nil {
+		return fmt.Errorf("IncreaseTaskVersion: %w", err)
+	}
+	return nil
+}
+
+// maxAttemptJobIDForAttempt returns the largest AttemptJobID currently in
+// use within a (run, attempt). Returns 0 when no rows exist.
+func maxAttemptJobIDForAttempt(ctx context.Context, runID, runAttemptID int64) (int64, error) {
+	var maxID int64
+	if _, err := db.GetEngine(ctx).
+		Select("COALESCE(MAX(attempt_job_id), 0)").
+		Table("action_run_job").
+		Where("run_id = ? AND run_attempt_id = ?", runID, runAttemptID).
+		Get(&maxID); err != nil {
+		return 0, err
+	}
+	return maxID, nil
 }
 
 func updateConcurrencyEvaluationForJobWithNeeds(ctx context.Context, actionRunJob *actions_model.ActionRunJob, vars map[string]string) error {

--- a/services/actions/job_emitter.go
+++ b/services/actions/job_emitter.go
@@ -501,6 +501,12 @@ func expandOnePlaceholder(ctx context.Context, run *actions_model.ActionRun, pla
 		return fmt.Errorf("no latest attempt for run %d", run.ID)
 	}
 
+	// GenerateGiteaContext reads run.TriggerUser and run.Repo, which are
+	// lazy-loaded — explicitly load them so the context build doesn't panic.
+	if err := run.LoadAttributes(ctx); err != nil {
+		return fmt.Errorf("run.LoadAttributes: %w", err)
+	}
+
 	giteaCtx := GenerateGiteaContext(ctx, run, runAttempt, nil)
 	expanded, err := jobparser.ExpandDeferredMatrix(
 		placeholder.WorkflowPayload,

--- a/services/actions/job_emitter.go
+++ b/services/actions/job_emitter.go
@@ -527,6 +527,7 @@ func expandOnePlaceholder(ctx context.Context, run *actions_model.ActionRun, pla
 		return fmt.Errorf("maxAttemptJobIDForAttempt: %w", err)
 	}
 
+	children := make([]*actions_model.ActionRunJob, 0, len(expanded))
 	for i, swf := range expanded {
 		id, job := swf.Job()
 		// Mirror InsertRun's payload contract: children are dispatched to
@@ -549,7 +550,7 @@ func expandOnePlaceholder(ctx context.Context, run *actions_model.ActionRun, pla
 			}
 		}
 
-		child := &actions_model.ActionRunJob{
+		children = append(children, &actions_model.ActionRunJob{
 			RunID:             placeholder.RunID,
 			RunAttemptID:      placeholder.RunAttemptID,
 			RepoID:            placeholder.RepoID,
@@ -566,10 +567,10 @@ func expandOnePlaceholder(ctx context.Context, run *actions_model.ActionRun, pla
 			Status:            actions_model.StatusWaiting,
 			TokenPermissions:  placeholder.TokenPermissions,
 			MatrixValues:      matrixValues,
-		}
-		if err := db.Insert(ctx, child); err != nil {
-			return fmt.Errorf("insert expanded child: %w", err)
-		}
+		})
+	}
+	if err := actions_model.InsertActionRunJobs(ctx, children); err != nil {
+		return fmt.Errorf("InsertActionRunJobs: %w", err)
 	}
 
 	if _, err := db.GetEngine(ctx).ID(placeholder.ID).Delete(&actions_model.ActionRunJob{}); err != nil {

--- a/services/actions/matrix_cache.go
+++ b/services/actions/matrix_cache.go
@@ -1,0 +1,124 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package actions
+
+import (
+	"crypto/sha256"
+	"sort"
+	"sync"
+	"time"
+
+	"code.gitea.io/gitea/modules/actions/jobparser"
+
+	"go.yaml.in/yaml/v4"
+)
+
+// Deferred-matrix expansion cache.
+//
+// The expansion is content-deterministic: identical (placeholder payload,
+// needs list, needs outputs) always produces identical N SingleWorkflows.
+// This cache lets the emitter skip re-parsing + re-evaluating when the
+// same placeholder is processed more than once (e.g. a queue retry, or
+// two runs whose placeholders + upstream outputs happen to match).
+//
+// Entries are stored as marshalled YAML so cache hits return fresh
+// SingleWorkflow values the caller is free to mutate (the expansion path
+// EraseNeeds+SetJob+Marshal each child). TTL keeps the map bounded; the
+// expected working set is tiny (one entry per concurrent expansion).
+
+const matrixCacheTTL = 30 * time.Second
+
+type matrixCacheKey [sha256.Size]byte
+
+type matrixCacheEntry struct {
+	payloads  [][]byte
+	expiresAt time.Time
+}
+
+var (
+	matrixCacheMu sync.Mutex
+	matrixCache   = map[matrixCacheKey]matrixCacheEntry{}
+)
+
+// computeMatrixCacheKey hashes the inputs that determine the expansion result.
+// Map iteration is sorted so map-key order doesn't perturb the hash.
+func computeMatrixCacheKey(payload []byte, needs []string, outputs map[string]map[string]string) matrixCacheKey {
+	h := sha256.New()
+	h.Write(payload)
+	h.Write([]byte{0})
+
+	sortedNeeds := append([]string(nil), needs...)
+	sort.Strings(sortedNeeds)
+	for _, need := range sortedNeeds {
+		h.Write([]byte(need))
+		h.Write([]byte{0})
+		needOutputs := outputs[need]
+		keys := make([]string, 0, len(needOutputs))
+		for k := range needOutputs {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			h.Write([]byte(k))
+			h.Write([]byte{0})
+			h.Write([]byte(needOutputs[k]))
+			h.Write([]byte{0})
+		}
+		h.Write([]byte{0})
+	}
+
+	var key matrixCacheKey
+	copy(key[:], h.Sum(nil))
+	return key
+}
+
+func matrixCacheGet(key matrixCacheKey) ([]*jobparser.SingleWorkflow, bool) {
+	matrixCacheMu.Lock()
+	defer matrixCacheMu.Unlock()
+	entry, ok := matrixCache[key]
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(entry.expiresAt) {
+		delete(matrixCache, key)
+		return nil, false
+	}
+	out := make([]*jobparser.SingleWorkflow, len(entry.payloads))
+	for i, p := range entry.payloads {
+		sw := &jobparser.SingleWorkflow{}
+		if err := yaml.Unmarshal(p, sw); err != nil {
+			// A cache entry that fails to unmarshal is unusable; drop it and
+			// behave like a miss so the caller will recompute.
+			delete(matrixCache, key)
+			return nil, false
+		}
+		out[i] = sw
+	}
+	return out, true
+}
+
+func matrixCachePut(key matrixCacheKey, expanded []*jobparser.SingleWorkflow) {
+	payloads := make([][]byte, 0, len(expanded))
+	for _, sw := range expanded {
+		b, err := sw.Marshal()
+		if err != nil {
+			// Don't cache partial results — caller will recompute.
+			return
+		}
+		payloads = append(payloads, b)
+	}
+	matrixCacheMu.Lock()
+	defer matrixCacheMu.Unlock()
+	matrixCache[key] = matrixCacheEntry{
+		payloads:  payloads,
+		expiresAt: time.Now().Add(matrixCacheTTL),
+	}
+	// Opportunistically evict expired entries to keep the map bounded.
+	now := time.Now()
+	for k, v := range matrixCache {
+		if now.After(v.expiresAt) {
+			delete(matrixCache, k)
+		}
+	}
+}

--- a/services/actions/matrix_cache_test.go
+++ b/services/actions/matrix_cache_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package actions
+
+import (
+	"testing"
+	"time"
+
+	"code.gitea.io/gitea/modules/actions/jobparser"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v4"
+)
+
+// resetMatrixCache helps individual tests run in isolation against the
+// package-level cache map.
+func resetMatrixCache() {
+	matrixCacheMu.Lock()
+	defer matrixCacheMu.Unlock()
+	matrixCache = map[matrixCacheKey]matrixCacheEntry{}
+}
+
+func buildSingleWorkflow(t *testing.T, name string) *jobparser.SingleWorkflow {
+	t.Helper()
+	src := []byte("name: " + name + "\non: push\njobs:\n  x:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo " + name + "\n")
+	sw := &jobparser.SingleWorkflow{}
+	require.NoError(t, yaml.Unmarshal(src, sw))
+	return sw
+}
+
+func TestMatrixCacheKeyDeterministic(t *testing.T) {
+	payload := []byte("hello")
+	needs := []string{"a", "b"}
+	out := map[string]map[string]string{
+		"a": {"k1": "v1", "k2": "v2"},
+		"b": {"x": "y"},
+	}
+	k1 := computeMatrixCacheKey(payload, needs, out)
+	// Reorder needs and re-shuffle output keys; key must stay identical.
+	k2 := computeMatrixCacheKey(payload, []string{"b", "a"}, map[string]map[string]string{
+		"b": {"x": "y"},
+		"a": {"k2": "v2", "k1": "v1"},
+	})
+	assert.Equal(t, k1, k2)
+}
+
+func TestMatrixCacheKeyChangesWithInputs(t *testing.T) {
+	payload := []byte("hello")
+	base := computeMatrixCacheKey(payload, []string{"a"}, map[string]map[string]string{"a": {"k": "v"}})
+	differentValue := computeMatrixCacheKey(payload, []string{"a"}, map[string]map[string]string{"a": {"k": "different"}})
+	differentPayload := computeMatrixCacheKey([]byte("other"), []string{"a"}, map[string]map[string]string{"a": {"k": "v"}})
+	assert.NotEqual(t, base, differentValue)
+	assert.NotEqual(t, base, differentPayload)
+}
+
+func TestMatrixCachePutGet(t *testing.T) {
+	resetMatrixCache()
+	key := computeMatrixCacheKey([]byte("p"), []string{"a"}, nil)
+	original := []*jobparser.SingleWorkflow{
+		buildSingleWorkflow(t, "first"),
+		buildSingleWorkflow(t, "second"),
+	}
+	matrixCachePut(key, original)
+
+	got, ok := matrixCacheGet(key)
+	require.True(t, ok, "cache hit expected")
+	require.Len(t, got, 2)
+	assert.Equal(t, "first", got[0].Name)
+	assert.Equal(t, "second", got[1].Name)
+
+	// Cache hit must return fresh values: mutating one must not affect a
+	// subsequent get.
+	got[0].Name = "tampered"
+	got2, _ := matrixCacheGet(key)
+	assert.Equal(t, "first", got2[0].Name, "subsequent gets must not see mutations")
+}
+
+func TestMatrixCacheExpiry(t *testing.T) {
+	resetMatrixCache()
+	key := computeMatrixCacheKey([]byte("p"), nil, nil)
+	matrixCacheMu.Lock()
+	matrixCache[key] = matrixCacheEntry{payloads: [][]byte{[]byte("name: x\non: push\njobs:\n  j:\n    steps:\n      - run: echo\n")}, expiresAt: time.Now().Add(-time.Second)}
+	matrixCacheMu.Unlock()
+	_, ok := matrixCacheGet(key)
+	assert.False(t, ok, "expired entries must miss")
+}

--- a/services/actions/matrix_metrics.go
+++ b/services/actions/matrix_metrics.go
@@ -1,0 +1,98 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package actions
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Prometheus instrumentation for the deferred-matrix expansion pipeline.
+//
+// Counters and histograms are registered unconditionally on package init so
+// the same /metrics endpoint Gitea already serves (when [metrics].ENABLED is
+// set) exposes them with no extra wiring. The counters add a few atomic
+// increments per expansion — negligible overhead when nobody scrapes.
+var (
+	matrixReevaluations = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "gitea_matrix_reevaluations_total",
+			Help: "Deferred-matrix re-evaluation attempts, partitioned by outcome (success, failure, deferred).",
+		},
+		[]string{"outcome"},
+	)
+	matrixJobsCreated = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "gitea_matrix_jobs_created_total",
+			Help: "Child RunJobs created by deferred-matrix expansion.",
+		},
+	)
+	matrixReevaluationDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "gitea_matrix_reevaluation_duration_seconds",
+			Help:    "End-to-end wall-clock time per deferred-matrix expansion.",
+			Buckets: prometheus.DefBuckets,
+		},
+	)
+	matrixParseDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "gitea_matrix_parse_duration_seconds",
+			Help:    "Wall-clock time re-parsing the placeholder WorkflowPayload and evaluating the matrix expression.",
+			Buckets: prometheus.DefBuckets,
+		},
+	)
+	matrixInsertDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "gitea_matrix_insert_duration_seconds",
+			Help:    "Wall-clock time inserting expanded child RunJobs into the database.",
+			Buckets: prometheus.DefBuckets,
+		},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(
+		matrixReevaluations,
+		matrixJobsCreated,
+		matrixReevaluationDuration,
+		matrixParseDuration,
+		matrixInsertDuration,
+	)
+}
+
+// matrixTimings tracks the per-expansion stopwatch so the histograms get
+// consistent observations. Use newMatrixTimings → startParse/endParse →
+// startInsert/endInsert → end(outcome, count).
+type matrixTimings struct {
+	overall time.Time
+	parse   time.Time
+	insert  time.Time
+}
+
+func newMatrixTimings() *matrixTimings {
+	return &matrixTimings{overall: time.Now()}
+}
+
+func (t *matrixTimings) startParse()  { t.parse = time.Now() }
+func (t *matrixTimings) endParse()    { matrixParseDuration.Observe(time.Since(t.parse).Seconds()) }
+func (t *matrixTimings) startInsert() { t.insert = time.Now() }
+func (t *matrixTimings) endInsert()   { matrixInsertDuration.Observe(time.Since(t.insert).Seconds()) }
+
+// end finalises the per-expansion observation. outcome ∈ {success, failure, deferred}.
+// childrenCount is only added for outcome="success".
+func (t *matrixTimings) end(outcome string, childrenCount int) {
+	matrixReevaluations.WithLabelValues(outcome).Inc()
+	if outcome == "success" && childrenCount > 0 {
+		matrixJobsCreated.Add(float64(childrenCount))
+	}
+	matrixReevaluationDuration.Observe(time.Since(t.overall).Seconds())
+}
+
+// observeDeferred records a placeholder check that found needs not yet
+// satisfied. No histogram observation here — the check is cheap and
+// otherwise floods the duration distribution with sub-millisecond samples.
+func observeDeferredCheck() {
+	matrixReevaluations.WithLabelValues("deferred").Inc()
+}

--- a/services/actions/matrix_metrics_test.go
+++ b/services/actions/matrix_metrics_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package actions
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatrixMetrics_DeferredCheckIncrementsCounter(t *testing.T) {
+	before := testutil.ToFloat64(matrixReevaluations.WithLabelValues("deferred"))
+	observeDeferredCheck()
+	observeDeferredCheck()
+	after := testutil.ToFloat64(matrixReevaluations.WithLabelValues("deferred"))
+	assert.InDelta(t, before+2, after, 0)
+}
+
+func TestMatrixMetrics_TimingsEndRecordsOutcome(t *testing.T) {
+	beforeSuccess := testutil.ToFloat64(matrixReevaluations.WithLabelValues("success"))
+	beforeJobs := testutil.ToFloat64(matrixJobsCreated)
+
+	timings := newMatrixTimings()
+	// Pretend the parse + insert phases took some time. The histograms are
+	// observed via the start/end pair; ToFloat64 doesn't read histogram bucket
+	// counts but we can at least exercise the methods without panicking.
+	timings.startParse()
+	time.Sleep(1 * time.Millisecond)
+	timings.endParse()
+	timings.startInsert()
+	time.Sleep(1 * time.Millisecond)
+	timings.endInsert()
+	timings.end("success", 4)
+
+	afterSuccess := testutil.ToFloat64(matrixReevaluations.WithLabelValues("success"))
+	afterJobs := testutil.ToFloat64(matrixJobsCreated)
+	assert.InDelta(t, beforeSuccess+1, afterSuccess, 0, "success counter must tick once per end(success, ...)")
+	assert.InDelta(t, beforeJobs+4, afterJobs, 0, "jobs counter must tick by childrenCount on success")
+}
+
+func TestMatrixMetrics_TimingsFailureDoesNotAddJobs(t *testing.T) {
+	beforeFailure := testutil.ToFloat64(matrixReevaluations.WithLabelValues("failure"))
+	beforeJobs := testutil.ToFloat64(matrixJobsCreated)
+
+	timings := newMatrixTimings()
+	timings.end("failure", 99) // childrenCount is ignored on non-success
+
+	afterFailure := testutil.ToFloat64(matrixReevaluations.WithLabelValues("failure"))
+	afterJobs := testutil.ToFloat64(matrixJobsCreated)
+	assert.InDelta(t, beforeFailure+1, afterFailure, 0)
+	assert.InDelta(t, beforeJobs, afterJobs, 0, "failures must not pollute the jobs-created counter")
+}

--- a/services/actions/run.go
+++ b/services/actions/run.go
@@ -16,6 +16,30 @@ import (
 	"go.yaml.in/yaml/v4"
 )
 
+// extractMatrixValues decodes the pinned single-combination matrix that
+// jobparser writes back onto the parsed Job for an expanded static-matrix
+// iteration (shape: `{key: [single_value]}`). Returns nil for placeholders
+// (isDeferred=true) and for jobs without a matrix.
+func extractMatrixValues(rawMatrix yaml.Node, isDeferred bool) map[string]any {
+	if isDeferred || rawMatrix.Kind == 0 {
+		return nil
+	}
+	var pinned map[string][]any
+	if err := rawMatrix.Decode(&pinned); err != nil || len(pinned) == 0 {
+		return nil
+	}
+	values := make(map[string]any, len(pinned))
+	for k, v := range pinned {
+		if len(v) == 1 {
+			values[k] = v[0]
+		}
+	}
+	if len(values) == 0 {
+		return nil
+	}
+	return values
+}
+
 // PrepareRunAndInsert prepares a run and inserts it into the database
 // It parses the workflow content, evaluates concurrency if needed, and inserts the run and its jobs into the database.
 // The title will be cut off at 255 characters if it's longer than 255 characters.
@@ -131,14 +155,45 @@ func InsertRun(ctx context.Context, run *actions_model.ActionRun, content []byte
 		for i, v := range jobs {
 			id, job := v.Job()
 			needs := job.Needs()
-			if err := v.SetJob(id, job.EraseNeeds()); err != nil {
+
+			// Detect a deferred-matrix placeholder before erasing needs:
+			// the jobparser returned this SingleWorkflow without expanding
+			// strategy.matrix because the matrix references upstream
+			// `needs.X.outputs.Y` that aren't available yet. The job emitter
+			// will expand it into N children once needs are satisfied.
+			isDeferredMatrix := jobparser.MatrixDependsOnNeedsOutputs(job.Strategy.RawMatrix)
+			var rawMatrix string
+			if isDeferredMatrix {
+				rawMatrixBytes, err := yaml.Marshal(&job.Strategy.RawMatrix)
+				if err != nil {
+					return fmt.Errorf("marshal raw matrix: %w", err)
+				}
+				rawMatrix = string(rawMatrixBytes)
+			}
+
+			// Deferred-matrix placeholders are never dispatched to a runner —
+			// they exist only to be re-parsed by the job emitter once needs
+			// are satisfied. Keep their RawNeeds so the emitter can build a
+			// proper expression context (the interpreter resolves `needs.X.outputs.Y`
+			// only for jobs listed in the placeholder job's needs).
+			if !isDeferredMatrix {
+				job.EraseNeeds()
+			}
+			if err := v.SetJob(id, job); err != nil {
 				return err
 			}
 			payload, _ := v.Marshal()
 
 			shouldBlockJob := runAttempt.Status == actions_model.StatusBlocked || len(needs) > 0 || run.NeedApproval
 
-			job.Name = util.EllipsisDisplayString(job.Name, 255)
+			// Placeholders use the bare job id as their display name
+			// (matches GitHub's pre-expansion UI). Expanded matrix iterations
+			// keep the name produced by jobparser (e.g. "build (linux)").
+			displayName := job.Name
+			if isDeferredMatrix {
+				displayName = id
+			}
+			displayName = util.EllipsisDisplayString(displayName, 255)
 			runJob := &actions_model.ActionRunJob{
 				RunID:             run.ID,
 				RunAttemptID:      runAttempt.ID,
@@ -146,7 +201,7 @@ func InsertRun(ctx context.Context, run *actions_model.ActionRun, content []byte
 				OwnerID:           run.OwnerID,
 				CommitSHA:         run.CommitSHA,
 				IsForkPullRequest: run.IsForkPullRequest,
-				Name:              job.Name,
+				Name:              displayName,
 				Attempt:           runAttempt.Attempt,
 				WorkflowPayload:   payload,
 				JobID:             id,
@@ -154,6 +209,8 @@ func InsertRun(ctx context.Context, run *actions_model.ActionRun, content []byte
 				Needs:             needs,
 				RunsOn:            job.RunsOn(),
 				Status:            util.Iif(shouldBlockJob, actions_model.StatusBlocked, actions_model.StatusWaiting),
+				RawMatrix:         rawMatrix,
+				MatrixValues:      extractMatrixValues(job.Strategy.RawMatrix, isDeferredMatrix),
 			}
 			// Parse workflow/job permissions (no clamping here)
 			if perms := ExtractJobPermissionsFromWorkflow(v, job); perms != nil {

--- a/templates/repo/actions/list.tmpl
+++ b/templates/repo/actions/list.tmpl
@@ -10,8 +10,8 @@
 				<div class="ui fluid vertical menu flex-items-block">
 					<a class="item {{if not $.CurWorkflow}}active{{end}}" href="?actor={{$.CurActor}}&status={{$.CurStatus}}">{{ctx.Locale.Tr "actions.runs.all_workflows"}}</a>
 					{{range .workflows}}
-						<a class="item {{if eq .Entry.Name $.CurWorkflow}}active{{end}}" href="?workflow={{.Entry.Name}}&actor={{$.CurActor}}&status={{$.CurStatus}}">
-							<span class="gt-ellipsis">{{.Entry.Name}}</span>
+						<a class="item {{if eq .Entry.Name $.CurWorkflow}}active{{end}}" href="?workflow={{.Entry.Name}}&actor={{$.CurActor}}&status={{$.CurStatus}}" data-tooltip-content="{{.Entry.Name}}">
+							<span class="gt-ellipsis">{{if and .Workflow .Workflow.Name}}{{.Workflow.Name}}{{else}}{{.Entry.Name}}{{end}}</span>
 
 							{{if .ErrMsg}}
 								<span class="flex-text-inline" data-tooltip-content="{{.ErrMsg}}">{{svg "octicon-alert" 16 "tw-text-red"}}</span>

--- a/templates/repo/actions/runs_list.tmpl
+++ b/templates/repo/actions/runs_list.tmpl
@@ -21,7 +21,7 @@
 					{{end}}
 				</span>
 				<div class="item-body">
-					<span><b>{{if not $.CurWorkflow}}{{$run.WorkflowID}} {{end}}#{{$run.Index}}</b>:</span>
+					<span><b>{{if not $.CurWorkflow}}{{index $.WorkflowDisplayNames $run.WorkflowID | or $run.WorkflowID}} {{end}}#{{$run.Index}}</b>:</span>
 
 					{{- if $run.ScheduleID -}}
 						{{ctx.Locale.Tr "actions.runs.scheduled"}}

--- a/tests/integration/actions_dynamic_matrix_test.go
+++ b/tests/integration/actions_dynamic_matrix_test.go
@@ -80,7 +80,7 @@ jobs:
 			"job2 (afile)":        true,
 			"job2 (another file)": true,
 		}
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			child := runner.fetchTask(t)
 			name := getTaskJobNameByTaskID(t, token, user2.Name, apiRepo.Name, child.Id)
 			assert.True(t, expectedNames[name], "unexpected child task name: %q", name)

--- a/tests/integration/actions_dynamic_matrix_test.go
+++ b/tests/integration/actions_dynamic_matrix_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	actions_model "code.gitea.io/gitea/models/actions"
+	auth_model "code.gitea.io/gitea/models/auth"
+	"code.gitea.io/gitea/models/unittest"
+	user_model "code.gitea.io/gitea/models/user"
+	api "code.gitea.io/gitea/modules/structs"
+
+	runnerv1 "code.gitea.io/actions-proto-go/runner/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDynamicMatrix exercises the deferred-matrix expansion flow:
+// job1 emits a JSON list as an output, job2's strategy.matrix references
+// `${{ fromJSON(needs.job1.outputs.matrix) }}`. The server must wait for
+// job1 to finish, then expand job2 into N concrete iterations — one per
+// list entry — and dispatch a task per iteration.
+//
+// Regression for go-gitea/gitea#25179 / gitea/runner#393.
+func TestDynamicMatrix(t *testing.T) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
+		user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+		session := loginUser(t, user2.Name)
+		token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteRepository, auth_model.AccessTokenScopeWriteUser)
+
+		apiRepo := createActionsTestRepo(t, token, "actions-dynamic-matrix", false)
+		runner := newMockRunner()
+		runner.registerAsRepoRunner(t, user2.Name, apiRepo.Name, "mock-runner", []string{"ubuntu-latest"}, false)
+
+		const treePath = ".gitea/workflows/dynamic-matrix.yml"
+		const workflow = `name: dynamic-matrix
+on:
+  push:
+    paths:
+      - '.gitea/workflows/dynamic-matrix.yml'
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - id: set
+        run: echo "matrix=[\"afile\",\"another file\"]" >> $GITHUB_OUTPUT
+  job2:
+    needs: job1
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        manifest: ${{ fromJSON(needs.job1.outputs.matrix) }}
+    steps:
+      - run: echo ${{ matrix.manifest }}
+`
+		opts := getWorkflowCreateFileOptions(user2, apiRepo.DefaultBranch, "create "+treePath, workflow)
+		fileResp := createWorkflowFile(t, token, user2.Name, apiRepo.Name, treePath, opts)
+
+		// 1. job1 fires first.
+		task := runner.fetchTask(t)
+		require.Equal(t, "job1", getTaskJobNameByTaskID(t, token, user2.Name, apiRepo.Name, task.Id))
+		runner.execTask(t, task, &mockTaskOutcome{
+			result: runnerv1.Result_RESULT_SUCCESS,
+			outputs: map[string]string{
+				"matrix": `["afile","another file"]`,
+			},
+		})
+
+		// 2. Server expands the deferred matrix into two job2 iterations.
+		// Each fetchTask should now return a distinct matrix iteration.
+		seen := map[string]bool{}
+		expectedNames := map[string]bool{
+			"job2 (afile)":        true,
+			"job2 (another file)": true,
+		}
+		for i := 0; i < 2; i++ {
+			child := runner.fetchTask(t)
+			name := getTaskJobNameByTaskID(t, token, user2.Name, apiRepo.Name, child.Id)
+			assert.True(t, expectedNames[name], "unexpected child task name: %q", name)
+			assert.False(t, seen[name], "matrix child %q dispatched twice", name)
+			seen[name] = true
+
+			// The runner must receive job1's outputs in task.Needs[job1].Outputs
+			// so steps inside the matrix iteration can reference them via
+			// `needs.job1.outputs.*` if they wish.
+			require.Contains(t, child.Needs, "job1")
+			assert.Equal(t, `["afile","another file"]`, child.Needs["job1"].Outputs["matrix"])
+
+			runner.execTask(t, child, &mockTaskOutcome{result: runnerv1.Result_RESULT_SUCCESS})
+		}
+		assert.Len(t, seen, 2, "both matrix iterations must be dispatched")
+
+		// 3. No further tasks should be pending — the run has only 3 jobs total.
+		req := NewRequest(t, "GET", fmt.Sprintf("/api/v1/repos/%s/%s/actions/tasks", user2.Name, apiRepo.Name)).
+			AddTokenAuth(token)
+		resp := MakeRequest(t, req, http.StatusOK)
+		taskResp := DecodeJSON(t, resp, &api.ActionTaskResponse{})
+		var thisRunTasks []*api.ActionTask
+		for _, apiTask := range taskResp.Entries {
+			if apiTask.HeadSHA == fileResp.Commit.SHA {
+				thisRunTasks = append(thisRunTasks, apiTask)
+			}
+		}
+		require.Len(t, thisRunTasks, 3, "1 job1 + 2 job2 iterations")
+		for _, apiTask := range thisRunTasks {
+			assert.Equal(t, actions_model.StatusSuccess.String(), apiTask.Status, "task %q should be success", apiTask.Name)
+		}
+
+		// 4. No placeholder row left behind: every RunJob for this run
+		// must carry a non-empty Name and have RawMatrix cleared on the
+		// concrete iterations (placeholders would have RawMatrix set).
+		jobs, err := unittest.GetXORMEngine().
+			Table("action_run_job").
+			Where("repo_id = ? AND commit_sha = ?", apiRepo.ID, fileResp.Commit.SHA).
+			Asc("id").
+			QueryString()
+		require.NoError(t, err)
+		require.Len(t, jobs, 3, "DB must contain exactly 3 RunJobs (no placeholder)")
+		for _, j := range jobs {
+			assert.Empty(t, j["raw_matrix"], "expanded children must not carry RawMatrix")
+			assert.NotEmpty(t, j["name"], "every row needs a display name")
+		}
+	})
+}

--- a/web_src/js/components/ActionRunView.ts
+++ b/web_src/js/components/ActionRunView.ts
@@ -87,22 +87,52 @@ export function createLogLineMessage(line: LogLine, cmd: LogLineCommand | null) 
   return logMsg;
 }
 
-export type DecoratedActionsJob = {
-  job: ActionsJob;
-  isMatrixChild: boolean;
+export type JobGroup = {
+  // The workflow job id shared by every entry. Renders as the group header
+  // label when iterations.length > 1.
+  jobId: string;
+  iterations: ActionsJob[];
+  // Aggregate status across iterations — mirrors the backend
+  // AggregateJobStatus precedence (cancelling > running > waiting > blocked
+  // > cancelled > failure; all-success or all-skipped collapse).
+  aggregateStatus: ActionsStatus;
 };
 
-// decorateJobsForMatrixGrouping flags jobs that should render as indented
-// matrix children in the run sidebar. A job is a child when its predecessor
-// shares the same workflow jobId — which is what static and dynamic matrix
-// iterations have in common (see SortMatrixGroupsByName on the backend, which
-// keeps these contiguous). Matches GitHub's flat-with-indent UI: no separate
-// parent header row, just visual grouping by name prefix.
-export function decorateJobsForMatrixGrouping(jobs: ReadonlyArray<ActionsJob>): DecoratedActionsJob[] {
-  return jobs.map((job, i) => ({
-    job,
-    isMatrixChild: i > 0 && jobs[i - 1].jobId === job.jobId,
-  }));
+// groupJobsByMatrix walks the (already contiguous-by-jobId, thanks to the
+// backend's SortMatrixGroupsByName) job list and bundles consecutive entries
+// sharing a workflow jobId into a group. Single-entry groups render flat;
+// multi-entry groups render a synthetic header followed by indented children.
+// Matches GitHub's modern run-detail UI (one expandable header per matrix).
+export function groupJobsByMatrix(jobs: ReadonlyArray<ActionsJob>): JobGroup[] {
+  const groups: JobGroup[] = [];
+  for (const job of jobs) {
+    const last = groups[groups.length - 1];
+    if (last && last.jobId === job.jobId) {
+      last.iterations.push(job);
+    } else {
+      groups.push({jobId: job.jobId, iterations: [job], aggregateStatus: 'unknown'});
+    }
+  }
+  for (const g of groups) {
+    g.aggregateStatus = aggregateIterationStatus(g.iterations.map((j) => j.status));
+  }
+  return groups;
+}
+
+// aggregateIterationStatus mirrors models/actions/run_job.go AggregateJobStatus
+// so the synthetic group header reflects the same precedence the backend
+// would compute for an attempt-level status.
+export function aggregateIterationStatus(statuses: ReadonlyArray<ActionsStatus>): ActionsStatus {
+  if (statuses.length === 0) return 'unknown';
+  if (statuses.every((s) => s === 'skipped')) return 'skipped';
+  if (statuses.every((s) => s === 'success' || s === 'skipped')) return 'success';
+  if (statuses.some((s) => s === 'cancelling')) return 'cancelling';
+  if (statuses.some((s) => s === 'running')) return 'running';
+  if (statuses.some((s) => s === 'waiting')) return 'waiting';
+  if (statuses.some((s) => s === 'blocked')) return 'blocked';
+  if (statuses.some((s) => s === 'cancelled')) return 'cancelled';
+  if (statuses.some((s) => s === 'failure')) return 'failure';
+  return 'unknown';
 }
 
 export function createEmptyActionsRun(): ActionsRun {

--- a/web_src/js/components/ActionRunView.ts
+++ b/web_src/js/components/ActionRunView.ts
@@ -87,6 +87,24 @@ export function createLogLineMessage(line: LogLine, cmd: LogLineCommand | null) 
   return logMsg;
 }
 
+export type DecoratedActionsJob = {
+  job: ActionsJob;
+  isMatrixChild: boolean;
+};
+
+// decorateJobsForMatrixGrouping flags jobs that should render as indented
+// matrix children in the run sidebar. A job is a child when its predecessor
+// shares the same workflow jobId — which is what static and dynamic matrix
+// iterations have in common (see SortMatrixGroupsByName on the backend, which
+// keeps these contiguous). Matches GitHub's flat-with-indent UI: no separate
+// parent header row, just visual grouping by name prefix.
+export function decorateJobsForMatrixGrouping(jobs: ReadonlyArray<ActionsJob>): DecoratedActionsJob[] {
+  return jobs.map((job, i) => ({
+    job,
+    isMatrixChild: i > 0 && jobs[i - 1].jobId === job.jobId,
+  }));
+}
+
 export function createEmptyActionsRun(): ActionsRun {
   return {
     repoId: 0,

--- a/web_src/js/components/ActionRunView.ts
+++ b/web_src/js/components/ActionRunView.ts
@@ -119,6 +119,29 @@ export function groupJobsByMatrix(jobs: ReadonlyArray<ActionsJob>): JobGroup[] {
   return groups;
 }
 
+// isMatrixGroupExpanded decides whether the iterations of a matrix group
+// should currently be rendered in the sidebar. The group is always shown when
+// the currently selected job belongs to it (otherwise users couldn't see the
+// job they navigated to). Otherwise the explicit user-toggled `collapsed` set
+// wins.
+export function isMatrixGroupExpanded(
+  group: {jobId: string; iterations: ReadonlyArray<{id: number}>},
+  selectedJobId: number,
+  collapsed: ReadonlySet<string>,
+): boolean {
+  for (const j of group.iterations) {
+    if (j.id === selectedJobId) return true;
+  }
+  return !collapsed.has(group.jobId);
+}
+
+// toggleCollapsedMatrixGroup flips the collapsed state for one jobId. Mutates
+// the passed set so Vue's reactivity tracks the change.
+export function toggleCollapsedMatrixGroup(collapsed: Set<string>, jobId: string): void {
+  if (collapsed.has(jobId)) collapsed.delete(jobId);
+  else collapsed.add(jobId);
+}
+
 // aggregateIterationStatus mirrors models/actions/run_job.go AggregateJobStatus
 // so the synthetic group header reflects the same precedence the backend
 // would compute for an attempt-level status.

--- a/web_src/js/components/RepoActionView.test.ts
+++ b/web_src/js/components/RepoActionView.test.ts
@@ -1,0 +1,60 @@
+import {decorateJobsForMatrixGrouping} from './ActionRunView.ts';
+import type {ActionsJob} from '../modules/gitea-actions.ts';
+
+function makeJob(id: number, jobId: string, name = jobId): ActionsJob {
+  return {
+    id,
+    link: `/run/job/${id}`,
+    jobId,
+    name,
+    status: 'success',
+    canRerun: false,
+    duration: '1s',
+  };
+}
+
+describe('decorateJobsForMatrixGrouping', () => {
+  test('empty list', () => {
+    expect(decorateJobsForMatrixGrouping([])).toEqual([]);
+  });
+
+  test('single job is not a matrix child', () => {
+    const out = decorateJobsForMatrixGrouping([makeJob(1, 'build')]);
+    expect(out).toHaveLength(1);
+    expect(out[0].isMatrixChild).toBe(false);
+  });
+
+  test('siblings with same jobId: first is parent, rest are children', () => {
+    const out = decorateJobsForMatrixGrouping([
+      makeJob(1, 'build', 'build (linux)'),
+      makeJob(2, 'build', 'build (windows)'),
+      makeJob(3, 'build', 'build (macos)'),
+    ]);
+    expect(out.map((d) => d.isMatrixChild)).toEqual([false, true, true]);
+  });
+
+  test('distinct jobIds are never grouped', () => {
+    const out = decorateJobsForMatrixGrouping([
+      makeJob(1, 'lint'),
+      makeJob(2, 'test'),
+      makeJob(3, 'deploy'),
+    ]);
+    expect(out.map((d) => d.isMatrixChild)).toEqual([false, false, false]);
+  });
+
+  test('mixed matrix and non-matrix jobs', () => {
+    const out = decorateJobsForMatrixGrouping([
+      makeJob(1, 'job1'),
+      makeJob(2, 'job2', 'job2 (afile)'),
+      makeJob(3, 'job2', 'job2 (another file)'),
+      makeJob(4, 'job3'),
+    ]);
+    expect(out.map((d) => d.isMatrixChild)).toEqual([false, false, true, false]);
+  });
+
+  test('preserves the job objects', () => {
+    const job = makeJob(42, 'build');
+    const [decorated] = decorateJobsForMatrixGrouping([job]);
+    expect(decorated.job).toBe(job);
+  });
+});

--- a/web_src/js/components/RepoActionView.test.ts
+++ b/web_src/js/components/RepoActionView.test.ts
@@ -1,60 +1,102 @@
-import {decorateJobsForMatrixGrouping} from './ActionRunView.ts';
-import type {ActionsJob} from '../modules/gitea-actions.ts';
+import {aggregateIterationStatus, groupJobsByMatrix} from './ActionRunView.ts';
+import type {ActionsJob, ActionsStatus} from '../modules/gitea-actions.ts';
 
-function makeJob(id: number, jobId: string, name = jobId): ActionsJob {
+function makeJob(id: number, jobId: string, name = jobId, status: ActionsStatus = 'success'): ActionsJob {
   return {
     id,
     link: `/run/job/${id}`,
     jobId,
     name,
-    status: 'success',
+    status,
     canRerun: false,
     duration: '1s',
   };
 }
 
-describe('decorateJobsForMatrixGrouping', () => {
+describe('groupJobsByMatrix', () => {
   test('empty list', () => {
-    expect(decorateJobsForMatrixGrouping([])).toEqual([]);
+    expect(groupJobsByMatrix([])).toEqual([]);
   });
 
-  test('single job is not a matrix child', () => {
-    const out = decorateJobsForMatrixGrouping([makeJob(1, 'build')]);
+  test('single job becomes a single-iteration group', () => {
+    const out = groupJobsByMatrix([makeJob(1, 'build')]);
     expect(out).toHaveLength(1);
-    expect(out[0].isMatrixChild).toBe(false);
+    expect(out[0].jobId).toBe('build');
+    expect(out[0].iterations).toHaveLength(1);
   });
 
-  test('siblings with same jobId: first is parent, rest are children', () => {
-    const out = decorateJobsForMatrixGrouping([
+  test('contiguous same-jobId entries form one group', () => {
+    const out = groupJobsByMatrix([
       makeJob(1, 'build', 'build (linux)'),
       makeJob(2, 'build', 'build (windows)'),
       makeJob(3, 'build', 'build (macos)'),
     ]);
-    expect(out.map((d) => d.isMatrixChild)).toEqual([false, true, true]);
+    expect(out).toHaveLength(1);
+    expect(out[0].iterations.map((j) => j.id)).toEqual([1, 2, 3]);
   });
 
-  test('distinct jobIds are never grouped', () => {
-    const out = decorateJobsForMatrixGrouping([
+  test('distinct jobIds become separate groups', () => {
+    const out = groupJobsByMatrix([
       makeJob(1, 'lint'),
       makeJob(2, 'test'),
       makeJob(3, 'deploy'),
     ]);
-    expect(out.map((d) => d.isMatrixChild)).toEqual([false, false, false]);
+    expect(out).toHaveLength(3);
+    expect(out.map((g) => g.jobId)).toEqual(['lint', 'test', 'deploy']);
+    expect(out.every((g) => g.iterations.length === 1)).toBe(true);
   });
 
-  test('mixed matrix and non-matrix jobs', () => {
-    const out = decorateJobsForMatrixGrouping([
+  test('mixed singleton + matrix is grouped correctly', () => {
+    const out = groupJobsByMatrix([
       makeJob(1, 'job1'),
       makeJob(2, 'job2', 'job2 (afile)'),
       makeJob(3, 'job2', 'job2 (another file)'),
       makeJob(4, 'job3'),
     ]);
-    expect(out.map((d) => d.isMatrixChild)).toEqual([false, false, true, false]);
+    expect(out.map((g) => ({id: g.jobId, n: g.iterations.length}))).toEqual([
+      {id: 'job1', n: 1},
+      {id: 'job2', n: 2},
+      {id: 'job3', n: 1},
+    ]);
   });
 
-  test('preserves the job objects', () => {
-    const job = makeJob(42, 'build');
-    const [decorated] = decorateJobsForMatrixGrouping([job]);
-    expect(decorated.job).toBe(job);
+  test('aggregateStatus reflects worst pending iteration', () => {
+    const out = groupJobsByMatrix([
+      makeJob(1, 'test', 'test (a)', 'success'),
+      makeJob(2, 'test', 'test (b)', 'running'),
+      makeJob(3, 'test', 'test (c)', 'waiting'),
+    ]);
+    expect(out[0].aggregateStatus).toBe('running');
+  });
+
+  test('aggregateStatus rolls up to success when all pass', () => {
+    const out = groupJobsByMatrix([
+      makeJob(1, 'test', 'test (a)', 'success'),
+      makeJob(2, 'test', 'test (b)', 'success'),
+    ]);
+    expect(out[0].aggregateStatus).toBe('success');
+  });
+});
+
+describe('aggregateIterationStatus', () => {
+  test('empty -> unknown', () => {
+    expect(aggregateIterationStatus([])).toBe('unknown');
+  });
+
+  test('all skipped collapses to skipped (not success)', () => {
+    expect(aggregateIterationStatus(['skipped', 'skipped'])).toBe('skipped');
+  });
+
+  test('success + skipped -> success', () => {
+    expect(aggregateIterationStatus(['success', 'skipped'])).toBe('success');
+  });
+
+  test('cancelling outranks running', () => {
+    expect(aggregateIterationStatus(['cancelling', 'running'])).toBe('cancelling');
+  });
+
+  test('failure only emerges when nothing pending', () => {
+    expect(aggregateIterationStatus(['failure', 'success'])).toBe('failure');
+    expect(aggregateIterationStatus(['failure', 'running'])).toBe('running');
   });
 });

--- a/web_src/js/components/RepoActionView.test.ts
+++ b/web_src/js/components/RepoActionView.test.ts
@@ -1,4 +1,9 @@
-import {aggregateIterationStatus, groupJobsByMatrix} from './ActionRunView.ts';
+import {
+  aggregateIterationStatus,
+  groupJobsByMatrix,
+  isMatrixGroupExpanded,
+  toggleCollapsedMatrixGroup,
+} from './ActionRunView.ts';
 import type {ActionsJob, ActionsStatus} from '../modules/gitea-actions.ts';
 
 function makeJob(id: number, jobId: string, name = jobId, status: ActionsStatus = 'success'): ActionsJob {
@@ -75,6 +80,49 @@ describe('groupJobsByMatrix', () => {
       makeJob(2, 'test', 'test (b)', 'success'),
     ]);
     expect(out[0].aggregateStatus).toBe('success');
+  });
+});
+
+describe('isMatrixGroupExpanded', () => {
+  const group = {jobId: 'test', iterations: [{id: 1}, {id: 2}, {id: 3}]};
+
+  test('expanded by default when not collapsed', () => {
+    expect(isMatrixGroupExpanded(group, 0, new Set())).toBe(true);
+  });
+
+  test('collapsed when explicitly in the collapsed set', () => {
+    expect(isMatrixGroupExpanded(group, 0, new Set(['test']))).toBe(false);
+  });
+
+  test('force-expanded when the currently viewed job lives in the group', () => {
+    // Even though "test" is in collapsed, the user is viewing job 2 inside
+    // it — the group must stay expanded so they can see their own row.
+    expect(isMatrixGroupExpanded(group, 2, new Set(['test']))).toBe(true);
+  });
+
+  test('unaffected by collapse state of other groups', () => {
+    expect(isMatrixGroupExpanded(group, 0, new Set(['other-group']))).toBe(true);
+  });
+});
+
+describe('toggleCollapsedMatrixGroup', () => {
+  test('adds when missing', () => {
+    const s = new Set<string>();
+    toggleCollapsedMatrixGroup(s, 'build');
+    expect(s.has('build')).toBe(true);
+  });
+
+  test('removes when present', () => {
+    const s = new Set(['build']);
+    toggleCollapsedMatrixGroup(s, 'build');
+    expect(s.has('build')).toBe(false);
+  });
+
+  test('only affects the named group', () => {
+    const s = new Set(['build', 'test']);
+    toggleCollapsedMatrixGroup(s, 'build');
+    expect(s.has('build')).toBe(false);
+    expect(s.has('test')).toBe(true);
   });
 });
 

--- a/web_src/js/components/RepoActionView.vue
+++ b/web_src/js/components/RepoActionView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import {SvgIcon} from '../svg.ts';
 import ActionStatusIcon from './ActionStatusIcon.vue';
-import {toRefs} from 'vue';
+import {computed, toRefs} from 'vue';
 import {POST, DELETE} from '../modules/fetch.ts';
 import ActionRunSummaryView from './ActionRunSummaryView.vue';
 import ActionRunJobView from './ActionRunJobView.vue';
@@ -49,6 +49,19 @@ async function deleteArtifact(name: string) {
   await DELETE(buildArtifactLink(name));
   await store.forceReloadCurrentRun();
 }
+
+// Matrix iterations share the same workflow jobId (e.g. two "build (linux)"
+// and "build (windows)" siblings both carry jobId "build"). The backend
+// already keeps them contiguous via SortMatrixGroupsByName, so detecting
+// children is a simple "previous sibling shares jobId" check. Matches the
+// flat-with-indent visual GitHub uses.
+const decoratedJobs = computed(() => {
+  const list = run.value.jobs ?? [];
+  return list.map((job, i) => ({
+    job,
+    isMatrixChild: i > 0 && list[i - 1].jobId === job.jobId,
+  }));
+});
 </script>
 <template>
   <!-- make the view container full width to make users easier to read logs -->
@@ -152,7 +165,7 @@ async function deleteArtifact(name: string) {
         <div class="left-list-header">{{ locale.allJobs }}</div>
         <!-- unlike other lists, the items have paddings already -->
         <ul class="ui relaxed list flex-items-block tw-p-0">
-          <li class="item job-brief-item" v-for="job in run.jobs" :key="job.id" :class="props.jobId === job.id ? 'selected' : ''">
+          <li class="item job-brief-item" v-for="{job, isMatrixChild} in decoratedJobs" :key="job.id" :class="[props.jobId === job.id ? 'selected' : '', isMatrixChild ? 'matrix-child' : '']">
             <a class="tw-contents silenced" :href="job.link">
               <ActionStatusIcon :locale-status="locale.status[job.status]" :status="job.status" icon-variant="circle-fill"/>
               <span class="tw-flex-1 gt-ellipsis">{{ job.name }}</span>
@@ -330,6 +343,10 @@ async function deleteArtifact(name: string) {
 .job-brief-item.selected {
   font-weight: var(--font-weight-bold);
   background-color: var(--color-active);
+}
+
+.job-brief-item.matrix-child {
+  padding-left: 24px;
 }
 
 /* ================ */

--- a/web_src/js/components/RepoActionView.vue
+++ b/web_src/js/components/RepoActionView.vue
@@ -6,7 +6,7 @@ import {POST, DELETE} from '../modules/fetch.ts';
 import ActionRunSummaryView from './ActionRunSummaryView.vue';
 import ActionRunJobView from './ActionRunJobView.vue';
 import type {ActionsRunAttempt} from '../modules/gitea-actions.ts';
-import {createActionRunViewStore, groupJobsByMatrix} from './ActionRunView.ts';
+import {createActionRunViewStore, groupJobsByMatrix, isMatrixGroupExpanded, toggleCollapsedMatrixGroup} from './ActionRunView.ts';
 import {buildArtifactTooltipHtml} from './ActionRunArtifacts.ts';
 
 defineOptions({
@@ -52,19 +52,14 @@ async function deleteArtifact(name: string) {
 
 const jobGroups = computed(() => groupJobsByMatrix(run.value.jobs ?? []));
 
-// Collapsed-by-user matrix groups (keyed by workflow jobId). Default: expanded.
-// The group that currently contains the selected job is force-expanded below.
+// User-collapsed matrix groups (keyed by workflow jobId). Default: expanded.
+// The group containing the currently selected job is force-expanded.
 const collapsedGroups = ref<Set<string>>(new Set());
 function toggleGroup(jobId: string) {
-  if (collapsedGroups.value.has(jobId)) {
-    collapsedGroups.value.delete(jobId);
-  } else {
-    collapsedGroups.value.add(jobId);
-  }
+  toggleCollapsedMatrixGroup(collapsedGroups.value, jobId);
 }
 function isGroupExpanded(group: {jobId: string; iterations: Array<{id: number}>}): boolean {
-  if (group.iterations.some((j) => j.id === props.jobId)) return true;
-  return !collapsedGroups.value.has(group.jobId);
+  return isMatrixGroupExpanded(group, props.jobId, collapsedGroups.value);
 }
 </script>
 <template>

--- a/web_src/js/components/RepoActionView.vue
+++ b/web_src/js/components/RepoActionView.vue
@@ -6,7 +6,7 @@ import {POST, DELETE} from '../modules/fetch.ts';
 import ActionRunSummaryView from './ActionRunSummaryView.vue';
 import ActionRunJobView from './ActionRunJobView.vue';
 import type {ActionsRunAttempt} from '../modules/gitea-actions.ts';
-import {createActionRunViewStore} from './ActionRunView.ts';
+import {createActionRunViewStore, decorateJobsForMatrixGrouping} from './ActionRunView.ts';
 import {buildArtifactTooltipHtml} from './ActionRunArtifacts.ts';
 
 defineOptions({
@@ -50,18 +50,7 @@ async function deleteArtifact(name: string) {
   await store.forceReloadCurrentRun();
 }
 
-// Matrix iterations share the same workflow jobId (e.g. two "build (linux)"
-// and "build (windows)" siblings both carry jobId "build"). The backend
-// already keeps them contiguous via SortMatrixGroupsByName, so detecting
-// children is a simple "previous sibling shares jobId" check. Matches the
-// flat-with-indent visual GitHub uses.
-const decoratedJobs = computed(() => {
-  const list = run.value.jobs ?? [];
-  return list.map((job, i) => ({
-    job,
-    isMatrixChild: i > 0 && list[i - 1].jobId === job.jobId,
-  }));
-});
+const decoratedJobs = computed(() => decorateJobsForMatrixGrouping(run.value.jobs ?? []));
 </script>
 <template>
   <!-- make the view container full width to make users easier to read logs -->

--- a/web_src/js/components/RepoActionView.vue
+++ b/web_src/js/components/RepoActionView.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import {SvgIcon} from '../svg.ts';
 import ActionStatusIcon from './ActionStatusIcon.vue';
-import {computed, toRefs} from 'vue';
+import {computed, ref, toRefs} from 'vue';
 import {POST, DELETE} from '../modules/fetch.ts';
 import ActionRunSummaryView from './ActionRunSummaryView.vue';
 import ActionRunJobView from './ActionRunJobView.vue';
 import type {ActionsRunAttempt} from '../modules/gitea-actions.ts';
-import {createActionRunViewStore, decorateJobsForMatrixGrouping} from './ActionRunView.ts';
+import {createActionRunViewStore, groupJobsByMatrix} from './ActionRunView.ts';
 import {buildArtifactTooltipHtml} from './ActionRunArtifacts.ts';
 
 defineOptions({
@@ -50,7 +50,22 @@ async function deleteArtifact(name: string) {
   await store.forceReloadCurrentRun();
 }
 
-const decoratedJobs = computed(() => decorateJobsForMatrixGrouping(run.value.jobs ?? []));
+const jobGroups = computed(() => groupJobsByMatrix(run.value.jobs ?? []));
+
+// Collapsed-by-user matrix groups (keyed by workflow jobId). Default: expanded.
+// The group that currently contains the selected job is force-expanded below.
+const collapsedGroups = ref<Set<string>>(new Set());
+function toggleGroup(jobId: string) {
+  if (collapsedGroups.value.has(jobId)) {
+    collapsedGroups.value.delete(jobId);
+  } else {
+    collapsedGroups.value.add(jobId);
+  }
+}
+function isGroupExpanded(group: {jobId: string; iterations: Array<{id: number}>}): boolean {
+  if (group.iterations.some((j) => j.id === props.jobId)) return true;
+  return !collapsedGroups.value.has(group.jobId);
+}
 </script>
 <template>
   <!-- make the view container full width to make users easier to read logs -->
@@ -154,14 +169,36 @@ const decoratedJobs = computed(() => decorateJobsForMatrixGrouping(run.value.job
         <div class="left-list-header">{{ locale.allJobs }}</div>
         <!-- unlike other lists, the items have paddings already -->
         <ul class="ui relaxed list flex-items-block tw-p-0">
-          <li class="item job-brief-item" v-for="{job, isMatrixChild} in decoratedJobs" :key="job.id" :class="[props.jobId === job.id ? 'selected' : '', isMatrixChild ? 'matrix-child' : '']">
-            <a class="tw-contents silenced" :href="job.link">
-              <ActionStatusIcon :locale-status="locale.status[job.status]" :status="job.status" icon-variant="circle-fill"/>
-              <span class="tw-flex-1 gt-ellipsis">{{ job.name }}</span>
-              <SvgIcon name="octicon-sync" role="button" :data-tooltip-content="locale.rerun" class="tw-cursor-pointer link-action interact-fg" :data-url="`${run.link}/jobs/${job.id}/rerun`" v-if="job.canRerun"/>
-              <span>{{ job.duration }}</span>
-            </a>
-          </li>
+          <template v-for="group in jobGroups" :key="group.jobId + ':' + group.iterations[0].id">
+            <!-- single iteration: render as a flat job item, no header -->
+            <li v-if="group.iterations.length === 1" class="item job-brief-item" :class="props.jobId === group.iterations[0].id ? 'selected' : ''">
+              <a class="tw-contents silenced" :href="group.iterations[0].link">
+                <ActionStatusIcon :locale-status="locale.status[group.iterations[0].status]" :status="group.iterations[0].status" icon-variant="circle-fill"/>
+                <span class="tw-flex-1 gt-ellipsis">{{ group.iterations[0].name }}</span>
+                <SvgIcon name="octicon-sync" role="button" :data-tooltip-content="locale.rerun" class="tw-cursor-pointer link-action interact-fg" :data-url="`${run.link}/jobs/${group.iterations[0].id}/rerun`" v-if="group.iterations[0].canRerun"/>
+                <span>{{ group.iterations[0].duration }}</span>
+              </a>
+            </li>
+            <!-- N>=2 iterations: synthetic header + indented children -->
+            <template v-else>
+              <li class="item job-brief-item matrix-group-header" @click="toggleGroup(group.jobId)">
+                <ActionStatusIcon :locale-status="locale.status[group.aggregateStatus]" :status="group.aggregateStatus" icon-variant="circle-fill"/>
+                <span class="tw-flex-1 gt-ellipsis">{{ group.jobId }}</span>
+                <span class="matrix-group-count">{{ group.iterations.length }}</span>
+                <SvgIcon :name="isGroupExpanded(group) ? 'octicon-chevron-down' : 'octicon-chevron-right'" :size="14"/>
+              </li>
+              <template v-if="isGroupExpanded(group)">
+                <li v-for="job in group.iterations" :key="job.id" class="item job-brief-item matrix-child" :class="props.jobId === job.id ? 'selected' : ''">
+                  <a class="tw-contents silenced" :href="job.link">
+                    <ActionStatusIcon :locale-status="locale.status[job.status]" :status="job.status" icon-variant="circle-fill"/>
+                    <span class="tw-flex-1 gt-ellipsis">{{ job.name }}</span>
+                    <SvgIcon name="octicon-sync" role="button" :data-tooltip-content="locale.rerun" class="tw-cursor-pointer link-action interact-fg" :data-url="`${run.link}/jobs/${job.id}/rerun`" v-if="job.canRerun"/>
+                    <span>{{ job.duration }}</span>
+                  </a>
+                </li>
+              </template>
+            </template>
+          </template>
         </ul>
 
         <!-- artifacts list -->
@@ -336,6 +373,20 @@ const decoratedJobs = computed(() => decorateJobsForMatrixGrouping(run.value.job
 
 .job-brief-item.matrix-child {
   padding-left: 24px;
+}
+
+.job-brief-item.matrix-group-header {
+  cursor: pointer;
+  user-select: none;
+  color: var(--color-text-light-2);
+}
+
+.matrix-group-count {
+  font-size: 12px;
+  color: var(--color-text-light-2);
+  padding: 0 4px;
+  background: var(--color-secondary-bg);
+  border-radius: var(--border-radius);
 }
 
 /* ================ */


### PR DESCRIPTION
# Support dynamic matrix strategies that depend on upstream job outputs

## Description

Gitea Actions currently expands `strategy.matrix` at workflow submission
time. When the matrix references the output of an earlier job —

```yaml
job2:
  needs: job1
  strategy:
    matrix:
      manifest: ${{ fromJSON(needs.job1.outputs.matrix) }}
```

— the referenced output is not known yet, the expression does not resolve,
and Gitea creates a single broken RunJob instead of one per matrix entry.

This PR defers matrix evaluation until the upstream `needs:` jobs have
finished, then expands the placeholder into N concrete RunJobs, matching
GitHub Actions' behaviour. The runner already executes each matrix
iteration correctly when it receives N tasks — the missing piece was on
the server, which never dispatched more than one. The runner-side
walkthrough on [gitea/runner#393](https://gitea.com/gitea/runner/issues/393)
documents the runner state in detail; this PR is the server fix it asked
for.

Closes #25179
Resolves [gitea/runner#393](https://gitea.com/gitea/runner/issues/393)

## Features

### 1. Deferred matrix expansion

`jobparser.MatrixDependsOnNeedsOutputs` detects matrix expressions that
reference `needs.<id>.outputs.<key>`. For those, `jobparser.Parse` emits a
single placeholder `SingleWorkflow` / `ActionRunJob` (status `Blocked`,
with the raw matrix YAML stored on the new `RawMatrix` column). The
placeholder is never dispatched to a runner.

Once all upstream `needs:` of the placeholder finish, the job emitter
calls `jobparser.ExpandDeferredMatrix` with the upstream outputs in
scope. The matrix YAML is re-evaluated, expanded via `getMatrixes`, and
inserted as N concrete child `ActionRunJob` rows (one per cartesian-
product combination, also for multi-needs / multi-key matrices). The
placeholder row is deleted in the same transaction.

### 2. Step-name interpolation per matrix iteration

`${{ matrix.* }}` in a step's `name:` field is now resolved per iteration.
A workflow with

```yaml
steps:
  - name: Build ${{ matrix.target }}
    run: ...
```

displays as "Build linux" / "Build darwin" in the UI for the two
iterations, instead of the literal expression. This also fixes the same
gap for **static** matrices, whose step names previously weren't
interpolated either.

### 3. Sidebar UI: virtual matrix group header

In the run-detail sidebar, contiguous iterations sharing a workflow
`jobId` are rolled up under a synthetic header showing the bare job id,
an iteration count, and an aggregate status icon mirroring backend
`AggregateJobStatus` precedence (cancelling > running > waiting > blocked
> cancelled > failure; all-skipped collapses to skipped, all-success
collapses to success). Click-to-collapse / -expand; the group containing
the currently viewed job is always kept open. Single-iteration jobs still
render flat (no header). Matches GitHub Actions' modern run-detail UI.

```
✓ detect
▾ test    [5]
    ✓ test (1.3.10)
    ✓ test (1.3.11)
    ✓ test (1.3.12)
    ✓ test (1.3.13)
    ✓ test (1.3.14)
```

<img width="1514" height="866" alt="Bildschirmfoto 2026-05-17 um 21 11 34" src="https://github.com/user-attachments/assets/882cc5cb-d1ae-4d8f-b339-c41ba1898895" />

### 4. Prometheus metrics

Five histograms / counters registered on the existing `/metrics` endpoint
when `[metrics].ENABLED=true`:

- `gitea_matrix_reevaluations_total{outcome="success|failure|deferred"}`
- `gitea_matrix_jobs_created_total`
- `gitea_matrix_reevaluation_duration_seconds` (histogram)
- `gitea_matrix_parse_duration_seconds` (histogram)
- `gitea_matrix_insert_duration_seconds` (histogram)

Counters use atomic increments — overhead is negligible when nobody
scrapes.

### 5. Matrix-expansion cache (TTL 30 s)

`services/actions/matrix_cache.go` keys by
`sha256(payload + sorted needs ids + sorted outputs)` and stores
marshalled `SingleWorkflow` YAML so cache hits return fresh values the
caller is safe to mutate (the emitter `EraseNeeds` + `SetJob` + `Marshal`
on each child). Working-set bounded by opportunistic eviction on every
put.

### 6. Batch insert

`actions_model.InsertActionRunJobs` does a single round-trip insert for
the N expanded children, replacing N individual inserts in the emitter.

## Supported workflow patterns

### A. The minimal reproduction from #25179

```yaml
name: From issue 25179 — dynamic matrix
on:
  push:
  workflow_dispatch:

jobs:
  job1:
    runs-on: ubuntu-latest
    outputs:
      matrix: ${{ steps.set-matrix.outputs.matrix }}
    steps:
      - id: set-matrix
        run: echo 'matrix=["afile","another file"]' >> $GITHUB_OUTPUT

  job2:
    needs: job1
    runs-on: ubuntu-latest
    strategy:
      matrix:
        manifest: ${{ fromJSON(needs.job1.outputs.matrix) }}
    steps:
      - name: Process manifest ${{ matrix.manifest }}
        run: echo "matrix.manifest = ${{ matrix.manifest }}"
```

After this PR: `job1` runs once, then `job2 (afile)` and
`job2 (another file)` are dispatched and run independently.

### B. Cartesian product across two upstream jobs

```yaml
jobs:
  list-versions:
    runs-on: ubuntu-latest
    outputs:
      versions: ${{ steps.set.outputs.versions }}
    steps:
      - id: set
        run: echo 'versions=["1.0","2.0"]' >> $GITHUB_OUTPUT

  list-targets:
    runs-on: ubuntu-latest
    outputs:
      targets: ${{ steps.set.outputs.targets }}
    steps:
      - id: set
        run: echo 'targets=["linux","darwin"]' >> $GITHUB_OUTPUT

  build:
    needs: [list-versions, list-targets]
    runs-on: ubuntu-latest
    strategy:
      matrix:
        version: ${{ fromJSON(needs.list-versions.outputs.versions) }}
        target:  ${{ fromJSON(needs.list-targets.outputs.targets) }}
    steps:
      - name: Build ${{ matrix.version }} for ${{ matrix.target }}
        run: echo "Building ${{ matrix.version }} for ${{ matrix.target }}"
```

Produces 4 iterations: `build (darwin, 1.0)`, `build (darwin, 2.0)`,
`build (linux, 1.0)`, `build (linux, 2.0)`.

### C. Driven by a local composite action

The values feeding the matrix can come from any `outputs:` source,
including a local composite action that talks to an external API:

`.gitea/actions/bun-versions/action.yml`:

```yaml
name: 'Latest bun-alpine versions'
description: 'Fetches the N most recent semver bun-alpine tags from Docker Hub'
inputs:
  count:
    required: false
    default: '5'
outputs:
  versions:
    description: 'JSON array of bun version tags (e.g. ["1.3.9","1.3.8",...])'
    value: ${{ steps.fetch.outputs.versions }}
runs:
  using: 'composite'
  steps:
    - id: fetch
      shell: bash
      env:
        COUNT: ${{ inputs.count }}
      run: |
        set -eu
        curl -fsSL --retry 3 -m 30 \
          "https://hub.docker.com/v2/repositories/oven/bun/tags/?page_size=100&ordering=last_updated" \
          -o /tmp/tags.json
        out=$(TAGS_JSON_FILE=/tmp/tags.json python3 <<'PY'
        import json, os, re
        with open(os.environ['TAGS_JSON_FILE']) as fh:
            data = json.load(fh)
        pat = re.compile(r'^(\d+)\.(\d+)\.(\d+)-alpine$')
        seen, versions = set(), []
        for r in data.get('results', []):
            m = pat.match(r['name'])
            if not m: continue
            v = tuple(int(x) for x in m.groups())
            if v in seen: continue
            seen.add(v); versions.append(v)
        versions.sort(reverse=True)
        count = int(os.environ.get('COUNT', '5'))
        top = ['.'.join(str(p) for p in v) for v in versions[:count]]
        print('versions=' + json.dumps(top))
        PY
        )
        echo "$out" >> "$GITHUB_OUTPUT"
```

`.gitea/workflows/bun-test.yml` (the consumer):

```yaml
name: bun test on last 5 alpine versions
on:
  push:
  workflow_dispatch:

jobs:
  detect:
    runs-on: ubuntu-latest
    outputs:
      versions: ${{ steps.bun.outputs.versions }}
    steps:
      - uses: actions/checkout@v4
      - id: bun
        uses: ./.gitea/actions/bun-versions
        with:
          count: '5'

  test:
    needs: detect
    runs-on: ubuntu-latest
    container: oven/bun:${{ matrix.bun_version }}-alpine
    strategy:
      fail-fast: false
      matrix:
        bun_version: ${{ fromJSON(needs.detect.outputs.versions) }}
    steps:
      - run: bun --version
      - name: Run bun test on ${{ matrix.bun_version }}
        shell: sh
        run: |
          cat > hello.test.ts <<'TS'
          import { test, expect } from 'bun:test';
          test('it works', () => { expect(2+2).toBe(4); });
          TS
          bun test
```

The composite action's `outputs:` and the consuming workflow's matrix
expression flow through the same deferred-evaluation path — the composite
action is just sugar over a step output as far as matrix expansion is
concerned.

## Testing

### Backend (Go)

```bash
# jobparser: needs.outputs detector, placeholder emission,
# ExpandDeferredMatrix happy path + single-job constraint,
# step-name interpolation for static AND dynamic matrices.
go test ./modules/actions/jobparser/

# Migration v335 — new RawMatrix / MatrixValues columns
go test ./models/migrations/v1_27/

# Batch insert of expanded children
go test -run TestInsertActionRunJobs ./models/actions/

# Matrix cache (key determinism, put/get freshness, expiry)
# + metric primitives (counter outcome labels, jobs counter only on success)
go test ./services/actions/

# Full integration: workflow with dynamic matrix, mock runner, asserts
# placeholder is deleted, two expanded children land with matching
# MatrixValues, task.Needs[job1].Outputs is populated for each child,
# no leftover rows.
make test-integration#TestDynamicMatrix
```

### Frontend (Vitest)

```bash
pnpm exec vitest run web_src/js/components/RepoActionView.test.ts
```

Covers `groupJobsByMatrix`, `aggregateIterationStatus`,
`isMatrixGroupExpanded` (incl. the auto-expand rule for the selected
job), and `toggleCollapsedMatrixGroup`.

### Linters

```bash
make lint-go
make lint-js
```

All green on this branch.

## Backward compatibility

- Existing workflows without a dynamic matrix continue to work
  unchanged. The new model fields (`RawMatrix`, `MatrixValues`) default
  to empty / NULL.
- Static-matrix expansion is unchanged at the data layer; only the
  step-name display changes (now interpolated, matching GitHub).
- Migration `v335` is additive (two nullable columns on
  `action_run_job`); pattern mirrors `v328`
  (`AddTokenPermissionsToActionRunJob`).
- No runner protocol changes — the existing `task.Needs[<id>].Outputs`
  contract carries the upstream outputs to each iteration.

## Checklist

- [x] Database migration added and tested
- [x] Workflow parsing implemented (deferred-matrix detection + expansion)
- [x] Backend unit + integration tests passing
- [x] Frontend unit tests (Vitest) passing
- [x] `make lint-go` clean
- [x] `make lint-js` clean
- [x] Backwards compatible — no breaking changes
- [x] The PR contains AI-generated lines of code

## Reviewer notes

- The deferred-expansion path lives in
  `services/actions/job_emitter.go:expandDeferredMatrixPlaceholders`. It
  runs inside the same `db.WithTx` as the resolver, so newly inserted
  child rows are visible atomically; the placeholder is deleted in the
  same transaction.
- Step-name interpolation copies the `Steps` slice before mutating to
  avoid bleed between cloned iterations (`Job.Clone` shares the backing
  array — the test
  `TestParseStaticMatrixInterpolatesStepNames` documents this).
- Matrix re-evaluation reuses the existing
  `modules/actions/jobparser/interpeter.go` evaluator — the server now
  passes a populated `results` map; the runner-side evaluator is
  unchanged.
- The cache and metrics modules are additive; if either is undesired
  they can be reverted independently from the four feature commits.
