### PR TITLE
fix: default sqlite journal mode to WAL

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -384,7 +384,7 @@ USER = root
 ;DB_TYPE = sqlite3
 ;PATH= ; defaults to data/gitea.db
 ;SQLITE_TIMEOUT = ; Query timeout in milliseconds, defaults to: 20000
-;SQLITE_JOURNAL_MODE = ; defaults to sqlite database default (often DELETE), can be used to enable WAL mode. https://www.sqlite.org/pragma.html#pragma_journal_mode
+;SQLITE_JOURNAL_MODE = WAL ; defaults to WAL; set to DELETE for single-file backups or NFS-hosted databases. https://www.sqlite.org/pragma.html#pragma_journal_mode
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;

--- a/modules/setting/database.go
+++ b/modules/setting/database.go
@@ -72,7 +72,7 @@ func loadDBSetting(rootCfg ConfigProvider) {
 	if Database.SQLiteBusyTimeout < 5000 {
 		Database.SQLiteBusyTimeout = defaultSQLiteBusyTimeout
 	}
-	Database.SQLiteJournalMode = sec.Key("SQLITE_JOURNAL_MODE").MustString("")
+	Database.SQLiteJournalMode = sec.Key("SQLITE_JOURNAL_MODE").MustString("WAL")
 
 	Database.MaxIdleConns = sec.Key("MAX_IDLE_CONNS").MustInt(2)
 	if Database.Type.IsMySQL() {

--- a/tests/integration/api_issue_test.go
+++ b/tests/integration/api_issue_test.go
@@ -149,17 +149,6 @@ func testAPICreateIssue(t *testing.T) {
 }
 
 func testAPICreateIssueParallel(t *testing.T) {
-	// HINT: There seems to be a bug in github.com/mattn/go-sqlite3 with sqlite_unlock_notify, when doing concurrent writes to the same database,
-	// some requests may get stuck in "go-sqlite3.(*SQLiteRows).Next", "go-sqlite3.(*SQLiteStmt).exec" and "go-sqlite3.unlock_notify_wait",
-	// because the "unlock_notify_wait" never returns and the internal lock never gets released.
-	//
-	// The trigger is: a previous test created issues and made the real issue indexer queue start processing, then this test does concurrent writing.
-	// Adding this "Sleep" makes go-sqlite3 "finish" some internal operations before concurrent writes and then won't get stuck.
-	// To reproduce: make a new test run these 2 tests enough times:
-	// > func testBug() { for i := 0; i < 100; i++ { testAPICreateIssue(t); testAPICreateIssueParallel(t) } }
-	// Usually the test gets stuck in fewer than 10 iterations without this "sleep".
-	time.Sleep(100 * time.Millisecond)
-
 	const body, title = "apiTestBody", "apiTestTitle"
 
 	repoBefore := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
@@ -173,6 +162,7 @@ func testAPICreateIssueParallel(t *testing.T) {
 	for i := range 10 {
 		wg.Add(1)
 		go func(parentT *testing.T, i int) {
+			defer wg.Done() // outside subtest so t.FailNow can't skip it
 			parentT.Run(fmt.Sprintf("ParallelCreateIssue_%d", i), func(t *testing.T) {
 				newTitle := title + strconv.Itoa(i)
 				newBody := body + strconv.Itoa(i)
@@ -192,8 +182,6 @@ func testAPICreateIssueParallel(t *testing.T) {
 					Content:    newBody,
 					Title:      newTitle,
 				})
-
-				wg.Done()
 			})
 		}(t, i)
 	}


### PR DESCRIPTION
DELETE journal mode serializes readers against writers on the same file. Concurrent issue creation plus the async indexer reading in the background can exceed the 5s busy timeout and return `SQLITE_BUSY`. WAL lets readers and one writer coexist.

Also fix `testAPICreateIssueParallel`: `wg.Done()` lived inside the subtest, so a `t.FailNow` skipped it and hung `wg.Wait` until the job timeout (the symptom in https://github.com/go-gitea/gitea/actions/runs/26009967009/job/76448592797). Move it to a `defer` on the outer goroutine. The obsolete 100ms sleep workaround for the old mattn `unlock_notify` bug is removed — modernc isn't affected.

### Drawbacks of WAL as default for existing installs

- backups via `cp gitea.db` need to include `-wal`/`-shm` or use `sqlite3 .backup`
- WAL needs `mmap`, so NFS/SMB-hosted DBs are unsupported
- once opened in WAL the DB persists in WAL; rollback needs `PRAGMA journal_mode=DELETE`

The example config notes when to opt back to DELETE.

---
This PR was written with the help of Claude Opus 4.7