### PR TITLE
Preserved squash message trailers before co-authors

### DIFF
--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -830,15 +830,17 @@ func GetSquashMergeCommitMessages(ctx context.Context, pr *issues_model.PullRequ
 	uniqueAuthors := make(container.Set[string])
 	authors := make([]string, 0, len(commits))
 	stringBuilder := strings.Builder{}
+	useCoAuthorSeparator := true
 
 	if !setting.Repository.PullRequest.PopulateSquashCommentWithCommitMessages {
 		// use PR's title and description as squash commit message
 		message := strings.TrimSpace(pr.Issue.Content)
+		messageHasTrailers := commitMessageTrailersPattern.MatchString(message)
+		useCoAuthorSeparator = !messageHasTrailers
 		stringBuilder.WriteString(message)
 		if stringBuilder.Len() > 0 {
 			stringBuilder.WriteRune('\n')
-			if !commitMessageTrailersPattern.MatchString(message) {
-				// TODO: this trailer check doesn't work with the separator line added below for the co-authors
+			if !messageHasTrailers {
 				stringBuilder.WriteRune('\n')
 			}
 		}
@@ -911,8 +913,13 @@ func GetSquashMergeCommitMessages(ctx context.Context, pr *issues_model.PullRequ
 		}
 	}
 
-	if stringBuilder.Len() > 0 && len(authors) > 0 {
-		// TODO: this separator line doesn't work with the trailer check (commitMessageTrailersPattern) above
+	appendCoAuthors(&stringBuilder, authors, useCoAuthorSeparator)
+
+	return stringBuilder.String()
+}
+
+func appendCoAuthors(stringBuilder *strings.Builder, authors []string, useSeparator bool) {
+	if stringBuilder.Len() > 0 && len(authors) > 0 && useSeparator {
 		stringBuilder.WriteString("---------\n\n")
 	}
 
@@ -921,8 +928,6 @@ func GetSquashMergeCommitMessages(ctx context.Context, pr *issues_model.PullRequ
 		stringBuilder.WriteString(author)
 		stringBuilder.WriteRune('\n')
 	}
-
-	return stringBuilder.String()
 }
 
 // GetIssuesAllCommitStatus returns a map of issue ID to a list of all statuses for the most recent commit as well as a map of issue ID to only the commit's latest status

--- a/services/pull/pull_test.go
+++ b/services/pull/pull_test.go
@@ -5,6 +5,7 @@
 package pull
 
 import (
+	"strings"
 	"testing"
 
 	issues_model "gitea.dev/models/issues"
@@ -33,6 +34,26 @@ func TestPullRequest_CommitMessageTrailersPattern(t *testing.T) {
 	assert.True(t, commitMessageTrailersPattern.MatchString("No space after colon is accepted.\n\nSigned-off-by:Bob <bob@example.com>"))
 	assert.True(t, commitMessageTrailersPattern.MatchString("Additional whitespace is accepted.\n\nSigned-off-by \t :  \tBob   <bob@example.com>   "))
 	assert.True(t, commitMessageTrailersPattern.MatchString("Folded value.\n\nFolded-trailer: This is\n a folded\n   trailer value\nOther-Trailer: Value"))
+}
+
+func TestPullRequest_AppendCoAuthors(t *testing.T) {
+	t.Run("keeps separator when message has no trailers", func(t *testing.T) {
+		stringBuilder := strings.Builder{}
+		stringBuilder.WriteString("Reviewed changes\n\n")
+
+		appendCoAuthors(&stringBuilder, []string{"Alice <alice@example.com>"}, true)
+
+		assert.Equal(t, "Reviewed changes\n\n---------\n\nCo-authored-by: Alice <alice@example.com>\n", stringBuilder.String())
+	})
+
+	t.Run("does not split existing trailers", func(t *testing.T) {
+		stringBuilder := strings.Builder{}
+		stringBuilder.WriteString("Reviewed changes\n\nIssue: TEST-123\n")
+
+		appendCoAuthors(&stringBuilder, []string{"Alice <alice@example.com>"}, false)
+
+		assert.Equal(t, "Reviewed changes\n\nIssue: TEST-123\nCo-authored-by: Alice <alice@example.com>\n", stringBuilder.String())
+	})
 }
 
 func TestPullRequest_GetDefaultMergeMessage_InternalTracker(t *testing.T) {


### PR DESCRIPTION
### What changed
- Kept generated `Co-authored-by` trailers in the existing trailer block when the squash message already ends with trailers.
- Preserved the existing `---------` separator for squash messages without trailers.
- Added regression coverage for both co-author formatting paths.

Closes #37529

### Testing
- go test ./services/pull -run "TestPullRequest_AppendCoAuthors|TestPullRequest_CommitMessageTrailersPattern" -count=1
- go test ./services/pull -run "TestPullRequest_AppendCoAuthors|TestPullRequest_CommitMessageTrailersPattern|TestPullRequest_GetDefaultMergeMessage" -count=1
- GOOS=linux TAGS=bindata golangci-lint run --build-tags=linux,bindata ./services/pull
- git diff --check

### AI assistance
AI assistance was used to prepare this patch and PR description.