### PR TITLE
fix(api): added issue comment pagination and sorting

### DIFF
--- a/models/issues/comment.go
+++ b/models/issues/comment.go
@@ -1075,6 +1075,7 @@ type FindCommentsOptions struct {
 	IssueIDs    []int64
 	Invalidated optional.Option[bool]
 	IsPull      optional.Option[bool]
+	OrderBy     db.SearchOrderBy
 }
 
 // ToConds implements FindOptions interface
@@ -1127,11 +1128,14 @@ func FindComments(ctx context.Context, opts *FindCommentsOptions) (CommentList, 
 		db.SetSessionPagination(sess, opts)
 	}
 
-	// WARNING: If you change this order you will need to fix createCodeComment
+	orderBy := opts.OrderBy
+	if orderBy == "" {
+		// WARNING: If you change this order you will need to fix createCodeComment
+		orderBy = db.SearchOrderBy("comment.created_unix ASC, comment.id ASC")
+	}
 
 	return comments, sess.
-		Asc("comment.created_unix").
-		Asc("comment.id").
+		OrderBy(orderBy.String()).
 		Find(&comments)
 }
 

--- a/routers/api/v1/repo/issue_comment.go
+++ b/routers/api/v1/repo/issue_comment.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"net/http"
 
+	"gitea.dev/models/db"
 	issues_model "gitea.dev/models/issues"
 	access_model "gitea.dev/models/perm/access"
 	repo_model "gitea.dev/models/repo"
@@ -22,6 +23,21 @@ import (
 	"gitea.dev/services/convert"
 	issue_service "gitea.dev/services/issue"
 )
