### PR TITLE
Added emoji dropdown config

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1386,6 +1386,9 @@ LEVEL = Info
 ;; Leave it empty to enable all emojis.
 ;ENABLED_EMOJIS =
 ;;
+;; Enable emoji autocomplete dropdowns in markdown editors.
+;ENABLE_EMOJI_DROPDOWN = true
+;;
 ;; Whether the full name of the users should be shown where possible. If the full name isn't set, the username will be used.
 ;DEFAULT_SHOW_FULL_NAME = false
 ;;

--- a/modules/setting/ui.go
+++ b/modules/setting/ui.go
@@ -35,6 +35,7 @@ var UI = struct {
 	CustomEmojisMap         map[string]string `ini:"-"`
 	EnabledEmojis           []string
 	EnabledEmojisSet        container.Set[string] `ini:"-"`
+	EnableEmojiDropdown     bool
 	SearchRepoDescription   bool
 	OnlyShowRelevantRepos   bool
 	ExploreDefaultSort      string `ini:"EXPLORE_PAGING_DEFAULT_SORT"`
@@ -101,6 +102,7 @@ var UI = struct {
 	Reactions:               []string{`+1`, `-1`, `laugh`, `hooray`, `confused`, `heart`, `rocket`, `eyes`},
 	CustomEmojis:            []string{`git`, `gitea`, `codeberg`, `gitlab`, `github`, `gogs`},
 	CustomEmojisMap:         map[string]string{"git": ":git:", "gitea": ":gitea:", "codeberg": ":codeberg:", "gitlab": ":gitlab:", "github": ":github:", "gogs": ":gogs:"},
+	EnableEmojiDropdown:     true,
 	ExploreDefaultSort:      "recentupdate",
 	PreferredTimestampTense: "mixed",
 

--- a/modules/setting/ui_test.go
+++ b/modules/setting/ui_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package setting
+
+import (
+	"testing"
+
+	"gitea.dev/modules/test"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadUIEnableEmojiDropdown(t *testing.T) {
+	t.Run("default enabled", func(t *testing.T) {
+		defer test.MockVariableValue(&UI)()
+
+		cfg, err := NewConfigProviderFromData(`
+[ui]
+`)
+		assert.NoError(t, err)
+		loadUIFrom(cfg)
+		assert.True(t, UI.EnableEmojiDropdown)
+	})
+
+	t.Run("can be disabled", func(t *testing.T) {
+		defer test.MockVariableValue(&UI)()
+
+		cfg, err := NewConfigProviderFromData(`
+[ui]
+ENABLE_EMOJI_DROPDOWN = false
+`)
+		assert.NoError(t, err)
+		loadUIFrom(cfg)
+		assert.False(t, UI.EnableEmojiDropdown)
+	})
+}

--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -99,6 +99,9 @@ func newFuncMapWebPage() template.FuncMap {
 		"CustomEmojis": func() map[string]string {
 			return setting.UI.CustomEmojisMap
 		},
+		"EnableEmojiDropdown": func() bool {
+			return setting.UI.EnableEmojiDropdown
+		},
 		"MetaAuthor": func() string {
 			return setting.UI.Meta.Author
 		},

--- a/templates/base/head_script.tmpl
+++ b/templates/base/head_script.tmpl
@@ -12,6 +12,7 @@ If you introduce mistakes in it, Gitea JavaScript code wouldn't run correctly.
 		assetUrlPrefix: '{{AssetUrlPrefix}}',
 		runModeIsProd: {{.RunModeIsProd}},
 		customEmojis: {{CustomEmojis}},
+		enableEmojiDropdown: {{EnableEmojiDropdown}},
 		pageData: {{.PageData}},
 		notificationSettings: {{NotificationSettings}}, {{/*a map provided by NewFuncMap in helper.go*/}}
 		enableTimeTracking: {{EnableTimetracking}},

--- a/web_src/js/features/comp/TextExpander.ts
+++ b/web_src/js/features/comp/TextExpander.ts
@@ -68,6 +68,8 @@ export function initTextExpander(expander: TextExpanderElement) {
     if (!e.detail) return;
     const {key, text, provide} = e.detail;
     if (key === ':') {
+      if (!window.config.enableEmojiDropdown) return provide({matched: false});
+
       const matches = matchEmoji(text);
       if (!matches.length) return provide({matched: false});
 

--- a/web_src/js/features/tribute.ts
+++ b/web_src/js/features/tribute.ts
@@ -48,11 +48,13 @@ export async function attachTribute(element: HTMLElement) {
     },
   };
 
+  const collections: TributeCollection<any>[] = [mentionCollection];
+  if (window.config.enableEmojiDropdown) {
+    collections.unshift(emojiCollection);
+  }
+
   const tribute = new Tribute({
-    collection: [
-      emojiCollection,
-      mentionCollection,
-    ] as TributeCollection<any>[],
+    collection: collections,
     noMatchTemplate: () => '',
   });
   tribute.attach(element);

--- a/web_src/js/globals.d.ts
+++ b/web_src/js/globals.d.ts
@@ -26,6 +26,7 @@ interface Window {
     sharedWorkerUri: string,
     runModeIsProd: boolean,
     customEmojis: Record<string, string>,
+    enableEmojiDropdown: boolean,
     pageData: Record<string, any> & {
       adminUserListSearchForm?: {
         SortType: string,

--- a/web_src/js/vitest.setup.ts
+++ b/web_src/js/vitest.setup.ts
@@ -7,6 +7,7 @@ window.config = {
   sharedWorkerUri: '',
   runModeIsProd: true,
   customEmojis: {},
+  enableEmojiDropdown: true,
   pageData: {},
   notificationSettings: {MinTimeout: 0, TimeoutStep: 0, MaxTimeout: 0, EventSourceUpdateTime: 0},
   enableTimeTracking: true,


### PR DESCRIPTION
## Summary
- Added `[ui].ENABLE_EMOJI_DROPDOWN` with a default of `true`.
- Exposed the setting to frontend config.
- Disabled emoji autocomplete in both Tribute and TextExpander when the setting is `false`.
- Documented the setting and covered config loading.

Closes #11343

## Tests
- `go test ./modules/setting -run 'TestLoadUIEnableEmojiDropdown' -count=1`
- `go test ./modules/setting ./modules/templates -count=1`
- `npx eslint web_src/js/features/tribute.ts web_src/js/features/comp/TextExpander.ts web_src/js/globals.d.ts web_src/js/vitest.setup.ts`
- `make lint-templates`
- `git diff --check`
- `GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./modules/setting ./modules/templates`

### AI assistance
AI assistance was used to prepare this patch and PR description.
