### PR TITLE
Hide existing dependencies from issue dependency search

### DIFF
--- a/templates/repo/issue/sidebar/issue_dependencies.tmpl
+++ b/templates/repo/issue/sidebar/issue_dependencies.tmpl
@@ -20,7 +20,7 @@
 			</span>
 			<div class="ui divided list">
 				{{range .BlockingDependencies}}
-					<div class="item dependency{{if .Issue.IsClosed}} is-closed{{end}} flex-left-right">
+					<div class="item dependency{{if .Issue.IsClosed}} is-closed{{end}} flex-left-right" data-issue-dependency-id="{{.Issue.ID}}">
 						<div class="item-left tw-flex tw-justify-center tw-flex-col tw-flex-1 gt-ellipsis">
 							<a class="muted issue-dependency-title gt-ellipsis" href="{{.Issue.Link}}" data-tooltip-content="#{{.Issue.Index}} {{.Issue.Title | ctx.RenderUtils.RenderEmoji}}">
 								#{{.Issue.Index}} {{.Issue.Title | ctx.RenderUtils.RenderEmoji}}
@@ -54,7 +54,7 @@
 			</span>
 			<div class="ui divided list">
 				{{range .BlockedByDependencies}}
-					<div class="item dependency{{if .Issue.IsClosed}} is-closed{{end}} flex-left-right">
+					<div class="item dependency{{if .Issue.IsClosed}} is-closed{{end}} flex-left-right" data-issue-dependency-id="{{.Issue.ID}}">
 						<div class="item-left tw-flex tw-justify-center tw-flex-col tw-flex-1 gt-ellipsis">
 							<a class="muted issue-dependency-title gt-ellipsis" href="{{.Issue.Link}}" data-tooltip-content="#{{.Issue.Index}} {{.Issue.Title | ctx.RenderUtils.RenderEmoji}}">
 								#{{.Issue.Index}} {{.Issue.Title | ctx.RenderUtils.RenderEmoji}}
@@ -76,7 +76,7 @@
 				{{end}}
 				{{if $.CanCreateIssueDependencies}}
 					{{range .BlockedByDependenciesNotPermitted}}
-						<div class="item dependency{{if .Issue.IsClosed}} is-closed{{end}} flex-left-right">
+						<div class="item dependency{{if .Issue.IsClosed}} is-closed{{end}} flex-left-right" data-issue-dependency-id="{{.Issue.ID}}">
 							<div class="item-left tw-flex tw-justify-center tw-flex-col tw-flex-1 gt-ellipsis">
 								<div class="gt-ellipsis">
 									<span data-tooltip-content="{{ctx.Locale.Tr "repo.issues.dependency.no_permission.can_remove"}}">{{svg "octicon-lock" 16}}</span>

--- a/web_src/js/features/repo-issue-sidebar.test.ts
+++ b/web_src/js/features/repo-issue-sidebar.test.ts
@@ -1,0 +1,14 @@
+import {filterDependencySearchResponse} from './repo-issue-sidebar.ts';
+
+test('filterDependencySearchResponse skips current issue and existing dependencies', () => {
+  const response = [
+    {id: 1, number: 1, title: 'current issue', repository: {full_name: 'owner/repo'}},
+    {id: 2, number: 2, title: 'new dependency', repository: {full_name: 'owner/repo'}},
+    {id: 3, number: 3, title: 'existing dependency', repository: {full_name: 'owner/repo'}},
+  ];
+
+  const result = filterDependencySearchResponse(response, '1', new Set(['3']));
+
+  expect(result.success).toBe(true);
+  expect(result.results.map((item) => item.value)).toEqual([2]);
+});

--- a/web_src/js/features/repo-issue-sidebar.ts
+++ b/web_src/js/features/repo-issue-sidebar.ts
@@ -9,6 +9,21 @@ import {showTemporaryTooltip} from '../modules/tippy.ts';
 
 const {appSubUrl} = window.config;
 
+export function filterDependencySearchResponse(response: any[], currentIssueId: string | null, existingDependencyIds: Set<string>) {
+  const filteredResponse = {success: true, results: [] as Array<Record<string, any>>};
+  // Parse the response from the api to work with our dropdown
+  for (const issue of response) {
+    const issueId = String(issue.id);
+    if (issueId === currentIssueId) continue;
+    if (existingDependencyIds.has(issueId)) continue;
+    filteredResponse.results.push({
+      value: issue.id,
+      name: html`<div class="gt-ellipsis">#${issue.number} ${issue.title}</div><div class="text small tw-break-anywhere">${issue.repository.full_name}</div>`,
+    });
+  }
+  return filteredResponse;
+}
+
 function initRepoIssueBranchSelector(elSidebar: HTMLElement) {
   // TODO: RemoveIssueRef: see "repo/issue/branch_selector_field.tmpl"
   const elSelectBranch = elSidebar.querySelector('.ui.dropdown.select-branch.branch-selector-dropdown');
@@ -55,6 +70,10 @@ export function initRepoIssueSidebarDependency(elSidebar: HTMLElement) {
 
   const issuePageInfo = parseIssuePageInfo();
   const crossRepoSearch = elDropdown.getAttribute('data-issue-cross-repo-search');
+  const existingDependencyIds = new Set(Array.from(
+    elSidebar.querySelectorAll<HTMLElement>('[data-issue-dependency-id]'),
+    (el) => el.getAttribute('data-issue-dependency-id')!,
+  ));
   let issueSearchUrl = `${issuePageInfo.repoLink}/issues/search?q={query}&type=${issuePageInfo.issueDependencySearchType}`;
   if (crossRepoSearch === 'true') {
     issueSearchUrl = `${appSubUrl}/issues/search?q={query}&priority_repo_id=${issuePageInfo.repoId}&type=${issuePageInfo.issueDependencySearchType}`;
@@ -66,18 +85,7 @@ export function initRepoIssueSidebarDependency(elSidebar: HTMLElement) {
       rawResponse: true,
       url: issueSearchUrl,
       onResponse(response: any) {
-        const filteredResponse = {success: true, results: [] as Array<Record<string, any>>};
-        const currIssueId = elDropdown.getAttribute('data-issue-id');
-        // Parse the response from the api to work with our dropdown
-        for (const issue of response) {
-          // Don't list current issue in the dependency list.
-          if (String(issue.id) === currIssueId) continue;
-          filteredResponse.results.push({
-            value: issue.id,
-            name: html`<div class="gt-ellipsis">#${issue.number} ${issue.title}</div><div class="text small tw-break-anywhere">${issue.repository.full_name}</div>`,
-          });
-        }
-        return filteredResponse;
+        return filterDependencySearchResponse(response, elDropdown.getAttribute('data-issue-id'), existingDependencyIds);
       },
     },
   });


### PR DESCRIPTION
## Summary
- marked rendered issue dependencies with their issue IDs
- filtered the dependency search dropdown to skip the current issue and already added dependencies
- added a frontend unit test for the dependency search response filter

Closes #27449

## Tests
- pnpm vitest run web_src/js/features/repo-issue-sidebar.test.ts
- pnpm exec eslint web_src/js/features/repo-issue-sidebar.ts web_src/js/features/repo-issue-sidebar.test.ts
- pnpm exec vue-tsc
- make lint-templates
- go test ./routers/web/repo -count=1
- go test ./tests/integration -run TestAPICreateIssueDependencyCrossRepoPermission -count=1
- git diff --check

### AI assistance
AI assistance was used to prepare this patch and PR description.