### PR TITLE
Restore dirty form state after canceled submits

### DIFF
--- a/web_src/js/vendor/jquery.are-you-sure.test.ts
+++ b/web_src/js/vendor/jquery.are-you-sure.test.ts
@@ -1,0 +1,44 @@
+import {applyAreYouSure, initAreYouSure, shouldTriggerAreYouSure} from './jquery.are-you-sure.ts';
+
+type AreYouSureWindow = Window & typeof globalThis & {
+  aysHasPrompted?: boolean;
+  aysUnloadSet?: boolean;
+};
+
+function changeInputValue(input: HTMLInputElement, value: string) {
+  input.setAttribute('value', value);
+  window.jQuery(input).val(value).trigger('input');
+}
+
+test('dirty form state is restored when another dirty form blocks unload', async () => {
+  delete (window as AreYouSureWindow).aysHasPrompted;
+  delete (window as AreYouSureWindow).aysUnloadSet;
+  document.body.innerHTML = `
+    <form id="profile"><input name="name" value="old"></form>
+    <form id="avatar"><input name="avatar" value="old"></form>
+  `;
+
+  initAreYouSure(window.jQuery);
+  applyAreYouSure('form:not(.ignore-dirty)', {fieldSelector: 'input'});
+
+  const profileForm = document.querySelector<HTMLFormElement>('#profile')!;
+  const avatarForm = document.querySelector<HTMLFormElement>('#avatar')!;
+
+  changeInputValue(profileForm.querySelector<HTMLInputElement>('input')!, 'new name');
+  changeInputValue(avatarForm.querySelector<HTMLInputElement>('input')!, 'new avatar');
+  window.jQuery(profileForm).trigger('checkform.areYouSure');
+  window.jQuery(avatarForm).trigger('checkform.areYouSure');
+
+  expect(profileForm.classList.contains('dirty')).toBe(true);
+  expect(avatarForm.classList.contains('dirty')).toBe(true);
+
+  profileForm.dispatchEvent(new Event('submit', {bubbles: true, cancelable: true}));
+  expect(profileForm.classList.contains('dirty')).toBe(false);
+  expect(shouldTriggerAreYouSure()).toBe(true);
+
+  await new Promise((resolve) => window.setTimeout(resolve, 0));
+  expect(profileForm.classList.contains('dirty')).toBe(true);
+
+  avatarForm.dispatchEvent(new Event('submit', {bubbles: true, cancelable: true}));
+  expect(shouldTriggerAreYouSure()).toBe(true);
+});

--- a/web_src/js/vendor/jquery.are-you-sure.ts
+++ b/web_src/js/vendor/jquery.are-you-sure.ts
@@ -189,6 +189,9 @@ export function initAreYouSure($) {
 
       $form.submit(function() {
         $form.removeClass(settings.dirtyClass);
+        window.setTimeout(function() {
+          $form.trigger('checkform.areYouSure');
+        }, 0);
       });
       $form.bind('reset', function() { setDirtyStatus($form, false); });
       // Add a custom events


### PR DESCRIPTION
## Summary
- re-check a submitted form after the submit attempt so canceled unload prompts restore its dirty state
- added a unit test covering two dirty forms where the first canceled submit must still protect the second submit

Closes #25956

## Tests
- pnpm vitest run web_src/js/vendor/jquery.are-you-sure.test.ts
- pnpm exec vue-tsc
- git diff --check

### AI assistance
AI assistance was used to prepare this patch and PR description.