### PR TITLE
Fix #24635

### DIFF
--- a/models/actions/config.go
+++ b/models/actions/config.go
@@ -51,10 +51,8 @@ func (cfg *OwnerActionsConfig) GetDefaultTokenPermissions() repo_model.ActionsTo
 	switch cfg.TokenPermissionMode {
 	case repo_model.ActionsTokenPermissionModeRestricted:
 		return repo_model.MakeRestrictedPermissions()
-	case repo_model.ActionsTokenPermissionModePermissive:
-		return repo_model.MakeActionsTokenPermissions(perm.AccessModeWrite)
 	default:
-		return repo_model.MakeActionsTokenPermissions(perm.AccessModeNone)
+		return repo_model.MakeActionsTokenPermissions(perm.AccessModeWrite)
 	}
 }
 

--- a/models/actions/config_test.go
+++ b/models/actions/config_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package actions
+
+import (
+	"testing"
+
+	"gitea.dev/models/perm"
+	repo_model "gitea.dev/models/repo"
+	"gitea.dev/models/unit"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOwnerActionsConfigTokenPermissions(t *testing.T) {
+	t.Run("Zero Value Permission Mode", func(t *testing.T) {
+		cfg := &OwnerActionsConfig{}
+		assert.Equal(t, perm.AccessModeWrite, cfg.GetDefaultTokenPermissions().UnitAccessModes[unit.TypeCode])
+	})
+
+	t.Run("Restricted Permission Mode", func(t *testing.T) {
+		cfg := &OwnerActionsConfig{
+			TokenPermissionMode: repo_model.ActionsTokenPermissionModeRestricted,
+		}
+		defaultPerms := cfg.GetDefaultTokenPermissions()
+		assert.Equal(t, perm.AccessModeRead, defaultPerms.UnitAccessModes[unit.TypeCode])
+		assert.Equal(t, perm.AccessModeNone, defaultPerms.UnitAccessModes[unit.TypeIssues])
+		assert.Equal(t, perm.AccessModeRead, defaultPerms.UnitAccessModes[unit.TypePackages])
+	})
+}

--- a/models/repo/repo_unit_actions.go
+++ b/models/repo/repo_unit_actions.go
@@ -118,10 +118,8 @@ func (cfg *ActionsConfig) GetDefaultTokenPermissions() ActionsTokenPermissions {
 	switch cfg.TokenPermissionMode {
 	case ActionsTokenPermissionModeRestricted:
 		return MakeRestrictedPermissions()
-	case ActionsTokenPermissionModePermissive:
-		return MakeActionsTokenPermissions(perm.AccessModeWrite)
 	default:
-		return ActionsTokenPermissions{}
+		return MakeActionsTokenPermissions(perm.AccessModeWrite)
 	}
 }
 

--- a/models/repo/repo_unit_test.go
+++ b/models/repo/repo_unit_test.go
@@ -34,6 +34,11 @@ func TestActionsConfig(t *testing.T) {
 }
 
 func TestActionsConfigTokenPermissions(t *testing.T) {
+	t.Run("Zero Value Permission Mode", func(t *testing.T) {
+		cfg := &ActionsConfig{}
+		assert.Equal(t, perm.AccessModeWrite, cfg.GetDefaultTokenPermissions().UnitAccessModes[unit.TypeCode])
+	})
+
 	t.Run("Default Permission Mode", func(t *testing.T) {
 		cfg := &ActionsConfig{TokenPermissionMode: "invalid-value"}
 		_ = cfg.FromDB(nil)

--- a/routers/web/shared/actions/general.go
+++ b/routers/web/shared/actions/general.go
@@ -35,11 +35,11 @@ func ParseMaxTokenPermissions(ctx *context.Context) *repo_model.ActionsTokenPerm
 			return perm.AccessModeNone
 		}
 	}
-	ret := new(repo_model.MakeActionsTokenPermissions(perm.AccessModeNone))
+	ret := repo_model.MakeActionsTokenPermissions(perm.AccessModeNone)
 	for _, ut := range repo_model.ActionsTokenUnitTypes {
 		ret.UnitAccessModes[ut] = parseMaxPerm(ut)
 	}
-	return ret
+	return &ret
 }
 
 // GeneralSettings renders the actions general settings page

--- a/services/actions/permission_parser.go
+++ b/services/actions/permission_parser.go
@@ -13,6 +13,10 @@ import (
 	"go.yaml.in/yaml/v4"
 )
 
+func actionsTokenPermissionsPtr(perms repo_model.ActionsTokenPermissions) *repo_model.ActionsTokenPermissions {
+	return &perms
+}
+
 // ExtractJobPermissionsFromWorkflow extracts permissions from an already parsed workflow/job.
 // It returns nil if neither workflow nor job explicitly specifies permissions.
 func ExtractJobPermissionsFromWorkflow(flow *jobparser.SingleWorkflow, job *jobparser.Job) *repo_model.ActionsTokenPermissions {
@@ -61,12 +65,12 @@ func parseRawPermissionsExplicit(rawPerms *yaml.Node) *repo_model.ActionsTokenPe
 	if node.Kind == yaml.ScalarNode {
 		switch node.Value {
 		case "read-all":
-			return new(repo_model.MakeActionsTokenPermissions(perm.AccessModeRead))
+			return actionsTokenPermissionsPtr(repo_model.MakeActionsTokenPermissions(perm.AccessModeRead))
 		case "write-all":
-			return new(repo_model.MakeActionsTokenPermissions(perm.AccessModeWrite))
+			return actionsTokenPermissionsPtr(repo_model.MakeActionsTokenPermissions(perm.AccessModeWrite))
 		default:
 			// Explicit but unrecognized scalar: return all-none permissions.
-			return new(repo_model.MakeActionsTokenPermissions(perm.AccessModeNone))
+			return actionsTokenPermissionsPtr(repo_model.MakeActionsTokenPermissions(perm.AccessModeNone))
 		}
 	}
 

--- a/services/actions/permission_parser_test.go
+++ b/services/actions/permission_parser_test.go
@@ -16,6 +16,10 @@ import (
 	"go.yaml.in/yaml/v4"
 )
 
+func expectedActionsTokenPermissions(perms repo_model.ActionsTokenPermissions) *repo_model.ActionsTokenPermissions {
+	return &perms
+}
+
 func TestParseRawPermissions_ReadAll(t *testing.T) {
 	var rawPerms yaml.Node
 	err := yaml.Unmarshal([]byte(`read-all`), &rawPerms)
@@ -208,9 +212,9 @@ jobs:
 `
 
 	expectedPerms := map[string]*repo_model.ActionsTokenPermissions{}
-	expectedPerms["job-read-only"] = new(repo_model.MakeActionsTokenPermissions(perm.AccessModeRead))
-	expectedPerms["job-none-perms"] = new(repo_model.MakeActionsTokenPermissions(perm.AccessModeNone))
-	expectedPerms["job-override"] = new(repo_model.MakeActionsTokenPermissions(perm.AccessModeNone))
+	expectedPerms["job-read-only"] = expectedActionsTokenPermissions(repo_model.MakeActionsTokenPermissions(perm.AccessModeRead))
+	expectedPerms["job-none-perms"] = expectedActionsTokenPermissions(repo_model.MakeActionsTokenPermissions(perm.AccessModeNone))
+	expectedPerms["job-override"] = expectedActionsTokenPermissions(repo_model.MakeActionsTokenPermissions(perm.AccessModeNone))
 	expectedPerms["job-override"].UnitAccessModes[unit.TypeCode] = perm.AccessModeWrite
 	expectedPerms["job-override"].UnitAccessModes[unit.TypeReleases] = perm.AccessModeWrite
 


### PR DESCRIPTION
## Fix #24635\n\nImplemented the missing fixes for Actions automatic token permissions.\n\nChanged:\n- [models/actions/config.go](/tmp/bounty-gitea_24635-m7brumde/repo/models/actions/config.go:50): zero-value owner Actions config now defaults to permissive write, preserving backwards compatibility.\n- [models/repo/repo_unit_actions.go](/tmp/bounty-gitea_24635-m7brumde/repo/models/repo/repo_unit_actions.go:117): zero-value repo Actions config now also defaults to permissive write.\n- [services/actions/permission_parse\n\n---\n*Auto-generated bounty fix*