### PR TITLE
Preserved additional squash commit messages

### DIFF
--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -835,7 +835,13 @@ func GetSquashMergeCommitMessages(ctx context.Context, pr *issues_model.PullRequ
 		// use PR's title and description as squash commit message
 		message := strings.TrimSpace(pr.Issue.Content)
 		stringBuilder.WriteString(message)
-		if stringBuilder.Len() > 0 {
+		additionalCommitMessages := formatSquashMergeCommitMessages(commits, true)
+		if additionalCommitMessages != "" {
+			if stringBuilder.Len() > 0 {
+				stringBuilder.WriteString("\n\n")
+			}
+			stringBuilder.WriteString(additionalCommitMessages)
+		} else if stringBuilder.Len() > 0 {
 			stringBuilder.WriteRune('\n')
 			if !commitMessageTrailersPattern.MatchString(message) {
 				// TODO: this trailer check doesn't work with the separator line added below for the co-authors
@@ -844,32 +850,7 @@ func GetSquashMergeCommitMessages(ctx context.Context, pr *issues_model.PullRequ
 		}
 	} else {
 		// use PR's commit messages as squash commit message
-		// commits list is in reverse chronological order
-		maxMsgSize := setting.Repository.PullRequest.DefaultMergeMessageSize
-		for _, commit := range slices.Backward(commits) {
-			msg := strings.TrimSpace(commit.MessageUTF8())
-			if msg == "" {
-				continue
-			}
-
-			// This format follows GitHub's squash commit message style,
-			// even if there are other "* " in the commit message body, they are written as-is.
-			// Maybe, ideally, we should indent those lines too.
-			_, _ = fmt.Fprintf(&stringBuilder, "* %s\n\n", msg)
-			if maxMsgSize > 0 && stringBuilder.Len() >= maxMsgSize {
-				tmp := stringBuilder.String()
-				wasValidUtf8 := utf8.ValidString(tmp)
-				tmp = tmp[:maxMsgSize] + "..."
-				if wasValidUtf8 {
-					// If the message was valid UTF-8 before truncation, ensure it remains valid after truncation
-					// For non-utf8 messages, we can't do much about it, end users should use utf-8 as much as possible
-					tmp = strings.ToValidUTF8(tmp, "")
-				}
-				stringBuilder.Reset()
-				stringBuilder.WriteString(tmp)
-				break
-			}
-		}
+		stringBuilder.WriteString(formatSquashMergeCommitMessages(commits, false))
 	}
 
 	// collect co-authors
@@ -922,6 +903,42 @@ func GetSquashMergeCommitMessages(ctx context.Context, pr *issues_model.PullRequ
 		stringBuilder.WriteRune('\n')
 	}
 
+	return stringBuilder.String()
+}
+
+func formatSquashMergeCommitMessages(commits []*git.Commit, skipFirst bool) string {
+	// commits list is in reverse chronological order
+	maxMsgSize := setting.Repository.PullRequest.DefaultMergeMessageSize
+	stringBuilder := strings.Builder{}
+	for _, commit := range slices.Backward(commits) {
+		if skipFirst {
+			skipFirst = false
+			continue
+		}
+
+		msg := strings.TrimSpace(commit.MessageUTF8())
+		if msg == "" {
+			continue
+		}
+
+		// This format follows GitHub's squash commit message style,
+		// even if there are other "* " in the commit message body, they are written as-is.
+		// Maybe, ideally, we should indent those lines too.
+		_, _ = fmt.Fprintf(&stringBuilder, "* %s\n\n", msg)
+		if maxMsgSize > 0 && stringBuilder.Len() >= maxMsgSize {
+			tmp := stringBuilder.String()
+			wasValidUtf8 := utf8.ValidString(tmp)
+			tmp = tmp[:maxMsgSize] + "..."
+			if wasValidUtf8 {
+				// If the message was valid UTF-8 before truncation, ensure it remains valid after truncation
+				// For non-utf8 messages, we can't do much about it, end users should use utf-8 as much as possible
+				tmp = strings.ToValidUTF8(tmp, "")
+			}
+			stringBuilder.Reset()
+			stringBuilder.WriteString(tmp)
+			break
+		}
+	}
 	return stringBuilder.String()
 }
 

--- a/services/pull/pull_test.go
+++ b/services/pull/pull_test.go
@@ -11,7 +11,9 @@ import (
 	repo_model "gitea.dev/models/repo"
 	"gitea.dev/models/unit"
 	"gitea.dev/models/unittest"
+	"gitea.dev/modules/git"
 	"gitea.dev/modules/gitrepo"
+	"gitea.dev/modules/setting"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -33,6 +35,29 @@ func TestPullRequest_CommitMessageTrailersPattern(t *testing.T) {
 	assert.True(t, commitMessageTrailersPattern.MatchString("No space after colon is accepted.\n\nSigned-off-by:Bob <bob@example.com>"))
 	assert.True(t, commitMessageTrailersPattern.MatchString("Additional whitespace is accepted.\n\nSigned-off-by \t :  \tBob   <bob@example.com>   "))
 	assert.True(t, commitMessageTrailersPattern.MatchString("Folded value.\n\nFolded-trailer: This is\n a folded\n   trailer value\nOther-Trailer: Value"))
+}
+
+func TestPullRequest_FormatSquashMergeCommitMessages(t *testing.T) {
+	oldestCommit := &git.Commit{CommitMessage: git.CommitMessage{MessageRaw: "commit msg 1"}}
+	newestCommit := &git.Commit{CommitMessage: git.CommitMessage{MessageRaw: "commit msg 2\n\nCommit description."}}
+
+	defer func(oldSize int) {
+		setting.Repository.PullRequest.DefaultMergeMessageSize = oldSize
+	}(setting.Repository.PullRequest.DefaultMergeMessageSize)
+	setting.Repository.PullRequest.DefaultMergeMessageSize = 0
+
+	assert.Equal(t, `* commit msg 1
+
+* commit msg 2
+
+Commit description.
+
+`, formatSquashMergeCommitMessages([]*git.Commit{newestCommit, oldestCommit}, false))
+	assert.Equal(t, `* commit msg 2
+
+Commit description.
+
+`, formatSquashMergeCommitMessages([]*git.Commit{newestCommit, oldestCommit}, true))
 }
 
 func TestPullRequest_GetDefaultMergeMessage_InternalTracker(t *testing.T) {


### PR DESCRIPTION
## Summary
- preserved PR description as the default squash merge body
- appended additional commit messages after the first commit in the default squash body
- reused the existing GitHub-style commit message formatting for the appended messages

Closes #33422

## Tests
- go test ./services/pull -run 'TestPullRequest_FormatSquashMergeCommitMessages|TestPullRequest_CommitMessageTrailersPattern' -count=1\n- go test ./services/pull -run 'TestPullRequest_FormatSquashMergeCommitMessages|TestPullRequest_CommitMessageTrailersPattern|TestPullRequest_GetDefaultMergeMessage' -count=1\n- GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./services/pull\n- git diff --check\n\nKnown local failure:\n- go test ./services/pull -count=1 fails in TestPullRequestMergeable because the local git merge-tree command does not support --merge-base; the targeted tests above passed.\n\n### AI assistance\nAI assistance was used to prepare this patch and PR description.