### PR TITLE
feat(projects): show owner projects in repository project lists

### DIFF
--- a/models/project/project.go
+++ b/models/project/project.go
@@ -207,26 +207,62 @@ type SearchOptions struct {
 	db.ListOptions
 	OwnerID  int64
 	RepoID   int64
+	Scopes   []SearchScope
 	IsClosed optional.Option[bool]
 	OrderBy  db.SearchOrderBy
 	Type     Type
 	Title    string
 }
 
+// SearchScope limits project search to one repository or owner project scope.
+type SearchScope struct {
+	OwnerID int64
+	RepoID  int64
+	Type    Type
+}
+
+// ToCond returns the search condition for a single project scope.
+func (scope SearchScope) ToCond() builder.Cond {
+	cond := builder.NewCond()
+	if scope.RepoID > 0 {
+		cond = cond.And(builder.Eq{"repo_id": scope.RepoID})
+	}
+	if scope.OwnerID > 0 {
+		cond = cond.And(builder.Eq{"owner_id": scope.OwnerID})
+	}
+	if scope.Type > 0 {
+		cond = cond.And(builder.Eq{"type": scope.Type})
+	}
+	return cond
+}
+
 func (opts SearchOptions) ToConds() builder.Cond {
 	cond := builder.NewCond()
-	if opts.RepoID > 0 {
-		cond = cond.And(builder.Eq{"repo_id": opts.RepoID})
-	}
-	if opts.IsClosed.Has() {
-		cond = cond.And(builder.Eq{"is_closed": opts.IsClosed.Value()})
+
+	if len(opts.Scopes) > 0 {
+		var scopeCond builder.Cond
+		for i, scope := range opts.Scopes {
+			if i == 0 {
+				scopeCond = scope.ToCond()
+			} else {
+				scopeCond = scopeCond.Or(scope.ToCond())
+			}
+		}
+		cond = cond.And(scopeCond)
+	} else {
+		if opts.RepoID > 0 {
+			cond = cond.And(builder.Eq{"repo_id": opts.RepoID})
+		}
+		if opts.Type > 0 {
+			cond = cond.And(builder.Eq{"type": opts.Type})
+		}
+		if opts.OwnerID > 0 {
+			cond = cond.And(builder.Eq{"owner_id": opts.OwnerID})
+		}
 	}
 
-	if opts.Type > 0 {
-		cond = cond.And(builder.Eq{"type": opts.Type})
-	}
-	if opts.OwnerID > 0 {
-		cond = cond.And(builder.Eq{"owner_id": opts.OwnerID})
+	if opts.IsClosed.Has() {
+		cond = cond.And(builder.Eq{"is_closed": opts.IsClosed.Value()})
 	}
 
 	if len(opts.Title) != 0 {

--- a/models/project/project_test.go
+++ b/models/project/project_test.go
@@ -8,6 +8,7 @@ import (
 
 	"gitea.dev/models/db"
 	"gitea.dev/models/unittest"
+	"gitea.dev/modules/optional"
 	"gitea.dev/modules/timeutil"
 
 	"github.com/stretchr/testify/assert"
@@ -81,6 +82,36 @@ func TestProject(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.True(t, projectFromDB.IsClosed)
+}
+
+func TestProjectsSearchScopes(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	ownerProject := &Project{
+		Type:         TypeIndividual,
+		TemplateType: TemplateTypeBasicKanban,
+		CardType:     CardTypeTextOnly,
+		Title:        "Owner Project",
+		OwnerID:      2,
+		CreatedUnix:  timeutil.TimeStampNow(),
+		CreatorID:    2,
+	}
+	assert.NoError(t, NewProject(t.Context(), ownerProject))
+
+	projects, count, err := db.FindAndCount[Project](t.Context(), SearchOptions{
+		Scopes: []SearchScope{
+			{RepoID: 1, Type: TypeRepository},
+			{OwnerID: 2, Type: TypeIndividual},
+		},
+		IsClosed: optional.Some(false),
+		OrderBy:  "id ASC",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), count)
+	if assert.Len(t, projects, 2) {
+		assert.Equal(t, int64(1), projects[0].ID)
+		assert.Equal(t, ownerProject.ID, projects[1].ID)
+	}
 }
 
 func TestProjectsSort(t *testing.T) {

--- a/routers/web/repo/projects.go
+++ b/routers/web/repo/projects.go
@@ -46,11 +46,33 @@ func MustEnableRepoProjects(ctx *context.Context) {
 
 	if ctx.Repo.Repository != nil {
 		projectsUnit := ctx.Repo.Repository.MustGetUnit(ctx, unit.TypeProjects)
-		if !ctx.Repo.Permission.CanRead(unit.TypeProjects) || !projectsUnit.ProjectsConfig().IsProjectsAllowed(repo_model.ProjectsModeRepo) {
+		if !ctx.Repo.Permission.CanRead(unit.TypeProjects) || len(projectSearchScopesForRepo(ctx.Repo.Repository, projectsUnit)) == 0 {
 			ctx.NotFound(nil)
 			return
 		}
 	}
+}
+
+func projectSearchScopesForRepo(repo *repo_model.Repository, projectsUnit *repo_model.RepoUnit) []project_model.SearchScope {
+	scopes := make([]project_model.SearchScope, 0, 2)
+	projectsConfig := projectsUnit.ProjectsConfig()
+	if projectsConfig.IsProjectsAllowed(repo_model.ProjectsModeRepo) {
+		scopes = append(scopes, project_model.SearchScope{
+			RepoID: repo.ID,
+			Type:   project_model.TypeRepository,
+		})
+	}
+	if projectsConfig.IsProjectsAllowed(repo_model.ProjectsModeOwner) {
+		projectType := project_model.TypeIndividual
+		if repo.Owner.IsOrganization() {
+			projectType = project_model.TypeOrganization
+		}
+		scopes = append(scopes, project_model.SearchScope{
+			OwnerID: repo.OwnerID,
+			Type:    projectType,
+		})
+	}
+	return scopes
 }
 
 // Projects renders the home page of projects
@@ -63,19 +85,17 @@ func Projects(ctx *context.Context) {
 	keyword := ctx.FormTrim("q")
 	repo := ctx.Repo.Repository
 	page := max(ctx.FormInt("page"), 1)
-
-	ctx.Data["OpenCount"] = repo.NumOpenProjects
-	ctx.Data["ClosedCount"] = repo.NumClosedProjects
+	projectsUnit := repo.MustGetUnit(ctx, unit.TypeProjects)
+	projectSearchScopes := projectSearchScopesForRepo(repo, projectsUnit)
 
 	projects, count, err := db.FindAndCount[project_model.Project](ctx, project_model.SearchOptions{
 		ListOptions: db.ListOptions{
 			PageSize: setting.UI.IssuePagingNum,
 			Page:     page,
 		},
-		RepoID:   repo.ID,
+		Scopes:   projectSearchScopes,
 		IsClosed: optional.Some(isShowClosed),
 		OrderBy:  project_model.GetSearchOrderByBySortType(sortType),
-		Type:     project_model.TypeRepository,
 		Title:    keyword,
 	})
 	if err != nil {
@@ -97,6 +117,24 @@ func Projects(ctx *context.Context) {
 		}
 	}
 
+	oppositeStateCount, err := db.Count[project_model.Project](ctx, project_model.SearchOptions{
+		Scopes:   projectSearchScopes,
+		IsClosed: optional.Some(!isShowClosed),
+		Title:    keyword,
+	})
+	if err != nil {
+		ctx.ServerError("CountProjects", err)
+		return
+	}
+
+	if isShowClosed {
+		ctx.Data["OpenCount"] = oppositeStateCount
+		ctx.Data["ClosedCount"] = count
+	} else {
+		ctx.Data["OpenCount"] = count
+		ctx.Data["ClosedCount"] = oppositeStateCount
+	}
+
 	ctx.Data["Projects"] = projects
 
 	if isShowClosed {
@@ -110,6 +148,7 @@ func Projects(ctx *context.Context) {
 	ctx.Data["Page"] = pager
 
 	ctx.Data["CanWriteProjects"] = ctx.Repo.Permission.CanWrite(unit.TypeProjects)
+	ctx.Data["CanWriteRepoProjects"] = ctx.Repo.Permission.CanWrite(unit.TypeProjects) && projectsUnit.ProjectsConfig().IsProjectsAllowed(repo_model.ProjectsModeRepo)
 	ctx.Data["IsShowClosed"] = isShowClosed
 	ctx.Data["IsProjectsPage"] = true
 	ctx.Data["SortType"] = sortType

--- a/templates/projects/list.tmpl
+++ b/templates/projects/list.tmpl
@@ -1,4 +1,5 @@
-{{if and $.CanWriteProjects (not $.Repository.IsArchived)}}
+{{$canWriteProject := and $.CanWriteProjects (or (not $.Repository) (and $.CanWriteRepoProjects (not $.Repository.IsArchived)))}}
+{{if $canWriteProject}}
 	<div class="flex-left-right tw-mb-4">
 		<div class="small-menu-items ui compact tiny menu list-header-toggle">
 			<a class="item{{if not .IsShowClosed}} active{{end}}" href="?state=open&q={{$.Keyword}}">
@@ -59,7 +60,7 @@
 						{{ctx.Locale.PrettyNumber .NumClosedIssues}}&nbsp;{{ctx.Locale.Tr "repo.issues.closed_title"}}
 					</div>
 				</div>
-				{{if and $.CanWriteProjects (not $.Repository.IsArchived)}}
+				{{if and $canWriteProject (or (not $.Repository) .IsRepositoryProject)}}
 				<div class="group">
 					<a class="flex-text-inline" href="{{.Link ctx}}/edit">{{svg "octicon-pencil" 14}}{{ctx.Locale.Tr "repo.issues.label_edit"}}</a>
 					{{if .IsClosed}}
@@ -93,7 +94,7 @@
 	{{template "base/paginate" .}}
 </div>
 
-{{if and $.CanWriteProjects (not $.Repository.IsArchived)}}
+{{if $canWriteProject}}
 <div class="ui small modal" id="repo-project-delete-modal">
 	<div class="header">{{svg "octicon-trash"}} {{ctx.Locale.Tr "repo.projects.deletion"}}</div>
 	<div class="content"><p>{{ctx.Locale.Tr "repo.projects.deletion_desc"}}</p></div>

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -129,7 +129,7 @@
 					{{end}}
 
 					{{$projectsUnit := .Repository.MustGetUnit ctx ctx.Consts.RepoUnitTypeProjects}}
-					{{if and (not ctx.Consts.RepoUnitTypeProjects.UnitGlobalDisabled) (.Permission.CanRead ctx.Consts.RepoUnitTypeProjects) ($projectsUnit.ProjectsConfig.IsProjectsAllowed "repo")}}
+					{{if and (not ctx.Consts.RepoUnitTypeProjects.UnitGlobalDisabled) (.Permission.CanRead ctx.Consts.RepoUnitTypeProjects) (or ($projectsUnit.ProjectsConfig.IsProjectsAllowed "repo") ($projectsUnit.ProjectsConfig.IsProjectsAllowed "owner"))}}
 						<a href="{{.RepoLink}}/projects" class="{{if .IsProjectsPage}}active {{end}}item">
 							{{svg "octicon-project"}} {{ctx.Locale.Tr "repo.projects"}}
 							{{if .Repository.NumOpenProjects}}


### PR DESCRIPTION
### Changes
- Included owner-level projects in repository project lists when the repository projects mode allows owner projects.
- Kept repository project create/edit/close/delete actions scoped to repository projects on repository pages.
- Added shared project search scopes so repository and owner project scopes can be queried together.

Fixes #33378

### Tests
- go test ./models/project -run 'TestProjectsSearchScopes|TestGetProjects|TestProjectsSort' -count=1
- go test ./routers/web/repo -run 'TestCheckProjectColumnChangePermissions' -count=1
- go test ./models/project ./routers/web/repo -count=1
- GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./models/project ./routers/web/repo
- make lint-templates
- git diff --check

### AI assistance
AI assistance was used to prepare this patch and PR description.