+
+var issueCommentOrderByMap = map[string]map[string]db.SearchOrderBy{
+	"asc": {
+		"created": db.SearchOrderBy("comment.created_unix ASC, comment.id ASC"),
+		"updated": db.SearchOrderBy("comment.updated_unix ASC, comment.id ASC"),
+	},
+	"desc": {
+		"created": db.SearchOrderBy("comment.created_unix DESC, comment.id DESC"),
+		"updated": db.SearchOrderBy("comment.updated_unix DESC, comment.id DESC"),
+	},
+}
+
+func getIssueCommentOrderBy(ctx *context.APIContext) (db.SearchOrderBy, bool) {
+	return utils.ResolveSortOrder(ctx, issueCommentOrderByMap, issueCommentOrderByMap["asc"]["created"])
+}
 
 // ListIssueComments list all the comments of an issue
 func ListIssueComments(ctx *context.APIContext) {
@@ -57,6 +73,22 @@ func ListIssueComments(ctx *context.APIContext) {
 	//   description: if provided, only comments updated before the provided time are returned.
 	//   type: string
 	//   format: date-time
+	// - name: page
+	//   in: query
+	//   description: page number of results to return (1-based)
+	//   type: integer
+	// - name: limit
+	//   in: query
+	//   description: page size of results
+	//   type: integer
+	// - name: sort
+	//   in: query
+	//   description: sort comments by attribute. Supported values are "created" and "updated". Default is "created"
+	//   type: string
+	// - name: order
+	//   in: query
+	//   description: sort order, either "asc" (ascending) or "desc" (descending). Default is "asc"
+	//   type: string
 	// responses:
 	//   "200":
 	//     "$ref": "#/responses/CommentList"
@@ -66,6 +98,10 @@ func ListIssueComments(ctx *context.APIContext) {
 	before, since, err := context.GetQueryBeforeSince(ctx.Base)
 	if err != nil {
 		ctx.APIError(http.StatusUnprocessableEntity, err)
+		return
+	}
+	orderBy, ok := getIssueCommentOrderBy(ctx)
+	if !ok {
 		return
 	}
 	issue, err := issues_model.GetIssueByIndex(ctx, ctx.Repo.Repository.ID, ctx.PathParamInt64("index"))
@@ -80,11 +116,14 @@ func ListIssueComments(ctx *context.APIContext) {
 
 	issue.Repo = ctx.Repo.Repository
 
+	listOptions := utils.GetListOptions(ctx)
 	opts := &issues_model.FindCommentsOptions{
-		IssueID: issue.ID,
-		Since:   since,
-		Before:  before,
-		Type:    issues_model.CommentTypeComment,
+		ListOptions: listOptions,
+		IssueID:     issue.ID,
+		Since:       since,
+		Before:      before,
+		Type:        issues_model.CommentTypeComment,
+		OrderBy:     orderBy,
 	}
 
 	comments, err := issues_model.FindComments(ctx, opts)
@@ -115,6 +154,7 @@ func ListIssueComments(ctx *context.APIContext) {
 		apiComments[i] = convert.ToAPIComment(ctx, ctx.Repo.Repository, comments[i])
 	}
 
+	ctx.SetLinkHeader(totalCount, listOptions.PageSize)
 	ctx.SetTotalCountHeader(totalCount)
 	ctx.JSON(http.StatusOK, &apiComments)
 }
@@ -266,6 +306,14 @@ func ListRepoIssueComments(ctx *context.APIContext) {
 	//   in: query
 	//   description: page size of results
 	//   type: integer
+	// - name: sort
+	//   in: query
+	//   description: sort comments by attribute. Supported values are "created" and "updated". Default is "created"
+	//   type: string
+	// - name: order
+	//   in: query
+	//   description: sort order, either "asc" (ascending) or "desc" (descending). Default is "asc"
+	//   type: string
 	// responses:
 	//   "200":
 	//     "$ref": "#/responses/CommentList"
@@ -275,6 +323,10 @@ func ListRepoIssueComments(ctx *context.APIContext) {
 	before, since, err := context.GetQueryBeforeSince(ctx.Base)
 	if err != nil {
 		ctx.APIError(http.StatusUnprocessableEntity, err)
+		return
+	}
+	orderBy, ok := getIssueCommentOrderBy(ctx)
+	if !ok {
 		return
 	}
 
@@ -292,13 +344,15 @@ func ListRepoIssueComments(ctx *context.APIContext) {
 		return
 	}
 
+	listOptions := utils.GetListOptions(ctx)
 	opts := &issues_model.FindCommentsOptions{
-		ListOptions: utils.GetListOptions(ctx),
+		ListOptions: listOptions,
 		RepoID:      ctx.Repo.Repository.ID,
 		Type:        issues_model.CommentTypeComment,
 		Since:       since,
 		Before:      before,
 		IsPull:      isPull,
+		OrderBy:     orderBy,
 	}
 
 	comments, err := issues_model.FindComments(ctx, opts)
@@ -335,6 +389,7 @@ func ListRepoIssueComments(ctx *context.APIContext) {
 		apiComments[i] = convert.ToAPIComment(ctx, ctx.Repo.Repository, comments[i])
 	}
 
+	ctx.SetLinkHeader(totalCount, listOptions.PageSize)
 	ctx.SetTotalCountHeader(totalCount)
 	ctx.JSON(http.StatusOK, &apiComments)
 }

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -9871,6 +9871,18 @@
             "description": "page size of results",
             "name": "limit",
             "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "sort comments by attribute. Supported values are \"created\" and \"updated\". Default is \"created\"",
+            "name": "sort",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "sort order, either \"asc\" (ascending) or \"desc\" (descending). Default is \"asc\"",
+            "name": "order",
+            "in": "query"
           }
         ],
         "responses": {
@@ -11152,6 +11164,30 @@
             "format": "date-time",
             "description": "if provided, only comments updated before the provided time are returned.",
             "name": "before",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "description": "page number of results to return (1-based)",
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "description": "page size of results",
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "sort comments by attribute. Supported values are \"created\" and \"updated\". Default is \"created\"",
+            "name": "sort",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "description": "sort order, either \"asc\" (ascending) or \"desc\" (descending). Default is \"asc\"",
+            "name": "order",
             "in": "query"
           }
         ],

--- a/templates/swagger/v1_openapi3_json.tmpl
+++ b/templates/swagger/v1_openapi3_json.tmpl
@@ -21180,6 +21180,22 @@
             "schema": {
               "type": "integer"
             }
+          },
+          {
+            "description": "sort comments by attribute. Supported values are \"created\" and \"updated\". Default is \"created\"",
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "sort order, either \"asc\" (ascending) or \"desc\" (descending). Default is \"asc\"",
+            "in": "query",
+            "name": "order",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -22580,6 +22596,38 @@
             "name": "before",
             "schema": {
               "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "description": "page number of results to return (1-based)",
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "page size of results",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "sort comments by attribute. Supported values are \"created\" and \"updated\". Default is \"created\"",
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "sort order, either \"asc\" (ascending) or \"desc\" (descending). Default is \"asc\"",
+            "in": "query",
+            "name": "order",
+            "schema": {
               "type": "string"
             }
           }

--- a/tests/integration/api_comment_test.go
+++ b/tests/integration/api_comment_test.go
@@ -35,16 +35,31 @@ func TestAPIListRepoComments(t *testing.T) {
 	resp := MakeRequest(t, req, http.StatusOK)
 
 	apiComments := DecodeJSON(t, resp, []*api.Comment{})
-	assert.Len(t, apiComments, 2)
+	if assert.Len(t, apiComments, 2) {
+		assert.EqualValues(t, 2, apiComments[0].ID)
+		assert.EqualValues(t, 3, apiComments[1].ID)
+	}
 	for _, apiComment := range apiComments {
 		c := &issues_model.Comment{ID: apiComment.ID}
 		unittest.AssertExistsAndLoadBean(t, c,
 			unittest.Cond("type = ?", issues_model.CommentTypeComment))
 		unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{ID: c.IssueID, RepoID: repo.ID})
 	}
+	assert.Equal(t, "2", resp.Header().Get("x-total-count"))
+
+	query := url.Values{"page": {"1"}, "limit": {"1"}, "sort": {"created"}, "order": {"desc"}}
+	link.RawQuery = query.Encode()
+	req = NewRequest(t, "GET", link.String())
+	resp = MakeRequest(t, req, http.StatusOK)
+	apiComments = DecodeJSON(t, resp, []*api.Comment{})
+	if assert.Len(t, apiComments, 1) {
+		assert.EqualValues(t, 3, apiComments[0].ID)
+	}
+	assert.Equal(t, "2", resp.Header().Get("x-total-count"))
+	assert.Contains(t, resp.Header().Get("Link"), `rel="next"`)
 
 	// test before and since filters
-	query := url.Values{}
+	query = url.Values{}
 	before := "2000-01-01T00:00:11+00:00" // unix: 946684811
 	since := "2000-01-01T00:00:12+00:00"  // unix: 946684812
 	query.Add("before", before)
@@ -75,7 +90,8 @@ func TestAPIListIssueComments(t *testing.T) {
 	repoOwner := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: repo.OwnerID})
 
 	token := getUserToken(t, repoOwner.Name, auth_model.AccessTokenScopeReadIssue)
