### PR TITLE
Show user email addresses on admin edit page

### DIFF
--- a/routers/web/admin/users.go
+++ b/routers/web/admin/users.go
@@ -257,6 +257,17 @@ func prepareUserInfo(ctx *context.Context) *user_model.User {
 	return u
 }
 
+func prepareUserEmails(ctx *context.Context, u *user_model.User) bool {
+	emails, err := user_model.GetEmailAddresses(ctx, u.ID)
+	if err != nil {
+		ctx.ServerError("GetEmailAddresses", err)
+		return false
+	}
+	ctx.Data["Emails"] = emails
+	ctx.Data["EmailsTotal"] = len(emails)
+	return true
+}
+
 func ViewUser(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("admin.users.details")
 	ctx.Data["PageIsAdminUsers"] = true
@@ -284,13 +295,9 @@ func ViewUser(ctx *context.Context) {
 	ctx.Data["Repos"] = repos
 	ctx.Data["ReposTotal"] = int(count)
 
-	emails, err := user_model.GetEmailAddresses(ctx, u.ID)
-	if err != nil {
-		ctx.ServerError("GetEmailAddresses", err)
+	if !prepareUserEmails(ctx, u) {
 		return
 	}
-	ctx.Data["Emails"] = emails
-	ctx.Data["EmailsTotal"] = len(emails)
 
 	orgs, err := db.Find[org_model.Organization](ctx, org_model.FindOrgOptions{
 		ListOptions:       db.ListOptionsAll,
@@ -322,8 +329,11 @@ func editUserCommon(ctx *context.Context) {
 // EditUser show editing user page
 func EditUser(ctx *context.Context) {
 	editUserCommon(ctx)
-	prepareUserInfo(ctx)
+	u := prepareUserInfo(ctx)
 	if ctx.Written() {
+		return
+	}
+	if !prepareUserEmails(ctx, u) {
 		return
 	}
 
@@ -335,6 +345,9 @@ func EditUserPost(ctx *context.Context) {
 	editUserCommon(ctx)
 	u := prepareUserInfo(ctx)
 	if ctx.Written() {
+		return
+	}
+	if !prepareUserEmails(ctx, u) {
 		return
 	}
 

--- a/routers/web/admin/users_test.go
+++ b/routers/web/admin/users_test.go
@@ -15,6 +15,7 @@ import (
 	"gitea.dev/services/forms"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewUserPost_MustChangePassword(t *testing.T) {
@@ -196,4 +197,19 @@ func TestNewUserPost_VisibilityPrivate(t *testing.T) {
 	assert.Equal(t, email, u.Email)
 	// As default user visibility
 	assert.True(t, u.Visibility.IsPrivate())
+}
+
+func TestEditUserLoadsEmailAddresses(t *testing.T) {
+	unittest.PrepareTestEnv(t)
+	ctx, _ := contexttest.MockContext(t, "admin/users/10/edit")
+	ctx.SetPathParam("userid", "10")
+
+	EditUser(ctx)
+
+	emails, ok := ctx.Data["Emails"].([]*user_model.EmailAddress)
+	require.True(t, ok)
+	require.Len(t, emails, 2)
+	assert.Equal(t, "user10@example.com", emails[0].Email)
+	assert.Equal(t, "user101@example.com", emails[1].Email)
+	assert.Equal(t, 2, ctx.Data["EmailsTotal"])
 }

--- a/templates/admin/user/edit.tmpl
+++ b/templates/admin/user/edit.tmpl
@@ -64,6 +64,12 @@
 					<label for="email">{{ctx.Locale.Tr "email"}}</label>
 					<input id="email" name="email" type="email" value="{{.User.Email}}" required>
 				</div>
+				{{if .Emails}}
+					<div class="field">
+						<label>{{ctx.Locale.Tr "settings.emails"}}</label>
+						{{template "admin/user/view_emails" .}}
+					</div>
+				{{end}}
 				<div class="local field {{if .Err_Password}}error{{end}} {{if not (or (.User.IsLocal) (.User.IsOAuth2))}}tw-hidden{{end}}">
 					<label for="password">{{ctx.Locale.Tr "password"}}</label>
 					<input id="password" name="password" type="password" autocomplete="new-password">


### PR DESCRIPTION
### What changed
- Loaded email addresses for the admin user edit page.
- Reused the existing admin user email list partial to show primary and activation labels.
- Added coverage for loading multiple email addresses on the edit page.

Closes #31570

### Testing
- `go test ./routers/web/admin`
- `GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./routers/web/admin`
- `make lint-templates`
- `git diff --check`

### AI assistance
AI assistance was used to prepare this patch and PR description.