### PR TITLE
Add failed and cancelled actions email preference

### DIFF
--- a/models/user/setting_options.go
+++ b/models/user/setting_options.go
@@ -18,10 +18,11 @@ const (
 
 	SettingsKeyCodeViewShowFileTree = "code_view.show_file_tree"
 
-	SettingsKeyEmailNotificationGiteaActions        = "email_notification.gitea_actions"
-	SettingEmailNotificationGiteaActionsAll         = "all"
-	SettingEmailNotificationGiteaActionsFailureOnly = "failure-only" // Default for actions email preference
-	SettingEmailNotificationGiteaActionsDisabled    = "disabled"
+	SettingsKeyEmailNotificationGiteaActions                = "email_notification.gitea_actions"
+	SettingEmailNotificationGiteaActionsAll                 = "all"
+	SettingEmailNotificationGiteaActionsFailureOnly         = "failure-only" // Default for actions email preference
+	SettingEmailNotificationGiteaActionsFailureAndCancelled = "failure-and-cancelled"
+	SettingEmailNotificationGiteaActionsDisabled            = "disabled"
 
 	SettingsKeyActionsConfig = "actions.config"
 )

--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -946,6 +946,7 @@
   "settings.email_notifications.andyourown": "And Your Own Notifications",
   "settings.email_notifications.actions.desc": "Notifications for workflow runs on repositories set up with <a target=\"_blank\" href=\"%s\">Gitea Actions</a>.",
   "settings.email_notifications.actions.failure_only": "Only notify for failed workflow runs",
+  "settings.email_notifications.actions.failure_and_cancelled": "Only notify for failed and cancelled workflow runs",
   "settings.visibility": "User visibility",
   "settings.visibility.public": "Public",
   "settings.visibility.public_tooltip": "Visible to everyone",