-	req := NewRequestf(t, "GET", "/api/v1/repos/%s/%s/issues/%d/comments", repoOwner.Name, repo.Name, issue.Index).
+	link, _ := url.Parse(fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/comments", repoOwner.Name, repo.Name, issue.Index))
+	req := NewRequest(t, "GET", link.String()).
 		AddTokenAuth(token)
 	resp := MakeRequest(t, req, http.StatusOK)
 
@@ -83,6 +99,36 @@ func TestAPIListIssueComments(t *testing.T) {
 	expectedCount := unittest.GetCount(t, &issues_model.Comment{IssueID: issue.ID},
 		unittest.Cond("type = ?", issues_model.CommentTypeComment))
 	assert.Len(t, comments, expectedCount)
+	assert.Equal(t, "2", resp.Header().Get("x-total-count"))
+
+	query := url.Values{"page": {"2"}, "limit": {"1"}}
+	link.RawQuery = query.Encode()
+	req = NewRequest(t, "GET", link.String()).
+		AddTokenAuth(token)
+	resp = MakeRequest(t, req, http.StatusOK)
+	comments = DecodeJSON(t, resp, []*api.Comment{})
+	if assert.Len(t, comments, 1) {
+		assert.EqualValues(t, 3, comments[0].ID)
+	}
+	assert.Equal(t, "2", resp.Header().Get("x-total-count"))
+	assert.Contains(t, resp.Header().Get("Link"), `rel="prev"`)
+
+	query = url.Values{"sort": {"updated"}, "order": {"desc"}}
+	link.RawQuery = query.Encode()
+	req = NewRequest(t, "GET", link.String()).
+		AddTokenAuth(token)
+	resp = MakeRequest(t, req, http.StatusOK)
+	comments = DecodeJSON(t, resp, []*api.Comment{})
+	if assert.Len(t, comments, expectedCount) {
+		assert.EqualValues(t, 3, comments[0].ID)
+		assert.EqualValues(t, 2, comments[1].ID)
+	}
+
+	query = url.Values{"sort": {"invalid"}}
+	link.RawQuery = query.Encode()
+	req = NewRequest(t, "GET", link.String()).
+		AddTokenAuth(token)
+	MakeRequest(t, req, http.StatusUnprocessableEntity)
 }
 
 func TestAPICreateComment(t *testing.T) {


### PR DESCRIPTION
### Changes
- Added `page` and `limit` support to `GET /repos/{owner}/{repo}/issues/{index}/comments`.
- Added `sort` and `order` support to both issue-level and repo-level issue comment list endpoints.
- Added pagination Link headers for both comment list endpoints.
- Regenerated Swagger and OpenAPI specs.

Closes #6132

### Tests
- go test ./models/issues -run 'Test' -count=1
- go test ./tests/integration -run 'TestAPIListRepoComments|TestAPIListIssueComments' -count=1
- go test ./tests/integration -run '^TestAPIList.*Comments$' -count=1
- go test ./models/issues ./routers/api/v1/repo -count=1
- GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./models/issues ./routers/api/v1/repo ./tests/integration
- GOEXPERIMENT= GOTOOLCHAIN=auto make generate-swagger
- GOEXPERIMENT= GOTOOLCHAIN=auto make swagger-check
- GOEXPERIMENT= GOTOOLCHAIN=auto make openapi3-check
- git diff --check

### AI assistance
AI assistance was used to prepare this patch and PR description.
