### PR TITLE
Show failed auto merge errors on pull requests

### DIFF
--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -413,6 +413,7 @@ func prepareMigrationTasks() []*migration {
 		newMigration(333, "Add bypass allowlist to branch protection", v1_27.AddBranchProtectionBypassAllowlist),
 		newMigration(334, "Add cancelling support to action runners", v1_27.AddCancellingSupportToActionRunner),
 		newMigration(335, "Add reusable workflow fields and action_run_attempt_job_id_index table for ActionRunJob", v1_27.AddReusableWorkflowFieldsToActionRunJob),
+		newMigration(336, "Add error message to auto merge", v1_27.AddErrorMessageToAutoMerge),
 	}
 	return preparedMigrations
 }

--- a/models/migrations/v1_27/v336.go
+++ b/models/migrations/v1_27/v336.go
@@ -1,0 +1,27 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v1_27
+
+import (
+	"gitea.dev/models/db"
+
+	"xorm.io/xorm"
+)
+
+type pullAutoMergeWithErrorMessage struct {
+	ErrorMessage string `xorm:"LONGTEXT"`
+}
+
+func (pullAutoMergeWithErrorMessage) TableName() string {
+	return "pull_auto_merge"
+}
+
+// AddErrorMessageToAutoMerge adds storage for the latest failed auto merge error.
+func AddErrorMessageToAutoMerge(x db.EngineMigration) error {
+	_, err := x.SyncWithOptions(xorm.SyncOptions{
+		IgnoreConstrains: true,
+		IgnoreIndices:    true,
+	}, new(pullAutoMergeWithErrorMessage))
+	return err
+}

--- a/models/pull/automerge.go
+++ b/models/pull/automerge.go
@@ -22,6 +22,7 @@ type AutoMerge struct {
 	MergeStyle             repo_model.MergeStyle `xorm:"varchar(30)"`
 	Message                string                `xorm:"LONGTEXT"`
 	DeleteBranchAfterMerge bool
+	ErrorMessage           string             `xorm:"LONGTEXT"`
 	CreatedUnix            timeutil.TimeStamp `xorm:"created"`
 }
 
@@ -78,6 +79,20 @@ func GetScheduledMergeByPullID(ctx context.Context, pullID int64) (bool, *AutoMe
 
 	scheduledPRM.DoerID, scheduledPRM.Doer, err = user_model.GetPossibleUserByID(ctx, scheduledPRM.DoerID)
 	return true, scheduledPRM, err
+}
+
+// SetScheduledAutoMergeError updates the last auto merge failure message.
+func SetScheduledAutoMergeError(ctx context.Context, pullID int64, message string) error {
+	cnt, err := db.GetEngine(ctx).
+		Where("pull_id = ?", pullID).
+		Cols("error_message").
+		Update(&AutoMerge{ErrorMessage: message})
+	if err != nil {
+		return err
+	} else if cnt == 0 {
+		return db.ErrNotExist{Resource: "auto_merge", ID: pullID}
+	}
+	return nil
 }
 
 // DeleteScheduledAutoMerge delete a scheduled pull request

--- a/models/pull/automerge_test.go
+++ b/models/pull/automerge_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package pull_test
+
+import (
+	"testing"
+
+	"gitea.dev/models/pull"
+	repo_model "gitea.dev/models/repo"
+	"gitea.dev/models/unittest"
+	user_model "gitea.dev/models/user"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetScheduledAutoMergeError(t *testing.T) {
+	unittest.PrepareTestEnv(t)
+
+	doer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 1})
+	require.NoError(t, pull.ScheduleAutoMerge(t.Context(), doer, 2, repo_model.MergeStyleMerge, "merge message", false))
+
+	require.NoError(t, pull.SetScheduledAutoMergeError(t.Context(), 2, "merge failed"))
+
+	exist, scheduled, err := pull.GetScheduledMergeByPullID(t.Context(), 2)
+	require.NoError(t, err)
+	require.True(t, exist)
+	assert.Equal(t, "merge failed", scheduled.ErrorMessage)
+}

--- a/models/pull/main_test.go
+++ b/models/pull/main_test.go
@@ -1,0 +1,18 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package pull_test
+
+import (
+	"testing"
+
+	"gitea.dev/models/unittest"
+
+	_ "gitea.dev/models"
+	_ "gitea.dev/models/actions"
+	_ "gitea.dev/models/activities"
+)
+
+func TestMain(m *testing.M) {
+	unittest.MainTest(m)
+}

--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -1902,6 +1902,7 @@
   "repo.pulls.auto_merge_newly_scheduled": "The pull request was scheduled to merge when all checks succeed.",
   "repo.pulls.auto_merge_has_pending_schedule": "%[1]s scheduled this pull request to auto merge when all checks succeed %[2]s.",
   "repo.pulls.auto_merge_cancel_schedule": "Cancel auto merge",
+  "repo.pulls.auto_merge_failed": "Auto merge failed with the following error:",
   "repo.pulls.auto_merge_not_scheduled": "This pull request is not scheduled to auto merge.",
   "repo.pulls.auto_merge_canceled_schedule": "The auto merge was canceled for this pull request.",
   "repo.pulls.auto_merge_newly_scheduled_comment": "scheduled this pull request to auto merge when all checks succeed %[1]s",

