### PR TITLE
Trigger webhooks for issue deadline changes

### DIFF
--- a/modules/structs/hook.go
+++ b/modules/structs/hook.go
@@ -422,6 +422,8 @@ type ChangesPayload struct {
 	Title *ChangesFromPayload `json:"title,omitempty"`
 	// Changes made to the body/description
 	Body *ChangesFromPayload `json:"body,omitempty"`
+	// Changes made to the due date
+	Deadline *ChangesFromPayload `json:"due_date,omitempty"`
 	// Changes made to the reference
 	Ref *ChangesFromPayload `json:"ref,omitempty"`
 	// Changes made to the labels added

--- a/routers/api/v1/repo/issue.go
+++ b/routers/api/v1/repo/issue.go
@@ -845,11 +845,10 @@ func EditIssue(ctx *context.APIContext) {
 			}
 		}
 
-		if err := issues_model.UpdateIssueDeadline(ctx, issue, deadlineUnix, ctx.Doer); err != nil {
+		if err := issue_service.ChangeDeadline(ctx, issue, ctx.Doer, deadlineUnix); err != nil {
 			ctx.APIErrorInternal(err)
 			return
 		}
-		issue.DeadlineUnix = deadlineUnix
 	}
 
 	// Add/delete assignees
@@ -1039,7 +1038,7 @@ func UpdateIssueDeadline(ctx *context.APIContext) {
 	}
 
 	deadlineUnix, _ := common.ParseAPIDeadlineToEndOfDay(form.Deadline)
