### PR TITLE
fix: Return 422 when create issue metadata needs write access

### DIFF
--- a/routers/api/v1/repo/issue.go
+++ b/routers/api/v1/repo/issue.go
@@ -638,8 +638,14 @@ func CreateIssue(ctx *context.APIContext) {
 	//     "$ref": "#/responses/repoArchivedError"
 
 	form := web.GetForm(ctx).(*api.CreateIssueOption)
+	canWriteIssues := ctx.Repo.Permission.CanWrite(unit.TypeIssues)
+	if !canWriteIssues && createIssueHasWriteOnlyFields(form) {
+		ctx.APIError(http.StatusUnprocessableEntity, "write permission is required to set issue metadata")
+		return
+	}
+
 	var deadlineUnix timeutil.TimeStamp
-	if form.Deadline != nil && ctx.Repo.Permission.CanWrite(unit.TypeIssues) {
+	if form.Deadline != nil && canWriteIssues {
 		deadlineUnix = timeutil.TimeStamp(form.Deadline.Unix())
 	}
 
@@ -656,7 +662,7 @@ func CreateIssue(ctx *context.APIContext) {
 
 	assigneeIDs := make([]int64, 0)
 	var err error
-	if ctx.Repo.Permission.CanWrite(unit.TypeIssues) {
+	if canWriteIssues {
 		issue.MilestoneID = form.Milestone
 		assigneeIDs, err = issues_model.MakeIDsFromAPIAssigneesToAdd(ctx, form.Assignee, form.Assignees)
 		if err != nil {
@@ -686,9 +692,6 @@ func CreateIssue(ctx *context.APIContext) {
 				return
 			}
 		}
-	} else {
-		// setting labels is not allowed if user is not a writer
-		form.Labels = make([]int64, 0)
 	}
 
 	if err := issue_service.NewIssue(ctx, ctx.Repo.Repository, issue, form.Labels, nil, assigneeIDs, form.Projects); err != nil {
@@ -720,6 +723,15 @@ func CreateIssue(ctx *context.APIContext) {
 		return
 	}
 	ctx.JSON(http.StatusCreated, convert.ToAPIIssue(ctx, ctx.Doer, issue))
+}
+
+func createIssueHasWriteOnlyFields(form *api.CreateIssueOption) bool {
+	return form.Deadline != nil ||
+		form.Milestone > 0 ||
+		len(form.Labels) > 0 ||
+		form.Assignee != "" ||
+		len(form.Assignees) > 0 ||
+		len(form.Projects) > 0
 }
 
 // EditIssue modify an issue of a repository

--- a/tests/integration/api_issue_test.go
+++ b/tests/integration/api_issue_test.go
@@ -146,6 +146,18 @@ func testAPICreateIssue(t *testing.T) {
 		Title: title,
 	}).AddTokenAuth(getUserToken(t, user34.Name, auth_model.AccessTokenScopeWriteIssue))
 	MakeRequest(t, req, http.StatusForbidden)
+
+	repoBeforeMetadataDenied := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: repoBefore.ID})
+	req = NewRequestWithJSON(t, "POST", urlStr, &api.CreateIssueOption{
+		Title:     "apiTestTitleWithMetadata",
+		Labels:    []int64{1},
+		Milestone: 1,
+	}).AddTokenAuth(getUserToken(t, "user1", auth_model.AccessTokenScopeWriteIssue)).
+		SetHeader("Sudo", "user4")
+	MakeRequest(t, req, http.StatusUnprocessableEntity)
+
+	repoAfterMetadataDenied := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: repoBefore.ID})
+	assert.Equal(t, repoBeforeMetadataDenied.NumIssues, repoAfterMetadataDenied.NumIssues)
 }
 
 func testAPICreateIssueParallel(t *testing.T) {


### PR DESCRIPTION
Closes #11320

### Summary
- Returned 422 when a read-only API user tries to create an issue with write-only metadata.
- Kept normal issue creation unchanged when no metadata is requested.
- Added an integration test covering admin sudo to a non-writer and verifying no partial issue is created.

### Tests
- `go test ./tests/integration -run TestAPIIssue/CreateIssue -count=1`
- `go test ./tests/integration -run TestAPIIssue -count=1`
- `go test ./routers/api/v1/repo -count=1`
- `GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./routers/api/v1/repo ./tests/integration`
- `git diff --check`

### AI assistance
AI assistance was used to prepare this patch and PR description.
