### PR TITLE
fix: remove "no-transfrom" from the cache-control header

### DIFF
--- a/modules/httpcache/httpcache.go
+++ b/modules/httpcache/httpcache.go
@@ -15,9 +15,8 @@ import (
 )
 
 type CacheControlOptions struct {
-	IsPublic    bool
-	MaxAge      time.Duration
-	NoTransform bool
+	IsPublic bool
+	MaxAge   time.Duration
 }
 
 // SetCacheControlInHeader sets suitable cache-control headers in the response
@@ -38,25 +37,19 @@ func SetCacheControlInHeader(h http.Header, opts *CacheControlOptions) {
 		directives = append(directives, "max-age=0", publicPrivate, "must-revalidate")
 		h.Set("X-Gitea-Debug", fmt.Sprintf("RUN_MODE=%v, MaxAge=%s", setting.RunMode, opts.MaxAge))
 	}
-
-	if opts.NoTransform {
-		directives = append(directives, "no-transform")
-	}
 	h.Set("Cache-Control", strings.Join(directives, ", "))
 }
 
 func CacheControlForPublicStatic() *CacheControlOptions {
 	return &CacheControlOptions{
-		IsPublic:    true,
-		MaxAge:      setting.StaticCacheTime,
-		NoTransform: true,
+		IsPublic: true,
+		MaxAge:   setting.StaticCacheTime,
 	}
 }
 
 func CacheControlForPrivateStatic() *CacheControlOptions {
 	return &CacheControlOptions{
-		MaxAge:      setting.StaticCacheTime,
-		NoTransform: true,
+		MaxAge: setting.StaticCacheTime,
 	}
 }
 

--- a/modules/httpcache/httpcache_test.go
+++ b/modules/httpcache/httpcache_test.go
@@ -18,7 +18,7 @@ func TestHandleGenericETagCache(t *testing.T) {
 	matchedEtag := `"matched-etag"`
 	lastModifiedTime := new(time.Date(2021, time.January, 2, 15, 4, 5, 0, time.FixedZone("test-zone", 8*3600)))
 	lastModified := lastModifiedTime.UTC().Format(http.TimeFormat)
-	cacheControl := "max-age=0, private, must-revalidate, no-transform"
+	cacheControl := "max-age=0, private, must-revalidate"
 	type testCase struct {
 		name        string
 		reqHeaders  map[string]string

--- a/modules/httplib/serve.go
+++ b/modules/httplib/serve.go
@@ -94,9 +94,8 @@ func ServeSetHeaders(w http.ResponseWriter, opts ServeHeaderOptions) {
 	}
 
 	httpcache.SetCacheControlInHeader(header, &httpcache.CacheControlOptions{
-		IsPublic:    opts.CacheIsPublic,
-		MaxAge:      opts.CacheDuration,
-		NoTransform: true,
+		IsPublic: opts.CacheIsPublic,
+		MaxAge:   opts.CacheDuration,
 	})
 
 	if !opts.LastModified.IsZero() {

--- a/routers/common/errpage.go
+++ b/routers/common/errpage.go
@@ -32,7 +32,7 @@ func renderServerErrorPage(w http.ResponseWriter, req *http.Request, respCode in
 		}
 	}
 
-	httpcache.SetCacheControlInHeader(w.Header(), &httpcache.CacheControlOptions{NoTransform: true})
+	httpcache.SetCacheControlInHeader(w.Header(), &httpcache.CacheControlOptions{})
 	tmplCtx := context.NewTemplateContextForWeb(reqctx.FromContext(req.Context()), req, middleware.Locale(w, req))
 	w.WriteHeader(respCode)
 

--- a/services/context/api.go
+++ b/services/context/api.go
@@ -242,7 +242,7 @@ func APIContexter() func(http.Handler) http.Handler {
 				}
 			}
 
-			httpcache.SetCacheControlInHeader(ctx.Resp.Header(), &httpcache.CacheControlOptions{NoTransform: true})
+			httpcache.SetCacheControlInHeader(ctx.Resp.Header(), &httpcache.CacheControlOptions{})
 			next.ServeHTTP(ctx.Resp, ctx.Req)
 		})
 	}

--- a/services/context/context.go
+++ b/services/context/context.go
@@ -196,7 +196,7 @@ func Contexter() func(next http.Handler) http.Handler {
 				}
 			}
 
-			httpcache.SetCacheControlInHeader(ctx.Resp.Header(), &httpcache.CacheControlOptions{NoTransform: true})
+			httpcache.SetCacheControlInHeader(ctx.Resp.Header(), &httpcache.CacheControlOptions{})
 
 			ctx.Data["SystemConfig"] = setting.Config()
 


### PR DESCRIPTION
Cloudflare has officially removed the "auto-minify" feature https://community.cloudflare.com/t/655677, so we don't need such option anymore.

Fix #34521