### PR TITLE
fix(issue): prevented duplicate consecutive comments

### DIFF
--- a/services/issue/comments.go
+++ b/services/issue/comments.go
@@ -64,6 +64,12 @@ func CreateIssueComment(ctx context.Context, doer *user_model.User, repo *repo_m
 		}
 	}
 
+	if comment, duplicate, err := findPreviousDuplicateIssueComment(ctx, doer, issue, content, attachments); err != nil {
+		return nil, err
+	} else if duplicate {
+		return comment, nil
+	}
+
 	comment, err := issues_model.CreateComment(ctx, &issues_model.CreateCommentOptions{
 		Type:        issues_model.CommentTypeComment,
 		Doer:        doer,
@@ -90,6 +96,25 @@ func CreateIssueComment(ctx context.Context, doer *user_model.User, repo *repo_m
 	notify_service.CreateIssueComment(ctx, doer, repo, issue, comment, mentions)
 
 	return comment, nil
+}
+
+func findPreviousDuplicateIssueComment(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, content string, attachments []string) (*issues_model.Comment, bool, error) {
+	if len(attachments) > 0 {
+		return nil, false, nil
+	}
+
+	comment := new(issues_model.Comment)
+	has, err := db.GetEngine(ctx).
+		Where("issue_id = ? AND type = ?", issue.ID, issues_model.CommentTypeComment).
+		Desc("created_unix", "id").
+		Get(comment)
+	if err != nil || !has {
+		return nil, false, err
+	}
+	if comment.PosterID != doer.ID || comment.Content != content {
+		return nil, false, nil
+	}
+	return comment, true, nil
 }
 
 // UpdateComment updates information of comment.

--- a/services/issue/comments_test.go
+++ b/services/issue/comments_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package issue
+
+import (
+	"testing"
+
+	issues_model "gitea.dev/models/issues"
+	repo_model "gitea.dev/models/repo"
+	"gitea.dev/models/unittest"
+	user_model "gitea.dev/models/user"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateIssueCommentSkipsConsecutiveDuplicate(t *testing.T) {
+	require.NoError(t, unittest.PrepareTestDatabase())
+
+	issue := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{ID: 1})
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: issue.RepoID})
+	doer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: repo.OwnerID})
+	issue.Repo = repo
+
+	before, err := issues_model.CountComments(t.Context(), &issues_model.FindCommentsOptions{
+		IssueID: issue.ID,
+		Type:    issues_model.CommentTypeComment,
+	})
+	require.NoError(t, err)
+
+	first, err := CreateIssueComment(t.Context(), doer, repo, issue, "duplicate comment", nil)
+	require.NoError(t, err)
+	second, err := CreateIssueComment(t.Context(), doer, repo, issue, "duplicate comment", nil)
+	require.NoError(t, err)
+
+	after, err := issues_model.CountComments(t.Context(), &issues_model.FindCommentsOptions{
+		IssueID: issue.ID,
+		Type:    issues_model.CommentTypeComment,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, first.ID, second.ID)
+	assert.Equal(t, before+1, after)
+}


### PR DESCRIPTION
### Changes
- Returned the previous issue comment instead of creating a new one when the immediately previous plain comment has the same author and body.
- Limited the de-duplication to comments without new attachments so attachment uploads are not dropped.
- Added service coverage for the duplicate-comment path.

Closes #11185

### Tests
- go test ./services/issue -run '^TestCreateIssueCommentSkipsConsecutiveDuplicate$' -count=1
- go test ./services/issue ./routers/api/v1/repo ./routers/web/repo -count=1
- go test ./tests/integration -run 'TestAPI.*Comment|Test_WebhookIssueComment|TestPullComment' -count=1
- GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./services/issue ./routers/api/v1/repo ./routers/web/repo ./tests/integration
- git diff --check

### AI assistance
AI assistance was used to prepare this patch and PR description.