### PR TITLE
feat: Support compare API ref suffixes

### DIFF
--- a/modules/git/ref.go
+++ b/modules/git/ref.go
@@ -223,11 +223,14 @@ func (ref RefName) RefWebLinkPath() string {
 
 func ParseRefSuffix(ref string) (string, string) {
 	// Partially support https://git-scm.com/docs/gitrevisions
-	if idx := strings.Index(ref, "@{"); idx != -1 {
-		return ref[:idx], ref[idx:]
+	suffixIndex := len(ref)
+	for _, marker := range []string{"@{", "^", "~"} {
+		if idx := strings.Index(ref, marker); idx != -1 && idx < suffixIndex {
+			suffixIndex = idx
+		}
 	}
-	if idx := strings.Index(ref, "^"); idx != -1 {
-		return ref[:idx], ref[idx:]
+	if suffixIndex != len(ref) {
+		return ref[:suffixIndex], ref[suffixIndex:]
 	}
 	return ref, ""
 }

--- a/modules/git/ref_test.go
+++ b/modules/git/ref_test.go
@@ -37,3 +37,24 @@ func TestRefWebLinkPath(t *testing.T) {
 	assert.Equal(t, "tag/foo", RefName("refs/tags/foo").RefWebLinkPath())
 	assert.Equal(t, "commit/c0ffee", RefName("c0ffee").RefWebLinkPath())
 }
+
+func TestParseRefSuffix(t *testing.T) {
+	tests := []struct {
+		ref       string
+		refName   string
+		refSuffix string
+	}{
+		{"main", "main", ""},
+		{"main^", "main", "^"},
+		{"main^2", "main", "^2"},
+		{"main~2", "main", "~2"},
+		{"main~2^", "main", "~2^"},
+		{"main@{upstream}", "main", "@{upstream}"},
+	}
+
+	for _, test := range tests {
+		refName, refSuffix := ParseRefSuffix(test.ref)
+		assert.Equal(t, test.refName, refName)
+		assert.Equal(t, test.refSuffix, refSuffix)
+	}
+}

--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -1091,12 +1091,6 @@ func parseCompareInfo(ctx *context.APIContext, compareParam string) (result *git
 	baseRepo := ctx.Repo.Repository
 	compareReq := common.ParseCompareRouterParam(compareParam)
 
-	// remove the check when we support compare with carets
-	if compareReq.BaseOriRefSuffix != "" {
-		ctx.APIError(http.StatusBadRequest, "Unsupported comparison syntax: ref with suffix")
-		return nil, nil
-	}
-
 	_, headRepo, err := common.GetHeadOwnerAndRepo(ctx, baseRepo, compareReq)
 	switch {
 	case errors.Is(err, util.ErrInvalidArgument):
@@ -1156,8 +1150,27 @@ func parseCompareInfo(ctx *context.APIContext, compareParam string) (result *git
 		return nil, nil
 	}
 
-	baseRef := ctx.Repo.GitRepo.UnstableGuessRefByShortName(util.IfZero(compareReq.BaseOriRef, baseRepo.GetPullRequestTargetBranch(ctx)))
-	headRef := headGitRepo.UnstableGuessRefByShortName(util.IfZero(compareReq.HeadOriRef, headRepo.DefaultBranch))
+	baseRefName := util.IfZero(compareReq.BaseOriRef, baseRepo.GetPullRequestTargetBranch(ctx))
+	baseRef, err := common.ResolveCompareRef(ctx.Repo.GitRepo, baseRefName, compareReq.BaseOriRefSuffix)
+	if err != nil {
+		if errors.Is(err, util.ErrNotExist) {
+			ctx.APIErrorNotFound()
+		} else {
+			ctx.APIErrorInternal(err)
+		}
+		return nil, nil
+	}
+
+	headRefName := util.IfZero(compareReq.HeadOriRef, headRepo.DefaultBranch)
+	headRef, err := common.ResolveCompareRef(headGitRepo, headRefName, compareReq.HeadOriRefSuffix)
+	if err != nil {
+		if errors.Is(err, util.ErrNotExist) {
+			ctx.APIErrorNotFound()
+		} else {
+			ctx.APIErrorInternal(err)
+		}
+		return nil, nil
+	}
 
 	log.Trace("Repo path: %q, base ref: %q->%q, head ref: %q->%q", ctx.Repo.Repository.RelativePath(), compareReq.BaseOriRef, baseRef, compareReq.HeadOriRef, headRef)
 

--- a/routers/common/compare.go
+++ b/routers/common/compare.go
@@ -19,9 +19,10 @@ type CompareRouterReq struct {
 
 	CompareSeparator string
 
-	HeadOwner    string
-	HeadRepoName string
-	HeadOriRef   string
+	HeadOwner        string
+	HeadRepoName     string
+	HeadOriRef       string
+	HeadOriRefSuffix string
 }
 
 func (cr *CompareRouterReq) DirectComparison() bool {
@@ -80,8 +81,10 @@ func ParseCompareRouterParam(routerParam string) *CompareRouterReq {
 		basePart, headPart, ok = strings.Cut(routerParam, sep)
 		if !ok {
 			headOwnerName, headRepoName, headRef := parseHead(routerParam)
+			headRef, headRefSuffix := git.ParseRefSuffix(headRef)
 			return &CompareRouterReq{
 				HeadOriRef:       headRef,
+				HeadOriRefSuffix: headRefSuffix,
 				HeadOwner:        headOwnerName,
 				HeadRepoName:     headRepoName,
 				CompareSeparator: "...",
@@ -92,7 +95,27 @@ func ParseCompareRouterParam(routerParam string) *CompareRouterReq {
 	ci := &CompareRouterReq{CompareSeparator: sep}
 	ci.BaseOriRef, ci.BaseOriRefSuffix = git.ParseRefSuffix(basePart)
 	ci.HeadOwner, ci.HeadRepoName, ci.HeadOriRef = parseHead(headPart)
+	ci.HeadOriRef, ci.HeadOriRefSuffix = git.ParseRefSuffix(ci.HeadOriRef)
 	return ci
+}
+
+func ResolveCompareRef(gitRepo *git.Repository, refName, refSuffix string) (git.RefName, error) {
+	ref := gitRepo.UnstableGuessRefByShortName(refName)
+	if ref == "" {
+		return "", util.NewNotExistErrorf("no ref: %s", refName)
+	}
+	if refSuffix == "" {
+		return ref, nil
+	}
+
+	commitID, err := gitRepo.ConvertToGitID(string(ref) + refSuffix)
+	if err != nil {
+		if git.IsErrNotExist(err) {
+			return "", util.NewNotExistErrorf("no ref: %s%s", refName, refSuffix)
+		}
+		return "", err
+	}
+	return git.RefName(commitID.String()), nil
 }
 
 // maxForkTraverseLevel defines the maximum levels to traverse when searching for the head repository.

--- a/routers/common/compare_test.go
+++ b/routers/common/compare_test.go
@@ -53,10 +53,28 @@ func TestCompareRouterReq(t *testing.T) {
 			},
 		},
 		{
+			input: "main~2...develop^",
+			CompareRouterReq: &CompareRouterReq{
+				BaseOriRef:       "main",
+				BaseOriRefSuffix: "~2",
+				CompareSeparator: "...",
+				HeadOriRef:       "develop",
+				HeadOriRefSuffix: "^",
+			},
+		},
+		{
 			input: "develop",
 			CompareRouterReq: &CompareRouterReq{
 				CompareSeparator: "...",
 				HeadOriRef:       "develop",
+			},
+		},
+		{
+			input: "develop~3",
+			CompareRouterReq: &CompareRouterReq{
+				CompareSeparator: "...",
+				HeadOriRef:       "develop",
+				HeadOriRefSuffix: "~3",
 			},
 		},
 		{
@@ -87,7 +105,7 @@ func TestCompareRouterReq(t *testing.T) {
 			},
 		},
 		{
-			input: "main^...lunny/forked_repo:develop",
+			input: "main^...lunny/forked_repo:develop~2",
 			CompareRouterReq: &CompareRouterReq{
 				BaseOriRef:       "main",
 				BaseOriRefSuffix: "^",
@@ -95,6 +113,7 @@ func TestCompareRouterReq(t *testing.T) {
 				HeadOwner:        "lunny",
 				HeadRepoName:     "forked_repo",
 				HeadOriRef:       "develop",
+				HeadOriRefSuffix: "~2",
 			},
 		},
 	}

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -208,11 +208,6 @@ func (cpi *comparePageInfoType) parseCompareInfo(ctx *context.Context) error {
 	// 1 Parse compare router param
 	compareReq := common.ParseCompareRouterParam(ctx.PathParam("*"))
 
-	// remove the check when we support compare with carets
-	if compareReq.BaseOriRefSuffix != "" {
-		return util.NewInvalidArgumentErrorf("unsupported comparison syntax: ref with suffix")
-	}
-
 	// 2 get repository and owner for head
 	headOwner, headRepo, err := common.GetHeadOwnerAndRepo(ctx, baseRepo, compareReq)
 	if err != nil {
@@ -241,18 +236,18 @@ func (cpi *comparePageInfoType) parseCompareInfo(ctx *context.Context) error {
 	baseRefName := util.IfZero(compareReq.BaseOriRef, baseRepo.GetPullRequestTargetBranch(ctx))
 	headRefName := util.IfZero(compareReq.HeadOriRef, headRepo.DefaultBranch)
 
-	baseRef := ctx.Repo.GitRepo.UnstableGuessRefByShortName(baseRefName)
-	if baseRef == "" {
-		return util.NewNotExistErrorf("no base ref: %s", baseRefName)
+	baseRef, err := common.ResolveCompareRef(ctx.Repo.GitRepo, baseRefName, compareReq.BaseOriRefSuffix)
+	if err != nil {
+		return err
 	}
 	headGitRepo, err := gitrepo.RepositoryFromRequestContextOrOpen(ctx, headRepo)
 	if err != nil {
 		return err
 	}
 
-	headRef := headGitRepo.UnstableGuessRefByShortName(headRefName)
-	if headRef == "" {
-		return util.NewNotExistErrorf("no head ref: %s", headRefName)
+	headRef, err := common.ResolveCompareRef(headGitRepo, headRefName, compareReq.HeadOriRefSuffix)
+	if err != nil {
+		return err
 	}
 
 	ctx.Data["BaseName"] = baseRepo.OwnerName

--- a/tests/integration/api_repo_compare_test.go
+++ b/tests/integration/api_repo_compare_test.go
@@ -44,6 +44,36 @@ func TestAPICompareBranches(t *testing.T) {
 			assert.Len(t, apiResp.Commits, 1)
 		})
 
+		t.Run("CompareBaseRefSuffix", func(t *testing.T) {
+			defer tests.PrintCurrentTest(t)()
+
+			req := NewRequestf(t, "GET", "/api/v1/repos/user2/repo20/compare/remove-files-b^...remove-files-b").AddTokenAuth(token2)
+			resp := MakeRequest(t, req, http.StatusOK)
+			apiResp := DecodeJSON(t, resp, &api.Compare{})
+			assert.Equal(t, 1, apiResp.TotalCommits)
+			assert.Len(t, apiResp.Commits, 1)
+		})
+
+		t.Run("CompareHeadRefSuffix", func(t *testing.T) {
+			defer tests.PrintCurrentTest(t)()
+
+			req := NewRequestf(t, "GET", "/api/v1/repos/user2/repo20/compare/add-csv...remove-files-b^").AddTokenAuth(token2)
+			resp := MakeRequest(t, req, http.StatusOK)
+			apiResp := DecodeJSON(t, resp, &api.Compare{})
+			assert.Equal(t, 1, apiResp.TotalCommits)
+			assert.Len(t, apiResp.Commits, 1)
+		})
+
+		t.Run("CompareTildeRefSuffix", func(t *testing.T) {
+			defer tests.PrintCurrentTest(t)()
+
+			req := NewRequestf(t, "GET", "/api/v1/repos/user2/repo20/compare/remove-files-b~2...remove-files-b").AddTokenAuth(token2)
+			resp := MakeRequest(t, req, http.StatusOK)
+			apiResp := DecodeJSON(t, resp, &api.Compare{})
+			assert.Equal(t, 2, apiResp.TotalCommits)
+			assert.Len(t, apiResp.Commits, 2)
+		})
+
 		t.Run("CompareForkOnlyCommit", func(t *testing.T) {
 			defer tests.PrintCurrentTest(t)()
 


### PR DESCRIPTION
## Summary
- Parsed ref suffixes on both base and head compare refs.
- Resolved `^` and `~N` suffixes through `ConvertToGitID` before running compare.
- Added API integration coverage for base, head, and tilde suffix comparisons.

## Tests
- go test ./modules/git -run TestRefName|TestRefWebLinkPath|TestParseRefSuffix -count=1
- go test ./routers/common ./routers/api/v1/repo ./routers/web/repo -count=1
- go test ./tests/integration -run TestAPICompareBranches -count=1
- GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./modules/git ./routers/common ./routers/api/v1/repo ./routers/web/repo
- git diff --check

Closes #33943

### AI assistance
AI assistance was used to prepare this patch and PR description.