### PR TITLE
fix: hide private reviewer suggestions from restricted users

### DIFF
--- a/services/pull/reviewer.go
+++ b/services/pull/reviewer.go
@@ -27,6 +27,11 @@ func GetReviewers(ctx context.Context, repo *repo_model.Repository, doerID, post
 		return nil, err
 	}
 
+	doer, err := getReviewerDoer(ctx, doerID)
+	if err != nil {
+		return nil, err
+	}
+
 	e := db.GetEngine(ctx)
 	uniqueUserIDs := make(container.Set[int64])
 
@@ -53,8 +58,12 @@ func GetReviewers(ctx context.Context, repo *repo_model.Repository, doerID, post
 	// and just waste 1 unit is cheaper than re-allocate memory once.
 	users := make([]*user_model.User, 0, len(uniqueUserIDs)+1)
 	if len(uniqueUserIDs) > 0 {
+		var userCond builder.Cond = builder.Eq{"`user`.is_active": true}
+		if visibilityCond := reviewerVisibilityCondition(doer); visibilityCond != nil {
+			userCond = userCond.And(visibilityCond)
+		}
 		if err := e.In("id", uniqueUserIDs.Values()).
-			Where(builder.Eq{"`user`.is_active": true}).
+			Where(userCond).
 			OrderBy(user_model.GetOrderByName()).
 			Find(&users); err != nil {
 			return nil, err
@@ -67,6 +76,28 @@ func GetReviewers(ctx context.Context, repo *repo_model.Repository, doerID, post
 	}
 
 	return users, nil
+}
+
+func getReviewerDoer(ctx context.Context, doerID int64) (*user_model.User, error) {
+	if doerID <= 0 {
+		return nil, nil
+	}
+	return user_model.GetUserByID(ctx, doerID)
+}
+
+func reviewerVisibilityCondition(doer *user_model.User) builder.Cond {
+	cond := user_model.BuildCanSeeUserCondition(doer)
+	if doer == nil || !doer.IsAdmin {
+		var restrictedCond builder.Cond = builder.Eq{"`user`.is_restricted": false}
+		if doer != nil {
+			restrictedCond = restrictedCond.Or(builder.Eq{"`user`.id": doer.ID})
+		}
+		if cond == nil {
+			return restrictedCond
+		}
+		return cond.And(restrictedCond)
+	}
+	return cond
 }
 
 // GetReviewerTeams get all teams can be requested to review

--- a/services/pull/reviewer.go
+++ b/services/pull/reviewer.go
@@ -27,9 +27,13 @@ func GetReviewers(ctx context.Context, repo *repo_model.Repository, doerID, post
 		return nil, err
 	}
 
-	doer, err := getReviewerDoer(ctx, doerID)
-	if err != nil {
-		return nil, err
+	var doer *user_model.User
+	if doerID > 0 {
+		var err error
+		doer, err = user_model.GetUserByID(ctx, doerID)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	e := db.GetEngine(ctx)
@@ -76,13 +80,6 @@ func GetReviewers(ctx context.Context, repo *repo_model.Repository, doerID, post
 	}
 
 	return users, nil
-}
-
-func getReviewerDoer(ctx context.Context, doerID int64) (*user_model.User, error) {
-	if doerID <= 0 {
-		return nil, nil
-	}
-	return user_model.GetUserByID(ctx, doerID)
 }
 
 func reviewerVisibilityCondition(doer *user_model.User) builder.Cond {

--- a/services/pull/reviewer_test.go
+++ b/services/pull/reviewer_test.go
@@ -8,6 +8,8 @@ import (
 
 	repo_model "gitea.dev/models/repo"
 	"gitea.dev/models/unittest"
+	user_model "gitea.dev/models/user"
+	"gitea.dev/modules/structs"
 	pull_service "gitea.dev/services/pull"
 
 	"github.com/stretchr/testify/assert"
@@ -54,6 +56,40 @@ func TestRepoGetReviewers(t *testing.T) {
 	reviewers, err = pull_service.GetReviewers(ctx, repo3, 2, 2)
 	assert.NoError(t, err)
 	assert.Len(t, reviewers, 1)
+
+	user4 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 4})
+	user4.Visibility = structs.VisibleTypePrivate
+	assert.NoError(t, user_model.UpdateUserCols(ctx, user4, "visibility"))
+
+	reviewers, err = pull_service.GetReviewers(ctx, repo3, 2, 1)
+	assert.NoError(t, err)
+	assertReviewerIDs(t, reviewers, 2)
+
+	reviewers, err = pull_service.GetReviewers(ctx, repo3, 1, 1)
+	assert.NoError(t, err)
+	assertReviewerIDs(t, reviewers, 2, 4)
+
+	user4.Visibility = structs.VisibleTypePublic
+	user4.IsRestricted = true
+	assert.NoError(t, user_model.UpdateUserCols(ctx, user4, "visibility", "is_restricted"))
+
+	reviewers, err = pull_service.GetReviewers(ctx, repo3, 2, 1)
+	assert.NoError(t, err)
+	assertReviewerIDs(t, reviewers, 2)
+
+	reviewers, err = pull_service.GetReviewers(ctx, repo3, 1, 1)
+	assert.NoError(t, err)
+	assertReviewerIDs(t, reviewers, 2, 4)
+}
+
+func assertReviewerIDs(t *testing.T, reviewers []*user_model.User, expectedIDs ...int64) {
+	t.Helper()
+
+	actualIDs := make([]int64, 0, len(reviewers))
+	for _, reviewer := range reviewers {
+		actualIDs = append(actualIDs, reviewer.ID)
+	}
+	assert.ElementsMatch(t, expectedIDs, actualIDs)
 }
 
 func TestRepoGetReviewerTeams(t *testing.T) {


### PR DESCRIPTION
Fixes #37371

## What changed
- Load the requester in `GetReviewers` only when a requester ID is available and apply Gitea's existing user visibility search condition to reviewer candidates.
- Hide private/restricted reviewer candidates from non-admin callers while preserving admin visibility.
- Add service coverage for private and restricted reviewer candidates.
- Avoid the optional-requester helper returning `nil, nil`, fixing the backend `nilnil` lint failure.

## Tests
- `GOMODCACHE=/tmp/gitea-37371-gomodcache GOCACHE=/tmp/gitea-37371-gocache go test ./services/pull -run TestRepoGetReviewers`
- `GOMODCACHE=/tmp/gitea-37371-gomodcache GOCACHE=/tmp/gitea-37371-gocache go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --no-config --enable nilnil services/pull/reviewer.go`
- `git diff --check`

I also tried `go test ./services/pull`, but the local run fails in unrelated merge-tree tests because Apple Git 2.39.5 does not support the `git merge-tree --merge-base` option those tests invoke.

AI-assisted tooling was used while preparing this change. I reviewed the code and ran the tests above manually.