### PR TITLE
fix(actions): return 404 when job log blob is missing

### DIFF
--- a/routers/common/actions.go
+++ b/routers/common/actions.go
@@ -4,7 +4,9 @@
 package common
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"strings"
 
 	actions_model "gitea.dev/models/actions"
@@ -51,6 +53,9 @@ func DownloadActionsRunJobLogs(ctx *context.Base, ctxRepo *repo_model.Repository
 
 	reader, err := actions.OpenLogs(ctx, task.LogInStorage, task.LogFilename)
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return util.NewNotExistErrorf("logs not found")
+		}
 		return fmt.Errorf("OpenLogs: %w", err)
 	}
 	defer reader.Close()


### PR DESCRIPTION
- When the `action_task` row exists but the underlying dbfs/storage blob is gone, `OpenLogs` returns a wrapped `os.ErrNotExist` which surfaces as a 500 on the job logs endpoints.
- Translate it to the same `util.NewNotExistErrorf` shape already used for unknown job ids / expired logs, so both the API (`/api/v1/repos/.../actions/jobs/<id>/logs`) and the web download handler return a clean 404 instead.

Fixes #37990.
