### PR TITLE
fix(repo): allowed unicode letters in topics

### DIFF
--- a/models/repo/topic.go
+++ b/models/repo/topic.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"gitea.dev/models/db"
 	"gitea.dev/modules/container"
@@ -22,7 +23,7 @@ func init() {
 	db.RegisterModel(new(RepoTopic))
 }
 
-var topicPattern = regexp.MustCompile(`^[a-z0-9][-.a-z0-9]*$`)
+var topicPattern = regexp.MustCompile(`^[\p{L}0-9][-\p{L}.0-9]*$`)
 
 // Topic represents a topic of repositories
 type Topic struct {
@@ -55,7 +56,7 @@ func (err ErrTopicNotExist) Unwrap() error {
 
 // ValidateTopic checks a topic by length and match pattern rules
 func ValidateTopic(topic string) bool {
-	return len(topic) <= 35 && topicPattern.MatchString(topic)
+	return utf8.RuneCountInString(topic) <= 35 && topicPattern.MatchString(topic)
 }
 
 // SanitizeAndValidateTopics sanitizes and checks an array or topics

--- a/models/repo/topic_test.go
+++ b/models/repo/topic_test.go
@@ -74,9 +74,21 @@ func TestTopicValidator(t *testing.T) {
 	assert.True(t, repo_model.ValidateTopic("first"))
 	assert.True(t, repo_model.ValidateTopic("second-test-topic"))
 	assert.True(t, repo_model.ValidateTopic("third-project-topic-with-max-length"))
+	assert.True(t, repo_model.ValidateTopic("ümlaut"))
+	assert.True(t, repo_model.ValidateTopic("hāwaii"))
+	assert.True(t, repo_model.ValidateTopic("ä-ö.ü"))
+	assert.True(t, repo_model.ValidateTopic("äbcdefghijklmnopqrstuvwxyz123456789"))
 
 	assert.False(t, repo_model.ValidateTopic("$fourth-test,topic"))
 	assert.False(t, repo_model.ValidateTopic("-fifth-test-topic"))
 	assert.False(t, repo_model.ValidateTopic("sixth-go-project-topic-with-excess-length"))
+	assert.False(t, repo_model.ValidateTopic("äbcdefghijklmnopqrstuvwxyz1234567890"))
 	assert.False(t, repo_model.ValidateTopic(".foo"))
+}
+
+func TestSanitizeAndValidateTopics(t *testing.T) {
+	validTopics, invalidTopics := repo_model.SanitizeAndValidateTopics([]string{" ÄÖÜ ", "hāwaii", "ümlaut", "ümlaut", "bad topic"})
+
+	assert.Equal(t, []string{"äöü", "hāwaii", "ümlaut"}, validTopics)
+	assert.Equal(t, []string{"bad topic"}, invalidTopics)
 }

--- a/tests/integration/api_repo_topic_test.go
+++ b/tests/integration/api_repo_topic_test.go
@@ -109,6 +109,11 @@ func TestAPIRepoTopic(t *testing.T) {
 		AddTokenAuth(token2)
 	MakeRequest(t, req, http.StatusNoContent)
 
+	// Test add a topic with unicode letters
+	req = NewRequestf(t, "PUT", "/api/v1/repos/%s/%s/topics/%s", user2.Name, repo2.Name, url.PathEscape("Ümlaut")).
+		AddTokenAuth(token2)
+	MakeRequest(t, req, http.StatusNoContent)
+
 	url := fmt.Sprintf("/api/v1/repos/%s/%s/topics", user2.Name, repo2.Name)
 
 	// Test read topics using token
@@ -116,10 +121,10 @@ func TestAPIRepoTopic(t *testing.T) {
 		AddTokenAuth(token2)
 	res = MakeRequest(t, req, http.StatusOK)
 	topics = DecodeJSON(t, res, &api.TopicName{})
-	assert.ElementsMatch(t, []string{"topicname2", "golang", "topicname3"}, topics.TopicNames)
+	assert.ElementsMatch(t, []string{"topicname2", "golang", "topicname3", "ümlaut"}, topics.TopicNames)
 
 	// Test replace topics
-	newTopics := []string{"   windows ", "   ", "MAC  "}
+	newTopics := []string{"   windows ", "   ", "MAC  ", "Hāwaii"}
 	req = NewRequestWithJSON(t, "PUT", url, &api.RepoTopicOptions{
 		Topics: newTopics,
 	}).AddTokenAuth(token2)
@@ -128,7 +133,7 @@ func TestAPIRepoTopic(t *testing.T) {
 		AddTokenAuth(token2)
 	res = MakeRequest(t, req, http.StatusOK)
 	topics = DecodeJSON(t, res, &api.TopicName{})
-	assert.ElementsMatch(t, []string{"windows", "mac"}, topics.TopicNames)
+	assert.ElementsMatch(t, []string{"windows", "mac", "hāwaii"}, topics.TopicNames)
 
 	// Test replace topics with something invalid
 	newTopics = []string{"topicname1", "topicname2", "topicname!"}
@@ -140,7 +145,7 @@ func TestAPIRepoTopic(t *testing.T) {
 		AddTokenAuth(token2)
 	res = MakeRequest(t, req, http.StatusOK)
 	topics = DecodeJSON(t, res, &api.TopicName{})
-	assert.ElementsMatch(t, []string{"windows", "mac"}, topics.TopicNames)
+	assert.ElementsMatch(t, []string{"windows", "mac", "hāwaii"}, topics.TopicNames)
 
 	// Test with some topics multiple times, less than 25 unique
 	newTopics = []string{"t1", "t2", "t1", "t3", "t4", "t5", "t6", "t7", "t8", "t9", "t10", "t11", "t12", "t13", "t14", "t15", "t16", "17", "t18", "t19", "t20", "t21", "t22", "t23", "t24", "t25"}


### PR DESCRIPTION
### Changes
- Allowed Unicode letters in repository topic validation.
- Counted the 35-character topic limit by runes instead of bytes.
- Covered Unicode topic add and replace flows in tests.

Closes #7528

### Tests
- go test ./models/repo -run 'TestTopicValidator|TestSanitizeAndValidateTopics' -count=1
- go test ./tests/integration -run '^TestAPIRepoTopic$' -count=1
- go test ./routers/api/v1/repo -count=1
- GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./models/repo ./routers/api/v1/repo ./routers/web/repo ./tests/integration
- git diff --check

### AI assistance
AI assistance was used to prepare this patch and PR description.
