### PR TITLE
fix(actions): exclude `workflow_call` from workflow trigger detection

### DIFF
--- a/modules/actions/jobparser/model.go
+++ b/modules/actions/jobparser/model.go
@@ -298,6 +298,9 @@ func toGitContext(input map[string]any) *model.GithubContext {
 	return gitContext
 }
 
+// workflowCallEvent is only fired by another workflow's `uses:`, so it is excluded from trigger detection.
+const workflowCallEvent = "workflow_call"
+
 func ParseRawOn(rawOn *yaml.Node) ([]*Event, error) {
 	switch rawOn.Kind {
 	case yaml.ScalarNode:
@@ -305,6 +308,9 @@ func ParseRawOn(rawOn *yaml.Node) ([]*Event, error) {
 		err := rawOn.Decode(&val)
 		if err != nil {
 			return nil, err
+		}
+		if val == workflowCallEvent {
+			return []*Event{}, nil
 		}
 		return []*Event{
 			{Name: val},
@@ -319,6 +325,9 @@ func ParseRawOn(rawOn *yaml.Node) ([]*Event, error) {
 		for _, v := range val {
 			switch t := v.(type) {
 			case string:
+				if t == workflowCallEvent {
+					continue
+				}
 				res = append(res, &Event{Name: t})
 			default:
 				return nil, fmt.Errorf("invalid type %T", t)
@@ -332,8 +341,7 @@ func ParseRawOn(rawOn *yaml.Node) ([]*Event, error) {
 		}
 		res := make([]*Event, 0, len(events))
 		for i, k := range events {
-			if k == "workflow_call" {
-				// `workflow_call` is only fired by another workflow's `uses:`, so it doesn't need trigger detection here.
+			if k == workflowCallEvent {
 				continue
 			}
 			v := triggers[i]

--- a/modules/actions/jobparser/model.go
+++ b/modules/actions/jobparser/model.go
@@ -332,6 +332,10 @@ func ParseRawOn(rawOn *yaml.Node) ([]*Event, error) {
 		}
 		res := make([]*Event, 0, len(events))
 		for i, k := range events {
+			if k == "workflow_call" {
+				// `workflow_call` is only fired by another workflow's `uses:`, so it doesn't need trigger detection here.
+				continue
+			}
 			v := triggers[i]
 			switch v.Kind {
 			case yaml.ScalarNode:

--- a/modules/actions/jobparser/model_test.go
+++ b/modules/actions/jobparser/model_test.go
@@ -254,6 +254,40 @@ func TestParseRawOn(t *testing.T) {
 				},
 			},
 		},
+		{
+			// `workflow_call` is only fired by another workflow's `uses:`, so ParseRawOn intentionally excludes it from trigger detection.
+			input: `on:
+  workflow_call:
+    inputs:
+      env:
+        type: string
+        required: true
+    outputs:
+      sha:
+        value: ${{ jobs.build.outputs.commit }}
+    secrets:
+      DEPLOY_KEY:
+        required: true
+`,
+			result: []*Event{},
+		},
+		{
+			// Mixed: a workflow that is both callable AND triggered by push. Only the "push" event surfaces.
+			input: `on:
+  workflow_call:
+    inputs:
+      env:
+        type: string
+  push:
+    branches: [main]
+`,
+			result: []*Event{
+				{
+					Name: "push",
+					acts: map[string][]string{"branches": {"main"}},
+				},
+			},
+		},
 	}
 	for _, kase := range kases {
 		t.Run(kase.input, func(t *testing.T) {

--- a/modules/actions/jobparser/model_test.go
+++ b/modules/actions/jobparser/model_test.go
@@ -288,6 +288,19 @@ func TestParseRawOn(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Scalar form: a purely reusable workflow has no event triggers.
+			input:  "on: workflow_call",
+			result: []*Event{},
+		},
+		{
+			// Sequence form: `workflow_call` is excluded while sibling events are kept.
+			input: "on:\n  - push\n  - workflow_call\n  - pull_request",
+			result: []*Event{
+				{Name: "push"},
+				{Name: "pull_request"},
+			},
+		},
 	}
 	for _, kase := range kases {
 		t.Run(kase.input, func(t *testing.T) {


### PR DESCRIPTION
Gitea now only allows `workflow_dispatch.inputs`. If a workflow contains `workflow_call.inputs`, the workflow cannot be triggered, even though the `on:` section contains other trigger events.

https://github.com/go-gitea/gitea/blob/428ee9fcce7928bf5405900345d43e9ba1b01564/modules/actions/jobparser/model.go#L402-L405

For example, this workflow cannot be triggered due to `workflow_call.inputs`:
```yaml
on:
  push:
  pull_request:
  workflow_call:
    inputs:
      name:
        type: string
```

---

This PR is extracted from #37478 for backport