### PR TITLE
fix: update swagger CSS path to swagger-render.css (fixes #37830)

### DIFF
--- a/modules/public/manifest.go
+++ b/modules/public/manifest.go
@@ -13,6 +13,7 @@ import (
 	"gitea.dev/modules/json"
 	"gitea.dev/modules/log"
 	"gitea.dev/modules/setting"
+	"strings"
 )
 
 type manifestEntry struct {
@@ -62,6 +63,18 @@ func parseManifest(data []byte) (map[string]string, map[string]string) {
 			cssKey := path.Dir(css) + "/" + entry.Name + path.Ext(css)
 			paths[cssKey] = css
 			names[css] = entry.Name
+
+			// Also index CSS files by their actual source filename (stripping Vite content hash)
+			// so that templates referencing the true source path resolve correctly in production.
+			// e.g. "css/swagger-render.XXXX.css" also keyed as "css/swagger-render.css"
+			if lastDot := strings.LastIndex(css, "."); lastDot > 0 {
+				if prevDot := strings.LastIndex(css[:lastDot], "."); prevDot > 0 {
+					sourceKey := css[:prevDot] + path.Ext(css)
+					if _, exists := paths[sourceKey]; !exists {
+						paths[sourceKey] = css
+					}
+				}
+			}
 		}
 	}
 	return paths, names

--- a/templates/swagger/openapi-viewer.tmpl
+++ b/templates/swagger/openapi-viewer.tmpl
@@ -5,7 +5,7 @@
 		<title>Gitea API</title>
 		<link rel="stylesheet" href="{{ctx.CurrentWebTheme.PublicAssetURI}}">
 		{{/* HINT: SWAGGER-CSS-IMPORT: import swagger styles ahead to avoid UI flicker (e.g.: the swagger-back-link element) */}}
-		<link rel="stylesheet" href="{{AssetURI "css/swagger.css"}}">
+		<link rel="stylesheet" href="{{AssetURI "css/swagger-render.css"}}">
 	</head>
 	<body>
 		{{/* TODO: add Help & Glossary to help users understand the API, and explain some concepts like "Owner" */}}


### PR DESCRIPTION
This PR fixes issue #37830: `/api/swagger` returns HTTP 500 in dev mode.

## Root Cause

Commit `cf3f8e807a` (PR #37272) renamed `web_src/css/swagger.css` → `web_src/css/swagger-render.css`, but the template `templates/swagger/openapi-viewer.tmpl` was never updated — it still referenced the old path `css/swagger.css`.

In **dev mode**, `AssetURI("css/swagger.css")` → `viteDevSourceURL` tries to find `web_src/css/swagger.css` on disk → file not found → panic.

In **production**, the manifest parser happened to work because it synthesizes keys from the entry name (`swagger`) + `.css` → `paths["css/swagger.css"]` resolves to whatever CSS the swagger entry produces.

## Changes

### 1. `templates/swagger/openapi-viewer.tmpl`
Update the `<link>` href from `css/swagger.css` to `css/swagger-render.css` — the actual filename on disk. This fixes the dev-mode 500 error.

### 2. `modules/public/manifest.go`
The manifest parser only indexed CSS files by `entry.Name + ext` (e.g., `css/swagger.css`). When the source CSS file has a different name than the entry, the production manifest lookup would fail for the new path.

Now also index CSS by their **actual source filename** by stripping the Vite content hash from the output filename. E.g., `css/swagger-render.XXXX.css` → also keyed as `css/swagger-render.css`. This ensures production builds (including `TAGS=bindata`) resolve the correct hashed asset path when the template references the source filename.

@wxiaoguang this should address your concern about the bindata build.