### PR TITLE
feat(actions): add before/after to PR synchronize event payload

### DIFF
--- a/modules/structs/hook.go
+++ b/modules/structs/hook.go
@@ -434,6 +434,10 @@ type ChangesPayload struct {
 type PullRequestPayload struct {
 	// The action performed on the pull request
 	Action HookIssueAction `json:"action"`
+	// The SHA of the most recent commit on the PR head branch before the push
+	Before string `json:"before,omitempty"`
+	// The SHA of the most recent commit on the PR head branch after the push
+	After string `json:"after,omitempty"`
 	// The index number of the pull request
 	Index int64 `json:"number"`
 	// Changes made to the pull request (for edit actions)

--- a/modules/structs/hook_test.go
+++ b/modules/structs/hook_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package structs
+
+import (
+	"testing"
+
+	"code.gitea.io/gitea/modules/json"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPullRequestPayloadSynchronizeBeforeAfter(t *testing.T) {
+	payload := &PullRequestPayload{
+		Action: HookIssueSynchronized,
+		Before: "1111111111111111111111111111111111111111",
+		After:  "2222222222222222222222222222222222222222",
+		Index:  12,
+	}
+
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, "synchronized", got["action"])
+	assert.Equal(t, "1111111111111111111111111111111111111111", got["before"])
+	assert.Equal(t, "2222222222222222222222222222222222222222", got["after"])
+	assert.EqualValues(t, 12, got["number"])
+}
+
+func TestPullRequestPayloadNonSynchronizeOmitsBeforeAfter(t *testing.T) {
+	payload := &PullRequestPayload{
+		Action: HookIssueOpened,
+		Index:  12,
+	}
+
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, "opened", got["action"])
+	assert.NotContains(t, got, "before")
+	assert.NotContains(t, got, "after")
+}

--- a/modules/structs/hook_test.go
+++ b/modules/structs/hook_test.go
@@ -23,12 +23,18 @@ func TestPullRequestPayloadSynchronizeBeforeAfter(t *testing.T) {
 	data, err := json.Marshal(payload)
 	require.NoError(t, err)
 
-	var got map[string]any
-	require.NoError(t, json.Unmarshal(data, &got))
-	assert.Equal(t, "synchronized", got["action"])
-	assert.Equal(t, "1111111111111111111111111111111111111111", got["before"])
-	assert.Equal(t, "2222222222222222222222222222222222222222", got["after"])
-	assert.EqualValues(t, 12, got["number"])
+	assert.JSONEq(t, `{
+		"action": "synchronized",
+		"before": "1111111111111111111111111111111111111111",
+		"after": "2222222222222222222222222222222222222222",
+		"number": 12,
+		"commit_id": "",
+		"pull_request": null,
+		"repository": null,
+		"requested_reviewer": null,
+		"review": null,
+		"sender": null
+	}`, string(data))
 }
 
 func TestPullRequestPayloadNonSynchronizeOmitsBeforeAfter(t *testing.T) {
@@ -40,9 +46,14 @@ func TestPullRequestPayloadNonSynchronizeOmitsBeforeAfter(t *testing.T) {
 	data, err := json.Marshal(payload)
 	require.NoError(t, err)
 
-	var got map[string]any
-	require.NoError(t, json.Unmarshal(data, &got))
-	assert.Equal(t, "opened", got["action"])
-	assert.NotContains(t, got, "before")
-	assert.NotContains(t, got, "after")
+	assert.JSONEq(t, `{
+		"action": "opened",
+		"number": 12,
+		"commit_id": "",
+		"pull_request": null,
+		"repository": null,
+		"requested_reviewer": null,
+		"review": null,
+		"sender": null
+	}`, string(data))
 }

--- a/services/actions/notifier.go
+++ b/services/actions/notifier.go
@@ -687,7 +687,7 @@ func (n *actionsNotifier) AutoMergePullRequest(ctx context.Context, doer *user_m
 	n.MergePullRequest(ctx, doer, pr)
 }
 
-func (n *actionsNotifier) PullRequestSynchronized(ctx context.Context, doer *user_model.User, pr *issues_model.PullRequest) {
+func (n *actionsNotifier) PullRequestSynchronized(ctx context.Context, doer *user_model.User, pr *issues_model.PullRequest, before, after string) {
 	ctx = withMethod(ctx, "PullRequestSynchronized")
 
 	if err := pr.LoadIssue(ctx); err != nil {
@@ -703,6 +703,8 @@ func (n *actionsNotifier) PullRequestSynchronized(ctx context.Context, doer *use
 	newNotifyInput(pr.Issue.Repo, doer, webhook_module.HookEventPullRequestSync).
 		WithPayload(&api.PullRequestPayload{
 			Action:      api.HookIssueSynchronized,
+			Before:      before,
+			After:       after,
 			Index:       pr.Issue.Index,
 			PullRequest: convert.ToAPIPullRequest(ctx, pr, nil),
 			Repository:  convert.ToRepo(ctx, pr.Issue.Repo, access_model.Permission{AccessMode: perm_model.AccessModeNone}),

--- a/services/agit/agit.go
+++ b/services/agit/agit.go
@@ -286,7 +286,7 @@ func ProcReceive(ctx context.Context, repo *repo_model.Repository, gitRepo *git.
 		} else if commentCreated {
 			notify_service.PullRequestPushCommits(ctx, pusher, pr, comment)
 		}
-		notify_service.PullRequestSynchronized(ctx, pusher, pr)
+		notify_service.PullRequestSynchronized(ctx, pusher, pr, oldCommitID, opts.NewCommitIDs[i])
 
 		results = append(results, private.HookProcReceiveRefResult{
 			OldOID:            oldCommitID,

--- a/services/notify/notifier.go
+++ b/services/notify/notifier.go
@@ -45,7 +45,7 @@ type Notifier interface {
 	NewPullRequest(ctx context.Context, pr *issues_model.PullRequest, mentions []*user_model.User)
 	MergePullRequest(ctx context.Context, doer *user_model.User, pr *issues_model.PullRequest)
 	AutoMergePullRequest(ctx context.Context, doer *user_model.User, pr *issues_model.PullRequest)
-	PullRequestSynchronized(ctx context.Context, doer *user_model.User, pr *issues_model.PullRequest)
+	PullRequestSynchronized(ctx context.Context, doer *user_model.User, pr *issues_model.PullRequest, before, after string)
 	PullRequestReview(ctx context.Context, pr *issues_model.PullRequest, review *issues_model.Review, comment *issues_model.Comment, mentions []*user_model.User)
 	PullRequestCodeComment(ctx context.Context, pr *issues_model.PullRequest, comment *issues_model.Comment, mentions []*user_model.User)
 	PullRequestChangeTargetBranch(ctx context.Context, doer *user_model.User, pr *issues_model.PullRequest, oldBranch string)

--- a/services/notify/notify.go
+++ b/services/notify/notify.go
@@ -120,9 +120,9 @@ func NewPullRequest(ctx context.Context, pr *issues_model.PullRequest, mentions 
 }
 
 // PullRequestSynchronized notifies Synchronized pull request
-func PullRequestSynchronized(ctx context.Context, doer *user_model.User, pr *issues_model.PullRequest) {
+func PullRequestSynchronized(ctx context.Context, doer *user_model.User, pr *issues_model.PullRequest, before, after string) {
 	for _, notifier := range notifiers {
-		notifier.PullRequestSynchronized(ctx, doer, pr)
+		notifier.PullRequestSynchronized(ctx, doer, pr, before, after)
 	}
 }
 

--- a/services/notify/null.go
+++ b/services/notify/null.go
@@ -63,7 +63,7 @@ func (*NullNotifier) AutoMergePullRequest(ctx context.Context, doer *user_model.
 }
 
 // PullRequestSynchronized places a place holder function
-func (*NullNotifier) PullRequestSynchronized(ctx context.Context, doer *user_model.User, pr *issues_model.PullRequest) {
+func (*NullNotifier) PullRequestSynchronized(ctx context.Context, doer *user_model.User, pr *issues_model.PullRequest, before, after string) {
 }
 
 // PullRequestChangeTargetBranch places a place holder function

--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -479,7 +479,7 @@ func AddTestPullRequestTask(opts TestPullRequestOptions) {
 						}
 					}
 
-					notify_service.PullRequestSynchronized(ctx, opts.Doer, pr)
+					notify_service.PullRequestSynchronized(ctx, opts.Doer, pr, opts.OldCommitID, opts.NewCommitID)
 				}
 			}
 		}

--- a/services/webhook/notifier.go
+++ b/services/webhook/notifier.go
@@ -818,7 +818,7 @@ func (m *webhookNotifier) CreateRef(ctx context.Context, pusher *user_model.User
 	}
 }
 
-func (m *webhookNotifier) PullRequestSynchronized(ctx context.Context, doer *user_model.User, pr *issues_model.PullRequest) {
+func (m *webhookNotifier) PullRequestSynchronized(ctx context.Context, doer *user_model.User, pr *issues_model.PullRequest, before, after string) {
 	if err := pr.LoadIssue(ctx); err != nil {
 		log.Error("LoadIssue: %v", err)
 		return
@@ -830,6 +830,8 @@ func (m *webhookNotifier) PullRequestSynchronized(ctx context.Context, doer *use
 
 	if err := PrepareWebhooks(ctx, EventSource{Repository: pr.Issue.Repo}, webhook_module.HookEventPullRequestSync, &api.PullRequestPayload{
 		Action:      api.HookIssueSynchronized,
+		Before:      before,
+		After:       after,
 		Index:       pr.Issue.Index,
 		PullRequest: convert.ToAPIPullRequest(ctx, pr, doer),
 		Repository:  convert.ToRepo(ctx, pr.Issue.Repo, access_model.Permission{AccessMode: perm.AccessModeOwner}),


### PR DESCRIPTION
## Summary

- Add `before` and `after` fields to `PullRequestPayload` for `synchronize` events
- Thread push old/new commit SHAs through the PR synchronize notifier path (regular and Agit flows)
- Populate the fields in webhook and Actions event payloads so workflows can access them via `github.event.before` and `github.event.after`

Fixes #33395