-	if err := issues_model.UpdateIssueDeadline(ctx, issue, deadlineUnix, ctx.Doer); err != nil {
+	if err := issue_service.ChangeDeadline(ctx, issue, ctx.Doer, deadlineUnix); err != nil {
 		ctx.APIErrorInternal(err)
 		return
 	}

--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -700,11 +700,10 @@ func EditPullRequest(ctx *context.APIContext) {
 			deadlineUnix = timeutil.TimeStamp(deadline.Unix())
 		}
 
-		if err := issues_model.UpdateIssueDeadline(ctx, issue, deadlineUnix, ctx.Doer); err != nil {
+		if err := issue_service.ChangeDeadline(ctx, issue, ctx.Doer, deadlineUnix); err != nil {
 			ctx.APIErrorInternal(err)
 			return
 		}
-		issue.DeadlineUnix = deadlineUnix
 	}
 
 	// Add/delete assignees

--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -393,7 +393,7 @@ func UpdateIssueDeadline(ctx *context.Context) {
 	}
 
 	deadlineUnix, _ := common.ParseDeadlineDateToEndOfDay(ctx.FormString("deadline"))
-	if err := issues_model.UpdateIssueDeadline(ctx, issue, deadlineUnix, ctx.Doer); err != nil {
+	if err := issue_service.ChangeDeadline(ctx, issue, ctx.Doer, deadlineUnix); err != nil {
 		ctx.HTTPError(http.StatusInternalServerError, "UpdateIssueDeadline", err.Error())
 		return
 	}

--- a/services/actions/notifier.go
+++ b/services/actions/notifier.go
@@ -6,6 +6,7 @@ package actions
 import (
 	"context"
 	"errors"
+	"time"
 
 	actions_model "gitea.dev/models/actions"
 	issues_model "gitea.dev/models/issues"
@@ -21,6 +22,7 @@ import (
 	"gitea.dev/modules/repository"
 	"gitea.dev/modules/setting"
 	api "gitea.dev/modules/structs"
+	"gitea.dev/modules/timeutil"
 	"gitea.dev/modules/util"
 	webhook_module "gitea.dev/modules/webhook"
 	"gitea.dev/services/convert"
@@ -71,11 +73,30 @@ func (n *actionsNotifier) IssueChangeTitle(ctx context.Context, doer *user_model
 	n.notifyIssueChangeWithTitleOrContent(ctx, doer, issue)
 }
 
-func (n *actionsNotifier) notifyIssueChangeWithTitleOrContent(ctx context.Context, doer *user_model.User, issue *issues_model.Issue) {
+func (n *actionsNotifier) IssueChangeDeadline(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, oldDeadlineUnix timeutil.TimeStamp) {
+	ctx = withMethod(ctx, "IssueChangeDeadline")
+	n.notifyIssueChangeWithTitleOrContent(ctx, doer, issue, &api.ChangesPayload{
+		Deadline: deadlineChangeFromPayload(oldDeadlineUnix),
+	})
+}
+
+func deadlineChangeFromPayload(deadlineUnix timeutil.TimeStamp) *api.ChangesFromPayload {
+	if deadlineUnix.IsZero() {
+		return &api.ChangesFromPayload{}
+	}
+	return &api.ChangesFromPayload{From: deadlineUnix.Format(time.RFC3339)}
+}
+
+func (n *actionsNotifier) notifyIssueChangeWithTitleOrContent(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, changes ...*api.ChangesPayload) {
 	var err error
 	if err = issue.LoadRepo(ctx); err != nil {
 		log.Error("LoadRepo: %v", err)
 		return
+	}
+
+	var changePayload *api.ChangesPayload
+	if len(changes) > 0 {
+		changePayload = changes[0]
 	}
 
 	permission, _ := access_model.GetIndividualUserRepoPermission(ctx, issue.Repo, issue.Poster)
@@ -89,6 +110,7 @@ func (n *actionsNotifier) notifyIssueChangeWithTitleOrContent(ctx context.Contex
 			WithPayload(&api.PullRequestPayload{
 				Action:      api.HookIssueEdited,
 				Index:       issue.Index,
+				Changes:     changePayload,
 				PullRequest: convert.ToAPIPullRequest(ctx, issue.PullRequest, nil),
 				Repository:  convert.ToRepo(ctx, issue.Repo, access_model.Permission{AccessMode: perm_model.AccessModeNone}),
 				Sender:      convert.ToUser(ctx, doer, nil),
@@ -102,6 +124,7 @@ func (n *actionsNotifier) notifyIssueChangeWithTitleOrContent(ctx context.Contex
 		WithPayload(&api.IssuePayload{
 			Action:     api.HookIssueEdited,
 			Index:      issue.Index,
+			Changes:    changePayload,
 			Issue:      convert.ToAPIIssue(ctx, doer, issue),
 			Repository: convert.ToRepo(ctx, issue.Repo, permission),
 			Sender:     convert.ToUser(ctx, doer, nil),

--- a/services/indexer/notify.go
+++ b/services/indexer/notify.go
@@ -15,6 +15,7 @@ import (
 	"gitea.dev/modules/log"
 	"gitea.dev/modules/repository"
 	"gitea.dev/modules/setting"
+	"gitea.dev/modules/timeutil"
 	notify_service "gitea.dev/services/notify"
 )
 
@@ -140,6 +141,10 @@ func (r *indexerNotifier) IssueChangeAssignee(ctx context.Context, doer *user_mo
 }
 
 func (r *indexerNotifier) IssueChangeMilestone(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, oldMilestoneID int64) {
+	issue_indexer.UpdateIssueIndexer(ctx, issue.ID)
+}
+
+func (r *indexerNotifier) IssueChangeDeadline(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, oldDeadlineUnix timeutil.TimeStamp) {
 	issue_indexer.UpdateIssueIndexer(ctx, issue.ID)
 }
 

--- a/services/issue/deadline.go
+++ b/services/issue/deadline.go
@@ -1,0 +1,34 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package issue
+
+import (
+	"context"
+
+	issues_model "gitea.dev/models/issues"
+	user_model "gitea.dev/models/user"
+	"gitea.dev/modules/timeutil"
+	notify_service "gitea.dev/services/notify"
+)
+
+// ChangeDeadline changes an issue deadline and notifies issue listeners.
+func ChangeDeadline(ctx context.Context, issue *issues_model.Issue, doer *user_model.User, deadlineUnix timeutil.TimeStamp) error {
+	oldDeadlineUnix := issue.DeadlineUnix
+	if oldDeadlineUnix == deadlineUnix {
+		return nil
+	}
+
+	if err := issue.LoadRepo(ctx); err != nil {
+		return err
+	}
+
+	if err := issues_model.UpdateIssueDeadline(ctx, issue, deadlineUnix, doer); err != nil {
+		return err
+	}
+
+	issue.DeadlineUnix = deadlineUnix
+	notify_service.IssueChangeDeadline(ctx, doer, issue, oldDeadlineUnix)
+
+	return nil
+}

--- a/services/notify/notifier.go
+++ b/services/notify/notifier.go
@@ -14,6 +14,7 @@ import (
 	user_model "gitea.dev/models/user"
 	"gitea.dev/modules/git"
 	"gitea.dev/modules/repository"
+	"gitea.dev/modules/timeutil"
 )
 
 // Notifier defines an interface to notify receiver
@@ -33,6 +34,7 @@ type Notifier interface {
 	IssueChangeStatus(ctx context.Context, doer *user_model.User, commitID string, issue *issues_model.Issue, actionComment *issues_model.Comment, closeOrReopen bool)
 	DeleteIssue(ctx context.Context, doer *user_model.User, issue *issues_model.Issue)
 	IssueChangeMilestone(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, oldMilestoneID int64)
+	IssueChangeDeadline(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, oldDeadlineUnix timeutil.TimeStamp)
 	IssueChangeAssignee(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, assignee *user_model.User, removed bool, comment *issues_model.Comment)
 	PullRequestReviewRequest(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, reviewer *user_model.User, isRequest bool, comment *issues_model.Comment)
 	IssueChangeContent(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, oldContent string)

--- a/services/notify/notify.go
+++ b/services/notify/notify.go
@@ -15,6 +15,7 @@ import (
 	"gitea.dev/modules/git"
 	"gitea.dev/modules/log"
 	"gitea.dev/modules/repository"
+	"gitea.dev/modules/timeutil"
 )
 
 var notifiers []Notifier
@@ -220,6 +221,13 @@ func DeleteRelease(ctx context.Context, doer *user_model.User, rel *repo_model.R
 func IssueChangeMilestone(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, oldMilestoneID int64) {
 	for _, notifier := range notifiers {
 		notifier.IssueChangeMilestone(ctx, doer, issue, oldMilestoneID)
+	}
+}
+
+// IssueChangeDeadline notifies change deadline to notifiers
+func IssueChangeDeadline(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, oldDeadlineUnix timeutil.TimeStamp) {
+	for _, notifier := range notifiers {
+		notifier.IssueChangeDeadline(ctx, doer, issue, oldDeadlineUnix)
 	}
 }
 

--- a/services/notify/null.go
+++ b/services/notify/null.go
@@ -14,6 +14,7 @@ import (
 	user_model "gitea.dev/models/user"
 	"gitea.dev/modules/git"
 	"gitea.dev/modules/repository"
+	"gitea.dev/modules/timeutil"
 )
 
 // NullNotifier implements a blank notifier
@@ -112,6 +113,10 @@ func (*NullNotifier) DeleteRelease(ctx context.Context, doer *user_model.User, r
 
 // IssueChangeMilestone places a place holder function
 func (*NullNotifier) IssueChangeMilestone(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, oldMilestoneID int64) {
+}
+
+// IssueChangeDeadline places a place holder function
+func (*NullNotifier) IssueChangeDeadline(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, oldDeadlineUnix timeutil.TimeStamp) {
 }
 
 // IssueChangeContent places a place holder function

--- a/services/webhook/notifier.go
+++ b/services/webhook/notifier.go
@@ -6,6 +6,7 @@ package webhook
 import (
 	"context"
 	"errors"
+	"time"
 
 	actions_model "gitea.dev/models/actions"
 	git_model "gitea.dev/models/git"
@@ -23,6 +24,7 @@ import (
 	"gitea.dev/modules/repository"
 	"gitea.dev/modules/setting"
 	api "gitea.dev/modules/structs"
+	"gitea.dev/modules/timeutil"
 	"gitea.dev/modules/util"
 	webhook_module "gitea.dev/modules/webhook"
 	"gitea.dev/services/convert"
@@ -401,6 +403,52 @@ func (m *webhookNotifier) IssueChangeContent(ctx context.Context, doer *user_mod
 	if err != nil {
 		log.Error("PrepareWebhooks [is_pull: %v]: %v", issue.IsPull, err)
 	}
+}
+
+func (m *webhookNotifier) IssueChangeDeadline(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, oldDeadlineUnix timeutil.TimeStamp) {
+	if err := issue.LoadRepo(ctx); err != nil {
+		log.Error("LoadRepo: %v", err)
+		return
+	}
+
+	changes := &api.ChangesPayload{
+		Deadline: deadlineChangeFromPayload(oldDeadlineUnix),
+	}
+	permission, _ := access_model.GetIndividualUserRepoPermission(ctx, issue.Repo, issue.Poster)
+	var err error
+	if issue.IsPull {
+		if err := issue.LoadPullRequest(ctx); err != nil {
+			log.Error("LoadPullRequest: %v", err)
+			return
+		}
+		err = PrepareWebhooks(ctx, EventSource{Repository: issue.Repo}, webhook_module.HookEventPullRequest, &api.PullRequestPayload{
+			Action:      api.HookIssueEdited,
+			Index:       issue.Index,
+			Changes:     changes,
+			PullRequest: convert.ToAPIPullRequest(ctx, issue.PullRequest, doer),
+			Repository:  convert.ToRepo(ctx, issue.Repo, permission),
+			Sender:      convert.ToUser(ctx, doer, nil),
+		})
+	} else {
+		err = PrepareWebhooks(ctx, EventSource{Repository: issue.Repo}, webhook_module.HookEventIssues, &api.IssuePayload{
+			Action:     api.HookIssueEdited,
+			Index:      issue.Index,
+			Changes:    changes,
+			Issue:      convert.ToAPIIssue(ctx, doer, issue),
+			Repository: convert.ToRepo(ctx, issue.Repo, permission),
+			Sender:     convert.ToUser(ctx, doer, nil),
+		})
+	}
+	if err != nil {
+		log.Error("PrepareWebhooks [is_pull: %v]: %v", issue.IsPull, err)
+	}
+}
+
+func deadlineChangeFromPayload(deadlineUnix timeutil.TimeStamp) *api.ChangesFromPayload {
+	if deadlineUnix.IsZero() {
+		return &api.ChangesFromPayload{}
+	}
+	return &api.ChangesFromPayload{From: deadlineUnix.Format(time.RFC3339)}
 }
 
 func (m *webhookNotifier) UpdateComment(ctx context.Context, doer *user_model.User, c *issues_model.Comment, oldContent string) {

--- a/tests/integration/repo_webhook_test.go
+++ b/tests/integration/repo_webhook_test.go
@@ -19,6 +19,7 @@ import (
 	actions_model "gitea.dev/models/actions"
 	auth_model "gitea.dev/models/auth"
 	db_model "gitea.dev/models/db"
+	issues_model "gitea.dev/models/issues"
 	"gitea.dev/models/perm"
 	"gitea.dev/models/repo"
 	"gitea.dev/models/unittest"
@@ -31,6 +32,7 @@ import (
 	"gitea.dev/modules/setting"
 	api "gitea.dev/modules/structs"
 	"gitea.dev/modules/test"
+	"gitea.dev/modules/timeutil"
 	webhook_module "gitea.dev/modules/webhook"
 	"gitea.dev/services/actions"
 	"gitea.dev/tests"
@@ -524,6 +526,47 @@ func Test_WebhookIssue(t *testing.T) {
 		assert.Equal(t, "Description1", payloads[0].Issue.Body)
 		assert.Positive(t, payloads[0].Issue.Created.Unix())
 		assert.Positive(t, payloads[0].Issue.Updated.Unix())
+	})
+}
+
+func Test_WebhookIssueDeadline(t *testing.T) {
+	onGiteaRun(t, func(t *testing.T, giteaURL *url.URL) {
+		var payloads []api.IssuePayload
+		var triggeredEvent string
+		provider := newMockWebhookProvider(func(r *http.Request) {
+			content, _ := io.ReadAll(r.Body)
+			var payload api.IssuePayload
+			err := json.Unmarshal(content, &payload)
+			assert.NoError(t, err)
+			payloads = append(payloads, payload)
+			triggeredEvent = "issues"
+		}, http.StatusOK)
+		defer provider.Close()
+
+		session := loginUser(t, "user2")
+		repo1 := unittest.AssertExistsAndLoadBean(t, &repo.Repository{ID: 1})
+		issueBefore := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{RepoID: repo1.ID, Index: 1})
+		issueBefore.DeadlineUnix = timeutil.TimeStamp(time.Date(2025, time.January, 2, 23, 59, 59, 0, time.UTC).Unix())
+		require.NoError(t, issues_model.UpdateIssueCols(t.Context(), issueBefore, "deadline_unix"))
+		oldDeadline := issueBefore.DeadlineUnix.Format(time.RFC3339)
+		testAPICreateWebhookForRepo(t, session, "user2", "repo1", provider.URL(), "issues")
+
+		req := NewRequestWithValues(t, "POST", fmt.Sprintf("%s/issues/%d/deadline", repo1.Link(), issueBefore.Index), map[string]string{
+			"deadline": "2026-01-02",
+		})
+		session.MakeRequest(t, req, http.StatusOK)
+
+		assert.Equal(t, "issues", triggeredEvent)
+		require.Len(t, payloads, 1)
+		assert.Equal(t, api.HookIssueEdited, payloads[0].Action)
+		assert.Equal(t, issueBefore.Index, payloads[0].Index)
+		assert.Equal(t, "repo1", payloads[0].Issue.Repo.Name)
+		assert.Equal(t, "user2/repo1", payloads[0].Issue.Repo.FullName)
+		require.NotNil(t, payloads[0].Issue.Deadline)
+		assert.Equal(t, "2026-01-02", payloads[0].Issue.Deadline.Format("2006-01-02"))
+		require.NotNil(t, payloads[0].Changes)
+		require.NotNil(t, payloads[0].Changes.Deadline)
+		assert.Equal(t, oldDeadline, payloads[0].Changes.Deadline.From)
 	})
 }
 


### PR DESCRIPTION
Closes #8793

### Summary
- routed issue and pull request deadline updates through the issue service notification path
- sent edited issue/pull request webhooks when the due date changes
- included the previous due date in `changes.due_date.from` and added an integration test

### Tests
- `go test ./services/issue ./services/notify ./services/actions ./services/webhook ./services/indexer -count=1`
- `go test ./tests/integration -run Test_WebhookIssueDeadline -count=1`
- `go test ./routers/web/repo ./routers/api/v1/repo -count=1`
- `go test ./tests/integration -run 'Test_WebhookIssue|Test_WebhookIssueDeadline|Test_WebhookIssueAssign|Test_WebhookIssueMilestone' -count=1`
- `go test ./modules/structs -count=1`
- `go test ./tests/integration -run 'TestUpdateIssueDeadline|TestAPIEditIssue|TestAPIEditPull' -count=1`
- `GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./modules/structs ./services/issue ./services/notify ./services/actions ./services/webhook ./services/indexer ./routers/web/repo ./routers/api/v1/repo ./tests/integration`
- `git diff --check`

### AI assistance
AI assistance was used to prepare this patch and PR description.