### PR TITLE
fix(git): clean up temporary cat-file batches on repo close

### DIFF
--- a/modules/git/repo_base_nogogit.go
+++ b/modules/git/repo_base_nogogit.go
@@ -23,9 +23,10 @@ type Repository struct {
 
 	tagCache *ObjectCache[*Tag]
 
-	mu                 sync.Mutex
-	catFileBatchCloser CatFileBatchCloser
-	catFileBatchInUse  bool
+	mu                    sync.Mutex
+	catFileBatchCloser    CatFileBatchCloser
+	catFileBatchInUse     bool
+	tempCatFileBatchStore map[CatFileBatchCloser]struct{}
 
 	Ctx             context.Context
 	LastCommitCache *LastCommitCache
@@ -82,7 +83,21 @@ func (repo *Repository) CatFileBatch(ctx context.Context) (_ CatFileBatch, close
 	if err != nil {
 		return nil, nil, err
 	}
-	return tempBatch, tempBatch.Close, nil
+	if repo.tempCatFileBatchStore == nil {
+		repo.tempCatFileBatchStore = make(map[CatFileBatchCloser]struct{})
+	}
+	repo.tempCatFileBatchStore[tempBatch] = struct{}{}
+	return tempBatch, func() {
+		repo.mu.Lock()
+		_, ok := repo.tempCatFileBatchStore[tempBatch]
+		if ok {
+			delete(repo.tempCatFileBatchStore, tempBatch)
+		}
+		repo.mu.Unlock()
+		if ok {
+			tempBatch.Close()
+		}
+	}, nil
 }
 
 func (repo *Repository) Close() error {
@@ -90,13 +105,23 @@ func (repo *Repository) Close() error {
 		return nil
 	}
 	repo.mu.Lock()
-	defer repo.mu.Unlock()
-	if repo.catFileBatchCloser != nil {
-		repo.catFileBatchCloser.Close()
-		repo.catFileBatchCloser = nil
-		repo.catFileBatchInUse = false
+	batchCloser := repo.catFileBatchCloser
+	tempBatchClosers := make([]CatFileBatchCloser, 0, len(repo.tempCatFileBatchStore))
+	for tempBatchCloser := range repo.tempCatFileBatchStore {
+		tempBatchClosers = append(tempBatchClosers, tempBatchCloser)
 	}
+	repo.catFileBatchCloser = nil
+	repo.catFileBatchInUse = false
+	repo.tempCatFileBatchStore = nil
 	repo.LastCommitCache = nil
 	repo.tagCache = nil
+	repo.mu.Unlock()
+
+	if batchCloser != nil {
+		batchCloser.Close()
+	}
+	for _, tempBatchCloser := range tempBatchClosers {
+		tempBatchCloser.Close()
+	}
 	return nil
 }

--- a/modules/git/repo_base_nogogit_test.go
+++ b/modules/git/repo_base_nogogit_test.go
@@ -9,8 +9,32 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func getBatchCommunicators(t *testing.T, batch CatFileBatchCloser) []*catFileBatchCommunicator {
+	t.Helper()
+	switch b := batch.(type) {
+	case *catFileBatchCommand:
+		if b.batch == nil {
+			return nil
+		}
+		return []*catFileBatchCommunicator{b.batch}
+	case *catFileBatchLegacy:
+		ret := make([]*catFileBatchCommunicator, 0, 2)
+		if b.batchCheck != nil {
+			ret = append(ret, b.batchCheck)
+		}
+		if b.batchContent != nil {
+			ret = append(ret, b.batchContent)
+		}
+		return ret
+	default:
+		t.Fatalf("unexpected batch type %T", batch)
+		return nil
+	}
+}
 
 func TestRepoCatFileBatch(t *testing.T) {
 	t.Run("MissingRepoAndClose", func(t *testing.T) {
@@ -20,6 +44,71 @@ func TestRepoCatFileBatch(t *testing.T) {
 		_, _, err = repo.CatFileBatch(t.Context())
 		require.Error(t, err)
 		require.NoError(t, repo.Close()) // shouldn't panic
+	})
+
+	t.Run("CloseCleansUpTemporaryBatch", func(t *testing.T) {
+		repo, err := OpenRepository(t.Context(), filepath.Join(testReposDir, "repo1_bare"))
+		require.NoError(t, err)
+
+		sharedBatch, sharedCancel, err := repo.CatFileBatch(t.Context())
+		require.NoError(t, err)
+		defer sharedCancel()
+
+		tempBatch, tempCancel, err := repo.CatFileBatch(t.Context())
+		require.NoError(t, err)
+
+		_, err = sharedBatch.QueryInfo("e2129701f1a4d54dc44f03c93bca0a2aec7c5449")
+		require.NoError(t, err)
+		_, err = tempBatch.QueryInfo("e2129701f1a4d54dc44f03c93bca0a2aec7c5449")
+		require.NoError(t, err)
+
+		require.Len(t, repo.tempCatFileBatchStore, 1)
+		communicators := getBatchCommunicators(t, tempBatch.(CatFileBatchCloser))
+		require.NotEmpty(t, communicators)
+		for _, c := range communicators {
+			require.NotNil(t, c.closeFunc.Load())
+		}
+
+		require.NoError(t, repo.Close())
+		assert.Nil(t, repo.tempCatFileBatchStore)
+		for _, c := range communicators {
+			assert.Nil(t, c.closeFunc.Load())
+		}
+
+		// The repo cleanup should already have released the temporary batch.
+		tempCancel()
+	})
+
+	t.Run("TemporaryBatchCloseRemovesTracking", func(t *testing.T) {
+		repo, err := OpenRepository(t.Context(), filepath.Join(testReposDir, "repo1_bare"))
+		require.NoError(t, err)
+		defer func() { require.NoError(t, repo.Close()) }()
+
+		sharedBatch, sharedCancel, err := repo.CatFileBatch(t.Context())
+		require.NoError(t, err)
+		defer sharedCancel()
+
+		tempBatch, tempCancel, err := repo.CatFileBatch(t.Context())
+		require.NoError(t, err)
+
+		_, err = sharedBatch.QueryInfo("e2129701f1a4d54dc44f03c93bca0a2aec7c5449")
+		require.NoError(t, err)
+		_, err = tempBatch.QueryInfo("e2129701f1a4d54dc44f03c93bca0a2aec7c5449")
+		require.NoError(t, err)
+
+		require.Len(t, repo.tempCatFileBatchStore, 1)
+		communicators := getBatchCommunicators(t, tempBatch.(CatFileBatchCloser))
+		require.NotEmpty(t, communicators)
+
+		tempCancel()
+		assert.Empty(t, repo.tempCatFileBatchStore)
+		for _, c := range communicators {
+			assert.Nil(t, c.closeFunc.Load())
+		}
+
+		// Closing again should stay a no-op.
+		tempCancel()
+		assert.Empty(t, repo.tempCatFileBatchStore)
 	})
 
 	// TODO: test more methods and concurrency queries


### PR DESCRIPTION
Related to #37370 

Track temporary cat-file batch processes created while the shared batch
is in use, and close them during repository cleanup.

This prevents orphaned `git cat-file --batch-command` subprocesses from
surviving when a caller forgets to close a temporary batch, which could
otherwise accumulate and cause later git process startup failures on
Windows.

Add regression tests to cover both repo-level cleanup and explicit
temporary batch close behavior.