### PR TITLE
Format activity code stats numbers

### DIFF
--- a/modules/translation/mock.go
+++ b/modules/translation/mock.go
@@ -57,3 +57,7 @@ func (l MockLocale) TrN(cnt any, key1, keyN string, args ...any) template.HTML {
 func (l MockLocale) PrettyNumber(v any) string {
 	return fmt.Sprint(v)
 }
+
+func (l MockLocale) PrettyNumberArg(v any) fmt.Formatter {
+	return prettyNumberArg(l.PrettyNumber(v))
+}

--- a/modules/translation/translation.go
+++ b/modules/translation/translation.go
@@ -5,6 +5,7 @@ package translation
 
 import (
 	"context"
+	"fmt"
 	"html/template"
 	"sort"
 	"strings"
@@ -34,6 +35,7 @@ type Locale interface {
 	TrN(cnt any, key1, keyN string, args ...any) template.HTML
 
 	PrettyNumber(v any) string
+	PrettyNumberArg(v any) fmt.Formatter
 }
 
 // LangType represents a lang type
@@ -229,6 +231,31 @@ func (l *locale) Tr(s string, args ...any) template.HTML {
 	return l.TrHTML(s, args...)
 }
 
+type prettyNumberArg string
+
+func (p prettyNumberArg) Format(s fmt.State, _ rune) {
+	_, _ = s.Write([]byte(p))
+}
+
+func (l *locale) TrHTML(trKey string, trArgs ...any) template.HTML {
+	args := append([]any(nil), trArgs...)
+	for i, v := range args {
+		switch v := v.(type) {
+		case prettyNumberArg:
+			// Keep the formatter intact so translated "%d" placeholders can use
+			// the locale-aware number string.
+		case nil, bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, template.HTML:
+		case string:
+			args[i] = template.HTMLEscapeString(v)
+		case fmt.Stringer:
+			args[i] = template.HTMLEscapeString(v.String())
+		default:
+			args[i] = template.HTMLEscapeString(fmt.Sprint(v))
+		}
+	}
+	return template.HTML(l.TrString(trKey, args...))
+}
+
 // TrN returns translated message for plural text translation
 func (l *locale) TrN(cnt any, key1, keyN string, args ...any) template.HTML {
 	var c int64
@@ -265,6 +292,10 @@ func (l *locale) PrettyNumber(v any) string {
 		}
 	}
 	return l.msgPrinter.Sprintf("%v", number.Decimal(v))
+}
+
+func (l *locale) PrettyNumberArg(v any) fmt.Formatter {
+	return prettyNumberArg(l.PrettyNumber(v))
 }
 
 func init() {

--- a/modules/translation/translation_test.go
+++ b/modules/translation/translation_test.go
@@ -30,3 +30,21 @@ func TestPrettyNumber(t *testing.T) {
 	assert.Equal(t, "1,000,000", l.PrettyNumber(1000000))
 	assert.Equal(t, "1,000,000.1", l.PrettyNumber(1000000.1))
 }
+
+func TestPrettyNumberArg(t *testing.T) {
+	i18n.ResetDefaultLocales()
+
+	allLangMap = make(map[string]*LangType)
+	allLangMap["id-ID"] = &LangType{Lang: "id-ID", Name: "Bahasa Indonesia"}
+
+	assert.NoError(t, i18n.DefaultLocales.AddLocaleByJSON("id-ID", "Bahasa Indonesia", []byte(`{
+		"item_1": "%d item",
+		"item_n": "%d items",
+		"message": "%d <span>%s</span>"
+	}`), nil))
+	i18n.DefaultLocales.SetDefaultLang("id-ID")
+
+	l := NewLocale("id-ID")
+	assert.EqualValues(t, "1.000 items", l.TrN(1000, "item_1", "item_n", l.PrettyNumberArg(1000)))
+	assert.EqualValues(t, "1.000 <span>a&amp;b</span>", l.Tr("message", l.PrettyNumberArg(1000), "a&b"))
+}

--- a/templates/repo/pulse.tmpl
+++ b/templates/repo/pulse.tmpl
@@ -90,19 +90,19 @@
 		<div class="ui attached segment horizontal segments">
 			<div class="ui attached segment text">
 				{{ctx.Locale.Tr "repo.activity.git_stats_exclude_merges"}}
-				<strong>{{ctx.Locale.TrN .Activity.Code.AuthorCount "repo.activity.git_stats_author_1" "repo.activity.git_stats_author_n" .Activity.Code.AuthorCount}}</strong>
+				<strong>{{ctx.Locale.TrN .Activity.Code.AuthorCount "repo.activity.git_stats_author_1" "repo.activity.git_stats_author_n" (ctx.Locale.PrettyNumberArg .Activity.Code.AuthorCount)}}</strong>
 				{{ctx.Locale.TrN .Activity.Code.AuthorCount "repo.activity.git_stats_pushed_1" "repo.activity.git_stats_pushed_n"}}
-				<strong>{{ctx.Locale.TrN .Activity.Code.CommitCount "repo.activity.git_stats_commit_1" "repo.activity.git_stats_commit_n" .Activity.Code.CommitCount}}</strong>
+				<strong>{{ctx.Locale.TrN .Activity.Code.CommitCount "repo.activity.git_stats_commit_1" "repo.activity.git_stats_commit_n" (ctx.Locale.PrettyNumberArg .Activity.Code.CommitCount)}}</strong>
 				{{ctx.Locale.Tr "repo.activity.git_stats_push_to_branch" .Repository.DefaultBranch}}
-				<strong>{{ctx.Locale.TrN .Activity.Code.CommitCountInAllBranches "repo.activity.git_stats_commit_1" "repo.activity.git_stats_commit_n" .Activity.Code.CommitCountInAllBranches}}</strong>
+				<strong>{{ctx.Locale.TrN .Activity.Code.CommitCountInAllBranches "repo.activity.git_stats_commit_1" "repo.activity.git_stats_commit_n" (ctx.Locale.PrettyNumberArg .Activity.Code.CommitCountInAllBranches)}}</strong>
 				{{ctx.Locale.Tr "repo.activity.git_stats_push_to_all_branches"}}
 				{{ctx.Locale.Tr "repo.activity.git_stats_on_default_branch" .Repository.DefaultBranch}}
-				<strong>{{ctx.Locale.TrN .Activity.Code.ChangedFiles "repo.activity.git_stats_file_1" "repo.activity.git_stats_file_n" .Activity.Code.ChangedFiles}}</strong>
+				<strong>{{ctx.Locale.TrN .Activity.Code.ChangedFiles "repo.activity.git_stats_file_1" "repo.activity.git_stats_file_n" (ctx.Locale.PrettyNumberArg .Activity.Code.ChangedFiles)}}</strong>
 				{{ctx.Locale.TrN .Activity.Code.ChangedFiles "repo.activity.git_stats_files_changed_1" "repo.activity.git_stats_files_changed_n"}}
 				{{ctx.Locale.Tr "repo.activity.git_stats_additions"}}
-				<strong class="tw-text-green">{{ctx.Locale.TrN .Activity.Code.Additions "repo.activity.git_stats_addition_1" "repo.activity.git_stats_addition_n" .Activity.Code.Additions}}</strong>
+				<strong class="tw-text-green">{{ctx.Locale.TrN .Activity.Code.Additions "repo.activity.git_stats_addition_1" "repo.activity.git_stats_addition_n" (ctx.Locale.PrettyNumberArg .Activity.Code.Additions)}}</strong>
 				{{ctx.Locale.Tr "repo.activity.git_stats_and_deletions"}}
-				<strong class="tw-text-red">{{ctx.Locale.TrN .Activity.Code.Deletions "repo.activity.git_stats_deletion_1" "repo.activity.git_stats_deletion_n" .Activity.Code.Deletions}}</strong>.
+				<strong class="tw-text-red">{{ctx.Locale.TrN .Activity.Code.Deletions "repo.activity.git_stats_deletion_1" "repo.activity.git_stats_deletion_n" (ctx.Locale.PrettyNumberArg .Activity.Code.Deletions)}}</strong>.
 			</div>
 			<div class="ui attached segment">
 				<div id="repo-activity-top-authors-chart"></div>


### PR DESCRIPTION
## Summary
- added a locale-aware formatter argument for translated numeric placeholders
- used it for repository activity code stats counts

Closes #9228

## Tests
- go test ./modules/translation -count=1
- go test ./modules/templates -count=1
- go test ./routers/web/repo -count=1
- go test ./tests/integration -run TestRepoActivity -count=1
- make lint-templates
- GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./modules/translation ./modules/templates ./routers/web/repo ./tests/integration
- git diff --check

### AI assistance
AI assistance was used to prepare this patch and PR description.