### PR TITLE
fix(auth): prevented repeated 2FA submissions

### DIFF
--- a/templates/user/auth/twofa.tmpl
+++ b/templates/user/auth/twofa.tmpl
@@ -2,7 +2,7 @@
 <div role="main" aria-label="{{.Title}}" class="page-content user signin">
 	<div class="ui middle very relaxed page grid">
 		<div class="column">
-			<form class="ui form tw-max-w-2xl tw-m-auto" action="{{.Link}}" method="post">
+			<form class="ui form tw-max-w-2xl tw-m-auto js-twofa-form" action="{{.Link}}" method="post">
 				<h3 class="ui top attached header">
 					{{ctx.Locale.Tr "twofa"}}
 				</h3>

--- a/templates/user/auth/twofa_scratch.tmpl
+++ b/templates/user/auth/twofa_scratch.tmpl
@@ -2,7 +2,7 @@
 <div role="main" aria-label="{{.Title}}" class="page-content user signin">
 	<div class="ui middle very relaxed page grid">
 		<div class="column">
-			<form class="ui form tw-max-w-2xl tw-m-auto" action="{{.Link}}" method="post">
+			<form class="ui form tw-max-w-2xl tw-m-auto js-twofa-form" action="{{.Link}}" method="post">
 				<h3 class="ui top attached header">
 					{{ctx.Locale.Tr "twofa_scratch"}}
 				</h3>

--- a/web_src/js/features/user-auth.test.ts
+++ b/web_src/js/features/user-auth.test.ts
@@ -1,0 +1,25 @@
+import {initUserAuthSubmitLoading} from './user-auth.ts';
+
+test('initUserAuthSubmitLoading disables submit button after first submit', () => {
+  document.body.innerHTML = `
+    <form class="js-twofa-form">
+      <input name="passcode" value="123456" required>
+      <button class="ui primary button">Verify</button>
+    </form>
+  `;
+
+  const form = document.querySelector<HTMLFormElement>('.js-twofa-form')!;
+  const button = form.querySelector<HTMLButtonElement>('button')!;
+  initUserAuthSubmitLoading();
+
+  const firstSubmit = new SubmitEvent('submit', {bubbles: true, cancelable: true, submitter: button});
+  expect(form.dispatchEvent(firstSubmit)).toBe(true);
+  expect(firstSubmit.defaultPrevented).toBe(false);
+  expect(button.disabled).toBe(true);
+  expect(button.classList.contains('is-loading')).toBe(true);
+  expect(button.classList.contains('loading-icon-2px')).toBe(true);
+
+  const secondSubmit = new SubmitEvent('submit', {bubbles: true, cancelable: true, submitter: button});
+  expect(form.dispatchEvent(secondSubmit)).toBe(false);
+  expect(secondSubmit.defaultPrevented).toBe(true);
+});

--- a/web_src/js/features/user-auth.ts
+++ b/web_src/js/features/user-auth.ts
@@ -25,3 +25,22 @@ export function initUserExternalLogins() {
     checkAppUrl();
   }
 }
+
+export function initUserAuthSubmitLoading() {
+  for (const form of document.querySelectorAll<HTMLFormElement>('.js-twofa-form')) {
+    form.addEventListener('submit', (e) => {
+      if (form.getAttribute('data-submitted') === 'true') {
+        e.preventDefault();
+        return;
+      }
+
+      const submitButton = e.submitter instanceof HTMLButtonElement || e.submitter instanceof HTMLInputElement ?
+        e.submitter :
+        form.querySelector<HTMLButtonElement | HTMLInputElement>('button[type="submit"], button:not([type]), input[type="submit"]');
+
+      form.setAttribute('data-submitted', 'true');
+      submitButton?.classList.add('is-loading', 'loading-icon-2px');
+      if (submitButton) submitButton.disabled = true;
+    });
+  }
+}

--- a/web_src/js/index.ts
+++ b/web_src/js/index.ts
@@ -19,7 +19,7 @@ import {initStopwatch} from './features/stopwatch.ts';
 import {initRepoFileSearch} from './features/repo-findfile.ts';
 import {initMarkupContent} from './markup/content.ts';
 import {initRepoFileView} from './features/file-view.ts';
-import {initUserExternalLogins, initUserCheckAppUrl} from './features/user-auth.ts';
+import {initUserAuthSubmitLoading, initUserExternalLogins, initUserCheckAppUrl} from './features/user-auth.ts';
 import {initRepoPullRequestReview, initRepoIssueFilterItemLabel} from './features/repo-issue.ts';
 import {initRepoEllipsisButton, initCommitStatuses} from './features/repo-commit.ts';
 import {initRepoTopicBar} from './features/repo-home.ts';
@@ -148,6 +148,7 @@ const initPerformanceTracer = callInitFunctions([
   initCaptcha,
 
   initUserCheckAppUrl,
+  initUserAuthSubmitLoading,
   initUserExternalLogins,
   initUserAuthWebAuthn,
   initUserAuthWebAuthnRegister,


### PR DESCRIPTION
## Summary
- Added a submit guard to the 2FA and scratch-code login forms.
- Disabled the verify button and showed its loading state after the first submit.
- Added frontend coverage for repeated 2FA form submissions.

Closes #27427

## Tests
- `pnpm exec vitest web_src/js/features/user-auth.test.ts --run`
- `pnpm exec eslint web_src/js/features/user-auth.ts web_src/js/features/user-auth.test.ts web_src/js/index.ts`
- `make lint-js`
- `make lint-templates`
- `make test-frontend`
- `git diff --check`

### AI assistance
AI assistance was used to prepare this patch and PR description.
