### PR TITLE
fix: validate gem name in rubygems parseMetadataFile

### DIFF
--- a/modules/packages/rubygems/metadata.go
+++ b/modules/packages/rubygems/metadata.go
@@ -25,13 +25,14 @@ var (
 	ErrInvalidVersion = util.NewInvalidArgumentErrorf("package version is invalid")
 )
 
-// https://github.com/rubygems/rubygems/blob/master/lib/rubygems/specification.rb (VALID_NAME_PATTERN)
-var nameMatcher = sync.OnceValue(func() *regexp.Regexp {
-	return regexp.MustCompile(`\A[a-zA-Z0-9._-]+\z`)
-})
-
-var versionMatcher = sync.OnceValue(func() *regexp.Regexp {
-	return regexp.MustCompile(`\A[0-9]+(?:\.[0-9a-zA-Z]+)*(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?\z`)
+var globalVars = sync.OnceValue(func() (ret struct {
+	nameMatcher, versionMatcher *regexp.Regexp
+},
+) {
+	// https://github.com/rubygems/rubygems/blob/master/lib/rubygems/specification.rb (VALID_NAME_PATTERN)
+	ret.nameMatcher = regexp.MustCompile(`\A[\w.-]+\z`)
+	ret.versionMatcher = regexp.MustCompile(`\A[0-9]+(?:\.[0-9a-zA-Z]+)*(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?\z`)
+	return ret
 })
 
 // Package represents a RubyGems package
@@ -179,11 +180,11 @@ func parseMetadataFile(r io.Reader) (*Package, error) {
 		return nil, err
 	}
 
-	if !nameMatcher().MatchString(spec.Name) {
+	if !globalVars().nameMatcher.MatchString(spec.Name) {
 		return nil, ErrInvalidName
 	}
 
-	if !versionMatcher().MatchString(spec.Version.Version) {
+	if !globalVars().versionMatcher.MatchString(spec.Version.Version) {
 		return nil, ErrInvalidVersion
 	}
 

--- a/modules/packages/rubygems/metadata.go
+++ b/modules/packages/rubygems/metadata.go
@@ -8,7 +8,6 @@ import (
 	"compress/gzip"
 	"io"
 	"regexp"
-	"strings"
 	"sync"
 
 	"gitea.dev/modules/util"
@@ -25,6 +24,11 @@ var (
 	// ErrInvalidVersion indicates an invalid version in the metadata.gz file
 	ErrInvalidVersion = util.NewInvalidArgumentErrorf("package version is invalid")
 )
+
+// https://github.com/rubygems/rubygems/blob/master/lib/rubygems/specification.rb (VALID_NAME_PATTERN)
+var nameMatcher = sync.OnceValue(func() *regexp.Regexp {
+	return regexp.MustCompile(`\A[a-zA-Z0-9._-]+\z`)
+})
 
 var versionMatcher = sync.OnceValue(func() *regexp.Regexp {
 	return regexp.MustCompile(`\A[0-9]+(?:\.[0-9a-zA-Z]+)*(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?\z`)
@@ -175,7 +179,7 @@ func parseMetadataFile(r io.Reader) (*Package, error) {
 		return nil, err
 	}
 
-	if len(spec.Name) == 0 || strings.Contains(spec.Name, "/") {
+	if !nameMatcher().MatchString(spec.Name) {
 		return nil, ErrInvalidName
 	}
 

--- a/modules/packages/rubygems/metadata_test.go
+++ b/modules/packages/rubygems/metadata_test.go
@@ -36,30 +36,13 @@ version:
 	t.Run("InvalidName", func(t *testing.T) {
 		// a name carrying a newline would be re-emitted verbatim into the
 		// line-based compact index, letting an upload forge extra entries
-		for _, name := range []string{"evil\n1.0.0 |checksum:deadbeef", "a b", "a/b", ""} {
-			content := test.CompressGzip("name: " + quoteYAML(name) + "\nversion:\n  version: 1\n")
+		for _, quotedName := range []string{`"evil\n1.0.0"`, `"a b"`, `"a/b"`, `""`} {
+			content := test.CompressGzip("name: " + quotedName + "\nversion:\n  version: 1\n")
 			rp, err := parseMetadataFile(content)
-			assert.ErrorIs(t, err, ErrInvalidName, "name %q should be rejected", name)
+			assert.ErrorIs(t, err, ErrInvalidName, "name %s should be rejected", quotedName)
 			assert.Nil(t, rp)
 		}
 	})
-}
-
-func quoteYAML(s string) string {
-	out := make([]byte, 0, len(s)+2)
-	out = append(out, '"')
-	for i := 0; i < len(s); i++ {
-		switch s[i] {
-		case '\n':
-			out = append(out, '\\', 'n')
-		case '"', '\\':
-			out = append(out, '\\', s[i])
-		default:
-			out = append(out, s[i])
-		}
-	}
-	out = append(out, '"')
-	return string(out)
 }
 
 func TestParseMetadataFile(t *testing.T) {

--- a/modules/packages/rubygems/metadata_test.go
+++ b/modules/packages/rubygems/metadata_test.go
@@ -32,6 +32,34 @@ version:
 		assert.NoError(t, err)
 		assert.NotNil(t, rp)
 	})
+
+	t.Run("InvalidName", func(t *testing.T) {
+		// a name carrying a newline would be re-emitted verbatim into the
+		// line-based compact index, letting an upload forge extra entries
+		for _, name := range []string{"evil\n1.0.0 |checksum:deadbeef", "a b", "a/b", ""} {
+			content := test.CompressGzip("name: " + quoteYAML(name) + "\nversion:\n  version: 1\n")
+			rp, err := parseMetadataFile(content)
+			assert.ErrorIs(t, err, ErrInvalidName, "name %q should be rejected", name)
+			assert.Nil(t, rp)
+		}
+	})
+}
+
+func quoteYAML(s string) string {
+	out := make([]byte, 0, len(s)+2)
+	out = append(out, '"')
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\n':
+			out = append(out, '\\', 'n')
+		case '"', '\\':
+			out = append(out, '\\', s[i])
+		default:
+			out = append(out, s[i])
+		}
+	}
+	out = append(out, '"')
+	return string(out)
 }
 
 func TestParseMetadataFile(t *testing.T) {


### PR DESCRIPTION
**Insufficient gem name validation in parseMetadataFile**

The registry writes the stored gem name straight into its line-based compact index, both the shared `/versions` listing (one `GEMNAME versions md5` line per gem) and the per-package `info/{name}` file. The parser only rejected an empty name or one containing a slash, so a `.gem` whose gemspec `name` carries a newline was accepted and persisted as the package name, letting an authenticated uploader forge extra lines in the shared index and so spoof additional gem names, versions and checksums to clients. The name is now checked against the upstream RubyGems name pattern in the parser, which is the layer that already validates the version.
