### PR TITLE
fix(actions): keep dependent blocked when a needed job is missing from snapshot

### DIFF
--- a/services/actions/job_emitter.go
+++ b/services/actions/job_emitter.go
@@ -278,11 +278,12 @@ func checkJobsOfCurrentRunAttempt(ctx context.Context, run *actions_model.Action
 }
 
 type jobStatusResolver struct {
-	statuses      map[int64]actions_model.Status
-	needs         map[int64][]int64
-	jobMap        map[int64]*actions_model.ActionRunJob
-	vars          map[string]string
-	cancelledJobs []*actions_model.ActionRunJob
+	statuses        map[int64]actions_model.Status
+	needs           map[int64][]int64
+	unresolvedNeeds map[int64][]string
+	jobMap          map[int64]*actions_model.ActionRunJob
+	vars            map[string]string
+	cancelledJobs   []*actions_model.ActionRunJob
 }
 
 func newJobStatusResolver(jobs actions_model.ActionJobList, vars map[string]string) *jobStatusResolver {
@@ -295,19 +296,30 @@ func newJobStatusResolver(jobs actions_model.ActionJobList, vars map[string]stri
 
 	statuses := make(map[int64]actions_model.Status, len(jobs))
 	needs := make(map[int64][]int64, len(jobs))
+	unresolvedNeeds := make(map[int64][]string)
 	for _, job := range jobs {
 		statuses[job.ID] = job.Status
 		for _, need := range job.Needs {
-			for _, v := range idToJobs[need] {
+			siblings := idToJobs[need]
+			if len(siblings) == 0 {
+				// A "needs" entry references a job that isn't in the current
+				// snapshot. Treating this as "no dependency" would silently
+				// promote the dependent out of Blocked. Track it so
+				// resolveCheckNeeds can keep the dependent blocked instead.
+				unresolvedNeeds[job.ID] = append(unresolvedNeeds[job.ID], need)
+				continue
+			}
+			for _, v := range siblings {
 				needs[job.ID] = append(needs[job.ID], v.ID)
 			}
 		}
 	}
 	return &jobStatusResolver{
-		statuses: statuses,
-		needs:    needs,
-		jobMap:   jobMap,
-		vars:     vars,
+		statuses:        statuses,
+		needs:           needs,
+		unresolvedNeeds: unresolvedNeeds,
+		jobMap:          jobMap,
+		vars:            vars,
 	}
 }
 
@@ -328,6 +340,13 @@ func (r *jobStatusResolver) Resolve(ctx context.Context) map[int64]actions_model
 
 func (r *jobStatusResolver) resolveCheckNeeds(id int64) (allDone, allSucceed bool) {
 	allDone, allSucceed = true, true
+	if missing, ok := r.unresolvedNeeds[id]; ok {
+		// A referenced need isn't present in the snapshot. Fail closed: keep
+		// the dependent Blocked. Otherwise an empty r.needs[id] would slip
+		// through as allDone=true and unblock the job.
+		log.Error("job %d cannot be resolved: needs %v not found in run snapshot; keeping job blocked", id, missing)
+		return false, false
+	}
 	for _, need := range r.needs[id] {
 		needStatus := r.statuses[need]
 		if !needStatus.IsDone() {

--- a/services/actions/job_emitter_test.go
+++ b/services/actions/job_emitter_test.go
@@ -111,6 +111,136 @@ jobs:
 			want: map[int64]actions_model.Status{2: actions_model.StatusWaiting},
 		},
 		{
+			// Regression: if a job listed in Needs is missing from the
+			// snapshot, the resolver must keep the dependent Blocked rather
+			// than silently treat the missing need as satisfied.
+			name: "needed job missing from snapshot keeps dependent blocked",
+			jobs: actions_model.ActionJobList{
+				{ID: 1, JobID: "A", Status: actions_model.StatusSuccess, Needs: []string{}},
+				{ID: 2, JobID: "B", Status: actions_model.StatusSuccess, Needs: []string{}},
+				// "C" intentionally absent from the list
+				{ID: 4, JobID: "Deploy", Status: actions_model.StatusBlocked, Needs: []string{"A", "B", "C"}},
+			},
+			want: map[int64]actions_model.Status{},
+		},
+		{
+			// Same scenario, but C is present and still running. Deploy must
+			// remain Blocked. This is the expected, correct behavior.
+			name: "needed job still running keeps dependent blocked",
+			jobs: actions_model.ActionJobList{
+				{ID: 1, JobID: "A", Status: actions_model.StatusSuccess, Needs: []string{}},
+				{ID: 2, JobID: "B", Status: actions_model.StatusSuccess, Needs: []string{}},
+				{ID: 3, JobID: "C", Status: actions_model.StatusRunning, Needs: []string{}},
+				{ID: 4, JobID: "Deploy", Status: actions_model.StatusBlocked, Needs: []string{"A", "B", "C"}},
+			},
+			want: map[int64]actions_model.Status{},
+		},
+		{
+			// Matrix-expanded C: two rows share JobID="C". One finished, one
+			// still running. Deploy must remain Blocked.
+			name: "matrix need partially running keeps dependent blocked",
+			jobs: actions_model.ActionJobList{
+				{ID: 1, JobID: "A", Status: actions_model.StatusSuccess, Needs: []string{}},
+				{ID: 2, JobID: "B", Status: actions_model.StatusSuccess, Needs: []string{}},
+				{ID: 3, JobID: "C", Name: "C (x)", Status: actions_model.StatusSuccess, Needs: []string{}},
+				{ID: 4, JobID: "C", Name: "C (y)", Status: actions_model.StatusRunning, Needs: []string{}},
+				{ID: 5, JobID: "Deploy", Status: actions_model.StatusBlocked, Needs: []string{"A", "B", "C"}},
+			},
+			want: map[int64]actions_model.Status{},
+		},
+		{
+			// Matrix where one matrix child of C has been Cancelled (e.g. by
+			// concurrency cancel-in-progress from another run) while the other
+			// is still Running. Deploy must remain Blocked because the second
+			// matrix row hasn't finished.
+			name: "matrix need with one cancelled one running keeps dependent blocked",
+			jobs: actions_model.ActionJobList{
+				{ID: 1, JobID: "A", Status: actions_model.StatusSuccess, Needs: []string{}},
+				{ID: 2, JobID: "B", Status: actions_model.StatusSuccess, Needs: []string{}},
+				{ID: 3, JobID: "C", Name: "C (x)", Status: actions_model.StatusCancelled, Needs: []string{}},
+				{ID: 4, JobID: "C", Name: "C (y)", Status: actions_model.StatusRunning, Needs: []string{}},
+				{ID: 5, JobID: "Deploy", Status: actions_model.StatusBlocked, Needs: []string{"A", "B", "C"}},
+			},
+			want: map[int64]actions_model.Status{},
+		},
+		{
+			// All matrix children of C have terminated: one Cancelled, one
+			// Success. Without an `if:` on Deploy, it should be Skipped.
+			name: "matrix need all done but partially cancelled skips dependent",
+			jobs: actions_model.ActionJobList{
+				{ID: 1, JobID: "A", Status: actions_model.StatusSuccess, Needs: []string{}},
+				{ID: 2, JobID: "B", Status: actions_model.StatusSuccess, Needs: []string{}},
+				{ID: 3, JobID: "C", Name: "C (x)", Status: actions_model.StatusCancelled, Needs: []string{}},
+				{ID: 4, JobID: "C", Name: "C (y)", Status: actions_model.StatusSuccess, Needs: []string{}},
+				{ID: 5, JobID: "Deploy", Status: actions_model.StatusBlocked, Needs: []string{"A", "B", "C"}},
+			},
+			want: map[int64]actions_model.Status{
+				5: actions_model.StatusSkipped,
+			},
+		},
+		{
+			// Even with `if: always()`, a missing need must not promote the
+			// dependent. The `if:` branch in resolve() is only reached when
+			// allDone=true; the unresolved-needs guard forces allDone=false
+			// before that check, so Deploy stays Blocked.
+			name: "needed job missing from snapshot keeps dependent blocked even with if: always()",
+			jobs: actions_model.ActionJobList{
+				{ID: 1, JobID: "A", Status: actions_model.StatusSuccess, Needs: []string{}},
+				{ID: 2, JobID: "B", Status: actions_model.StatusSuccess, Needs: []string{}},
+				// "C" intentionally absent
+				{ID: 4, JobID: "Deploy", Status: actions_model.StatusBlocked, Needs: []string{"A", "B", "C"}, WorkflowPayload: []byte(
+					`
+name: test
+on: push
+jobs:
+  Deploy:
+    runs-on: ubuntu-latest
+    needs: [A, B, C]
+    if: ${{ always() }}
+    steps:
+      - run: echo "must not run while C is unresolved"
+`)},
+			},
+			want: map[int64]actions_model.Status{},
+		},
+		{
+			// Same scenario but the missing need is only one of several; the
+			// `if:` clause must not let Deploy slip through.
+			name: "partial missing need with if: always() keeps dependent blocked",
+			jobs: actions_model.ActionJobList{
+				{ID: 1, JobID: "A", Status: actions_model.StatusFailure, Needs: []string{}},
+				{ID: 2, JobID: "B", Status: actions_model.StatusSuccess, Needs: []string{}},
+				// "C" intentionally absent
+				{ID: 4, JobID: "Deploy", Status: actions_model.StatusBlocked, Needs: []string{"A", "B", "C"}, WorkflowPayload: []byte(
+					`
+name: test
+on: push
+jobs:
+  Deploy:
+    runs-on: ubuntu-latest
+    needs: [A, B, C]
+    if: ${{ always() }}
+    steps:
+      - run: echo
+`)},
+			},
+			want: map[int64]actions_model.Status{},
+		},
+		{
+			// Matrix that expanded to zero rows (e.g. include/exclude removed
+			// every combination) means JobID="C" is entirely absent. The
+			// resolver must keep Deploy blocked rather than treat the missing
+			// need as satisfied.
+			name: "matrix expanded to zero rows keeps dependent blocked",
+			jobs: actions_model.ActionJobList{
+				{ID: 1, JobID: "A", Status: actions_model.StatusSuccess, Needs: []string{}},
+				{ID: 2, JobID: "B", Status: actions_model.StatusSuccess, Needs: []string{}},
+				// "C" rows entirely absent — matrix produced no entries.
+				{ID: 5, JobID: "Deploy", Status: actions_model.StatusBlocked, Needs: []string{"A", "B", "C"}},
+			},
+			want: map[int64]actions_model.Status{},
+		},
+		{
 			name: "`if` is empty and not all jobs in `needs` completed successfully",
 			jobs: actions_model.ActionJobList{
 				{ID: 1, JobID: "job1", Status: actions_model.StatusFailure, Needs: []string{}},


### PR DESCRIPTION
## Summary

The job status resolver in `services/actions/job_emitter.go` built its `needs` map from `idToJobs[need]`. If a `JobID` listed in a job's `Needs` had no matching row in the snapshot, the entry was silently dropped, and `resolveCheckNeeds` then iterated an empty slice and returned `allDone=true, allSucceed=true`. The dependent was promoted out of `Blocked` even though one of its declared dependencies wasn't accounted for at all.

## Symptom

In a workflow with shape `A, B, C, D, E, F → G` (with `C` and `D` matrix-expanded), `G` could transition to `Waiting` and start executing while one of its needs was still `Running`, because the resolver had no defense against a snapshot that didn't include every referenced need.

## Fix

- Track unresolved-need references explicitly in `jobStatusResolver` via a new `unresolvedNeeds` map.
- In `resolveCheckNeeds`, if a job has any unresolved need, return `allDone=false, allSucceed=false` (keep `Blocked`) and emit a `log.Error` naming the job ID and the missing needs.

Behavior changes:

- Before: a missing `Needs` entry was a silent no-op; the dependent could be promoted.
- After: the dependent stays `Blocked` and the next occurrence leaves a visible error log instead of a silent gate bypass.

This also closes a latent edge case where a matrix expanded to zero rows (e.g. all combinations excluded) would unblock anything that declared `needs:` against it.

The `if:` branch in `resolve()` is only reached after `allDone=true`, so clauses like `if: always()` no longer slip past a missing dependency either.