### PR TITLE
fix: show mode for created diff files

### DIFF
--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -558,7 +558,7 @@ func (diffFile *DiffFile) TranslateDiffEntryMode(locale translation.Locale) stri
 		return locale.TrString("git.filemode.changed_filemode", oldMode, newMode)
 	}
 	if diffFile.EntryMode != "" {
-		if entryMode := git.ParseEntryMode(diffFile.EntryMode); !entryMode.IsRegular() {
+		if entryMode := git.ParseEntryMode(diffFile.EntryMode); diffFile.IsCreated || !entryMode.IsRegular() {
 			return entryModeTr(diffFile.EntryMode)
 		}
 	}

--- a/services/gitdiff/gitdiff_test.go
+++ b/services/gitdiff/gitdiff_test.go
@@ -18,10 +18,31 @@ import (
 	"gitea.dev/modules/git/gitcmd"
 	"gitea.dev/modules/json"
 	"gitea.dev/modules/setting"
+	"gitea.dev/modules/translation"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDiffFileTranslateDiffEntryMode(t *testing.T) {
+	locale := translation.MockLocale{}
+
+	assert.Equal(t, "git.filemode.normal_file", (&DiffFile{
+		IsCreated: true,
+		EntryMode: "100644",
+	}).TranslateDiffEntryMode(locale))
+	assert.Equal(t, "git.filemode.executable_file", (&DiffFile{
+		IsCreated: true,
+		EntryMode: "100755",
+	}).TranslateDiffEntryMode(locale))
+	assert.Empty(t, (&DiffFile{
+		EntryMode: "100644",
+	}).TranslateDiffEntryMode(locale))
+	assert.Equal(t, "git.filemode.changed_filemode:git.filemode.normal_file,git.filemode.executable_file", (&DiffFile{
+		OldEntryMode: "100644",
+		EntryMode:    "100755",
+	}).TranslateDiffEntryMode(locale))
+}
 
 func TestParsePatch_skipTo(t *testing.T) {
 	type testcase struct {


### PR DESCRIPTION
### Summary
- shows the parsed entry mode label for newly created files in diff headers
- keeps unchanged regular files without a mode label
- adds coverage for created regular/executable files and existing mode changes

Closes #36023

### Testing
- `go test ./services/gitdiff`
- `GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./services/gitdiff`

### AI assistance
AI assistance was used to prepare this patch and PR description.