### PR TITLE
Render commit reference message bodies

### DIFF
--- a/models/issues/comment.go
+++ b/models/issues/comment.go
@@ -12,6 +12,8 @@ import (
 	"html/template"
 	"slices"
 	"strconv"
+	"strings"
+	"unicode"
 	"unicode/utf8"
 
 	"gitea.dev/models/db"
@@ -248,6 +250,7 @@ type CommentMetaData struct {
 	ProjectTitle       string `json:"project_title,omitempty"`
 
 	SpecialDoerName SpecialDoerNameType `json:"special_doer_name,omitempty"` // e.g. "CODEOWNERS" for CODEOWNERS-triggered review requests
+	CommitMessage   string              `json:"commit_message,omitempty"`
 }
 
 // Comment represents a comment in commit and issue page.
@@ -539,6 +542,26 @@ func (c *Comment) GetSanitizedContentHTML() template.HTML {
 	// mainly for type=4 CommentTypeCommitRef
 	// the content is a link like <a href="{RepoLink}/commit/{CommitID}">message title</a> (from CreateRefComment)
 	return markup.Sanitize(c.Content)
+}
+
+func (c *Comment) CommitMessage() string {
+	if c.CommentMetaData == nil {
+		return ""
+	}
+	return c.CommentMetaData.CommitMessage
+}
+
+func (c *Comment) CommitMessageTitle() string {
+	msgLine := strings.TrimLeftFunc(c.CommitMessage(), unicode.IsSpace)
+	if lineEnd := strings.IndexByte(msgLine, '\n'); lineEnd >= 0 {
+		msgLine = msgLine[:lineEnd]
+	}
+	return strings.TrimRightFunc(msgLine, unicode.IsSpace)
+}
+
+func (c *Comment) CommitMessageBody() string {
+	_, body, _ := strings.Cut(strings.TrimSpace(c.CommitMessage()), "\n")
+	return strings.TrimSpace(body)
 }
 
 // LoadLabel if comment.Type is CommentTypeLabel, then load Label
@@ -836,6 +859,12 @@ func CreateComment(ctx context.Context, opts *CreateCommentOptions) (_ *Comment,
 				SpecialDoerName: opts.SpecialDoerName,
 			}
 		}
