### PR TITLE
fix: don't fail dump when repository root path doesn't exist

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -162,9 +162,16 @@ func runDump(ctx context.Context, cmd *cli.Command) error {
 	if cmd.IsSet("skip-repository") && cmd.Bool("skip-repository") {
 		log.Info("Skip dumping local repositories")
 	} else {
-		log.Info("Dumping local repositories... %s", setting.RepoRootPath)
-		if err := dumper.AddRecursiveExclude("repos", setting.RepoRootPath, nil); err != nil {
-			fatal("Failed to include repositories: %v", err)
+		isExist, existErr := util.IsExist(setting.RepoRootPath)
+		if existErr != nil {
+			log.Error("Unable to check if %s exists. Error: %v", setting.RepoRootPath, existErr)
+		} else if !isExist {
+			log.Warn("Repository root path %s does not exist (no repositories created yet?), skip dumping local repositories", setting.RepoRootPath)
+		} else {
+			log.Info("Dumping local repositories... %s", setting.RepoRootPath)
+			if err := dumper.AddRecursiveExclude("repos", setting.RepoRootPath, nil); err != nil {
+				fatal("Failed to include repositories: %v", err)
+			}
 		}
 
 		if cmd.IsSet("skip-lfs-data") && cmd.Bool("skip-lfs-data") {


### PR DESCRIPTION
`gitea dump` fails with a fatal error when the repository root path doesn't exist yet: `[F] Failed to include repositories: open /data/git/repositories: no such file or directory`.

This happens on a headless install (e.g. the Helm chart): the GUI installer is what creates the repo directory, so when you install without it and haven't created any repositories, the folder simply isn't there. The dump then dies instead of just skipping the empty repo step.

## Fix

Check if the repo root exists before dumping it, the same way the custom/data/log directories are already handled. If it's missing, log a warning and move on instead of failing.

## How I tested

Start Gitea headlessly (sqlite, install locked, no repos), add a user, then run a dump:

```bash
docker run -d --name gitea-repro \
  -e SECRET_KEY=reprosecretkey \
  -e INSTALL_LOCK=true \
  -p 3000:3000 \
  gitea:localfix
sleep 8
docker exec gitea-repro ls -la /data/git/          # no "repositories" dir
docker exec -u git gitea-repro gitea admin user create \
  --username repro --password repro1234 --email repro@example.com --admin
docker exec -u git gitea-repro gitea dump --file /tmp/repro-dump.zip --tempdir /tmp
docker rm -f gitea-repro
```
The output:
```text
04f90a995ebca93bfdfeeb0f07ffbaf3bdbd7abbc041ffb18b6c4f4bc0110db2
total 12
drwxr-xr-x    3 git      git           4096 Jun  2 09:04 .
drwxr-xr-x    5 root     root          4096 Jun  2 09:04 ..
drwx------    2 git      git           4096 Jun  2 09:04 .ssh
New user 'repro' has been successfully created!
2026/06/02 09:05:02 modules/storage/storage.go:208:initAttachments() [I] Initialising Attachment storage with type: local
2026/06/02 09:05:02 modules/storage/local.go:48:NewLocalStorage() [I] Creating new Local Storage at /data/gitea/attachments
2026/06/02 09:05:02 modules/storage/storage.go:198:initAvatars() [I] Initialising Avatar storage with type: local
2026/06/02 09:05:02 modules/storage/local.go:48:NewLocalStorage() [I] Creating new Local Storage at /data/gitea/avatars
2026/06/02 09:05:02 modules/storage/storage.go:224:initRepoAvatars() [I] Initialising Repository Avatar storage with type: local
2026/06/02 09:05:02 modules/storage/local.go:48:NewLocalStorage() [I] Creating new Local Storage at /data/gitea/repo-avatars
2026/06/02 09:05:02 modules/storage/storage.go:230:initRepoArchives() [I] Initialising Repository Archive storage with type: local
2026/06/02 09:05:02 modules/storage/local.go:48:NewLocalStorage() [I] Creating new Local Storage at /data/gitea/repo-archive
2026/06/02 09:05:02 modules/storage/storage.go:240:initPackages() [I] Initialising Packages storage with type: local
2026/06/02 09:05:02 modules/storage/local.go:48:NewLocalStorage() [I] Creating new Local Storage at /data/gitea/packages
2026/06/02 09:05:02 modules/storage/storage.go:251:initActions() [I] Initialising Actions storage with type: local
2026/06/02 09:05:02 modules/storage/local.go:48:NewLocalStorage() [I] Creating new Local Storage at /data/gitea/actions_log
2026/06/02 09:05:02 modules/storage/storage.go:255:initActions() [I] Initialising ActionsArtifacts storage with type: local
2026/06/02 09:05:02 modules/storage/local.go:48:NewLocalStorage() [I] Creating new Local Storage at /data/gitea/actions_artifacts
2026/06/02 09:05:02 cmd/dump.go:169:runDump() [W] Repository root path /data/git/repositories does not exist (no repositories created yet?), skip dumping local repositories
2026/06/02 09:05:02 cmd/dump.go:180:runDump() [I] LFS isn't enabled. Skip dumping LFS data
2026/06/02 09:05:02 cmd/dump.go:217:runDump() [I] Dumping database...
2026/06/02 09:05:02 cmd/dump.go:229:runDump() [I] Adding custom configuration file from /data/gitea/conf/app.ini
2026/06/02 09:05:02 cmd/dump.go:244:runDump() [I] Custom dir /data/gitea is inside data dir /data/gitea, skipped
2026/06/02 09:05:02 cmd/dump.go:256:runDump() [I] Packing data directory.../data/gitea
2026/06/02 09:05:02 cmd/dump.go:332:runDump() [I] Finish dumping in file /tmp/repro-dump.zip
gitea-repro
```

Running same commands with latest gitea image (`gitea/gitea:latest`) will give error:
```text
2026/06/02 09:06:58 cmd/dump.go:165:runDump() [I] Dumping local repositories... /data/git/repositories
2026/06/02 09:06:58 cmd/dump.go:102:fatal() [F] Failed to include repositories: open /data/git/repositories: no such file or directory
```