### PR TITLE
fix(ui): keep actions run title intact when subject contains an issue ref

### DIFF
--- a/models/repo/repo.go
+++ b/models/repo/repo.go
@@ -23,6 +23,7 @@ import (
 	"gitea.dev/modules/base"
 	"gitea.dev/modules/git"
 	giturl "gitea.dev/modules/git/url"
+	"gitea.dev/modules/htmlutil"
 	"gitea.dev/modules/httplib"
 	"gitea.dev/modules/log"
 	"gitea.dev/modules/markup"
@@ -641,12 +642,7 @@ func (repo *Repository) CanContentChange() bool {
 
 // DescriptionHTML does special handles to description and return HTML string.
 func (repo *Repository) DescriptionHTML(ctx context.Context) template.HTML {
-	desc, err := markup.PostProcessDescriptionHTML(markup.NewRenderContext(ctx), repo.Description)
-	if err != nil {
-		log.Error("Failed to render description for %s (ID: %d): %v", repo.Name, repo.ID, err)
-		return template.HTML(markup.SanitizeDescription(repo.Description))
-	}
-	return template.HTML(markup.SanitizeDescription(desc))
+	return markup.PostProcessDescriptionHTML(markup.NewRenderContext(ctx), htmlutil.EscapeString(repo.Description))
 }
 
 // CloneLink represents different types of clone URLs of repository.

--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -14,8 +14,10 @@ import (
 	"sync"
 
 	"gitea.dev/modules/htmlutil"
+	"gitea.dev/modules/log"
 	"gitea.dev/modules/markup/common"
 	"gitea.dev/modules/translation"
+	"gitea.dev/modules/util"
 
 	"golang.org/x/net/html"
 	"golang.org/x/net/html/atom"
@@ -151,8 +153,7 @@ func PostProcessDefault(ctx *RenderContext, input io.Reader, output io.Writer) e
 }
 
 // PostProcessCommitMessage will use the same logic as PostProcess, but will disable the shortLinkProcessor.
-// FIXME: this function and its family have a very strange design: it takes HTML as input and output, processes the "escaped" content.
-func PostProcessCommitMessage(ctx *RenderContext, content template.HTML) (template.HTML, error) {
+func PostProcessCommitMessage(ctx *RenderContext, content template.HTML) template.HTML {
 	procs := []processor{
 		fullIssuePatternProcessor,
 		comparePatternProcessor,
@@ -166,8 +167,7 @@ func PostProcessCommitMessage(ctx *RenderContext, content template.HTML) (templa
 		emojiProcessor,
 		emojiShortCodeProcessor,
 	}
-	s, err := postProcessString(ctx, procs, string(content))
-	return template.HTML(s), err
+	return postProcessHTML(ctx, procs, content)
 }
 
 var emojiProcessors = []processor{
@@ -189,7 +189,7 @@ func isBareURLSubject(content string) bool {
 // PostProcessCommitMessageSubject will use the same logic as PostProcess and
 // PostProcessCommitMessage, but will disable the shortLinkProcessor and
 // emailAddressProcessor, and wraps the whole subject in defaultLink.
-func PostProcessCommitMessageSubject(ctx *RenderContext, defaultLink, content string) (string, error) {
+func PostProcessCommitMessageSubject(ctx *RenderContext, defaultLink string, content template.HTML) template.HTML {
 	procs := []processor{
 		fullIssuePatternProcessor,
 		comparePatternProcessor,
@@ -207,7 +207,7 @@ func PostProcessCommitMessageSubject(ctx *RenderContext, defaultLink, content st
 	// plain text inside defaultLink. Partial URLs inside larger text still become
 	// their own links (nested anchors aren't legal HTML, so the outer defaultLink
 	// naturally breaks on that span, same as on GitHub).
-	if !isBareURLSubject(content) {
+	if !isBareURLSubject(string(content)) {
 		procs = append(procs, linkProcessor)
 	}
 	procs = append(procs, func(ctx *RenderContext, node *html.Node) {
@@ -215,27 +215,28 @@ func PostProcessCommitMessageSubject(ctx *RenderContext, defaultLink, content st
 		node.Type = html.ElementNode
 		node.Data = "a"
 		node.DataAtom = atom.A
-		node.Attr = []html.Attribute{{Key: "href", Val: defaultLink}, {Key: "class", Val: "muted"}}
+		node.Attr = []html.Attribute{{Key: "href", Val: defaultLink}, {Key: "class", Val: "muted title-full-link"}}
 		node.FirstChild, node.LastChild = ch, ch
 	})
-	return postProcessString(ctx, procs, content)
+	rendered := postProcessHTML(ctx, procs, content)
+	return htmlutil.HTMLFormat(`<span class="title-full-link-hover">%s</span>`, rendered)
 }
 
 // PostProcessIssueTitle to process title on individual issue/pull page
-func PostProcessIssueTitle(ctx *RenderContext, title string) (string, error) {
-	return postProcessString(ctx, []processor{
+func PostProcessIssueTitle(ctx *RenderContext, titleHTML template.HTML) template.HTML {
+	return postProcessHTML(ctx, []processor{
 		issueIndexPatternProcessor,
 		commitCrossReferencePatternProcessor,
 		hashCurrentPatternProcessor,
 		emojiShortCodeProcessor,
 		emojiProcessor,
-	}, title)
+	}, titleHTML)
 }
 
 // PostProcessDescriptionHTML will use similar logic as PostProcess, but will
 // use a single special linkProcessor.
-func PostProcessDescriptionHTML(ctx *RenderContext, content string) (string, error) {
-	return postProcessString(ctx, []processor{
+func PostProcessDescriptionHTML(ctx *RenderContext, content template.HTML) template.HTML {
+	return postProcessHTML(ctx, []processor{
 		descriptionLinkProcessor,
 		emojiShortCodeProcessor,
 		emojiProcessor,
@@ -243,17 +244,18 @@ func PostProcessDescriptionHTML(ctx *RenderContext, content string) (string, err
 }
 
 // PostProcessEmoji for when we want to just process emoji and shortcodes
-// in various places it isn't already run through the normal markdown processor
-func PostProcessEmoji(ctx *RenderContext, content string) (string, error) {
-	return postProcessString(ctx, emojiProcessors, content)
+// in various places it isn't already run through the normal Markdown processor
+func PostProcessEmoji(ctx *RenderContext, content template.HTML) template.HTML {
+	return postProcessHTML(ctx, emojiProcessors, content)
 }
 
-func postProcessString(ctx *RenderContext, procs []processor, content string) (string, error) {
+func postProcessHTML(ctx *RenderContext, procs []processor, content template.HTML) template.HTML {
 	var buf strings.Builder
-	if err := postProcess(ctx, procs, strings.NewReader(content), &buf); err != nil {
-		return "", err
+	if err := postProcess(ctx, procs, strings.NewReader(string(content)), &buf); err != nil {
+		log.Warn("postProcessHTML err: %v, input: %s", err, util.TruncateRunes(string(content), 200))
+		return content
 	}
-	return buf.String(), nil
+	return template.HTML(buf.String())
 }
 
 func RenderTocHeadingItems(ctx *RenderContext, nodeDetailsAttrs map[string]string, out io.Writer) {

--- a/modules/markup/html_internal_test.go
+++ b/modules/markup/html_internal_test.go
@@ -260,8 +260,7 @@ func TestRender_PostProcessIssueTitle(t *testing.T) {
 		"repo":   "someRepo",
 		"style":  IssueNameStyleNumeric,
 	}
-	actual, err := PostProcessIssueTitle(NewTestRenderContext(metas), "#1")
-	assert.NoError(t, err)
+	actual := PostProcessIssueTitle(NewTestRenderContext(metas), "#1")
 	assert.Equal(t, "#1", actual)
 }
 

--- a/modules/markup/html_internal_test.go
+++ b/modules/markup/html_internal_test.go
@@ -5,6 +5,7 @@ package markup
 
 import (
 	"fmt"
+	"html/template"
 	"strconv"
 	"strings"
 	"testing"
@@ -261,7 +262,7 @@ func TestRender_PostProcessIssueTitle(t *testing.T) {
 		"style":  IssueNameStyleNumeric,
 	}
 	actual := PostProcessIssueTitle(NewTestRenderContext(metas), "#1")
-	assert.Equal(t, "#1", actual)
+	assert.Equal(t, template.HTML("#1"), actual)
 }
 
 func testRenderIssueIndexPattern(t *testing.T, input, expected string, ctx *RenderContext) {

--- a/modules/templates/util_render.go
+++ b/modules/templates/util_render.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
-	"unicode"
 
 	issues_model "gitea.dev/models/issues"
 	"gitea.dev/models/renderhelper"
@@ -39,60 +38,35 @@ func NewRenderUtils(ctx reqctx.RequestContext) *RenderUtils {
 	return &RenderUtils{ctx: ctx}
 }
 
-// RenderCommitMessage renders commit message with XSS-safe and special links.
+// RenderCommitMessage renders commit message title (only title)
 func (ut *RenderUtils) RenderCommitMessage(msg string, repo *repo.Repository) template.HTML {
-	cleanMsg := template.HTML(template.HTMLEscapeString(msg))
-	// we can safely assume that it will not return any error, since there shouldn't be any special HTML.
-	// "repo" can be nil when rendering commit messages for deleted repositories in a user's dashboard feed.
-	fullMessage, err := markup.PostProcessCommitMessage(renderhelper.NewRenderContextRepoComment(ut.ctx, repo), cleanMsg)
-	if err != nil {
-		log.Error("PostProcessCommitMessage: %v", err)
-		return ""
-	}
-	msgLines := strings.Split(strings.TrimSpace(string(fullMessage)), "\n")
-	if len(msgLines) == 0 {
-		return ""
-	}
-	return renderCodeBlock(template.HTML(msgLines[0]))
+	msgLine := strings.TrimSpace(msg)
+	msgLine, _, _ = strings.Cut(msgLine, "\n")
+	msgLine = strings.TrimSpace(msgLine)
+	rendered := markup.PostProcessCommitMessage(renderhelper.NewRenderContextRepoComment(ut.ctx, repo), htmlutil.EscapeString(msgLine))
+	return renderCodeBlock(rendered)
 }
 
 // RenderCommitMessageLinkSubject renders commit message as a XSS-safe link to
 // the provided default url, handling for special links without email to links.
 func (ut *RenderUtils) RenderCommitMessageLinkSubject(msg, urlDefault string, repo *repo.Repository) template.HTML {
-	msgLine := strings.TrimLeftFunc(msg, unicode.IsSpace)
-	lineEnd := strings.IndexByte(msgLine, '\n')
-	if lineEnd > 0 {
-		msgLine = msgLine[:lineEnd]
-	}
-	msgLine = strings.TrimRightFunc(msgLine, unicode.IsSpace)
-	if len(msgLine) == 0 {
-		return ""
-	}
-
-	// we can safely assume that it will not return any error, since there shouldn't be any special HTML.
-	renderedMessage, err := markup.PostProcessCommitMessageSubject(renderhelper.NewRenderContextRepoComment(ut.ctx, repo), urlDefault, template.HTMLEscapeString(msgLine))
-	if err != nil {
-		log.Error("PostProcessCommitMessageSubject: %v", err)
-		return ""
-	}
-	return renderCodeBlock(template.HTML(renderedMessage))
+	msgLine := strings.TrimSpace(msg)
+	msgLine, _, _ = strings.Cut(msgLine, "\n")
+	msgLine = strings.TrimSpace(msgLine)
+	rctx := renderhelper.NewRenderContextRepoComment(ut.ctx, repo)
+	rendered := markup.PostProcessCommitMessageSubject(rctx, urlDefault, htmlutil.EscapeString(msgLine))
+	return renderCodeBlock(rendered)
 }
 
 // RenderCommitBody extracts the body of a commit message without its title.
 func (ut *RenderUtils) RenderCommitBody(msg string, repo *repo.Repository) template.HTML {
 	_, body, _ := strings.Cut(strings.TrimSpace(msg), "\n")
-	body = strings.TrimFunc(body, unicode.IsSpace)
+	body = strings.TrimSpace(body)
 	if body == "" {
 		return ""
 	}
-
 	rctx := renderhelper.NewRenderContextRepoComment(ut.ctx, repo)
-	htmlContent := template.HTML(template.HTMLEscapeString(body))
-	renderedMessage, err := markup.PostProcessCommitMessage(rctx, htmlContent)
-	if err != nil {
-		log.Error("PostProcessCommitMessage: %v", err)
-		return ""
-	}
+	renderedMessage := markup.PostProcessCommitMessage(rctx, htmlutil.EscapeString(body))
 	return renderedMessage
 }
 
@@ -108,25 +82,15 @@ func renderCodeBlock(htmlEscapedTextToRender template.HTML) template.HTML {
 // RenderIssueTitle renders issue/pull title with defined post processors
 func (ut *RenderUtils) RenderIssueTitle(text string, repo *repo.Repository) template.HTML {
 	// wrap "`…`" in <code> before post-processing so code-span content stays literal, like comment bodies
-	htmlWithCode := renderCodeBlock(template.HTML(template.HTMLEscapeString(text)))
-	renderedText, err := markup.PostProcessIssueTitle(renderhelper.NewRenderContextRepoComment(ut.ctx, repo), string(htmlWithCode))
-	if err != nil {
-		log.Error("PostProcessIssueTitle: %v", err)
-		return ""
-	}
-	return template.HTML(renderedText)
+	htmlWithCode := renderCodeBlock(htmlutil.EscapeString(text))
+	return markup.PostProcessIssueTitle(renderhelper.NewRenderContextRepoComment(ut.ctx, repo), htmlWithCode)
 }
 
 // RenderIssueSimpleTitle only renders with emoji and inline code block
 func (ut *RenderUtils) RenderIssueSimpleTitle(text string) template.HTML {
 	// see RenderIssueTitle: wrap code spans before processing emoji
-	htmlWithCode := renderCodeBlock(template.HTML(template.HTMLEscapeString(text)))
-	renderedText, err := markup.PostProcessEmoji(markup.NewRenderContext(ut.ctx), string(htmlWithCode))
-	if err != nil {
-		log.Error("RenderIssueSimpleTitle: %v", err)
-		return ""
-	}
-	return template.HTML(renderedText)
+	htmlWithCode := renderCodeBlock(htmlutil.EscapeString(text))
+	return markup.PostProcessEmoji(markup.NewRenderContext(ut.ctx), htmlWithCode)
 }
 
 func (ut *RenderUtils) RenderLabel(label *issues_model.Label) template.HTML {
@@ -202,12 +166,7 @@ func (ut *RenderUtils) RenderLabel(label *issues_model.Label) template.HTML {
 
 // RenderEmoji renders html text with emoji post processors
 func (ut *RenderUtils) RenderEmoji(text string) template.HTML {
-	renderedText, err := markup.PostProcessEmoji(markup.NewRenderContext(ut.ctx), template.HTMLEscapeString(text))
-	if err != nil {
-		log.Error("RenderEmoji: %v", err)
-		return ""
-	}
-	return template.HTML(renderedText)
+	return markup.PostProcessEmoji(markup.NewRenderContext(ut.ctx), htmlutil.EscapeString(text))
 }
 
 // reactionToEmoji renders emoji for use in reactions

--- a/modules/templates/util_render_test.go
+++ b/modules/templates/util_render_test.go
@@ -131,24 +131,24 @@ com 88fc37a3c0a4dda553bdcfc80c178a58247f42fb mit
 	})
 
 	t.Run("RenderCommitMessage", func(t *testing.T) {
-		expected := `space <a href="/mention-user" data-markdown-generated-content="">@mention-user</a>  `
+		expected := `space <a href="/mention-user" data-markdown-generated-content="">@mention-user</a>`
 		assert.EqualValues(t, expected, newTestRenderUtils(t).RenderCommitMessage(testInput(), mockRepo))
 	})
 
 	t.Run("RenderCommitMessageLinkSubject", func(t *testing.T) {
-		expected := `<a href="https://example.com/link" class="muted">space </a><a href="/mention-user" data-markdown-generated-content="">@mention-user</a>`
+		expected := `<span class="title-full-link-hover"><a href="https://example.com/link" class="muted title-full-link">space </a><a href="/mention-user" data-markdown-generated-content="">@mention-user</a></span>`
 		assert.EqualValues(t, expected, newTestRenderUtils(t).RenderCommitMessageLinkSubject(testInput(), "https://example.com/link", mockRepo))
 	})
 
 	t.Run("RenderCommitMessageLinkSubjectURLOnly", func(t *testing.T) {
 		// a bare URL in the subject must not hijack the default link
-		expected := `<a href="https://example.com/link" class="muted">https://example.com/file.bin</a>`
+		expected := `<span class="title-full-link-hover"><a href="https://example.com/link" class="muted title-full-link">https://example.com/file.bin</a></span>`
 		assert.EqualValues(t, expected, newTestRenderUtils(t).RenderCommitMessageLinkSubject("https://example.com/file.bin", "https://example.com/link", mockRepo))
 	})
 
 	t.Run("RenderCommitMessageLinkSubjectPartialURL", func(t *testing.T) {
 		// a URL embedded in larger subject text still becomes its own link
-		expected := `<a href="https://example.com/link" class="muted">see </a><a href="https://example.com/x" data-markdown-generated-content="">https://example.com/x</a><a href="https://example.com/link" class="muted"> here</a>`
+		expected := `<span class="title-full-link-hover"><a href="https://example.com/link" class="muted title-full-link">see </a><a href="https://example.com/x" data-markdown-generated-content="">https://example.com/x</a><a href="https://example.com/link" class="muted title-full-link"> here</a></span>`
 		assert.EqualValues(t, expected, newTestRenderUtils(t).RenderCommitMessageLinkSubject("see https://example.com/x here", "https://example.com/link", mockRepo))
 	})
 

--- a/routers/web/repo/commit.go
+++ b/routers/web/repo/commit.go
@@ -414,11 +414,7 @@ func Diff(ctx *context.Context) {
 		ctx.Data["NoteAuthor"] = user_model.ValidateCommitWithEmail(ctx, note.Commit)
 		rctx := renderhelper.NewRenderContextRepoComment(ctx, ctx.Repo.Repository, renderhelper.RepoCommentOptions{CurrentRefSubURL: "commit/" + util.PathEscapeSegments(commitID)})
 		htmlMessage := template.HTML(template.HTMLEscapeString(string(charset.ToUTF8WithFallback(note.Message, charset.ConvertOpts{}))))
-		ctx.Data["NoteRendered"], err = markup.PostProcessCommitMessage(rctx, htmlMessage)
-		if err != nil {
-			ctx.ServerError("PostProcessCommitMessage", err)
-			return
-		}
+		ctx.Data["NoteRendered"] = markup.PostProcessCommitMessage(rctx, htmlMessage)
 	} else if !git.IsErrNotExist(err) {
 		log.Error("GetNote: %v", err)
 	}

--- a/templates/repo/actions/runs_list.tmpl
+++ b/templates/repo/actions/runs_list.tmpl
@@ -13,15 +13,10 @@
 				</span>
 			</div>
 			<div class="item-main">
-				<span class="item-title" title="{{$run.Title}}">
-					<span>
-						{{if $run.Title}}
-							{{ctx.RenderUtils.RenderCommitMessageLinkSubject $run.Title $run.Link $.Repository}}
-						{{else}}
-							<a href="{{$run.Link}}">{{ctx.Locale.Tr "actions.runs.empty_commit_message"}}</a>
-						{{end}}
-					</span>
-				</span>
+				<div class="list-item-large-title">
+					{{$title := or $run.Title (ctx.Locale.Tr "actions.runs.empty_commit_message")}}
+					{{ctx.RenderUtils.RenderCommitMessageLinkSubject $title $run.Link $.Repository}}
+				</div>
 				<div class="item-body">
 					{{$workflowName := index $.WorkflowNames $run.WorkflowID}}
 					<span><b>{{if not $.CurWorkflow}}{{if $workflowName}}{{$workflowName}}{{else}}{{$run.WorkflowID}}{{end}} {{end}}#{{$run.Index}}</b>:</span>

--- a/templates/repo/actions/runs_list.tmpl
+++ b/templates/repo/actions/runs_list.tmpl
@@ -13,7 +13,7 @@
 				</span>
 			</div>
 			<div class="item-main">
-				<div class="list-item-large-title">
+				<div class="item-title">
 					{{$title := or $run.Title (ctx.Locale.Tr "actions.runs.empty_commit_message")}}
 					{{ctx.RenderUtils.RenderCommitMessageLinkSubject $title $run.Link $.Repository}}
 				</div>

--- a/templates/repo/actions/runs_list.tmpl
+++ b/templates/repo/actions/runs_list.tmpl
@@ -14,11 +14,13 @@
 			</div>
 			<div class="item-main">
 				<span class="item-title" title="{{$run.Title}}">
-					{{if $run.Title}}
-						{{ctx.RenderUtils.RenderCommitMessageLinkSubject $run.Title $run.Link $.Repository}}
-					{{else}}
-						<a href="{{$run.Link}}">{{ctx.Locale.Tr "actions.runs.empty_commit_message"}}</a>
-					{{end}}
+					<span>
+						{{if $run.Title}}
+							{{ctx.RenderUtils.RenderCommitMessageLinkSubject $run.Title $run.Link $.Repository}}
+						{{else}}
+							<a href="{{$run.Link}}">{{ctx.Locale.Tr "actions.runs.empty_commit_message"}}</a>
+						{{end}}
+					</span>
 				</span>
 				<div class="item-body">
 					{{$workflowName := index $.WorkflowNames $run.WorkflowID}}

--- a/web_src/css/repo/issue-list.css
+++ b/web_src/css/repo/issue-list.css
@@ -93,17 +93,7 @@
   text-align: left;
 }
 
-.title-full-link-hover:hover > a.title-full-link {
+.title-full-link-hover:not(:has(:not(.title-full-link):hover)):hover > a.title-full-link {
   color: var(--color-primary);
   text-decoration: underline;
 }
-
-/* this style is extracted from the pending PR: chore: fix various layout problems#37983 */
-.list-item-large-title {
-  font-size: 16px;
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text);
-  text-decoration: none;
-  overflow-wrap: anywhere;
-}
-

--- a/web_src/css/repo/issue-list.css
+++ b/web_src/css/repo/issue-list.css
@@ -92,3 +92,18 @@
   margin-right: 8px;
   text-align: left;
 }
+
+.title-full-link-hover:hover > a.title-full-link {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+/* this style is extracted from the pending PR: chore: fix various layout problems#37983 */
+.list-item-large-title {
+  font-size: 16px;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+  text-decoration: none;
+  overflow-wrap: anywhere;
+}
+

--- a/web_src/css/repo/issue-list.css
+++ b/web_src/css/repo/issue-list.css
@@ -93,6 +93,15 @@
   text-align: left;
 }
 
+/* for "title (#123)":
+  <span "title-full-link-hover">
+    <a "title-full-link muted">title (</a>
+    <a "muted">#123</a>
+    <a "title-full-link muted">)</a>
+  </span>
+  * hover on "title": also highlight the right parentheses
+  * hover on "#123": don't highlight other parts
+ */
 .title-full-link-hover:not(:has(:not(.title-full-link):hover)):hover > a.title-full-link {
   color: var(--color-primary);
   text-decoration: underline;

--- a/web_src/css/shared/flex-list.css
+++ b/web_src/css/shared/flex-list.css
@@ -88,15 +88,6 @@
   overflow-wrap: anywhere;
 }
 
-/* When a commit subject contains a ref like `#1234`, the nested anchor splits the
-   outer "muted" link into siblings. Treat all muted siblings as one hover target
-   so the highlight isn't confined to the fragment under the cursor, while leaving
-   the inner ref anchor (e.g. `#1234`) independently hoverable. */
-.items-with-main > .item .item-title:has(a.muted:hover) a.muted {
-  color: var(--color-primary);
-  text-decoration: underline;
-}
-
 .items-with-main > .item .item-body {
   display: flex;
   align-items: center;

--- a/web_src/css/shared/flex-list.css
+++ b/web_src/css/shared/flex-list.css
@@ -88,6 +88,15 @@
   overflow-wrap: anywhere;
 }
 
+/* When a commit subject contains a ref like `#1234`, the nested anchor splits the
+   outer "muted" link into siblings. Treat all muted siblings as one hover target
+   so the highlight isn't confined to the fragment under the cursor, while leaving
+   the inner ref anchor (e.g. `#1234`) independently hoverable. */
+.items-with-main > .item .item-title:has(a.muted:hover) a.muted {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
 .items-with-main > .item .item-body {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Problem

On the repository **Actions** page, workflow run titles that contain an issue reference (e.g. a merge commit like `fix(deps): … (#1009)`) render with two visual glitches:

1. The title can **break mid-subject** onto a new line, with a visible gap, even when there's plenty of horizontal space.
2. Hovering the title only **highlights the fragment under the cursor**, not the whole subject — so the title looks like several disconnected links.


## Examples

- Before: title broken across two lines with a gap after `(`; hovering only the second fragment underlines it.
<img width="1042" height="139"  src="https://github.com/user-attachments/assets/d4a2f62c-b26e-4359-b016-9473cbcddc3e" />

- After: title flows naturally, hovering anywhere on the muted text underlines the entire subject, `#1009` still hoverable as a separate link.
<img width="773" height="97" src="https://github.com/user-attachments/assets/61e2373e-fd22-47de-b319-f23f18c91368" />
