### PR TITLE
feat: allow disabling organization projects

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1294,6 +1294,8 @@ LEVEL = Info
 ;; Default templates for project boards
 ;PROJECT_BOARD_BASIC_KANBAN_TYPE = To Do, In Progress, Done
 ;PROJECT_BOARD_BUG_TRIAGE_TYPE = Needs Triage, High Priority, Low Priority, Closed
+;; Disable organization-level projects
+;DISABLE_ORGANIZATION_PROJECTS = false
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/models/project/project.go
+++ b/models/project/project.go
@@ -177,6 +177,9 @@ func (p *Project) CanBeAccessedByOwnerRepo(ownerID int64, repo *repo_model.Repos
 	if p.Type == TypeRepository {
 		return repo != nil && p.RepoID == repo.ID // if a project belongs to a repository, then its OwnerID is 0 and can be ignored
 	}
+	if p.Type == TypeOrganization && setting.Project.DisableOrganizationProjects {
+		return false
+	}
 	return p.OwnerID == ownerID && p.RepoID == 0
 }
 

--- a/models/project/project_test.go
+++ b/models/project/project_test.go
@@ -7,7 +7,10 @@ import (
 	"testing"
 
 	"gitea.dev/models/db"
+	repo_model "gitea.dev/models/repo"
 	"gitea.dev/models/unittest"
+	"gitea.dev/modules/setting"
+	"gitea.dev/modules/test"
 	"gitea.dev/modules/timeutil"
 
 	"github.com/stretchr/testify/assert"
@@ -29,6 +32,22 @@ func TestIsProjectTypeValid(t *testing.T) {
 	for _, v := range cases {
 		assert.Equal(t, v.valid, IsTypeValid(v.typ))
 	}
+}
+
+func TestProjectCanBeAccessedByOwnerRepoWithDisabledOrganizationProjects(t *testing.T) {
+	defer test.MockVariableValue(&setting.Project.DisableOrganizationProjects)()
+
+	orgProject := &Project{Type: TypeOrganization, OwnerID: 3}
+	repoProject := &Project{Type: TypeRepository, RepoID: 1}
+	repo := &repo_model.Repository{ID: 1}
+
+	setting.Project.DisableOrganizationProjects = false
+	assert.True(t, orgProject.CanBeAccessedByOwnerRepo(3, nil))
+	assert.True(t, repoProject.CanBeAccessedByOwnerRepo(3, repo))
+
+	setting.Project.DisableOrganizationProjects = true
+	assert.False(t, orgProject.CanBeAccessedByOwnerRepo(3, nil))
+	assert.True(t, repoProject.CanBeAccessedByOwnerRepo(3, repo))
 }
 
 func TestGetProjects(t *testing.T) {

--- a/modules/setting/project.go
+++ b/modules/setting/project.go
@@ -6,9 +6,11 @@ package setting
 // Project settings
 var (
 	Project = struct {
+		DisableOrganizationProjects bool `ini:"DISABLE_ORGANIZATION_PROJECTS"`
 		ProjectBoardBasicKanbanType []string
 		ProjectBoardBugTriageType   []string
 	}{
+		DisableOrganizationProjects: false,
 		ProjectBoardBasicKanbanType: []string{"To Do", "In Progress", "Done"},
 		ProjectBoardBugTriageType:   []string{"Needs Triage", "High Priority", "Low Priority", "Closed"},
 	}

--- a/modules/setting/project_test.go
+++ b/modules/setting/project_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package setting
+
+import (
+	"testing"
+
+	"gitea.dev/modules/test"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadProjectDisableOrganizationProjects(t *testing.T) {
+	defer test.MockVariableValue(&Project)()
+
+	cfg, err := NewConfigProviderFromData(`
+[project]
+DISABLE_ORGANIZATION_PROJECTS = true
+`)
+	assert.NoError(t, err)
+
+	loadProjectFrom(cfg)
+	assert.True(t, Project.DisableOrganizationProjects)
+}

--- a/routers/web/org/projects.go
+++ b/routers/web/org/projects.go
@@ -119,7 +119,7 @@ func Projects(ctx *context.Context) {
 
 func canWriteProjects(ctx *context.Context) bool {
 	if ctx.ContextUser.IsOrganization() {
-		return ctx.Org.CanWriteUnit(ctx, unit.TypeProjects)
+		return !setting.Project.DisableOrganizationProjects && ctx.Org.CanWriteUnit(ctx, unit.TypeProjects)
 	}
 	return ctx.Doer != nil && ctx.ContextUser.ID == ctx.Doer.ID
 }

--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -24,6 +24,7 @@ import (
 	"gitea.dev/modules/log"
 	"gitea.dev/modules/markup/markdown"
 	"gitea.dev/modules/optional"
+	"gitea.dev/modules/setting"
 	api "gitea.dev/modules/structs"
 	"gitea.dev/modules/templates"
 	"gitea.dev/modules/util"
@@ -148,7 +149,8 @@ func retrieveProjectsInternal(ctx *context.Context, repo *repo_model.Repository)
 		}
 	}
 
-	if projectsUnit.ProjectsConfig().IsProjectsAllowed(repo_model.ProjectsModeOwner) {
+	if projectsUnit.ProjectsConfig().IsProjectsAllowed(repo_model.ProjectsModeOwner) &&
+		(!repo.Owner.IsOrganization() || !setting.Project.DisableOrganizationProjects) {
 		openProjects2, err := db.Find[project_model.Project](ctx, project_model.SearchOptions{
 			ListOptions: db.ListOptionsAll,
 			OwnerID:     repo.OwnerID,

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -434,6 +434,11 @@ func registerWebRoutes(m *web.Router, webAuth *AuthMiddleware) {
 				return
 			}
 
+			if unitType == unit.TypeProjects && ctx.ContextUser.IsOrganization() && setting.Project.DisableOrganizationProjects {
+				ctx.NotFound(nil)
+				return
+			}
+
 			if ctx.ContextUser.IsOrganization() {
 				if ctx.Org.Organization.UnitPermission(ctx, ctx.Doer, unitType) < accessMode {
 					ctx.NotFound(nil)

--- a/services/context/org.go
+++ b/services/context/org.go
@@ -229,7 +229,7 @@ func OrgAssignment(orgAssignmentOpts OrgAssignmentOptions) func(ctx *Context) {
 		}
 		ctx.Data["ContextUser"] = ctx.ContextUser
 
-		ctx.Data["CanReadProjects"] = ctx.Org.CanReadUnit(ctx, unit.TypeProjects)
+		ctx.Data["CanReadProjects"] = !setting.Project.DisableOrganizationProjects && ctx.Org.CanReadUnit(ctx, unit.TypeProjects)
 		ctx.Data["CanReadPackages"] = ctx.Org.CanReadUnit(ctx, unit.TypePackages)
 		ctx.Data["CanReadCode"] = ctx.Org.CanReadUnit(ctx, unit.TypeCode)
 

--- a/tests/integration/org_project_test.go
+++ b/tests/integration/org_project_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	unit_model "gitea.dev/models/unit"
+	"gitea.dev/modules/setting"
+	"gitea.dev/modules/test"
 	"gitea.dev/tests"
 )
 
@@ -58,4 +60,21 @@ func TestOrgProjectAccess(t *testing.T) {
 	session = loginUser(t, "user4")
 	req = NewRequest(t, "GET", "/org3/-/projects")
 	session.MakeRequest(t, req, http.StatusNotFound)
+}
+
+func TestDisableOrganizationProjects(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+	defer test.MockVariableValue(&setting.Project.DisableOrganizationProjects, true)()
+
+	// repo projects remain available
+	req := NewRequest(t, "GET", "/user2/repo1/projects")
+	MakeRequest(t, req, http.StatusOK)
+
+	// user projects remain available
+	req = NewRequest(t, "GET", "/user2/-/projects")
+	MakeRequest(t, req, http.StatusOK)
+
+	// organization projects are disabled
+	req = NewRequest(t, "GET", "/org3/-/projects")
+	MakeRequest(t, req, http.StatusNotFound)
 }


### PR DESCRIPTION
### Summary
- added `[project] DISABLE_ORGANIZATION_PROJECTS` with a default of `false`
- returned not found for organization project routes when the setting is enabled
- kept repository and user projects available
- prevented disabled organization projects from appearing in repository issue project selection and assignment

Closes #37490

### Testing
- `go test ./modules/setting ./models/project`
- `go test -timeout 40m -run TestDisableOrganizationProjects gitea.dev/tests/integration`
- `go test ./routers/web/... ./services/context`
- `GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./modules/setting ./models/project ./routers/web/org ./routers/web/repo ./routers/web ./services/context ./tests/integration`

### AI assistance
AI assistance was used to prepare this patch and PR description.