### PR TITLE
Remove merged pull request branch delete modal

### DIFF
--- a/templates/repo/issue/view_content.tmpl
+++ b/templates/repo/issue/view_content.tmpl
@@ -171,14 +171,3 @@
 
 {{template "repo/issue/view_content/reference_issue_dialog" .}}
 {{template "shared/user/block_user_dialog" .}}
-
-<div class="ui g-modal-confirm delete modal">
-	<div class="header">
-		{{svg "octicon-trash"}}
-		{{ctx.Locale.Tr "repo.branch.delete" .HeadTarget}}
-	</div>
-	<div class="content">
-		<p>{{ctx.Locale.Tr "repo.branch.delete_desc"}}</p>
-	</div>
-	{{template "base/modal_actions_confirm" .}}
-</div>

--- a/tests/integration/pull_merge_test.go
+++ b/tests/integration/pull_merge_test.go
@@ -87,6 +87,8 @@ func testPullCleanUp(t *testing.T, session *TestSession, user, repo, pullnum str
 
 	// Click the little button to create a pull
 	htmlDoc := NewHTMLParser(t, resp.Body)
+	modalCount := htmlDoc.doc.Find(".g-modal-confirm.delete.modal").Length()
+	assert.Zero(t, modalCount, "merged pull request branch cleanup should not render a confirmation modal")
 	link, exists := htmlDoc.doc.Find(".timeline-item .delete-branch-after-merge").Attr("data-url")
 	assert.True(t, exists, "The template has changed, can not find delete button url")
 	req = NewRequest(t, "POST", link)


### PR DESCRIPTION
## Summary
- removed the stale delete-branch confirmation modal from pull request pages
- kept the merged pull request cleanup button as a direct `link-action` without confirmation
- added an integration assertion that the cleanup view no longer renders the confirmation modal

## Tests
- `go test ./tests/integration -run TestPullCleanUpAfterMerge -count=1`
- `make lint-templates`
- `GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./tests/integration`
- `git diff --check`

Closes #31503

### AI assistance
AI assistance was used to prepare this patch and PR description.