### PR TITLE
Include effective subscribers in issue subscriptions API

### DIFF
--- a/models/issues/issue_watch.go
+++ b/models/issues/issue_watch.go
@@ -10,6 +10,8 @@ import (
 	repo_model "gitea.dev/models/repo"
 	user_model "gitea.dev/models/user"
 	"gitea.dev/modules/timeutil"
+
+	"xorm.io/builder"
 )
 
 // IssueWatch is connection request for receiving issue notification.
@@ -112,6 +114,61 @@ func GetIssueWatchers(ctx context.Context, issueID int64, listOptions db.ListOpt
 	}
 	watches := make([]*IssueWatch, 0, 8)
 	return watches, sess.Find(&watches)
+}
+
+func issueSubscriberCond(issue *Issue) builder.Cond {
+	explicitWatchers := builder.In("`user`.id",
+		builder.Select("user_id").
+			From("issue_watch").
+			Where(builder.Eq{"issue_id": issue.ID, "is_watching": true}),
+	)
+	participants := builder.In("`user`.id",
+		builder.Select("poster_id").
+			From("comment").
+			Where(builder.Eq{"issue_id": issue.ID}.
+				And(builder.In("type", CommentTypeComment, CommentTypeCode, CommentTypeReview))),
+	)
+	repoWatchers := builder.In("`user`.id",
+		builder.Select("user_id").
+			From("watch").
+			Where(builder.Eq{"repo_id": issue.RepoID}.
+				And(builder.In("mode", repo_model.WatchModeNormal, repo_model.WatchModeAuto))),
+	)
+	explicitUnwatchers := builder.NotIn("`user`.id",
+		builder.Select("user_id").
+			From("issue_watch").
+			Where(builder.Eq{"issue_id": issue.ID, "is_watching": false}),
+	)
+
+	return builder.Eq{"`user`.is_active": true, "`user`.prohibit_login": false}.
+		And(explicitUnwatchers).
+		And(builder.Or(
+			explicitWatchers,
+			participants,
+			builder.Eq{"`user`.id": issue.PosterID},
+			repoWatchers,
+		))
+}
+
+// GetIssueSubscribers returns users effectively subscribed to an issue.
+func GetIssueSubscribers(ctx context.Context, issue *Issue, listOptions db.ListOptions) ([]*user_model.User, error) {
+	sess := db.GetEngine(ctx).
+		Where(issueSubscriberCond(issue)).
+		OrderBy("`user`.id")
+	if listOptions.Page > 0 {
+		db.SetSessionPagination(sess, &listOptions)
+		users := make([]*user_model.User, 0, listOptions.PageSize)
+		return users, sess.Find(&users)
+	}
+	users := make([]*user_model.User, 0, 8)
+	return users, sess.Find(&users)
+}
+
+// CountIssueSubscribers counts users effectively subscribed to an issue.
+func CountIssueSubscribers(ctx context.Context, issue *Issue) (int64, error) {
+	return db.GetEngine(ctx).
+		Where(issueSubscriberCond(issue)).
+		Count(new(user_model.User))
 }
 
 // CountIssueWatchers count watchers/unwatchers of a given issue

--- a/models/issues/issue_watch_test.go
+++ b/models/issues/issue_watch_test.go
@@ -65,3 +65,25 @@ func TestGetIssueWatchers(t *testing.T) {
 	// Issue has one watcher
 	assert.Len(t, iws, 1)
 }
+
+func TestGetIssueSubscribers(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	checkSubscribers := func(issueID int64, expectedNames []string, expectedCount int64) {
+		issue := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{ID: issueID})
+		users, err := issues_model.GetIssueSubscribers(t.Context(), issue, db.ListOptions{})
+		assert.NoError(t, err)
+		names := make([]string, 0, len(users))
+		for _, user := range users {
+			names = append(names, user.Name)
+		}
+		assert.ElementsMatch(t, expectedNames, names)
+
+		count, err := issues_model.CountIssueSubscribers(t.Context(), issue)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedCount, count)
+	}
+
+	checkSubscribers(1, []string{"user1", "user4", "user5", "user11"}, 4)
+	checkSubscribers(7, []string{"user2"}, 1)
+}

