### PR TITLE
fix(webhook): added issue dependency events

### DIFF
--- a/modules/structs/hook.go
+++ b/modules/structs/hook.go
@@ -379,6 +379,10 @@ const (
 	HookIssueMilestoned HookIssueAction = "milestoned"
 	// HookIssueDemilestoned is an issue action for when a milestone is cleared on an issue.
 	HookIssueDemilestoned HookIssueAction = "demilestoned"
+	// HookIssueDependencyAdded is an issue action for when a dependency is added.
+	HookIssueDependencyAdded HookIssueAction = "dependency_added"
+	// HookIssueDependencyRemoved is an issue action for when a dependency is removed.
+	HookIssueDependencyRemoved HookIssueAction = "dependency_removed"
 	// HookIssueReviewed is an issue action for when a pull request is reviewed
 	HookIssueReviewed HookIssueAction = "reviewed"
 	// HookIssueReviewRequested is an issue action for when a reviewer is requested for a pull request.
@@ -397,6 +401,8 @@ type IssuePayload struct {
 	Changes *ChangesPayload `json:"changes,omitempty"`
 	// The issue that was acted upon
 	Issue *Issue `json:"issue"`
+	// The dependency issue that was added or removed
+	Dependency *Issue `json:"dependency,omitempty"`
 	// The repository containing the issue
 	Repository *Repository `json:"repository"`
 	// The user who performed the action
@@ -444,6 +450,8 @@ type PullRequestPayload struct {
 	Changes *ChangesPayload `json:"changes,omitempty"`
 	// The pull request that was acted upon
 	PullRequest *PullRequest `json:"pull_request"`
+	// The dependency issue that was added or removed
+	Dependency *Issue `json:"dependency,omitempty"`
 	// The reviewer that was requested (for review request actions)
 	RequestedReviewer *User `json:"requested_reviewer"`
 	// The repository containing the pull request

--- a/routers/api/v1/repo/issue_dependency.go
+++ b/routers/api/v1/repo/issue_dependency.go
@@ -16,6 +16,7 @@ import (
 	"gitea.dev/routers/api/v1/utils"
 	"gitea.dev/services/context"
 	"gitea.dev/services/convert"
+	issue_service "gitea.dev/services/issue"
 )
 
 // GetIssueDependencies list an issue's dependencies
@@ -565,7 +566,7 @@ func createIssueDependency(ctx *context.APIContext, target, dependency *issues_m
 		return
 	}
 
-	err := issues_model.CreateIssueDependency(ctx, ctx.Doer, target, dependency)
+	err := issue_service.CreateIssueDependency(ctx, ctx.Doer, target, dependency)
 	if err != nil {
 		ctx.APIErrorInternal(err)
 		return
@@ -591,7 +592,7 @@ func removeIssueDependency(ctx *context.APIContext, target, dependency *issues_m
 		return
 	}
 
-	err := issues_model.RemoveIssueDependency(ctx, ctx.Doer, target, dependency, issues_model.DependencyTypeBlockedBy)
+	err := issue_service.RemoveIssueDependency(ctx, ctx.Doer, target, dependency, issues_model.DependencyTypeBlockedBy)
 	if err != nil {
 		ctx.APIErrorInternal(err)
 		return

--- a/routers/web/repo/issue_dependency.go
+++ b/routers/web/repo/issue_dependency.go
@@ -10,6 +10,7 @@ import (
 	access_model "gitea.dev/models/perm/access"
 	"gitea.dev/modules/setting"
 	"gitea.dev/services/context"
+	issue_service "gitea.dev/services/issue"
 )
 
 // AddDependency adds new dependencies
@@ -72,7 +73,7 @@ func AddDependency(ctx *context.Context) {
 		return
 	}
 
-	err = issues_model.CreateIssueDependency(ctx, ctx.Doer, issue, dep)
+	err = issue_service.CreateIssueDependency(ctx, ctx.Doer, issue, dep)
 	if err != nil {
 		if issues_model.IsErrDependencyExists(err) {
 			ctx.Flash.Error(ctx.Tr("repo.issues.dependency.add_error_dep_exists"))
@@ -130,7 +131,7 @@ func RemoveDependency(ctx *context.Context) {
 		return
 	}
 
-	if err = issues_model.RemoveIssueDependency(ctx, ctx.Doer, issue, dep, depType); err != nil {
+	if err = issue_service.RemoveIssueDependency(ctx, ctx.Doer, issue, dep, depType); err != nil {
 		if issues_model.IsErrDependencyNotExists(err) {
 			ctx.Flash.Error(ctx.Tr("repo.issues.dependency.add_error_dep_not_exist"))
 			return

--- a/services/issue/dependency.go
+++ b/services/issue/dependency.go
@@ -1,0 +1,32 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package issue
+
+import (
+	"context"
+
+	issues_model "gitea.dev/models/issues"
+	user_model "gitea.dev/models/user"
+	notify_service "gitea.dev/services/notify"
+)
+
+// CreateIssueDependency creates a dependency and notifies subscribers.
+func CreateIssueDependency(ctx context.Context, doer *user_model.User, issue, dependency *issues_model.Issue) error {
+	if err := issues_model.CreateIssueDependency(ctx, doer, issue, dependency); err != nil {
+		return err
+	}
+
+	notify_service.IssueChangeDependency(ctx, doer, issue, dependency, true)
+	return nil
+}
+
+// RemoveIssueDependency removes a dependency and notifies subscribers.
+func RemoveIssueDependency(ctx context.Context, doer *user_model.User, issue, dependency *issues_model.Issue, depType issues_model.DependencyType) error {
+	if err := issues_model.RemoveIssueDependency(ctx, doer, issue, dependency, depType); err != nil {
+		return err
+	}
+
+	notify_service.IssueChangeDependency(ctx, doer, issue, dependency, false)
+	return nil
+}

--- a/services/notify/notifier.go
+++ b/services/notify/notifier.go
@@ -41,6 +41,7 @@ type Notifier interface {
 	IssueChangeRef(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, oldRef string)
 	IssueChangeLabels(ctx context.Context, doer *user_model.User, issue *issues_model.Issue,
 		addedLabels, removedLabels []*issues_model.Label)
+	IssueChangeDependency(ctx context.Context, doer *user_model.User, issue, dependency *issues_model.Issue, added bool)
 
 	NewPullRequest(ctx context.Context, pr *issues_model.PullRequest, mentions []*user_model.User)
 	MergePullRequest(ctx context.Context, doer *user_model.User, pr *issues_model.PullRequest)

--- a/services/notify/notify.go
+++ b/services/notify/notify.go
@@ -274,6 +274,13 @@ func IssueChangeLabels(ctx context.Context, doer *user_model.User, issue *issues
 	}
 }
 
+// IssueChangeDependency notifies when an issue dependency changes
+func IssueChangeDependency(ctx context.Context, doer *user_model.User, issue, dependency *issues_model.Issue, added bool) {
+	for _, notifier := range notifiers {
+		notifier.IssueChangeDependency(ctx, doer, issue, dependency, added)
+	}
+}
+
 // CreateRepository notifies create repository to notifiers
 func CreateRepository(ctx context.Context, doer, u *user_model.User, repo *repo_model.Repository) {
 	for _, notifier := range notifiers {

--- a/services/notify/null.go
+++ b/services/notify/null.go
@@ -143,6 +143,10 @@ func (*NullNotifier) IssueChangeLabels(ctx context.Context, doer *user_model.Use
 	addedLabels, removedLabels []*issues_model.Label) {
 }
 
+// IssueChangeDependency places a place holder function
+func (*NullNotifier) IssueChangeDependency(ctx context.Context, doer *user_model.User, issue, dependency *issues_model.Issue, added bool) {
+}
+
 // CreateRepository places a place holder function
 func (*NullNotifier) CreateRepository(ctx context.Context, doer, u *user_model.User, repo *repo_model.Repository) {
 }

--- a/services/webhook/general.go
+++ b/services/webhook/general.go
@@ -133,6 +133,10 @@ func getIssuesPayloadInfo(p *api.IssuePayload, linkFormatter linkFormatter, with
 			linkFormatter(mileStoneLink, p.Issue.Milestone.Title), titleLink)
 	case api.HookIssueDemilestoned:
 		text = fmt.Sprintf("[%s] Issue milestone cleared: %s", repoLink, titleLink)
+	case api.HookIssueDependencyAdded:
+		text = fmt.Sprintf("[%s] Issue dependency added: %s", repoLink, titleLink)
+	case api.HookIssueDependencyRemoved:
+		text = fmt.Sprintf("[%s] Issue dependency removed: %s", repoLink, titleLink)
 	}
 	if withSender {
 		text += " by " + linkFormatter(setting.AppURL+url.PathEscape(p.Sender.UserName), p.Sender.UserName)
@@ -191,6 +195,10 @@ func getPullRequestPayloadInfo(p *api.PullRequestPayload, linkFormatter linkForm
 			linkFormatter(mileStoneLink, p.PullRequest.Milestone.Title), titleLink)
 	case api.HookIssueDemilestoned:
 		text = fmt.Sprintf("[%s] Pull request milestone cleared: %s", repoLink, titleLink)
+	case api.HookIssueDependencyAdded:
+		text = fmt.Sprintf("[%s] Pull request dependency added: %s", repoLink, titleLink)
+	case api.HookIssueDependencyRemoved:
+		text = fmt.Sprintf("[%s] Pull request dependency removed: %s", repoLink, titleLink)
 	case api.HookIssueReviewed:
 		text = fmt.Sprintf("[%s] Pull request reviewed: %s", repoLink, titleLink)
 		extraMarkdown = p.Review.Content

--- a/services/webhook/notifier.go
+++ b/services/webhook/notifier.go
@@ -403,6 +403,51 @@ func (m *webhookNotifier) IssueChangeContent(ctx context.Context, doer *user_mod
 	}
 }
 
+func (m *webhookNotifier) IssueChangeDependency(ctx context.Context, doer *user_model.User, issue, dependency *issues_model.Issue, added bool) {
+	if err := issue.LoadRepo(ctx); err != nil {
+		log.Error("LoadRepo: %v", err)
+		return
+	}
+	if err := dependency.LoadRepo(ctx); err != nil {
+		log.Error("LoadRepo: %v", err)
+		return
+	}
+
+	action := api.HookIssueDependencyRemoved
+	if added {
+		action = api.HookIssueDependencyAdded
+	}
+
+	permission, _ := access_model.GetDoerRepoPermission(ctx, issue.Repo, doer)
+	var err error
+	if issue.IsPull {
+		if err := issue.LoadPullRequest(ctx); err != nil {
+			log.Error("LoadPullRequest: %v", err)
+			return
+		}
+		err = PrepareWebhooks(ctx, EventSource{Repository: issue.Repo}, webhook_module.HookEventPullRequest, &api.PullRequestPayload{
+			Action:      action,
+			Index:       issue.Index,
+			PullRequest: convert.ToAPIPullRequest(ctx, issue.PullRequest, doer),
+			Dependency:  convert.ToAPIIssue(ctx, doer, dependency),
+			Repository:  convert.ToRepo(ctx, issue.Repo, permission),
+			Sender:      convert.ToUser(ctx, doer, nil),
+		})
+	} else {
+		err = PrepareWebhooks(ctx, EventSource{Repository: issue.Repo}, webhook_module.HookEventIssues, &api.IssuePayload{
+			Action:     action,
+			Index:      issue.Index,
+			Issue:      convert.ToAPIIssue(ctx, doer, issue),
+			Dependency: convert.ToAPIIssue(ctx, doer, dependency),
+			Repository: convert.ToRepo(ctx, issue.Repo, permission),
+			Sender:     convert.ToUser(ctx, doer, nil),
+		})
+	}
+	if err != nil {
+		log.Error("PrepareWebhooks [is_pull: %v, dependency_id: %d]: %v", issue.IsPull, dependency.ID, err)
+	}
+}
+
 func (m *webhookNotifier) UpdateComment(ctx context.Context, doer *user_model.User, c *issues_model.Comment, oldContent string) {
 	if err := c.LoadPoster(ctx); err != nil {
 		log.Error("LoadPoster: %v", err)

--- a/tests/integration/api_issue_dependency_test.go
+++ b/tests/integration/api_issue_dependency_test.go
@@ -17,7 +17,9 @@ import (
 	"gitea.dev/models/unit"
 	"gitea.dev/models/unittest"
 	user_model "gitea.dev/models/user"
+	webhook_model "gitea.dev/models/webhook"
 	api "gitea.dev/modules/structs"
+	webhook_module "gitea.dev/modules/webhook"
 	repo_service "gitea.dev/services/repository"
 	"gitea.dev/tests"
 
@@ -81,6 +83,16 @@ func TestAPICreateIssueDependencyCrossRepoPermission(t *testing.T) {
 	// add user40 as a collaborator to target repository with write permission
 	assert.NoError(t, repo_service.AddOrUpdateCollaborator(t.Context(), targetRepo, user40, perm.AccessModeWrite))
 
+	hook := &webhook_model.Webhook{
+		RepoID:      targetRepo.ID,
+		URL:         "http://localhost/gitea-webhook-test-issue-dependency-created",
+		ContentType: webhook_model.ContentTypeJSON,
+		Events:      `{"choose_events":true,"events":{"issues":true}}`,
+		IsActive:    true,
+		Type:        webhook_module.GITEA,
+	}
+	assert.NoError(t, db.Insert(t.Context(), hook))
+
 	req = NewRequestWithJSON(t, "POST", url, dependencyMeta).
 		AddTokenAuth(writerToken)
 	MakeRequest(t, req, http.StatusCreated)
@@ -88,6 +100,9 @@ func TestAPICreateIssueDependencyCrossRepoPermission(t *testing.T) {
 		IssueID:      targetIssue.ID,
 		DependencyID: dependencyIssue.ID,
 	})
+	hookTask := unittest.AssertExistsAndLoadBean(t, &webhook_model.HookTask{HookID: hook.ID, EventType: webhook_module.HookEventIssues})
+	assert.Contains(t, hookTask.PayloadContent, `"action": "dependency_added"`)
+	assert.Contains(t, hookTask.PayloadContent, `"dependency": {`)
 }
 
 func TestAPIDeleteIssueDependencyCrossRepoPermission(t *testing.T) {
@@ -142,6 +157,16 @@ func TestAPIDeleteIssueDependencyCrossRepoPermission(t *testing.T) {
 	// add user40 as a collaborator to target repository with write permission
 	assert.NoError(t, repo_service.AddOrUpdateCollaborator(t.Context(), targetRepo, user40, perm.AccessModeWrite))
 
+	hook := &webhook_model.Webhook{
+		RepoID:      targetRepo.ID,
+		URL:         "http://localhost/gitea-webhook-test-issue-dependency-removed",
+		ContentType: webhook_model.ContentTypeJSON,
+		Events:      `{"choose_events":true,"events":{"issues":true}}`,
+		IsActive:    true,
+		Type:        webhook_module.GITEA,
+	}
+	assert.NoError(t, db.Insert(t.Context(), hook))
+
 	req = NewRequestWithJSON(t, "DELETE", url, dependencyMeta).
 		AddTokenAuth(writerToken)
 	MakeRequest(t, req, http.StatusCreated)
@@ -149,4 +174,7 @@ func TestAPIDeleteIssueDependencyCrossRepoPermission(t *testing.T) {
 		IssueID:      targetIssue.ID,
 		DependencyID: dependencyIssue.ID,
 	})
+	hookTask := unittest.AssertExistsAndLoadBean(t, &webhook_model.HookTask{HookID: hook.ID, EventType: webhook_module.HookEventIssues})
+	assert.Contains(t, hookTask.PayloadContent, `"action": "dependency_removed"`)
+	assert.Contains(t, hookTask.PayloadContent, `"dependency": {`)
 }


### PR DESCRIPTION
### Changes
- Added issue dependency webhook actions for dependency add and remove operations.
- Routed web and API dependency changes through the issue service so successful model updates notify subscribers.
- Included the changed dependency issue in the issue or pull request webhook payload.
- Covered API dependency create and delete flows with webhook task assertions.

Closes #11765

### Tests
- go test ./services/issue ./services/notify ./services/webhook ./routers/api/v1/repo -count=1
- go test ./tests/integration -run 'TestAPICreateIssueDependencyCrossRepoPermission|TestAPIDeleteIssueDependencyCrossRepoPermission' -count=1
- GOEXPERIMENT= GOTOOLCHAIN=auto make generate-swagger
- go test ./modules/actions ./modules/structs ./services/actions ./services/issue ./services/notify ./services/webhook ./routers/api/v1/repo -count=1
- GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./modules/structs ./routers/api/v1/repo ./routers/web/repo ./services/issue ./services/notify ./services/webhook ./tests/integration
- GOEXPERIMENT= GOTOOLCHAIN=auto make swagger-check
- GOEXPERIMENT= GOTOOLCHAIN=auto make openapi3-check
- git diff --check

### AI assistance
AI assistance was used to prepare this patch and PR description.
