### PR TITLE
fix(fomantic): dropdown text disappearing when user types new text

### DIFF
--- a/web_src/fomantic/build/components/dropdown.js
+++ b/web_src/fomantic/build/components/dropdown.js
@@ -3051,8 +3051,10 @@ $.fn.dropdown = function(parameters) {
             $search.css('width', '');
           },
           searchTerm: function() {
-            module.verbose('Cleared search term');
-            $search.val('');
+            if(!module.setting('keepSearchTerm') || module.setting('apiSettings').cache) { // GITEA-PATCH: ensures that the search term isn't cleared when a user types a character
+              module.verbose('Cleared search term');
+              $search.val('');
+            }
             module.set.filtered();
           },
           userAddition: function() {


### PR DESCRIPTION
this change adds two checks before setting the search input's value to an empty string:
- whether `keepSearchTerm` setting is falsy
- whether `apiSettings.cache` is truthy

the search box will only be cleared if either of these conditions are met. otherwise, it keeps newly typed text until an item is explicitly selected.

fixes #38018 .