### PR TITLE
Added system notice type filters

### DIFF
--- a/models/system/notice.go
+++ b/models/system/notice.go
@@ -13,6 +13,8 @@ import (
 	"gitea.dev/modules/log"
 	"gitea.dev/modules/storage"
 	"gitea.dev/modules/timeutil"
+
+	"xorm.io/builder"
 )
 
 // NoticeType describes the notice type
@@ -73,18 +75,23 @@ func RemoveStorageWithNotice(ctx context.Context, bucket storage.ObjectStorage, 
 }
 
 // CountNotices returns number of notices.
-func CountNotices(ctx context.Context) int64 {
-	count, _ := db.GetEngine(ctx).Count(new(Notice))
+func CountNotices(ctx context.Context, tp NoticeType) int64 {
+	sess := db.GetEngine(ctx)
+	if tp != 0 {
+		sess = sess.Where(builder.Eq{"type": tp})
+	}
+	count, _ := sess.Count(new(Notice))
 	return count
 }
 
 // Notices returns notices in given page.
-func Notices(ctx context.Context, page, pageSize int) ([]*Notice, error) {
+func Notices(ctx context.Context, page, pageSize int, tp NoticeType) ([]*Notice, error) {
 	notices := make([]*Notice, 0, pageSize)
-	return notices, db.GetEngine(ctx).
-		Limit(pageSize, (page-1)*pageSize).
-		Desc("created_unix").
-		Find(&notices)
+	sess := db.GetEngine(ctx)
+	if tp != 0 {
+		sess = sess.Where(builder.Eq{"type": tp})
+	}
+	return notices, sess.Limit(pageSize, (page-1)*pageSize).Desc("created_unix").Find(&notices)
 }
 
 // DeleteNotices deletes all notices with ID from start to end (inclusive).

--- a/models/system/notice_test.go
+++ b/models/system/notice_test.go
@@ -47,24 +47,49 @@ func TestCreateRepositoryNotice(t *testing.T) {
 
 func TestCountNotices(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
-	assert.Equal(t, int64(3), system.CountNotices(t.Context()))
+	assert.Equal(t, int64(3), system.CountNotices(t.Context(), 0))
+	assert.Equal(t, int64(3), system.CountNotices(t.Context(), system.NoticeRepository))
+	assert.Equal(t, int64(0), system.CountNotices(t.Context(), system.NoticeTask))
 }
 
 func TestNotices(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
 
-	notices, err := system.Notices(t.Context(), 1, 2)
+	notices, err := system.Notices(t.Context(), 1, 2, 0)
 	assert.NoError(t, err)
 	if assert.Len(t, notices, 2) {
 		assert.Equal(t, int64(3), notices[0].ID)
 		assert.Equal(t, int64(2), notices[1].ID)
 	}
 
-	notices, err = system.Notices(t.Context(), 2, 2)
+	notices, err = system.Notices(t.Context(), 2, 2, 0)
 	assert.NoError(t, err)
 	if assert.Len(t, notices, 1) {
 		assert.Equal(t, int64(1), notices[0].ID)
 	}
+}
+
+func TestNoticesByType(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+	assert.NoError(t, system.CreateNotice(t.Context(), system.NoticeTask, "task notice"))
+
+	notices, err := system.Notices(t.Context(), 1, 10, system.NoticeRepository)
+	assert.NoError(t, err)
+	if assert.Len(t, notices, 3) {
+		for _, notice := range notices {
+			assert.Equal(t, system.NoticeRepository, notice.Type)
+		}
+	}
+
+	notices, err = system.Notices(t.Context(), 1, 10, system.NoticeTask)
+	assert.NoError(t, err)
+	if assert.Len(t, notices, 1) {
+		assert.Equal(t, system.NoticeTask, notices[0].Type)
+		assert.Equal(t, "task notice", notices[0].Description)
+	}
+
+	assert.Equal(t, int64(3), system.CountNotices(t.Context(), system.NoticeRepository))
+	assert.Equal(t, int64(1), system.CountNotices(t.Context(), system.NoticeTask))
 }
 
 func TestDeleteNotices(t *testing.T) {

--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -3412,6 +3412,7 @@
   "admin.notices.delete_selected": "Delete Selected",
   "admin.notices.delete_all": "Delete All Notices",
   "admin.notices.type": "Type",
+  "admin.notices.type_all": "All types",
   "admin.notices.type_1": "Repository",
   "admin.notices.type_2": "Task",
   "admin.notices.desc": "Description",

--- a/routers/web/admin/notice.go
+++ b/routers/web/admin/notice.go
@@ -20,24 +20,43 @@ const (
 	tplNotices templates.TplName = "admin/notice"
 )
 
+func parseNoticeType(raw string) system_model.NoticeType {
+	switch raw {
+	case "repository":
+		return system_model.NoticeRepository
+	case "task":
+		return system_model.NoticeTask
+	default:
+		return 0
+	}
+}
+
 // Notices show notices for admin
 func Notices(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("admin.notices")
 	ctx.Data["PageIsAdminNotices"] = true
 
-	total := system_model.CountNotices(ctx)
+	noticeTypeName := ctx.FormString("type")
+	noticeType := parseNoticeType(noticeTypeName)
+	if noticeType == 0 {
+		noticeTypeName = ""
+	}
+	total := system_model.CountNotices(ctx, noticeType)
 	page := max(ctx.FormInt("page"), 1)
 
-	notices, err := system_model.Notices(ctx, page, setting.UI.Admin.NoticePagingNum)
+	notices, err := system_model.Notices(ctx, page, setting.UI.Admin.NoticePagingNum, noticeType)
 	if err != nil {
 		ctx.ServerError("Notices", err)
 		return
 	}
 	ctx.Data["Notices"] = notices
+	ctx.Data["NoticeType"] = noticeTypeName
 
 	ctx.Data["Total"] = total
 
-	ctx.Data["Page"] = context.NewPagination(total, setting.UI.Admin.NoticePagingNum, page, 5)
+	pager := context.NewPagination(total, setting.UI.Admin.NoticePagingNum, page, 5)
+	pager.AddParamFromRequest(ctx.Req)
+	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplNotices)
 }

--- a/templates/admin/notice.tmpl
+++ b/templates/admin/notice.tmpl
@@ -3,6 +3,22 @@
 		<h4 class="ui top attached header">
 			{{ctx.Locale.Tr "admin.notices.system_notice_list"}} ({{ctx.Locale.Tr "admin.total" .Total}})
 		</h4>
+		<form class="ui attached segment form ignore-dirty" method="get">
+			<div class="fields">
+				<div class="field">
+					<label for="notice-type">{{ctx.Locale.Tr "admin.notices.type"}}</label>
+					<select id="notice-type" name="type" class="ui dropdown">
+						<option value="">{{ctx.Locale.Tr "admin.notices.type_all"}}</option>
+						<option value="repository" {{if eq .NoticeType "repository"}}selected{{end}}>{{ctx.Locale.Tr "admin.notices.type_1"}}</option>
+						<option value="task" {{if eq .NoticeType "task"}}selected{{end}}>{{ctx.Locale.Tr "admin.notices.type_2"}}</option>
+					</select>
+				</div>
+				<div class="field">
+					<label>&nbsp;</label>
+					<button class="ui small primary button">{{ctx.Locale.Tr "filter_title"}}</button>
+				</div>
+			</div>
+		</form>
 		<table class="ui attached segment select selectable table unstackable g-table-auto-ellipsis">
 			<thead>
 				<tr>


### PR DESCRIPTION
### Summary
- added repository/task filtering to the admin system notices list
- kept notice pagination scoped to the selected type filter
- covered filtered notice counts and lists in model tests

### Tests
- `go test ./models/system ./routers/web/admin -run Test -count=1`
- `make lint-templates`
- `GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./models/system ./routers/web/admin`
- `git diff --check`

Closes #11983

### AI assistance
AI assistance was used to prepare this patch and PR description.