### PR TITLE
ci: bound seeded Go cache size and speed up disk cleanup

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,9 +1,18 @@
 name: free-disk-space
 description: Free space on / before large cache restores
 
-# Delete preinstalled toolchains which gitea doesn't use
+# Delete unused preinstalled toolchains in parallel (independent trees). The df
+# calls bracket the cleanup to log real free space.
 runs:
   using: composite
   steps:
     - shell: bash
-      run: sudo rm -rf /usr/local/lib/android /usr/local/.ghcup /opt/ghc /usr/share/dotnet
+      run: |
+        echo "free space before cleanup:"
+        df -h /
+        for dir in /usr/local/lib/android /usr/local/.ghcup /opt/ghc /usr/share/dotnet; do
+          sudo rm -rf "$dir" &
+        done
+        wait
+        echo "free space after cleanup:"
+        df -h /

--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,10 +1,18 @@
 name: free-disk-space
 description: Free space on / before large cache restores
 
-# EXPERIMENT (#37974): toolchain deletion disabled to test whether the ~89G free
-# baseline suffices on its own. df logs starting headroom; restore the rm if low.
+# Delete unused preinstalled toolchains in parallel (independent trees). The df
+# calls bracket the cleanup to log real free space.
 runs:
   using: composite
   steps:
     - shell: bash
-      run: df -h /
+      run: |
+        echo "free space before cleanup:"
+        df -h /
+        for dir in /usr/local/lib/android /usr/local/.ghcup /opt/ghc /usr/share/dotnet; do
+          sudo rm -rf "$dir" &
+        done
+        wait
+        echo "free space after cleanup:"
+        df -h /

--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,8 +1,7 @@
 name: free-disk-space
 description: Free space on / before large cache restores
 
-# Delete unused preinstalled toolchains in parallel (independent trees). The df
-# calls bracket the cleanup to log real free space.
+# Delete preinstalled toolchains which gitea doesn't use and show disk space usage
 runs:
   using: composite
   steps:

--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,18 +1,10 @@
 name: free-disk-space
 description: Free space on / before large cache restores
 
-# Delete unused preinstalled toolchains in parallel (independent trees). The df
-# calls bracket the cleanup to log real free space.
+# EXPERIMENT (#37974): toolchain deletion disabled to test whether the ~89G free
+# baseline suffices on its own. df logs starting headroom; restore the rm if low.
 runs:
   using: composite
   steps:
     - shell: bash
-      run: |
-        echo "free space before cleanup:"
-        df -h /
-        for dir in /usr/local/lib/android /usr/local/.ghcup /opt/ghc /usr/share/dotnet; do
-          sudo rm -rf "$dir" &
-        done
-        wait
-        echo "free space after cleanup:"
-        df -h /
+      run: df -h /

--- a/.github/actions/go-cache/action.yml
+++ b/.github/actions/go-cache/action.yml
@@ -4,6 +4,8 @@ description: Restore the go module, build, and golangci-lint caches. Save only o
 # Only the cache-seeder workflow saves; rename requires updating cache-seeder.yml.
 # The lint job restores but does not save the gobuild cache, so only one writer
 # (the gobuild job) populates it and there is no contention on the cache key.
+# Seeder restores by exact key only (no restore-keys) so each go.sum seeds a clean
+# cache and size stays bounded; do not add restore-keys here. PR runs keep them.
 
 inputs:
   lint-cache:
@@ -18,7 +20,6 @@ runs:
       with:
         path: ~/go/pkg/mod
         key: gomod-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}
-        restore-keys: gomod-${{ runner.os }}-${{ runner.arch }}
     - if: ${{ github.workflow != 'cache-seeder' }}
       uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
@@ -30,7 +31,6 @@ runs:
       with:
         path: ~/.cache/go-build
         key: gobuild-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}