--- a/routers/api/v1/repo/issue_subscription.go
+++ b/routers/api/v1/repo/issue_subscription.go
@@ -262,18 +262,7 @@ func GetIssueSubscribers(ctx *context.APIContext) {
 		return
 	}
 
-	iwl, err := issues_model.GetIssueWatchers(ctx, issue.ID, utils.GetListOptions(ctx))
-	if err != nil {
-		ctx.APIErrorInternal(err)
-		return
-	}
-
-	userIDs := make([]int64, 0, len(iwl))
-	for _, iw := range iwl {
-		userIDs = append(userIDs, iw.UserID)
-	}
-
-	users, err := user_model.GetUsersByIDs(ctx, userIDs)
+	users, err := issues_model.GetIssueSubscribers(ctx, issue, utils.GetListOptions(ctx))
 	if err != nil {
 		ctx.APIErrorInternal(err)
 		return
@@ -283,7 +272,7 @@ func GetIssueSubscribers(ctx *context.APIContext) {
 		apiUsers = append(apiUsers, convert.ToUser(ctx, v, ctx.Doer))
 	}
 
-	count, err := issues_model.CountIssueWatchers(ctx, issue.ID)
+	count, err := issues_model.CountIssueSubscribers(ctx, issue)
 	if err != nil {
 		ctx.APIErrorInternal(err)
 		return

--- a/tests/integration/api_issue_subscription_test.go
+++ b/tests/integration/api_issue_subscription_test.go
@@ -27,6 +27,7 @@ func TestAPIIssueSubscriptions(t *testing.T) {
 	issue3 := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{ID: 3})
 	issue4 := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{ID: 4})
 	issue5 := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{ID: 8})
+	issue7 := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{ID: 7})
 
 	owner := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: issue1.PosterID})
 
@@ -53,6 +54,23 @@ func TestAPIIssueSubscriptions(t *testing.T) {
 	testSubscription(issue3, true)
 	testSubscription(issue4, false)
 	testSubscription(issue5, false)
+
+	testSubscribers := func(issue *issues_model.Issue, expectedNames []string, expectedTotal string) {
+		issueRepo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: issue.RepoID})
+		req := NewRequest(t, "GET", fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/subscriptions", issueRepo.OwnerName, issueRepo.Name, issue.Index)).
+			AddTokenAuth(token)
+		resp := MakeRequest(t, req, http.StatusOK)
+		users := DecodeJSON(t, resp, []*api.User{})
+		names := make([]string, 0, len(users))
+		for _, user := range users {
+			names = append(names, user.UserName)
+		}
+		assert.ElementsMatch(t, expectedNames, names)
+		assert.Equal(t, expectedTotal, resp.Header().Get("X-Total-Count"))
+	}
+
+	testSubscribers(issue1, []string{"user1", "user4", "user5", "user11"}, "4")
+	testSubscribers(issue7, []string{"user2"}, "1")
 
 	issue1Repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: issue1.RepoID})
 	urlStr := fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/subscriptions/%s", issue1Repo.OwnerName, issue1Repo.Name, issue1.Index, owner.Name)


### PR DESCRIPTION
Closes #26750

### Summary
- Included issue participants, issue authors, and repository watchers in `GET /repos/{owner}/{repo}/issues/{index}/subscriptions`.
- Kept explicit issue unsubscriptions authoritative, matching `/subscriptions/check` behavior.
- Added model and integration coverage for participants, repo watchers, inactive users, and explicit unwatchers.

### Tests
- `go test ./models/issues -run 'TestGetIssueWatchers|TestGetIssueSubscribers|TestGetIssueWatch|TestCreateOrUpdateIssueWatch' -count=1`
- `go test ./tests/integration -run TestAPIIssueSubscriptions -count=1`
- `go test ./models/issues -count=1`
- `go test ./routers/api/v1/repo -count=1`
- `GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./models/issues ./routers/api/v1/repo ./tests/integration`
- `git diff --check`

### AI assistance
AI assistance was used to prepare this patch and PR description.
