### PR TITLE
Added mirror repository context to queue errors

### DIFF
--- a/services/mirror/mirror.go
+++ b/services/mirror/mirror.go
@@ -6,7 +6,9 @@ package mirror
 import (
 	"context"
 	"errors"
+	"fmt"
 
+	"gitea.dev/models/db"
 	repo_model "gitea.dev/models/repo"
 	"gitea.dev/modules/log"
 	"gitea.dev/modules/queue"
@@ -30,6 +32,42 @@ func doMirrorSync(ctx context.Context, req *SyncRequest) {
 }
 
 var errLimit = errors.New("reached limit")
+
+func describeMirrorSync(mirrorType SyncType, repo *repo_model.Repository) string {
+	repoName := "unknown repository"
+	if repo != nil {
+		repoName = repo.FullName()
+	}
+
+	switch mirrorType {
+	case PullMirrorType:
+		return "pull mirror repository " + repoName
+	case PushMirrorType:
+		return "push mirror repository " + repoName
+	default:
+		return "mirror repository " + repoName
+	}
+}
+
+func queueMirrorSync(ctx context.Context, repo *repo_model.Repository, mirrorType SyncType, referenceID int64) error {
+	mirrorDesc := describeMirrorSync(mirrorType, repo)
+
+	select {
+	case <-ctx.Done():
+		return db.ErrCancelledf("before queueing %s", mirrorDesc)
+	default:
+	}
+
+	if err := PushToQueue(mirrorType, referenceID); err != nil {
+		if err == queue.ErrAlreadyInQueue {
+			log.Trace("%s already queued for sync", mirrorDesc)
+			return nil
+		}
+		return fmt.Errorf("queue %s: %w", mirrorDesc, err)
+	}
+
+	return nil
+}
 
 // Update checks and updates mirror repositories.
 func Update(ctx context.Context, pullLimit, pushLimit int) error {
@@ -65,26 +103,7 @@ func Update(ctx context.Context, pullLimit, pushLimit int) error {
 			return nil
 		}
 
-		// Check we've not been cancelled
-		select {
-		case <-ctx.Done():
-			return errors.New("aborted")
-		default:
-		}
-
-		// Push to the Queue
-		if err := PushToQueue(mirrorType, referenceID); err != nil {
-			if err == queue.ErrAlreadyInQueue {
-				if mirrorType == PushMirrorType {
-					log.Trace("PushMirrors for %-v already queued for sync", repo)
-				} else {
-					log.Trace("PullMirrors for %-v already queued for sync", repo)
-				}
-				return nil
-			}
-			return err
-		}
-		return nil
+		return queueMirrorSync(ctx, repo, mirrorType, referenceID)
 	}
 
 	pullMirrorsRequested := 0

--- a/services/mirror/mirror_test.go
+++ b/services/mirror/mirror_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package mirror
+
+import (
+	"context"
+	"testing"
+
+	"gitea.dev/models/db"
+	repo_model "gitea.dev/models/repo"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDescribeMirrorSync(t *testing.T) {
+	repo := &repo_model.Repository{OwnerName: "owner", Name: "repo"}
+
+	assert.Equal(t, "pull mirror repository owner/repo", describeMirrorSync(PullMirrorType, repo))
+	assert.Equal(t, "push mirror repository owner/repo", describeMirrorSync(PushMirrorType, repo))
+	assert.Equal(t, "mirror repository owner/repo", describeMirrorSync(SyncType(100), repo))
+	assert.Equal(t, "pull mirror repository unknown repository", describeMirrorSync(PullMirrorType, nil))
+}
+
+func TestQueueMirrorSyncCancelledIncludesRepository(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := queueMirrorSync(ctx, &repo_model.Repository{OwnerName: "owner", Name: "repo"}, PullMirrorType, 1)
+	require.Error(t, err)
+	assert.True(t, db.IsErrCancelled(err))
+	assert.Equal(t, "Cancelled: before queueing pull mirror repository owner/repo", err.Error())
+}


### PR DESCRIPTION
### Summary
- added repository-specific context to pull/push mirror queue errors
- changed mirror cron cancellation from a generic aborted error to a canceled notice that includes the affected repository
- covered mirror queue cancellation messages with unit tests

### Tests
- `go test ./services/mirror -count=1`
- `GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./services/mirror`
- `git diff --check`

Closes #25496

### AI assistance
AI assistance was used to prepare this patch and PR description.
