### PR TITLE
Expanded issue mention suggestions

### DIFF
--- a/models/issues/issue.go
+++ b/models/issues/issue.go
@@ -672,6 +672,27 @@ func (issue *Issue) GetParticipantIDsByIssue(ctx context.Context) ([]int64, erro
 	return userIDs, nil
 }
 
+// GetMentionSuggestionUserIDsByIssue returns the issue author and active users who posted any issue timeline event.
+func (issue *Issue) GetMentionSuggestionUserIDsByIssue(ctx context.Context) ([]int64, error) {
+	if issue == nil {
+		return nil, nil
+	}
+	userIDs := make([]int64, 0, 5)
+	if err := db.GetEngine(ctx).Table("comment").Cols("poster_id").
+		Where("`comment`.issue_id = ?", issue.ID).
+		And("`user`.is_active = ?", true).
+		And("`user`.prohibit_login = ?", false).
+		Join("INNER", "`user`", "`user`.id = `comment`.poster_id").
+		Distinct("poster_id").
+		Find(&userIDs); err != nil {
+		return nil, fmt.Errorf("get mention suggestion user IDs: %w", err)
+	}
+	if !slices.Contains(userIDs, issue.PosterID) {
+		return append(userIDs, issue.PosterID), nil
+	}
+	return userIDs, nil
+}
+
 // BlockedByDependencies finds all Dependencies an issue is blocked by
 func (issue *Issue) BlockedByDependencies(ctx context.Context, opts db.ListOptions) (issueDeps []*DependencyInfo, total int64, err error) {
 	sess := db.GetEngine(ctx).

--- a/models/issues/issue_test.go
+++ b/models/issues/issue_test.go
@@ -110,6 +110,26 @@ func TestGetParticipantIDsByIssue(t *testing.T) {
 	checkParticipants(1, []int{1, 5})
 }
 
+func TestGetMentionSuggestionUserIDsByIssue(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	issue, err := issues_model.GetIssueByID(t.Context(), 1)
+	assert.NoError(t, err)
+
+	userIDs, err := issue.GetMentionSuggestionUserIDsByIssue(t.Context())
+	assert.NoError(t, err)
+
+	ids := make([]int, len(userIDs))
+	for i, uid := range userIDs {
+		ids[i] = int(uid)
+	}
+	sort.Ints(ids)
+
+	// User 1 is issue poster, user 2 only labeled the issue, user 5 commented.
+	// User 3 also commented but is inactive, so it is not suggested.
+	assert.Equal(t, []int{1, 2, 5}, ids)
+}
+
 func TestIssue_ClearLabels(t *testing.T) {
 	tests := []struct {
 		issueID int64

--- a/routers/web/repo/mention.go
+++ b/routers/web/repo/mention.go
@@ -27,9 +27,9 @@ func GetMentionsInRepo(ctx *context.Context) {
 			return
 		}
 		if issue != nil {
-			userIDs, err := issue.GetParticipantIDsByIssue(ctx)
+			userIDs, err := issue.GetMentionSuggestionUserIDsByIssue(ctx)
 			if err != nil {
-				ctx.ServerError("GetParticipantIDsByIssue", err)
+				ctx.ServerError("GetMentionSuggestionUserIDsByIssue", err)
 				return
 			}
 			users, err := user_model.GetUsersByIDs(ctx, userIDs)


### PR DESCRIPTION
## Summary
- Added a mention autocomplete user list for issue timelines.
- Included users who posted timeline actions such as labels, closes, merges, assignments, and pushes.
- Kept the existing participant helper unchanged so mail/watch behavior was not expanded.
- Added a regression test for action-only users in mention suggestions.

Closes #32101

## Tests
- `go test ./models/issues -run 'TestGetParticipantIDsByIssue|TestGetMentionSuggestionUserIDsByIssue' -count=1`
- `go test ./routers/web/repo -run 'Test' -count=1`
- `go test ./models/issues ./routers/web/repo -count=1`
- `git diff --check`
- `GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./models/issues ./routers/web/repo`

### AI assistance
AI assistance was used to prepare this patch and PR description.
