### PR TITLE
fix(auth): updated last login for reverse proxy sign-in

### DIFF
--- a/services/auth/auth.go
+++ b/services/auth/auth.go
@@ -79,4 +79,8 @@ func handleSignIn(resp http.ResponseWriter, req *http.Request, sess SessionStore
 	}
 
 	middleware.SetLocaleCookie(resp, user.Language, 0)
+
+	if err := user_service.UpdateUser(req.Context(), user, &user_service.UpdateOptions{SetLastLogin: true}); err != nil {
+		log.Error("Error updating user last login [user: %d]: %v", user.ID, err)
+	}
 }

--- a/services/auth/reverseproxy_test.go
+++ b/services/auth/reverseproxy_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"gitea.dev/models/unittest"
+	user_model "gitea.dev/models/user"
+	"gitea.dev/modules/reqctx"
+	session_module "gitea.dev/modules/session"
+	"gitea.dev/modules/setting"
+	"gitea.dev/modules/timeutil"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReverseProxyVerifyUpdatesLastLogin(t *testing.T) {
+	require.NoError(t, unittest.PrepareTestDatabase())
+
+	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	user.LastLoginUnix = timeutil.TimeStamp(0)
+	require.NoError(t, user_model.UpdateUserCols(t.Context(), user, "last_login_unix"))
+
+	sess := session_module.NewMockMemStore("reverse-proxy-last-login")
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(
+		context.WithValue(t.Context(), session_module.MockStoreContextKey, sess),
+	)
+	req.Header.Set(setting.ReverseProxyAuthUser, user.Name)
+
+	verifiedUser, err := (&ReverseProxy{CreateSession: true}).Verify(req, httptest.NewRecorder(), reqctx.ContextData{}, sess)
+	require.NoError(t, err)
+	require.NotNil(t, verifiedUser)
+
+	updatedUser := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: user.ID})
+	assert.NotZero(t, updatedUser.LastLoginUnix)
+}


### PR DESCRIPTION
### Changes
- Updated session-backed external sign-in to record last login after a successful session login.
- Covered reverse proxy authentication with a test that verifies LastLoginUnix is updated.

Closes #7836

### Tests
- go test ./services/auth -run '^TestReverseProxyVerifyUpdatesLastLogin$' -count=1
- go test ./services/auth -count=1
- go test ./services/auth ./routers/web/auth -count=1
- GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./services/auth ./routers/web/auth
- git diff --check

### AI assistance
AI assistance was used to prepare this patch and PR description.