### PR TITLE
ci: tweak `files-changed`, add `free-disk-space`

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,9 @@
+name: free-disk-space
+description: Free space on / before large cache restores
+
+# Delete preinstalled toolchains which gitea doesn't use
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: sudo rm -rf /usr/local/lib/android /usr/local/.ghcup /opt/ghc /usr/share/dotnet

--- a/.github/actions/go-setup/action.yml
+++ b/.github/actions/go-setup/action.yml
@@ -12,6 +12,7 @@ inputs:
 runs:
   using: composite
   steps:
+    - uses: ./.github/actions/free-disk-space
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod

--- a/.github/workflows/files-changed.yml
+++ b/.github/workflows/files-changed.yml
@@ -69,6 +69,8 @@ jobs:
               - "*.ts"
               - "web_src/**"
               - "tools/generate-svg.ts"
+              - "tools/generate-svg-vscode-extensions.json"
+              - "tsconfig.json"
               - "assets/emoji.json"
               - "package.json"
               - "pnpm-lock.yaml"
@@ -88,13 +90,14 @@ jobs:
               - "Makefile"
 
             templates:
-              - "tools/lint-templates-*.js"
+              - "tools/lint-templates-*.ts"
               - "templates/**/*.tmpl"
               - "pyproject.toml"
               - "uv.lock"
 
             docker:
               - ".github/workflows/pull-docker-dryrun.yml"
+              - ".github/actions/docker-dryrun/**"
               - "Dockerfile"
               - "Dockerfile.rootless"
               - "docker/**"
@@ -122,6 +125,7 @@ jobs:
             json:
               - "**/*.json"
               - "**/*.json5"
+              - "eslint.json.config.ts"
 
             e2e:
               - "tests/e2e/**"

--- a/.github/workflows/pull-db-tests.yml
+++ b/.github/workflows/pull-db-tests.yml
@@ -85,7 +85,6 @@ jobs:
           shard: 2
           total-shards: 2
 
-  # sqlite doubles as the smoke test when CI workflows or actions change
   test-sqlite:
     if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
     needs: files-changed

--- a/.github/workflows/pull-db-tests.yml
+++ b/.github/workflows/pull-db-tests.yml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/files-changed.yml
 
   test-pgsql-shard-1:
-    if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
+    if: needs.files-changed.outputs.backend == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
     timeout-minutes: 50
@@ -51,7 +51,7 @@ jobs:
           run-migration: "true"
 
   test-pgsql-shard-2:
-    if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
+    if: needs.files-changed.outputs.backend == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
     timeout-minutes: 50
@@ -85,6 +85,7 @@ jobs:
           shard: 2
           total-shards: 2
 
+  # sqlite doubles as the smoke test when CI workflows or actions change
   test-sqlite:
     if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
     needs: files-changed
@@ -110,7 +111,7 @@ jobs:
           GOEXPERIMENT:
 
   test-unit:
-    if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
+    if: needs.files-changed.outputs.backend == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
     services:
@@ -174,7 +175,7 @@ jobs:
       - run: make test-check
 
   test-mysql:
-    if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
+    if: needs.files-changed.outputs.backend == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
     services:
@@ -220,7 +221,7 @@ jobs:
           TEST_INDEXER_CODE_ES_URL: "http://elastic:changeme@elasticsearch:9200"
 
   test-mssql:
-    if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
+    if: needs.files-changed.outputs.backend == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
     services:


### PR DESCRIPTION
Reduces CI minutes consumption by narrowing the `files-changed` filters.

- DB matrix (`pgsql`/`mysql`/`mssql`/`unit`) now runs only on real backend changes. `test-sqlite` stays gated on `actions`, so it remains the smoke check that validates CI-infra changes (composite-action edits, workflow edits, renovate action-pin bumps) without spinning up the full matrix.
- Fix the `templates` filter: the SVG template linter is `tools/lint-templates-svg.ts`, so the `tools/lint-templates-*.js` glob matched nothing.
- Add missed paths: `tsconfig.json` and `tools/generate-svg-vscode-extensions.json` to `frontend`, `eslint.json.config.ts` to `json`, and `.github/actions/docker-dryrun/**` to `docker`.

---
This PR was written with the help of Claude Opus 4.7