### PR TITLE
ci: skip `giteabot` on bot-submitted PR reviews

### DIFF
--- a/.github/workflows/giteabot.yml
+++ b/.github/workflows/giteabot.yml
@@ -39,7 +39,7 @@ concurrency:
 
 jobs:
   giteabot:
-    if: github.repository == 'go-gitea/gitea'
+    if: github.repository == 'go-gitea/gitea' && github.event.review.user.type != 'Bot'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/giteabot.yml
+++ b/.github/workflows/giteabot.yml
@@ -39,6 +39,7 @@ concurrency:
 
 jobs:
   giteabot:
+    # skip on bot reviews because they never affect lgtm counting
     if: github.repository == 'go-gitea/gitea' && github.event.review.user.type != 'Bot'
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
`giteabot` triggers on `pull_request_review`, so a Copilot review fires the workflow. Bot reviews never affect lgtm counting, so should be skipped for this workflow. This fix gets rid of useless approval prompts after a bot review:

<img width="796" height="134" alt="image" src="https://github.com/user-attachments/assets/a1da55d7-b99a-4866-ac6e-79e77da60901" />

---
This PR was written with the help of Claude Opus 4.7