### PR TITLE
fix(api): clarified alpha validation errors

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -66,6 +66,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 
 	auth_model "gitea.dev/models/auth"
@@ -759,11 +760,47 @@ func bind[T any](_ T) any {
 		theObj := new(T) // create a new form obj for every request but not use obj directly
 		errs := binding.Bind(ctx.Req, theObj)
 		if len(errs) > 0 {
-			ctx.APIError(http.StatusUnprocessableEntity, fmt.Sprintf("%s: %s", errs[0].FieldNames, errs[0].Error()))
+			ctx.APIError(http.StatusUnprocessableEntity, bindingErrorMessage(theObj, errs[0]))
 			return
 		}
 		web.SetForm(ctx, theObj)
 	}
+}
+
+func bindingErrorMessage(form any, err binding.Error) string {
+	fieldName := strings.Join(err.FieldNames, ", ")
+	if len(err.FieldNames) == 1 {
+		fieldName = bindingErrorFieldName(form, err.FieldNames[0])
+	}
+
+	switch err.Classification {
+	case binding.ERR_ALPHA_DASH:
+		return fieldName + " may only contain letters, numbers, hyphens (-), and underscores (_)"
+	case binding.ERR_ALPHA_DASH_DOT:
+		return fieldName + " may only contain letters, numbers, hyphens (-), underscores (_), and dots (.)"
+	default:
+		return fmt.Sprintf("%s: %s", err.FieldNames, err.Error())
+	}
+}
+
+func bindingErrorFieldName(form any, fieldName string) string {
+	formType := reflect.TypeOf(form)
+	if formType.Kind() == reflect.Pointer {
+		formType = formType.Elem()
+	}
+	if formType.Kind() != reflect.Struct {
+		return fieldName
+	}
+
+	field, ok := formType.FieldByName(fieldName)
+	if !ok {
+		return fieldName
+	}
+	jsonName, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+	if jsonName == "" || jsonName == "-" {
+		return fieldName
+	}
+	return jsonName
 }
 
 func buildAuthGroup() *auth.Group {

--- a/tests/integration/api_team_test.go
+++ b/tests/integration/api_team_test.go
@@ -62,8 +62,18 @@ func TestAPITeam(t *testing.T) {
 
 	org = unittest.AssertExistsAndLoadBean(t, &organization.Organization{ID: 6})
 
-	// Create team.
+	// Invalid team names should return a readable validation error.
 	teamToCreate := &api.CreateTeamOption{
+		Name: "team with spaces",
+	}
+	req = NewRequestWithJSON(t, "POST", fmt.Sprintf("/api/v1/orgs/%s/teams", org.Name), teamToCreate).
+		AddTokenAuth(token)
+	resp = MakeRequest(t, req, http.StatusUnprocessableEntity)
+	apiError := DecodeJSON(t, resp, &api.APIError{})
+	assert.Equal(t, "name may only contain letters, numbers, hyphens (-), underscores (_), and dots (.)", apiError.Message)
+
+	// Create team.
+	teamToCreate = &api.CreateTeamOption{
 		Name:                    "team1",
 		Description:             "team one",
 		IncludesAllRepositories: true,


### PR DESCRIPTION
## Summary
- Replaced cryptic API `AlphaDash` and `AlphaDashDot` binding errors with readable messages.
- Used the JSON field name in the response so team creation now reports `name` instead of `Name`.
- Added integration coverage for creating a team with spaces in the name.

Closes #4827

## Tests
- `go test ./tests/integration -run '^TestAPITeam$' -count=1`
- `go test ./routers/api/v1 -count=1`
- `go test ./routers/api/v1/... -count=1`
- `GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./routers/api/v1 ./tests/integration`
- `git diff --check`

### AI assistance
AI assistance was used to prepare this patch and PR description.