--- a/routers/web/repo/pull_merge_form.go
+++ b/routers/web/repo/pull_merge_form.go
@@ -55,9 +55,11 @@ func (prInfo *pullRequestViewInfo) prepareMergeBoxFormProps(ctx *context.Context
 	}
 
 	var hasPendingPullRequestMergeTip template.HTML
+	var pendingPullRequestMergeError string
 	if hasPendingPullRequestMerge {
 		createdPRMergeStr := templates.TimeSince(pendingPullRequestMerge.CreatedUnix)
 		hasPendingPullRequestMergeTip = ctx.Locale.Tr("repo.pulls.auto_merge_has_pending_schedule", pendingPullRequestMerge.Doer.Name, createdPRMergeStr)
+		pendingPullRequestMergeError = pendingPullRequestMerge.ErrorMessage
 	}
 
 	defaultMergeTitle, defaultMergeBody, err := pull_service.GetDefaultMergeMessage(ctx, ctx.Repo.GitRepo, pull, mergeStyle)
@@ -84,6 +86,7 @@ func (prInfo *pullRequestViewInfo) prepareMergeBoxFormProps(ctx *context.Context
 		"textAutoMergeButtonWhenSucceed": ctx.Locale.Tr("repo.pulls.auto_merge_button_when_succeed"),
 		"textAutoMergeWhenSucceed":       ctx.Locale.Tr("repo.pulls.auto_merge_when_succeed"),
 		"textAutoMergeCancelSchedule":    ctx.Locale.Tr("repo.pulls.auto_merge_cancel_schedule"),
+		"textAutoMergeFailed":            ctx.Locale.Tr("repo.pulls.auto_merge_failed"),
 		"textClearMergeMessage":          ctx.Locale.Tr("repo.pulls.clear_merge_message"),
 		"textClearMergeMessageHint":      ctx.Locale.Tr("repo.pulls.clear_merge_message_hint"),
 		"textMergeCommitId":              ctx.Locale.Tr("repo.pulls.merge_commit_id"),
@@ -100,6 +103,7 @@ func (prInfo *pullRequestViewInfo) prepareMergeBoxFormProps(ctx *context.Context
 
 		"hasPendingPullRequestMerge":    hasPendingPullRequestMerge,
 		"hasPendingPullRequestMergeTip": hasPendingPullRequestMergeTip,
+		"pendingPullRequestMergeError":  pendingPullRequestMergeError,
 	}
 
 	// if this pr can be merged now, then hide the auto merge

--- a/services/automerge/automerge.go
+++ b/services/automerge/automerge.go
@@ -262,9 +262,9 @@ func handlePullRequestAutoMerge(pullID int64, sha string) {
 
 	if err := pull_service.Merge(ctx, pr, doer, scheduledPRM.MergeStyle, "", scheduledPRM.Message, true); err != nil {
 		log.Error("pull_service.Merge: %v", err)
-		// FIXME: if merge failed, we should display some error message to the pull request page.
-		// The resolution is add a new column on automerge table named `error_message` to store the error message and displayed
-		// on the pull request page. But this should not be finished in a bug fix PR which will be backport to release branch.
+		if err := pull_model.SetScheduledAutoMergeError(ctx, pr.ID, err.Error()); err != nil {
+			log.Error("SetScheduledAutoMergeError[%d]: %v", pr.ID, err)
+		}
 		return
 	}
 

--- a/web_src/js/components/PullRequestMergeForm.vue
+++ b/web_src/js/components/PullRequestMergeForm.vue
@@ -103,6 +103,10 @@ function clearMergeMessage() {
   <div>
     <!-- eslint-disable-next-line vue/no-v-html -->
     <div v-if="mergeForm.hasPendingPullRequestMerge" v-html="mergeForm.hasPendingPullRequestMergeTip" class="ui info message"/>
+    <div v-if="mergeForm.pendingPullRequestMergeError" class="ui negative message auto-merge-error">
+      <div>{{ mergeForm.textAutoMergeFailed }}</div>
+      <pre>{{ mergeForm.pendingPullRequestMergeError }}</pre>
+    </div>
 
     <!-- another similar form is in pull.tmpl (manual merge)-->
     <form class="ui form form-fetch-action" v-if="showActionForm" :action="mergeForm.baseLink+'/merge'" method="post">
@@ -204,6 +208,10 @@ function clearMergeMessage() {
 }
 .ui.checkbox label {
   cursor: pointer;
+}
+.auto-merge-error pre {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 /* make the dropdown list left-aligned */


### PR DESCRIPTION
### What changed
- Added `error_message` storage for scheduled auto merges.
- Saved the merge failure error when queued auto merge fails.
- Displayed the saved failure on the pull request merge box while the auto merge remains scheduled.

Closes #30691

### Testing
- `go test ./models/pull ./services/automerge ./routers/web/repo ./models/migrations/v1_27`
- `GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./models/pull ./services/automerge ./routers/web/repo ./models/migrations/...`
- `pnpm exec eslint web_src/js/components/PullRequestMergeForm.vue`
- `pnpm exec stylelint --color --max-warnings=0 web_src/js/components/PullRequestMergeForm.vue`
- `pnpm exec eslint -c eslint.json.config.ts --color --max-warnings=0 --concurrency 2 options/locale/locale_en-US.json`
- `git diff --check`

### AI assistance
AI assistance was used to prepare this patch and PR description.