### PR TITLE
feat: add data-lexer-name attribute to file-info-entry

### DIFF
--- a/templates/repo/file_info.tmpl
+++ b/templates/repo/file_info.tmpl
@@ -21,7 +21,7 @@
 		</div>
 	{{end}}
 	{{if .LexerName}}
-		<div class="file-info-entry">
+		<div class="file-info-entry" data-lexer-name="{{.LexerName}}">
 			{{.LexerName}}
 		</div>
 	{{end}}


### PR DESCRIPTION
This makes it easy to customize syntax highlighting.
e.g., in templates/custom/header.tmpl.

```bash
/* Lexer name: Go */
:root:has(.file-info-entry[data-lexer-name="Go"]) {
  /* Add custom syntax highlighting */
}
```
