### PR TITLE
fix(webhook): added issue lock events

### DIFF
--- a/modules/actions/workflows.go
+++ b/modules/actions/workflows.go
@@ -394,12 +394,12 @@ func matchIssuesEvent(issuePayload *api.IssuePayload, evt *jobparser.Event) bool
 		case "types":
 			// See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issues
 			// Actions with the same name:
-			// opened, edited, closed, reopened, assigned, unassigned, milestoned, demilestoned
+			// opened, edited, closed, reopened, assigned, unassigned, locked, unlocked, milestoned, demilestoned
 			// Actions need to be converted:
 			// label_updated -> labeled (when adding) or unlabeled (when removing)
 			// label_cleared -> unlabeled
 			// Unsupported activity types:
-			// deleted, transferred, pinned, unpinned, locked, unlocked
+			// deleted, transferred, pinned, unpinned
 
 			actions := []string{}
 			switch issuePayload.Action {
@@ -441,13 +441,13 @@ func matchPullRequestEvent(gitRepo *git.Repository, commit *git.Commit, prPayloa
 	} else {
 		// See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
 		// Actions with the same name:
-		// opened, edited, closed, reopened, assigned, unassigned, review_requested, review_request_removed, milestoned, demilestoned
+		// opened, edited, closed, reopened, assigned, unassigned, locked, unlocked, review_requested, review_request_removed, milestoned, demilestoned
 		// Actions need to be converted:
 		// synchronized -> synchronize
 		// label_updated -> labeled
 		// label_cleared -> unlabeled
 		// Unsupported activity types:
-		// converted_to_draft, ready_for_review, locked, unlocked, auto_merge_enabled, auto_merge_disabled, enqueued, dequeued
+		// converted_to_draft, ready_for_review, auto_merge_enabled, auto_merge_disabled, enqueued, dequeued
 
 		action := prPayload.Action
 		switch action {

--- a/modules/structs/hook.go
+++ b/modules/structs/hook.go
@@ -365,6 +365,10 @@ const (
 	HookIssueEdited HookIssueAction = "edited"
 	// HookIssueDeleted is an issue action for deleting an issue
 	HookIssueDeleted HookIssueAction = "deleted"
+	// HookIssueLocked is an issue action for locking an issue conversation.
+	HookIssueLocked HookIssueAction = "locked"
+	// HookIssueUnlocked is an issue action for unlocking an issue conversation.
+	HookIssueUnlocked HookIssueAction = "unlocked"
 	// HookIssueAssigned assigned
 	HookIssueAssigned HookIssueAction = "assigned"
 	// HookIssueUnassigned unassigned

--- a/routers/api/v1/repo/issue_lock.go
+++ b/routers/api/v1/repo/issue_lock.go
@@ -11,6 +11,7 @@ import (
 	api "gitea.dev/modules/structs"
 	"gitea.dev/modules/web"
 	"gitea.dev/services/context"
+	issue_service "gitea.dev/services/issue"
 )
 
 // LockIssue lock an issue
@@ -75,7 +76,7 @@ func LockIssue(ctx *context.APIContext) {
 		}
 
 		issue.Repo = ctx.Repo.Repository
-		err = issues_model.LockIssue(ctx, opt)
+		err = issue_service.LockIssue(ctx, opt)
 		if err != nil {
 			ctx.APIErrorInternal(err)
 			return
@@ -141,7 +142,7 @@ func UnlockIssue(ctx *context.APIContext) {
 		}
 
 		issue.Repo = ctx.Repo.Repository
-		err = issues_model.UnlockIssue(ctx, opt)
+		err = issue_service.UnlockIssue(ctx, opt)
 		if err != nil {
 			ctx.APIErrorInternal(err)
 			return

--- a/routers/web/repo/issue_lock.go
+++ b/routers/web/repo/issue_lock.go
@@ -8,6 +8,7 @@ import (
 	"gitea.dev/modules/web"
 	"gitea.dev/services/context"
 	"gitea.dev/services/forms"
+	issue_service "gitea.dev/services/issue"
 )
 
 // LockIssue locks an issue. This would limit commenting abilities to
@@ -24,7 +25,7 @@ func LockIssue(ctx *context.Context) {
 		return
 	}
 
-	if err := issues_model.LockIssue(ctx, &issues_model.IssueLockOptions{
+	if err := issue_service.LockIssue(ctx, &issues_model.IssueLockOptions{
 		Doer:   ctx.Doer,
 		Issue:  issue,
 		Reason: form.Reason,
@@ -48,7 +49,7 @@ func UnlockIssue(ctx *context.Context) {
 		return
 	}
 
-	if err := issues_model.UnlockIssue(ctx, &issues_model.IssueLockOptions{
+	if err := issue_service.UnlockIssue(ctx, &issues_model.IssueLockOptions{
 		Doer:  ctx.Doer,
 		Issue: issue,
 	}); err != nil {

--- a/services/actions/notifier.go
+++ b/services/actions/notifier.go
@@ -193,6 +193,22 @@ func (n *actionsNotifier) IssueChangeMilestone(ctx context.Context, doer *user_m
 	notifyIssueChange(ctx, doer, issue, hookEvent, action, nil, nil)
 }
 
+func (n *actionsNotifier) IssueChangeLock(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, locked bool) {
+	ctx = withMethod(ctx, "IssueChangeLock")
+
+	action := api.HookIssueUnlocked
+	if locked {
+		action = api.HookIssueLocked
+	}
+
+	hookEvent := webhook_module.HookEventIssues
+	if issue.IsPull {
+		hookEvent = webhook_module.HookEventPullRequest
+	}
+
+	notifyIssueChange(ctx, doer, issue, hookEvent, action, nil, nil)
+}
+
 func (n *actionsNotifier) IssueChangeLabels(ctx context.Context, doer *user_model.User, issue *issues_model.Issue,
 	addedLabels, removedLabels []*issues_model.Label,
 ) {

--- a/services/issue/lock.go
+++ b/services/issue/lock.go
@@ -1,0 +1,40 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package issue
+
+import (
+	"context"
+
+	issues_model "gitea.dev/models/issues"
+	notify_service "gitea.dev/services/notify"
+)
+
+// LockIssue locks an issue and notifies subscribers after a successful change.
+func LockIssue(ctx context.Context, opts *issues_model.IssueLockOptions) error {
+	return changeIssueLock(ctx, opts, true)
+}
+
+// UnlockIssue unlocks an issue and notifies subscribers after a successful change.
+func UnlockIssue(ctx context.Context, opts *issues_model.IssueLockOptions) error {
+	return changeIssueLock(ctx, opts, false)
+}
+
+func changeIssueLock(ctx context.Context, opts *issues_model.IssueLockOptions, locked bool) error {
+	if opts.Issue.IsLocked == locked {
+		return nil
+	}
+
+	var err error
+	if locked {
+		err = issues_model.LockIssue(ctx, opts)
+	} else {
+		err = issues_model.UnlockIssue(ctx, opts)
+	}
+	if err != nil {
+		return err
+	}
+
+	notify_service.IssueChangeLock(ctx, opts.Doer, opts.Issue, locked)
+	return nil
+}

--- a/services/notify/notifier.go
+++ b/services/notify/notifier.go
@@ -32,6 +32,7 @@ type Notifier interface {
 	NewIssue(ctx context.Context, issue *issues_model.Issue, mentions []*user_model.User)
 	IssueChangeStatus(ctx context.Context, doer *user_model.User, commitID string, issue *issues_model.Issue, actionComment *issues_model.Comment, closeOrReopen bool)
 	DeleteIssue(ctx context.Context, doer *user_model.User, issue *issues_model.Issue)
+	IssueChangeLock(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, locked bool)
 	IssueChangeMilestone(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, oldMilestoneID int64)
 	IssueChangeAssignee(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, assignee *user_model.User, removed bool, comment *issues_model.Comment)
 	PullRequestReviewRequest(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, reviewer *user_model.User, isRequest bool, comment *issues_model.Comment)

--- a/services/notify/notify.go
+++ b/services/notify/notify.go
@@ -91,6 +91,13 @@ func DeleteIssue(ctx context.Context, doer *user_model.User, issue *issues_model
 	}
 }
 
+// IssueChangeLock notifies issue conversation lock or unlock changes to notifiers
+func IssueChangeLock(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, locked bool) {
+	for _, notifier := range notifiers {
+		notifier.IssueChangeLock(ctx, doer, issue, locked)
+	}
+}
+
 // MergePullRequest notifies merge pull request to notifiers
 func MergePullRequest(ctx context.Context, doer *user_model.User, pr *issues_model.PullRequest) {
 	for _, notifier := range notifiers {

--- a/services/notify/null.go
+++ b/services/notify/null.go
@@ -110,6 +110,10 @@ func (*NullNotifier) UpdateRelease(ctx context.Context, doer *user_model.User, r
 func (*NullNotifier) DeleteRelease(ctx context.Context, doer *user_model.User, rel *repo_model.Release) {
 }
 
+// IssueChangeLock places a place holder function
+func (*NullNotifier) IssueChangeLock(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, locked bool) {
+}
+
 // IssueChangeMilestone places a place holder function
 func (*NullNotifier) IssueChangeMilestone(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, oldMilestoneID int64) {
 }

--- a/services/webhook/general.go
+++ b/services/webhook/general.go
@@ -112,6 +112,10 @@ func getIssuesPayloadInfo(p *api.IssuePayload, linkFormatter linkFormatter, with
 		text = fmt.Sprintf("[%s] Issue re-opened: %s", repoLink, titleLink)
 	case api.HookIssueEdited:
 		text = fmt.Sprintf("[%s] Issue edited: %s", repoLink, titleLink)
+	case api.HookIssueLocked:
+		text = fmt.Sprintf("[%s] Issue locked: %s", repoLink, titleLink)
+	case api.HookIssueUnlocked:
+		text = fmt.Sprintf("[%s] Issue unlocked: %s", repoLink, titleLink)
 	case api.HookIssueAssigned:
 		list := make([]string, len(p.Issue.Assignees))
 		for i, user := range p.Issue.Assignees {
@@ -169,6 +173,10 @@ func getPullRequestPayloadInfo(p *api.PullRequestPayload, linkFormatter linkForm
 	case api.HookIssueEdited:
 		text = fmt.Sprintf("[%s] Pull request edited: %s", repoLink, titleLink)
 		extraMarkdown = p.PullRequest.Body
+	case api.HookIssueLocked:
+		text = fmt.Sprintf("[%s] Pull request locked: %s", repoLink, titleLink)
+	case api.HookIssueUnlocked:
+		text = fmt.Sprintf("[%s] Pull request unlocked: %s", repoLink, titleLink)
 	case api.HookIssueAssigned:
 		list := make([]string, len(p.PullRequest.Assignees))
 		for i, user := range p.PullRequest.Assignees {

--- a/services/webhook/notifier.go
+++ b/services/webhook/notifier.go
@@ -333,6 +333,45 @@ func (m *webhookNotifier) DeleteIssue(ctx context.Context, doer *user_model.User
 	}
 }
 
+func (m *webhookNotifier) IssueChangeLock(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, locked bool) {
+	if err := issue.LoadRepo(ctx); err != nil {
+		log.Error("issue.LoadRepo: %v", err)
+		return
+	}
+
+	action := api.HookIssueUnlocked
+	if locked {
+		action = api.HookIssueLocked
+	}
+
+	permission, _ := access_model.GetDoerRepoPermission(ctx, issue.Repo, doer)
+	if issue.IsPull {
+		if err := issue.LoadPullRequest(ctx); err != nil {
+			log.Error("LoadPullRequest: %v", err)
+			return
+		}
+		if err := PrepareWebhooks(ctx, EventSource{Repository: issue.Repo}, webhook_module.HookEventPullRequest, &api.PullRequestPayload{
+			Action:      action,
+			Index:       issue.Index,
+			PullRequest: convert.ToAPIPullRequest(ctx, issue.PullRequest, doer),
+			Repository:  convert.ToRepo(ctx, issue.Repo, permission),
+			Sender:      convert.ToUser(ctx, doer, nil),
+		}); err != nil {
+			log.Error("PrepareWebhooks [is_pull: %v, locked: %v]: %v", issue.IsPull, locked, err)
+		}
+	} else {
+		if err := PrepareWebhooks(ctx, EventSource{Repository: issue.Repo}, webhook_module.HookEventIssues, &api.IssuePayload{
+			Action:     action,
+			Index:      issue.Index,
+			Issue:      convert.ToAPIIssue(ctx, doer, issue),
+			Repository: convert.ToRepo(ctx, issue.Repo, permission),
+			Sender:     convert.ToUser(ctx, doer, nil),
+		}); err != nil {
+			log.Error("PrepareWebhooks [is_pull: %v, locked: %v]: %v", issue.IsPull, locked, err)
+		}
+	}
+}
+
 func (m *webhookNotifier) NewPullRequest(ctx context.Context, pull *issues_model.PullRequest, mentions []*user_model.User) {
 	if err := pull.LoadIssue(ctx); err != nil {
 		log.Error("pull.LoadIssue: %v", err)

--- a/tests/integration/api_issue_lock_test.go
+++ b/tests/integration/api_issue_lock_test.go
@@ -9,14 +9,19 @@ import (
 	"testing"
 
 	auth_model "gitea.dev/models/auth"
+	"gitea.dev/models/db"
 	issues_model "gitea.dev/models/issues"
 	repo_model "gitea.dev/models/repo"
 	"gitea.dev/models/unittest"
 	user_model "gitea.dev/models/user"
+	webhook_model "gitea.dev/models/webhook"
+	"gitea.dev/modules/json"
 	api "gitea.dev/modules/structs"
+	webhook_module "gitea.dev/modules/webhook"
 	"gitea.dev/tests"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAPILockIssue(t *testing.T) {
@@ -28,6 +33,7 @@ func TestAPILockIssue(t *testing.T) {
 		repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: issueBefore.RepoID})
 		owner := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: repo.OwnerID})
 		urlStr := fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/lock", owner.Name, repo.Name, issueBefore.Index)
+		hook := prepareIssueLockWebhook(t, repo.ID)
 
 		session := loginUser(t, owner.Name)
 		token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteIssue)
@@ -37,6 +43,7 @@ func TestAPILockIssue(t *testing.T) {
 		MakeRequest(t, req, http.StatusNoContent)
 		issueAfter := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{ID: 1})
 		assert.True(t, issueAfter.IsLocked)
+		assertIssueLockWebhookTask(t, hook, api.HookIssueLocked)
 
 		// check with other user
 		user34 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 34})
@@ -51,18 +58,21 @@ func TestAPILockIssue(t *testing.T) {
 		repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: issueBefore.RepoID})
 		owner := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: repo.OwnerID})
 		urlStr := fmt.Sprintf("/api/v1/repos/%s/%s/issues/%d/lock", owner.Name, repo.Name, issueBefore.Index)
+		hook := prepareIssueLockWebhook(t, repo.ID)
 
 		session := loginUser(t, owner.Name)
 		token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteIssue)
 
 		lockReq := NewRequestWithJSON(t, "PUT", urlStr, api.LockIssueOption{Reason: "Spam"}).AddTokenAuth(token)
 		MakeRequest(t, lockReq, http.StatusNoContent)
+		require.NoError(t, db.TruncateBeans(t.Context(), &webhook_model.HookTask{}))
 
 		// check unlock issue
 		req := NewRequest(t, "DELETE", urlStr).AddTokenAuth(token)
 		MakeRequest(t, req, http.StatusNoContent)
 		issueAfter := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{ID: 1})
 		assert.False(t, issueAfter.IsLocked)
+		assertIssueLockWebhookTask(t, hook, api.HookIssueUnlocked)
 
 		// check with other user
 		user34 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 34})
@@ -71,4 +81,37 @@ func TestAPILockIssue(t *testing.T) {
 		req = NewRequest(t, "DELETE", urlStr).AddTokenAuth(token34)
 		MakeRequest(t, req, http.StatusForbidden)
 	})
+}
+
+func prepareIssueLockWebhook(t *testing.T, repoID int64) *webhook_model.Webhook {
+	t.Helper()
+
+	require.NoError(t, db.TruncateBeans(t.Context(), &webhook_model.Webhook{}, &webhook_model.HookTask{}))
+	hook := &webhook_model.Webhook{
+		RepoID:      repoID,
+		URL:         "http://example.com/gitea-test-issue-lock",
+		ContentType: webhook_model.ContentTypeJSON,
+		IsActive:    true,
+		Type:        webhook_module.GITEA,
+		HookEvent: &webhook_module.HookEvent{
+			ChooseEvents: true,
+			HookEvents: webhook_module.HookEvents{
+				webhook_module.HookEventIssues: true,
+			},
+		},
+	}
+	require.NoError(t, hook.UpdateEvent())
+	require.NoError(t, webhook_model.CreateWebhook(t.Context(), hook))
+	return hook
+}
+
+func assertIssueLockWebhookTask(t *testing.T, hook *webhook_model.Webhook, action api.HookIssueAction) {
+	t.Helper()
+
+	task := unittest.AssertExistsAndLoadBean(t, &webhook_model.HookTask{HookID: hook.ID, EventType: webhook_module.HookEventIssues})
+	var payload api.IssuePayload
+	require.NoError(t, json.Unmarshal([]byte(task.PayloadContent), &payload))
+	assert.Equal(t, action, payload.Action)
+	assert.Equal(t, hook.RepoID, payload.Repository.ID)
+	assert.Equal(t, "issue1", payload.Issue.Title)
 }


### PR DESCRIPTION
### Changes
- Added locked and unlocked issue actions for issue and pull request webhook payloads.
- Routed API and web lock/unlock flows through the issue service so successful changes notify webhooks and Actions.
- Covered API lock/unlock with webhook task assertions.

Closes #11764

### Tests
- go test ./tests/integration -run '^TestAPILockIssue$' -count=1
- go test ./services/issue ./services/notify ./services/webhook ./services/actions ./routers/api/v1/repo ./routers/web/repo ./modules/actions ./modules/structs -count=1
- GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./modules/structs ./modules/actions ./routers/api/v1/repo ./routers/web/repo ./services/actions ./services/issue ./services/notify ./services/webhook ./tests/integration
- GOEXPERIMENT= GOTOOLCHAIN=auto make generate-swagger
- GOEXPERIMENT= GOTOOLCHAIN=auto make swagger-check
- GOEXPERIMENT= GOTOOLCHAIN=auto make openapi3-check
- git diff --check

### AI assistance
AI assistance was used to prepare this patch and PR description.