--- a/routers/web/user/setting/notifications.go
+++ b/routers/web/user/setting/notifications.go
@@ -75,7 +75,8 @@ func NotificationsActionsEmailPost(ctx *context.Context) {
 	preference := ctx.FormString("preference")
 	if !(preference == user_model.SettingEmailNotificationGiteaActionsAll ||
 		preference == user_model.SettingEmailNotificationGiteaActionsDisabled ||
-		preference == user_model.SettingEmailNotificationGiteaActionsFailureOnly) {
+		preference == user_model.SettingEmailNotificationGiteaActionsFailureOnly ||
+		preference == user_model.SettingEmailNotificationGiteaActionsFailureAndCancelled) {
 		ctx.Flash.Error(ctx.Tr("invalid_data", preference))
 		ctx.Redirect(setting.AppSubURL + "/user/settings/notifications")
 		return

--- a/services/mailer/mail_test.go
+++ b/services/mailer/mail_test.go
@@ -442,6 +442,57 @@ func TestGenerateMessageIDForActionsWorkflowRunStatusEmail(t *testing.T) {
 	assert.Equal(t, "<user2/repo2/actions/runs/191@localhost>", msgID)
 }
 
+func TestShouldSendActionsWorkflowRunStatusEmail(t *testing.T) {
+	tests := []struct {
+		name       string
+		preference string
+		status     actions_model.Status
+		want       bool
+	}{
+		{
+			name:       "all sends cancelled",
+			preference: user_model.SettingEmailNotificationGiteaActionsAll,
+			status:     actions_model.StatusCancelled,
+			want:       true,
+		},
+		{
+			name:       "failure only skips cancelled",
+			preference: user_model.SettingEmailNotificationGiteaActionsFailureOnly,
+			status:     actions_model.StatusCancelled,
+			want:       false,
+		},
+		{
+			name:       "failure only sends failure",
+			preference: user_model.SettingEmailNotificationGiteaActionsFailureOnly,
+			status:     actions_model.StatusFailure,
+			want:       true,
+		},
+		{
+			name:       "failure and cancelled sends cancelled",
+			preference: user_model.SettingEmailNotificationGiteaActionsFailureAndCancelled,
+			status:     actions_model.StatusCancelled,
+			want:       true,
+		},
+		{
+			name:       "failure and cancelled skips success",
+			preference: user_model.SettingEmailNotificationGiteaActionsFailureAndCancelled,
+			status:     actions_model.StatusSuccess,
+			want:       false,
+		},
+		{
+			name:       "disabled skips failure",
+			preference: user_model.SettingEmailNotificationGiteaActionsDisabled,
+			status:     actions_model.StatusFailure,
+			want:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shouldSendActionsWorkflowRunStatusEmail(tt.preference, tt.status))
+		})
+	}
+}
+
 func TestFromDisplayName(t *testing.T) {
 	tmpl, err := texttmpl.New("mailFrom").Parse("{{ .DisplayName }}")
 	assert.NoError(t, err)

--- a/services/mailer/mail_workflow_run.go
+++ b/services/mailer/mail_workflow_run.go
@@ -149,6 +149,19 @@ func composeAndSendActionsWorkflowRunStatusEmail(ctx context.Context, repo *repo
 	return nil
 }
 
+func shouldSendActionsWorkflowRunStatusEmail(notifyPref string, runStatus actions_model.Status) bool {
+	switch notifyPref {
+	case user_model.SettingEmailNotificationGiteaActionsDisabled:
+		return false
+	case user_model.SettingEmailNotificationGiteaActionsAll:
+		return true
+	case user_model.SettingEmailNotificationGiteaActionsFailureAndCancelled:
+		return runStatus.IsFailure() || runStatus.IsCancelled()
+	default:
+		return runStatus.IsFailure()
+	}
+}
+
 func MailActionsTrigger(ctx context.Context, recipient *user_model.User, repo *repo_model.Repository, run *actions_model.ActionRun) error {
 	if setting.MailService == nil {
 		return nil
@@ -165,12 +178,7 @@ func MailActionsTrigger(ctx context.Context, recipient *user_model.User, repo *r
 	if err != nil {
 		return err
 	}
-	// "disabled" never sends
-	if notifyPref == user_model.SettingEmailNotificationGiteaActionsDisabled {
-		return nil
-	}
-	// "failure-only" skips non-failure runs
-	if notifyPref != user_model.SettingEmailNotificationGiteaActionsAll && !run.Status.IsFailure() {
+	if !shouldSendActionsWorkflowRunStatusEmail(notifyPref, run.Status) {
 		return nil
 	}
 

--- a/templates/user/settings/notifications.tmpl
+++ b/templates/user/settings/notifications.tmpl
@@ -46,6 +46,7 @@
 								<div class="menu">
 									<div data-value="all" class="item">{{ctx.Locale.Tr "all"}}</div>
 									<div data-value="failure-only" class="item">{{ctx.Locale.Tr "settings.email_notifications.actions.failure_only"}}</div>
+									<div data-value="failure-and-cancelled" class="item">{{ctx.Locale.Tr "settings.email_notifications.actions.failure_and_cancelled"}}</div>
 									<div data-value="disabled" class="item">{{ctx.Locale.Tr "disabled"}}</div>
 								</div>
 							</div>


### PR DESCRIPTION
### What changed
- Added an Actions email preference for failed and cancelled workflow runs.
- Added the new option to the user notification settings dropdown and form validation.
- Kept `failure-only` as failed-only and covered the status filter with tests.

Closes #35872

### Testing
- `go test ./models/user ./routers/web/user/setting ./services/mailer`
- `GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./models/user ./routers/web/user/setting ./services/mailer`
- `make lint-templates`
- `pnpm exec eslint -c eslint.json.config.ts --color --max-warnings=0 --concurrency 2 options/locale/locale_en-US.json`
- `git diff --check`

### AI assistance
AI assistance was used to prepare this patch and PR description.