### PR TITLE
Update issue indexes after project changes

### DIFF
--- a/routers/api/v1/repo/issue.go
+++ b/routers/api/v1/repo/issue.go
@@ -31,6 +31,7 @@ import (
 	"gitea.dev/services/context"
 	"gitea.dev/services/convert"
 	issue_service "gitea.dev/services/issue"
+	notify_service "gitea.dev/services/notify"
 )
 
 // buildSearchIssuesRepoIDs builds the list of repository IDs for issue search based on query parameters.
@@ -924,6 +925,7 @@ func EditIssue(ctx *context.APIContext) {
 			}
 			return
 		}
+		notify_service.IssueChangeProject(ctx, ctx.Doer, issue)
 	}
 
 	// Refetch from database to assign some automatic values

--- a/routers/web/repo/projects.go
+++ b/routers/web/repo/projects.go
@@ -28,6 +28,7 @@ import (
 	shared_user "gitea.dev/routers/web/shared/user"
 	"gitea.dev/services/context"
 	"gitea.dev/services/forms"
+	notify_service "gitea.dev/services/notify"
 	project_service "gitea.dev/services/projects"
 )
 
@@ -459,6 +460,7 @@ func UpdateIssueProject(ctx *context.Context) {
 			ctx.ServerError("IssueAssignOrRemoveProject", err)
 			return
 		}
+		notify_service.IssueChangeProject(ctx, ctx.Doer, issue)
 	}
 
 	if len(failedIssues) > 0 {

--- a/services/indexer/notify.go
+++ b/services/indexer/notify.go
@@ -143,6 +143,10 @@ func (r *indexerNotifier) IssueChangeMilestone(ctx context.Context, doer *user_m
 	issue_indexer.UpdateIssueIndexer(ctx, issue.ID)
 }
 
+func (r *indexerNotifier) IssueChangeProject(ctx context.Context, doer *user_model.User, issue *issues_model.Issue) {
+	issue_indexer.UpdateIssueIndexer(ctx, issue.ID)
+}
+
 func (r *indexerNotifier) IssueChangeLabels(ctx context.Context, doer *user_model.User, issue *issues_model.Issue,
 	addedLabels, removedLabels []*issues_model.Label,
 ) {

--- a/services/notify/notifier.go
+++ b/services/notify/notifier.go
@@ -33,6 +33,7 @@ type Notifier interface {
 	IssueChangeStatus(ctx context.Context, doer *user_model.User, commitID string, issue *issues_model.Issue, actionComment *issues_model.Comment, closeOrReopen bool)
 	DeleteIssue(ctx context.Context, doer *user_model.User, issue *issues_model.Issue)
 	IssueChangeMilestone(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, oldMilestoneID int64)
+	IssueChangeProject(ctx context.Context, doer *user_model.User, issue *issues_model.Issue)
 	IssueChangeAssignee(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, assignee *user_model.User, removed bool, comment *issues_model.Comment)
 	PullRequestReviewRequest(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, reviewer *user_model.User, isRequest bool, comment *issues_model.Comment)
 	IssueChangeContent(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, oldContent string)

--- a/services/notify/notify.go
+++ b/services/notify/notify.go
@@ -223,6 +223,13 @@ func IssueChangeMilestone(ctx context.Context, doer *user_model.User, issue *iss
 	}
 }
 
+// IssueChangeProject notifies change project to notifiers
+func IssueChangeProject(ctx context.Context, doer *user_model.User, issue *issues_model.Issue) {
+	for _, notifier := range notifiers {
+		notifier.IssueChangeProject(ctx, doer, issue)
+	}
+}
+
 // IssueChangeContent notifies change content to notifiers
 func IssueChangeContent(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, oldContent string) {
 	for _, notifier := range notifiers {

--- a/services/notify/null.go
+++ b/services/notify/null.go
@@ -114,6 +114,10 @@ func (*NullNotifier) DeleteRelease(ctx context.Context, doer *user_model.User, r
 func (*NullNotifier) IssueChangeMilestone(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, oldMilestoneID int64) {
 }
 
+// IssueChangeProject places a place holder function
+func (*NullNotifier) IssueChangeProject(ctx context.Context, doer *user_model.User, issue *issues_model.Issue) {
+}
+
 // IssueChangeContent places a place holder function
 func (*NullNotifier) IssueChangeContent(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, oldContent string) {
 }


### PR DESCRIPTION
## Summary
- added an issue project-change notification event
- updated the issue indexer when projects are changed through the web or API
- kept new issue and pull request creation paths unchanged because they already reindex after creation

## Tests
- `go test ./services/notify ./services/indexer ./routers/web/repo ./routers/api/v1/repo -run 'Test' -count=1`
- `GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./services/notify ./services/indexer ./routers/web/repo ./routers/api/v1/repo`
- `git diff --check`

Closes #33451

### AI assistance
AI assistance was used to prepare this patch and PR description.