+		if opts.CommitMessage != "" {
+			if commentMetaData == nil {
+				commentMetaData = &CommentMetaData{}
+			}
+			commentMetaData.CommitMessage = opts.CommitMessage
+		}
 
 		comment := &Comment{
 			Type:             opts.Type,
@@ -1019,6 +1048,7 @@ type CreateCommentOptions struct {
 	NewRef             string
 	CommitID           int64
 	CommitSHA          string
+	CommitMessage      string
 	Patch              string
 	LineNum            int64
 	TreePath           string

--- a/routers/web/repo/issue_view.go
+++ b/routers/web/repo/issue_view.go
@@ -685,6 +685,28 @@ func prepareIssueViewCommentsAndSidebarParticipants(ctx *context.Context, issue 
 				ctx.ServerError("LoadLabel", err)
 				return
 			}
+		} else if comment.Type == issues_model.CommentTypeCommitRef {
+			if comment.RefRepoID == issue.RepoID {
+				if ctx.Repo.Permission.CanRead(unit.TypeCode) {
+					comment.RefRepo = issue.Repo
+				}
+			} else if comment.RefRepoID != 0 {
+				refRepo, err := repo_model.GetRepositoryByID(ctx, comment.RefRepoID)
+				if err != nil && !repo_model.IsErrRepoNotExist(err) {
+					ctx.ServerError("GetRepositoryByID", err)
+					return
+				}
+				if refRepo != nil {
+					perm, err := access_model.GetDoerRepoPermission(ctx, refRepo, ctx.Doer)
+					if err != nil {
+						ctx.ServerError("GetDoerRepoPermission", err)
+						return
+					}
+					if perm.CanRead(unit.TypeCode) {
+						comment.RefRepo = refRepo
+					}
+				}
+			}
 		} else if comment.Type == issues_model.CommentTypeMilestone {
 			if err = comment.LoadMilestone(ctx); err != nil {
 				ctx.ServerError("LoadMilestone", err)

--- a/services/issue/comments.go
+++ b/services/issue/comments.go
@@ -22,7 +22,7 @@ import (
 )
 
 // CreateRefComment creates a commit reference comment to issue.
-func CreateRefComment(ctx context.Context, doer *user_model.User, repo *repo_model.Repository, issue *issues_model.Issue, content, commitSHA string) error {
+func CreateRefComment(ctx context.Context, doer *user_model.User, repo *repo_model.Repository, issue *issues_model.Issue, content, commitMessage, commitSHA string, refRepoID int64) error {
 	if len(commitSHA) == 0 {
 		return errors.New("cannot create reference with empty commit SHA")
 	}
@@ -46,12 +46,14 @@ func CreateRefComment(ctx context.Context, doer *user_model.User, repo *repo_mod
 	}
 
 	_, err = issues_model.CreateComment(ctx, &issues_model.CreateCommentOptions{
-		Type:      issues_model.CommentTypeCommitRef,
-		Doer:      doer,
-		Repo:      repo,
-		Issue:     issue,
-		CommitSHA: commitSHA,
-		Content:   content,
+		Type:          issues_model.CommentTypeCommitRef,
+		Doer:          doer,
+		Repo:          repo,
+		Issue:         issue,
+		CommitSHA:     commitSHA,
+		CommitMessage: commitMessage,
+		Content:       content,
+		RefRepoID:     refRepoID,
 	})
 	return err
 }

--- a/services/issue/commit.go
+++ b/services/issue/commit.go
@@ -181,7 +181,7 @@ func UpdateIssuesCommit(ctx context.Context, doer *user_model.User, repo *repo_m
 			}
 
 			message := fmt.Sprintf(`<a href="%s/commit/%s">%s</a>`, html.EscapeString(repo.Link()), html.EscapeString(url.PathEscape(c.Sha1)), html.EscapeString(strings.SplitN(c.Message, "\n", 2)[0]))
-			if err = CreateRefComment(ctx, doer, refRepo, refIssue, message, c.Sha1); err != nil {
+			if err = CreateRefComment(ctx, doer, refRepo, refIssue, message, c.Message, c.Sha1, repo.ID); err != nil {
 				if errors.Is(err, user_model.ErrBlockedUser) {
 					continue
 				}

--- a/services/issue/commit_test.go
+++ b/services/issue/commit_test.go
@@ -144,6 +144,42 @@ func TestUpdateIssuesCommit_Colon(t *testing.T) {
 	unittest.CheckConsistencyFor(t, &activities_model.Action{})
 }
 
+func TestUpdateIssuesCommit_StoresMultilineCommitMessage(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	message := "Implement the thing\n\nKeep this line visible\nKeep this line too\n\nRefs #1"
+	pushCommits := []*repository.PushCommit{
+		{
+			Sha1:           "abcdef-multiline",
+			CommitterEmail: "user2@example.com",
+			CommitterName:  "User Two",
+			AuthorEmail:    "user2@example.com",
+			AuthorName:     "User Two",
+			Message:        message,
+		},
+	}
+
+	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+	repo.Owner = user
+
+	assert.NoError(t, UpdateIssuesCommit(t.Context(), user, repo, pushCommits, repo.DefaultBranch))
+
+	comment := unittest.AssertExistsAndLoadBean(t, &issues_model.Comment{
+		Type:      issues_model.CommentTypeCommitRef,
+		CommitSHA: "abcdef-multiline",
+		PosterID:  user.ID,
+		IssueID:   1,
+	})
+	assert.NotNil(t, comment.CommentMetaData)
+	assert.Equal(t, message, comment.CommentMetaData.CommitMessage)
+	assert.Contains(t, comment.Content, "Implement the thing")
+	assert.NotContains(t, comment.Content, "Keep this line visible")
+	assert.Equal(t, "Implement the thing", comment.CommitMessageTitle())
+	assert.Contains(t, comment.CommitMessageBody(), "Keep this line too")
+	assert.Equal(t, repo.ID, comment.RefRepoID)
+}
+
 func TestUpdateIssuesCommit_Issue5957(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
 	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
@@ -208,7 +244,8 @@ func TestUpdateIssuesCommit_AnotherRepo(t *testing.T) {
 	unittest.AssertNotExistsBean(t, commentBean)
 	unittest.AssertNotExistsBean(t, issueBean, "is_closed=1")
 	assert.NoError(t, UpdateIssuesCommit(t.Context(), user, repo, pushCommits, repo.DefaultBranch))
-	unittest.AssertExistsAndLoadBean(t, commentBean)
+	comment := unittest.AssertExistsAndLoadBean(t, commentBean)
+	assert.Equal(t, repo.ID, comment.RefRepoID)
 	unittest.AssertExistsAndLoadBean(t, issueBean, "is_closed=1")
 	unittest.CheckConsistencyFor(t, &activities_model.Action{})
 }

--- a/templates/repo/issue/view_content/comments.tmpl
+++ b/templates/repo/issue/view_content/comments.tmpl
@@ -163,8 +163,19 @@
 				</span>
 				<div class="detail flex-text-block">
 					{{svg "octicon-git-commit"}}
-					{{/* the content is a link like <a href="{RepoLink}/commit/{CommitID}">message title</a> (from CreateRefComment) */}}
-					<span class="comment-text-line">{{.GetSanitizedContentHTML}}</span>
+					{{if and .RefRepo .CommitMessage}}
+						{{$commitLink:= printf "%s/commit/%s" .RefRepo.Link (PathEscape .CommitSHA)}}
+						<span class="commit-summary comment-text-line" title="{{.CommitMessageTitle}}">
+							<span class="message-wrapper">{{ctx.RenderUtils.RenderCommitMessageLinkSubject .CommitMessage $commitLink .RefRepo}}</span>
+							{{if .CommitMessageBody}}
+								<button class="ui button ellipsis-button" aria-expanded="false" data-global-click="onRepoEllipsisButtonClick">...</button>
+								<pre class="commit-body tw-hidden">{{ctx.RenderUtils.RenderCommitBody .CommitMessage .RefRepo}}</pre>
+							{{end}}
+						</span>
+					{{else}}
+						{{/* Legacy commit reference comments stored a pre-rendered commit link in Content. */}}
+						<span class="comment-text-line">{{.GetSanitizedContentHTML}}</span>
+					{{end}}
 				</div>
 			</div>
 		{{else if eq .Type 7}}


### PR DESCRIPTION
## Summary
- stored the full commit message for commit reference timeline events while keeping the existing short linked content as fallback
- rendered commit reference events with a linked subject and expandable body when the viewer can read the source repository code
- kept legacy rendering for older commit reference comments

## Tests
- `go test ./models/issues ./routers/web/repo ./services/issue -count=1`
- `make lint-templates`
- `GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./models/issues ./routers/web/repo ./services/issue`
- `git diff --check`

Closes #12541

### AI assistance
AI assistance was used to prepare this patch and PR description.