### PR TITLE
ci(giteabot): drop pull_request_review trigger

### DIFF
--- a/.github/workflows/giteabot.yml
+++ b/.github/workflows/giteabot.yml
@@ -10,7 +10,6 @@ on:
   pull_request_target: # zizmor: ignore[dangerous-triggers]
     types:
       - opened
-      - synchronize
       - labeled
       - unlabeled
       - closed

--- a/.github/workflows/giteabot.yml
+++ b/.github/workflows/giteabot.yml
@@ -14,13 +14,6 @@ on:
       - labeled
       - unlabeled
       - closed
-      - review_requested
-      - review_request_removed
-  pull_request_review:
-    types:
-      - submitted
-      - edited
-      - dismissed
   schedule:
     - cron: "15 3 * * *"
   workflow_dispatch:
@@ -29,7 +22,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ format('{0}-{1}', github.workflow, (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review') && format('pr-{0}', github.event.pull_request.number) || 'maintenance') }}
+  group: ${{ format('{0}-{1}', github.workflow, github.event_name == 'pull_request_target' && format('pr-{0}', github.event.pull_request.number) || 'maintenance') }}
   cancel-in-progress: false
 
 jobs:

--- a/docs/community-governance.md
+++ b/docs/community-governance.md
@@ -16,7 +16,7 @@ Almost all labels used inside Gitea can be classified as one of the following:
 - `modifies/…`: Determines which parts of the codebase are affected. These labels will be set through the CI.
 - `topic/…`:  Determines the conceptual component of Gitea that is affected, i.e. issues, projects, or authentication. At best, PRs should only target one component but there might be overlap. Must be set manually.
 - `type/…`: Determines the type of an issue or PR (feature, refactoring, docs, bug, …). If GitHub supported scoped labels, these labels would be exclusive, so you should set **exactly** one, not more or less (every PR should fall into one of the provided categories, and only one).
-- `issue/…` / `lgtm/…`: Labels that are specific to issues or PRs respectively and that are only necessary in a given context, i.e. `issue/not-a-bug` or `lgtm/need 2`
+- `issue/…`: Labels that are specific to issues and that are only necessary in a given context, i.e. `issue/not-a-bug`
 
 Every PR should be labeled correctly with every label that applies.
 
@@ -42,9 +42,9 @@ Maintainers are encouraged to review pull requests in areas where they have expe
 
 Changes to Gitea must be reviewed before they are accepted, including changes from owners and maintainers. The exception is critical bugs that prevent Gitea from compiling or starting.
 
-We require two maintainer approvals for every PR. When that is satisfied, your PR gets the `lgtm/done` label. After that, you mainly fix merge conflicts and respond to or implement maintainer requests; maintainers drive getting the PR merged.
+We require two maintainer approvals for every PR (enforced by GitHub's branch protection). After that is satisfied you mainly fix merge conflicts and respond to or implement maintainer requests; maintainers drive getting the PR merged.
 
-If a PR has `lgtm/done`, no open discussions, and no merge conflicts, any maintainer may add `reviewed/wait-merge`. That puts the PR in the merge queue. PRs are merged from the queue in the order of this list:
+Once a PR has the required approvals, no open discussions, and no merge conflicts, any maintainer may add `reviewed/wait-merge`. That puts the PR in the merge queue. PRs are merged from the queue in the order of this list:
 
 <https://github.com/go-gitea/gitea/pulls?q=is%3Apr+label%3Areviewed%2Fwait-merge+sort%3Acreated-asc+is%3Aopen>
 


### PR DESCRIPTION
Fork-PR `pull_request_review` events run without secrets ([fork-secret policy](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_review)), so the bot exits 1 and `giteabot/lgtm` never refreshes. Drop the `pull_request_review` trigger and the review-related `pull_request_target` types that only fed LGTM tracking; merge gating moves to native `required_pull_request_reviews`. Companion change: https://github.com/go-gitea/giteabot/pull/4.

**Merge sequence** (no window where the bot still emits `giteabot/lgtm` while the check is still required):

1. Merge https://github.com/go-gitea/giteabot/pull/4 and cut a new tag.
2. Update branch protection on `main`: add `required_pull_request_reviews.required_approving_review_count: 2`, drop `giteabot/lgtm` from required checks (Settings → Branches).
3. Optionally enable native auto-merge: Settings → General → "Allow auto-merge". Reduces reliance on the bot's `reviewed/wait-merge` queue for the common case.
4. Bump the pinned action SHA here, then merge.
5. Delete the `lgtm/need 2`, `lgtm/need 1`, `lgtm/done`, `lgtm/blocked` labels (Issues → Labels).

Replacement for `label:lgtm/blocked` is [`review:changes_requested`](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests#search-by-review-status); the count-distinguishing labels have no exact native equivalent but the merge gate enforces the count anyway.

---
This PR was written with the help of Claude Opus 4.7