### PR TITLE
Add repository rename webhooks

### DIFF
--- a/modules/structs/hook.go
+++ b/modules/structs/hook.go
@@ -418,6 +418,8 @@ type ChangesFromPayload struct {
 
 // ChangesPayload represents the payload information of issue change
 type ChangesPayload struct {
+	// Changes made to the name
+	Name *ChangesFromPayload `json:"name,omitempty"`
 	// Changes made to the title
 	Title *ChangesFromPayload `json:"title,omitempty"`
 	// Changes made to the body/description
@@ -506,6 +508,8 @@ type HookRepoAction string
 const (
 	// HookRepoCreated created
 	HookRepoCreated HookRepoAction = "created"
+	// HookRepoRenamed renamed
+	HookRepoRenamed HookRepoAction = "renamed"
 	// HookRepoDeleted deleted
 	HookRepoDeleted HookRepoAction = "deleted"
 )
@@ -514,6 +518,8 @@ const (
 type RepositoryPayload struct {
 	// The action performed on the repository
 	Action HookRepoAction `json:"action"`
+	// Changes made to the repository
+	Changes *ChangesPayload `json:"changes,omitempty"`
 	// The repository that was acted upon
 	Repository *Repository `json:"repository"`
 	// The organization that owns the repository (if applicable)

--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -2297,7 +2297,7 @@
   "repo.settings.event_force_push": "Force Push",
   "repo.settings.event_push_desc": "Git push to a repository.",
   "repo.settings.event_repository": "Repository",
-  "repo.settings.event_repository_desc": "Repository created or deleted.",
+  "repo.settings.event_repository_desc": "Repository created, renamed, or deleted.",
   "repo.settings.event_header_issue": "Issue Events",
   "repo.settings.event_issues": "Issues",
   "repo.settings.event_issues_desc": "Issue opened, closed, reopened, edited or deleted.",

--- a/services/webhook/dingtalk.go
+++ b/services/webhook/dingtalk.go
@@ -142,6 +142,9 @@ func (dc dingtalkConvertor) Repository(p *api.RepositoryPayload) (DingtalkPayloa
 	case api.HookRepoCreated:
 		title := fmt.Sprintf("[%s] Repository created", p.Repository.FullName)
 		return createDingtalkPayload(title, title, "view repository", p.Repository.HTMLURL), nil
+	case api.HookRepoRenamed:
+		title := formatRepositoryRenamed(p.Repository.FullName, getRepositoryOldName(p))
+		return createDingtalkPayload(title, title, "view repository", p.Repository.HTMLURL), nil
 	case api.HookRepoDeleted:
 		title := fmt.Sprintf("[%s] Repository deleted", p.Repository.FullName)
 		return DingtalkPayload{

--- a/services/webhook/dingtalk_test.go
+++ b/services/webhook/dingtalk_test.go
@@ -157,6 +157,15 @@ func TestDingTalkPayload(t *testing.T) {
 		assert.Equal(t, "[test/repo] Repository created", pl.ActionCard.Title)
 		assert.Equal(t, "view repository", pl.ActionCard.SingleTitle)
 		assert.Equal(t, "http://localhost:3000/test/repo", parseRealSingleURL(pl.ActionCard.SingleURL))
+
+		p = repositoryRenamedTestPayload()
+		pl, err = dc.Repository(p)
+		require.NoError(t, err)
+
+		assert.Equal(t, "[test/repo] Repository renamed from old-repo", pl.ActionCard.Text)
+		assert.Equal(t, "[test/repo] Repository renamed from old-repo", pl.ActionCard.Title)
+		assert.Equal(t, "view repository", pl.ActionCard.SingleTitle)
+		assert.Equal(t, "http://localhost:3000/test/repo", parseRealSingleURL(pl.ActionCard.SingleURL))
 	})
 
 	t.Run("Package", func(t *testing.T) {

--- a/services/webhook/discord.go
+++ b/services/webhook/discord.go
@@ -241,6 +241,10 @@ func (d discordConvertor) Repository(p *api.RepositoryPayload) (DiscordPayload, 
 	case api.HookRepoDeleted:
 		title = fmt.Sprintf("[%s] Repository deleted", p.Repository.FullName)
 		color = redColor
+	case api.HookRepoRenamed:
+		title = formatRepositoryRenamed(p.Repository.FullName, getRepositoryOldName(p))
+		url = p.Repository.HTMLURL
+		color = yellowColor
 	}
 
 	return d.createPayload(p.Sender, title, "", url, color), nil

--- a/services/webhook/discord_test.go
+++ b/services/webhook/discord_test.go
@@ -62,6 +62,15 @@ func TestDiscordPayload(t *testing.T) {
 		assert.Equal(t, p.Sender.UserName, pl.Embeds[0].Author.Name)
 		assert.Equal(t, setting.AppURL+p.Sender.UserName, pl.Embeds[0].Author.URL)
 		assert.Equal(t, p.Sender.AvatarURL, pl.Embeds[0].Author.IconURL)
+
+		pRenamed := repositoryRenamedTestPayload()
+		pl, err = dc.Repository(pRenamed)
+		require.NoError(t, err)
+
+		assert.Len(t, pl.Embeds, 1)
+		assert.Equal(t, "[test/repo] Repository renamed from old-repo", pl.Embeds[0].Title)
+		assert.Empty(t, pl.Embeds[0].Description)
+		assert.Equal(t, "http://localhost:3000/test/repo", pl.Embeds[0].URL)
 	})
 
 	t.Run("Push", func(t *testing.T) {

--- a/services/webhook/feishu.go
+++ b/services/webhook/feishu.go
@@ -145,6 +145,9 @@ func (fc feishuConvertor) Repository(p *api.RepositoryPayload) (FeishuPayload, e
 	case api.HookRepoCreated:
 		text = fmt.Sprintf("[%s] Repository created", p.Repository.FullName)
 		return newFeishuTextPayload(text), nil
+	case api.HookRepoRenamed:
+		text = formatRepositoryRenamed(p.Repository.FullName, getRepositoryOldName(p))
+		return newFeishuTextPayload(text), nil
 	case api.HookRepoDeleted:
 		text = fmt.Sprintf("[%s] Repository deleted", p.Repository.FullName)
 		return newFeishuTextPayload(text), nil

--- a/services/webhook/feishu_test.go
+++ b/services/webhook/feishu_test.go
@@ -113,6 +113,12 @@ func TestFeishuPayload(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "[test/repo] Repository created", pl.Content.Text)
+
+		p = repositoryRenamedTestPayload()
+		pl, err = fc.Repository(p)
+		require.NoError(t, err)
+
+		assert.Equal(t, "[test/repo] Repository renamed from old-repo", pl.Content.Text)
 	})
 
 	t.Run("Package", func(t *testing.T) {

--- a/services/webhook/general.go
+++ b/services/webhook/general.go
@@ -311,6 +311,20 @@ func getPackagePayloadInfo(p *api.PackagePayload, linkFormatter linkFormatter, w
 	return text, color
 }
 
+func getRepositoryOldName(p *api.RepositoryPayload) string {
+	if p.Changes != nil && p.Changes.Name != nil {
+		return p.Changes.Name.From
+	}
+	return ""
+}
+
+func formatRepositoryRenamed(fullName, oldName string) string {
+	if oldName == "" {
+		return fmt.Sprintf("[%s] Repository renamed", fullName)
+	}
+	return fmt.Sprintf("[%s] Repository renamed from %s", fullName, oldName)
+}
+
 func getStatusPayloadInfo(p *api.CommitStatusPayload, linkFormatter linkFormatter, withSender bool) (text string, color int) {
 	refLink := linkFormatter(p.TargetURL, fmt.Sprintf("%s [%s]", p.Context, base.ShortSha(p.SHA)))
 

--- a/services/webhook/general_test.go
+++ b/services/webhook/general_test.go
@@ -311,6 +311,15 @@ func repositoryTestPayload() *api.RepositoryPayload {
 	}
 }
 
+func repositoryRenamedTestPayload() *api.RepositoryPayload {
+	p := repositoryTestPayload()
+	p.Action = api.HookRepoRenamed
+	p.Changes = &api.ChangesPayload{
+		Name: &api.ChangesFromPayload{From: "old-repo"},
+	}
+	return p
+}
+
 func packageTestPayload() *api.PackagePayload {
 	return &api.PackagePayload{
 		Action: api.HookPackageCreated,

--- a/services/webhook/matrix.go
+++ b/services/webhook/matrix.go
@@ -227,6 +227,8 @@ func (m matrixConvertor) Repository(p *api.RepositoryPayload) (MatrixPayload, er
 		text = fmt.Sprintf("[%s] Repository created by %s", repoLink, senderLink)
 	case api.HookRepoDeleted:
 		text = fmt.Sprintf("[%s] Repository deleted by %s", repoLink, senderLink)
+	case api.HookRepoRenamed:
+		text = formatRepositoryRenamed(repoLink, getRepositoryOldName(p)) + " by " + senderLink
 	}
 	return m.newPayload(text)
 }

--- a/services/webhook/matrix_test.go
+++ b/services/webhook/matrix_test.go
@@ -139,6 +139,14 @@ func TestMatrixPayload(t *testing.T) {
 
 		assert.Equal(t, `[[test/repo](http://localhost:3000/test/repo)] Repository created by [user1](https://try.gitea.io/user1)`, pl.Body)
 		assert.Equal(t, `[<a href="http://localhost:3000/test/repo">test/repo</a>] Repository created by <a href="https://try.gitea.io/user1">user1</a>`, pl.FormattedBody)
+
+		p = repositoryRenamedTestPayload()
+		pl, err = mc.Repository(p)
+		require.NoError(t, err)
+		require.NotNil(t, pl)
+
+		assert.Equal(t, `[[test/repo](http://localhost:3000/test/repo)] Repository renamed from old-repo by [user1](https://try.gitea.io/user1)`, pl.Body)
+		assert.Equal(t, `[<a href="http://localhost:3000/test/repo">test/repo</a>] Repository renamed from old-repo by <a href="https://try.gitea.io/user1">user1</a>`, pl.FormattedBody)
 	})
 
 	t.Run("Package", func(t *testing.T) {

--- a/services/webhook/msteams.go
+++ b/services/webhook/msteams.go
@@ -247,6 +247,10 @@ func (m msteamsConvertor) Repository(p *api.RepositoryPayload) (MSTeamsPayload, 
 	case api.HookRepoDeleted:
 		title = fmt.Sprintf("[%s] Repository deleted", p.Repository.FullName)
 		color = yellowColor
+	case api.HookRepoRenamed:
+		title = formatRepositoryRenamed(p.Repository.FullName, getRepositoryOldName(p))
+		url = p.Repository.HTMLURL
+		color = yellowColor
 	}
 
 	return createMSTeamsPayload(

--- a/services/webhook/msteams_test.go
+++ b/services/webhook/msteams_test.go
@@ -298,6 +298,16 @@ func TestMSTeamsPayload(t *testing.T) {
 		assert.Len(t, pl.PotentialAction, 1)
 		assert.Len(t, pl.PotentialAction[0].Targets, 1)
 		assert.Equal(t, "http://localhost:3000/test/repo", pl.PotentialAction[0].Targets[0].URI)
+
+		p = repositoryRenamedTestPayload()
+		pl, err = mc.Repository(p)
+		require.NoError(t, err)
+
+		assert.Equal(t, "[test/repo] Repository renamed from old-repo", pl.Title)
+		assert.Equal(t, "[test/repo] Repository renamed from old-repo", pl.Summary)
+		assert.Len(t, pl.PotentialAction, 1)
+		assert.Len(t, pl.PotentialAction[0].Targets, 1)
+		assert.Equal(t, "http://localhost:3000/test/repo", pl.PotentialAction[0].Targets[0].URI)
 	})
 
 	t.Run("Package", func(t *testing.T) {

--- a/services/webhook/notifier.go
+++ b/services/webhook/notifier.go
@@ -135,6 +135,20 @@ func (m *webhookNotifier) DeleteRepository(ctx context.Context, doer *user_model
 	}
 }
 
+func (m *webhookNotifier) RenameRepository(ctx context.Context, doer *user_model.User, repo *repo_model.Repository, oldRepoName string) {
+	if err := PrepareWebhooks(ctx, EventSource{Repository: repo}, webhook_module.HookEventRepository, &api.RepositoryPayload{
+		Action: api.HookRepoRenamed,
+		Changes: &api.ChangesPayload{
+			Name: &api.ChangesFromPayload{From: oldRepoName},
+		},
+		Repository:   convert.ToRepo(ctx, repo, access_model.Permission{AccessMode: perm.AccessModeOwner}),
+		Organization: convert.ToUser(ctx, repo.MustOwner(ctx), nil),
+		Sender:       convert.ToUser(ctx, doer, nil),
+	}); err != nil {
+		log.Error("PrepareWebhooks [repo_id: %d]: %v", repo.ID, err)
+	}
+}
+
 func (m *webhookNotifier) MigrateRepository(ctx context.Context, doer, u *user_model.User, repo *repo_model.Repository) {
 	// Add to hook queue for created repo after session commit.
 	if err := PrepareWebhooks(ctx, EventSource{Repository: repo}, webhook_module.HookEventRepository, &api.RepositoryPayload{

--- a/services/webhook/slack.go
+++ b/services/webhook/slack.go
@@ -277,6 +277,8 @@ func (s slackConvertor) Repository(p *api.RepositoryPayload) (SlackPayload, erro
 		text = fmt.Sprintf("[%s] Repository created by %s", repoLink, senderLink)
 	case api.HookRepoDeleted:
 		text = fmt.Sprintf("[%s] Repository deleted by %s", repoLink, senderLink)
+	case api.HookRepoRenamed:
+		text = formatRepositoryRenamed(repoLink, getRepositoryOldName(p)) + " by " + senderLink
 	}
 
 	return s.createPayload(text, nil), nil

--- a/services/webhook/slack_test.go
+++ b/services/webhook/slack_test.go
@@ -114,6 +114,12 @@ func TestSlackPayload(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "[<http://localhost:3000/test/repo|test/repo>] Repository created by <https://try.gitea.io/user1|user1>", pl.Text)
+
+		p = repositoryRenamedTestPayload()
+		pl, err = sc.Repository(p)
+		require.NoError(t, err)
+
+		assert.Equal(t, "[<http://localhost:3000/test/repo|test/repo>] Repository renamed from old-repo by <https://try.gitea.io/user1|user1>", pl.Text)
 	})
 
 	t.Run("Package", func(t *testing.T) {

--- a/services/webhook/telegram.go
+++ b/services/webhook/telegram.go
@@ -147,6 +147,9 @@ func (t telegramConvertor) Repository(p *api.RepositoryPayload) (TelegramPayload
 	case api.HookRepoCreated:
 		title = fmt.Sprintf(`[%s] Repository created`, htmlLinkFormatter(p.Repository.HTMLURL, p.Repository.FullName))
 		return createTelegramPayloadHTML(title), nil
+	case api.HookRepoRenamed:
+		title = formatRepositoryRenamed(htmlLinkFormatter(p.Repository.HTMLURL, p.Repository.FullName), html.EscapeString(getRepositoryOldName(p)))
+		return createTelegramPayloadHTML(title), nil
 	case api.HookRepoDeleted:
 		title = fmt.Sprintf("[%s] Repository deleted", html.EscapeString(p.Repository.FullName))
 		return createTelegramPayloadHTML(title), nil

--- a/services/webhook/telegram_test.go
+++ b/services/webhook/telegram_test.go
@@ -131,6 +131,12 @@ good job`, pl.Message)
 		require.NoError(t, err)
 
 		assert.Equal(t, `[<a href="http://localhost:3000/test/repo" rel="nofollow">test/repo</a>] Repository created`, pl.Message)
+
+		p = repositoryRenamedTestPayload()
+		pl, err = tc.Repository(p)
+		require.NoError(t, err)
+
+		assert.Equal(t, `[<a href="http://localhost:3000/test/repo" rel="nofollow">test/repo</a>] Repository renamed from old-repo`, pl.Message)
 	})
 
 	t.Run("Package", func(t *testing.T) {

--- a/services/webhook/webhook_test.go
+++ b/services/webhook/webhook_test.go
@@ -12,6 +12,7 @@ import (
 	user_model "gitea.dev/models/user"
 	webhook_model "gitea.dev/models/webhook"
 	"gitea.dev/modules/git"
+	"gitea.dev/modules/json"
 	"gitea.dev/modules/setting"
 	api "gitea.dev/modules/structs"
 	"gitea.dev/modules/test"
@@ -28,6 +29,7 @@ func TestWebhookService(t *testing.T) {
 	t.Run("PrepareWebhooks", testWebhookPrepare)
 	t.Run("PrepareBranchFilterMatch", testWebhookPrepareBranchFilterMatch)
 	t.Run("PrepareBranchFilterNoMatch", testWebhookPrepareBranchFilterNoMatch)
+	t.Run("RenameRepositoryWebhook", testWebhookRenameRepository)
 	t.Run("WebhookUserMail", testWebhookUserMail)
 	t.Run("CheckBranchFilter", testWebhookCheckBranchFilter)
 }
@@ -97,6 +99,41 @@ func testWebhookPrepareBranchFilterNoMatch(t *testing.T) {
 	err := PrepareWebhooks(t.Context(), EventSource{Repository: repo}, webhook_module.HookEventPush, &api.PushPayload{Ref: "refs/heads/fix_weird_bug"})
 	require.NoError(t, err)
 	unittest.AssertNotExistsBean(t, hookTask)
+}
+
+func testWebhookRenameRepository(t *testing.T) {
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+	doer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	hook := &webhook_model.Webhook{
+		RepoID:      repo.ID,
+		URL:         "http://localhost/gitea-webhook-test-rename_repository",
+		ContentType: webhook_model.ContentTypeJSON,
+		IsActive:    true,
+		HookEvent: &webhook_module.HookEvent{
+			HookEvents: webhook_module.HookEvents{
+				webhook_module.HookEventRepository: true,
+			},
+		},
+	}
+	require.NoError(t, hook.UpdateEvent())
+	require.NoError(t, db.Insert(t.Context(), hook))
+
+	oldName := repo.Name
+	repo.Name = "repo1-renamed"
+
+	hookTask := &webhook_model.HookTask{HookID: hook.ID, EventType: webhook_module.HookEventRepository}
+	unittest.AssertNotExistsBean(t, hookTask)
+	NewNotifier().RenameRepository(t.Context(), doer, repo, oldName)
+	hookTask = unittest.AssertExistsAndLoadBean(t, hookTask)
+
+	var payload api.RepositoryPayload
+	require.NoError(t, json.Unmarshal([]byte(hookTask.PayloadContent), &payload))
+	assert.Equal(t, api.HookRepoRenamed, payload.Action)
+	require.NotNil(t, payload.Changes)
+	require.NotNil(t, payload.Changes.Name)
+	assert.Equal(t, oldName, payload.Changes.Name.From)
+	assert.Equal(t, repo.Name, payload.Repository.Name)
+	assert.Equal(t, doer.Name, payload.Sender.UserName)
 }
 
 func testWebhookUserMail(t *testing.T) {

--- a/services/webhook/wechatwork.go
+++ b/services/webhook/wechatwork.go
@@ -147,6 +147,9 @@ func (wc wechatworkConvertor) Repository(p *api.RepositoryPayload) (WechatworkPa
 	case api.HookRepoCreated:
 		title = fmt.Sprintf("[%s] Repository created", p.Repository.FullName)
 		return newWechatworkMarkdownPayload(title), nil
+	case api.HookRepoRenamed:
+		title = formatRepositoryRenamed(p.Repository.FullName, getRepositoryOldName(p))
+		return newWechatworkMarkdownPayload(title), nil
 	case api.HookRepoDeleted:
 		title = fmt.Sprintf("[%s] Repository deleted", p.Repository.FullName)
 		return newWechatworkMarkdownPayload(title), nil

--- a/tests/integration/repo_webhook_test.go
+++ b/tests/integration/repo_webhook_test.go
@@ -860,6 +860,23 @@ func Test_WebhookRepository(t *testing.T) {
 		assert.Equal(t, "org3", payloads[0].Organization.UserName)
 		assert.Equal(t, "repo_new", payloads[0].Repository.Name)
 		assert.Equal(t, "org3/repo_new", payloads[0].Repository.FullName)
+
+		newRepoName := "repo_renamed"
+		token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteRepository)
+		req := NewRequestWithJSON(t, "PATCH", "/api/v1/repos/org3/repo_new", &api.EditRepoOption{
+			Name: &newRepoName,
+		}).AddTokenAuth(token)
+		MakeRequest(t, req, http.StatusOK)
+
+		assert.Equal(t, "repository", triggeredEvent)
+		assert.Len(t, payloads, 2)
+		assert.EqualValues(t, "renamed", payloads[1].Action)
+		require.NotNil(t, payloads[1].Changes)
+		require.NotNil(t, payloads[1].Changes.Name)
+		assert.Equal(t, "repo_new", payloads[1].Changes.Name.From)
+		assert.Equal(t, "org3", payloads[1].Organization.UserName)
+		assert.Equal(t, "repo_renamed", payloads[1].Repository.Name)
+		assert.Equal(t, "org3/repo_renamed", payloads[1].Repository.FullName)
 	})
 }
 


### PR DESCRIPTION
Closes #34891

This adds repository rename delivery for the repository webhook event.

Changes:
- added a `renamed` repository webhook action with `changes.name.from`
- sent repository webhooks from `RenameRepository`
- handled renamed repository payloads in chat webhook adapters
- updated the repository event description

Tests:
- `go test ./services/webhook`
- `go test ./tests/integration -run Test_WebhookRepository -count=1`
- `go test ./modules/structs ./services/webhook`
- `jq empty options/locale/locale_en-US.json`
- `GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./modules/structs ./services/webhook`
- `git diff --check`

### AI assistance
AI assistance was used to prepare this patch and PR description.