-        restore-keys: gobuild-${{ runner.os }}-${{ runner.arch }}
     - if: ${{ github.workflow != 'cache-seeder' || inputs.lint-cache == 'true' }}
       uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
@@ -42,7 +42,6 @@ runs:
       with:
         path: ~/.cache/golangci-lint
         key: golint-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum', '.golangci.yml') }}
-        restore-keys: golint-${{ runner.os }}-${{ runner.arch }}
     - if: ${{ inputs.lint-cache == 'true' && github.workflow != 'cache-seeder' }}
       uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:

--- a/.github/workflows/pull-db-tests.yml
+++ b/.github/workflows/pull-db-tests.yml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/files-changed.yml
 
   test-pgsql-shard-1:
-    if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
+    if: needs.files-changed.outputs.backend == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
     timeout-minutes: 50
@@ -49,11 +49,9 @@ jobs:
           shard: 1
           total-shards: 2
           run-migration: "true"
-      - if: always()
-        run: df -h /
 
   test-pgsql-shard-2:
-    if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
+    if: needs.files-changed.outputs.backend == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
     timeout-minutes: 50
@@ -86,8 +84,6 @@ jobs:
         with:
           shard: 2
           total-shards: 2
-      - if: always()
-        run: df -h /
 
   test-sqlite:
     if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
@@ -112,8 +108,6 @@ jobs:
           GOTEST_FLAGS: -timeout=40m
           TAGS: bindata gogit
           GOEXPERIMENT:
-      - if: always()
-        run: df -h /
 
   test-unit:
     if: needs.files-changed.outputs.backend == 'true'

--- a/.github/workflows/pull-db-tests.yml
+++ b/.github/workflows/pull-db-tests.yml
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/files-changed.yml
 
   test-pgsql-shard-1:
-    if: needs.files-changed.outputs.backend == 'true'
+    if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
     timeout-minutes: 50
@@ -49,9 +49,11 @@ jobs:
           shard: 1
           total-shards: 2
           run-migration: "true"
+      - if: always()
+        run: df -h /
 
   test-pgsql-shard-2:
-    if: needs.files-changed.outputs.backend == 'true'
+    if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
     needs: files-changed
     runs-on: ubuntu-latest
     timeout-minutes: 50
@@ -84,6 +86,8 @@ jobs:
         with:
           shard: 2
           total-shards: 2
+      - if: always()
+        run: df -h /
 
   test-sqlite:
     if: needs.files-changed.outputs.backend == 'true' || needs.files-changed.outputs.actions == 'true'
@@ -108,6 +112,8 @@ jobs:
           GOTEST_FLAGS: -timeout=40m
           TAGS: bindata gogit
           GOEXPERIMENT:
+      - if: always()
+        run: df -h /
 
   test-unit:
     if: needs.files-changed.outputs.backend == 'true'


### PR DESCRIPTION
Reduces the CI cache growth and disk pressure behind the flaky `No space left on device` failures in https://github.com/go-gitea/gitea/issues/37974.

**`go-cache`** — the cache-seeder saved with a `restore-keys` prefix fallback, so every `go.sum` change restored the previous cache and re-saved the union; old module versions and stale build objects accumulated (~3 GB → ~7 GB) and overflowed disk on smaller runners. Drop `restore-keys` from the seeder **save** branches so each `go.sum` seeds a clean, size-bounded cache. PR runs keep `restore-keys` for warm-start fallback.

**`free-disk-space`** — delete the unused preinstalled toolchains in parallel (~86 s → ~54 s) and log `df -h /` before/after.

Measured during review: the hosted `ubuntu-latest` fleet is heterogeneous — most runners have ~89 GB free on `/` (a full pgsql integration shard peaks at ~17 GB used), but a minority arrive nearly full and fail mid cache-restore. The toolchain deletion is the headroom that keeps those runners green, so it stays; the cache bound shrinks the footprint for every runner.

Authored with assistance from Claude (Opus 4.8).