### PR TITLE
Sort PR commits chronologically

### DIFF
--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -389,8 +389,7 @@ func autoTitleFromBranchName(name string) string {
 func prepareNewPullRequestTitleContent(ci *git_service.CompareInfo, commits []*git_model.SignCommitWithStatuses, defaultTitleSource string) (title, content string) {
 	useFirstCommitAsTitle := len(commits) == 1 || (defaultTitleSource == setting.RepoPRTitleSourceFirstCommit && len(commits) > 0)
 	if useFirstCommitAsTitle {
-		// the "commits" are from "ShowPrettyFormatLogToList", which is ordered from newest to oldest, here take the oldest one
-		c := commits[len(commits)-1]
+		c := commits[0]
 		title = c.UserCommit.MessageTitle()
 	} else {
 		title = autoTitleFromBranchName(ci.HeadRef.ShortName())

--- a/routers/web/repo/compare_test.go
+++ b/routers/web/repo/compare_test.go
@@ -81,9 +81,9 @@ func TestNewPullRequestTitleContent(t *testing.T) {
 
 	// multiple commits
 	commits := []*git_model.SignCommitWithStatuses{
-		// ordered from newest to oldest
-		mockCommit("title2\nbody2"),
+		// ordered from oldest to newest
 		mockCommit("title1\nbody1"),
+		mockCommit("title2\nbody2"),
 	}
 	title, content = prepareNewPullRequestTitleContent(ci, commits, setting.RepoPRTitleSourceAuto)
 	assert.Equal(t, "Head branch", title)

--- a/services/git/compare.go
+++ b/services/git/compare.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	repo_model "gitea.dev/models/repo"
 	"gitea.dev/modules/git"
@@ -103,6 +104,7 @@ func GetCompareInfo(ctx context.Context, baseRepo, headRepo *repo_model.Reposito
 		if err != nil {
 			return compareInfo, fmt.Errorf("ShowPrettyFormatLogToList: %w", err)
 		}
+		slices.Reverse(compareInfo.Commits)
 	}
 
 	// Count number of changed files.

--- a/tests/integration/api_repo_compare_test.go
+++ b/tests/integration/api_repo_compare_test.go
@@ -6,6 +6,7 @@ package integration
 import (
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
 	auth_model "gitea.dev/models/auth"
@@ -32,6 +33,8 @@ func TestAPICompareBranches(t *testing.T) {
 			apiResp := DecodeJSON(t, resp, &api.Compare{})
 			assert.Equal(t, 2, apiResp.TotalCommits)
 			assert.Len(t, apiResp.Commits, 2)
+			assert.True(t, strings.HasPrefix(apiResp.Commits[0].SHA, "b67e43a"))
+			assert.True(t, strings.HasPrefix(apiResp.Commits[1].SHA, "8babce9"))
 		})
 
 		t.Run("CompareCommits", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Sorted compare/PR commit lists from oldest to newest.
- Kept the first-commit PR title source aligned with the new chronological order.
- Added API compare coverage for commit order.

## Tests
- go test ./services/git ./routers/web/repo ./routers/api/v1/repo -count=1
- go test ./tests/integration -run TestAPICompareBranches -count=1
- GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./services/git ./routers/web/repo ./routers/api/v1/repo
- git diff --check

Closes #30449

### AI assistance
AI assistance was used to prepare this patch and PR description.