### PR TITLE
fix(lfs): handle nil LFS endpoint instead of panicking

### DIFF
--- a/modules/lfs/endpoint_test.go
+++ b/modules/lfs/endpoint_test.go
@@ -64,6 +64,18 @@ func TestDetermineEndpoint(t *testing.T) {
 			lfsurl:   "git://gitlfs.com/repo",
 			expected: str2url("https://gitlfs.com/repo"),
 		},
+		// case 7: ssh remotes have no LFS endpoint, callers must handle nil (#38016)
+		{
+			cloneurl: "ssh://git@example.com/owner/repo.git",
+			lfsurl:   "",
+			expected: nil,
+		},
+		// case 8: scp-like ssh syntax
+		{
+			cloneurl: "git@example.com:owner/repo.git",
+			lfsurl:   "",
+			expected: nil,
+		},
 	}
 
 	for n, c := range cases {

--- a/services/mirror/mirror_pull.go
+++ b/services/mirror/mirror_pull.go
@@ -173,9 +173,14 @@ func runSync(ctx context.Context, m *repo_model.Mirror) ([]*repo_module.SyncResu
 	if m.LFS && setting.LFS.StartServer {
 		log.Trace("SyncMirrors [repo: %-v]: syncing LFS objects...", m.Repo)
 		endpoint := lfs.DetermineEndpoint(remoteURL.String(), m.LFSEndpoint)
-		lfsClient := lfs.NewClient(endpoint, migrations.NewMigrationHTTPTransport())
-		if err = repo_module.StoreMissingLfsObjectsInRepository(ctx, m.Repo, gitRepo, lfsClient); err != nil {
-			log.Error("SyncMirrors [repo: %-v]: failed to synchronize LFS objects for repository: %v", m.Repo.FullName(), err)
+		if endpoint == nil {
+			// the LFS client only supports http(s) and file endpoints, skip LFS but still sync the git data (#38016)
+			log.Warn("SyncMirrors [repo: %-v]: no LFS endpoint could be determined from remote %q, skipping LFS sync", m.Repo, util.SanitizeCredentialURLs(remoteURL.String()))
+		} else {
+			lfsClient := lfs.NewClient(endpoint, migrations.NewMigrationHTTPTransport())
+			if err = repo_module.StoreMissingLfsObjectsInRepository(ctx, m.Repo, gitRepo, lfsClient); err != nil {
+				log.Error("SyncMirrors [repo: %-v]: failed to synchronize LFS objects for repository: %v", m.Repo.FullName(), err)
+			}
 		}
 	}
 

--- a/services/mirror/mirror_push.go
+++ b/services/mirror/mirror_push.go
@@ -137,17 +137,22 @@ func runPushSync(ctx context.Context, m *repo_model.PushMirror) error {
 		if setting.LFS.StartServer {
 			log.Trace("SyncMirrors [repo: %-v]: syncing LFS objects...", m.Repo)
 
-			gitRepo, err := gitrepo.OpenRepository(ctx, storageRepo)
-			if err != nil {
-				log.Error("OpenRepository: %v", err)
-				return errors.New("Unexpected error")
-			}
-			defer gitRepo.Close()
-
 			endpoint := lfs.DetermineEndpoint(remoteURL.String(), "")
-			lfsClient := lfs.NewClient(endpoint, migrations.NewMigrationHTTPTransport())
-			if err := pushAllLFSObjects(ctx, gitRepo, lfsClient); err != nil {
-				return util.SanitizeErrorCredentialURLs(err)
+			if endpoint == nil {
+				// the LFS client only supports http(s) and file endpoints, skip LFS but still push the git data (#38016)
+				log.Warn("SyncMirrors [repo: %-v]: no LFS endpoint could be determined from remote %q, skipping LFS sync", m.Repo, util.SanitizeCredentialURLs(remoteURL.String()))
+			} else {
+				gitRepo, err := gitrepo.OpenRepository(ctx, storageRepo)
+				if err != nil {
+					log.Error("OpenRepository: %v", err)
+					return errors.New("Unexpected error")
+				}
+				defer gitRepo.Close()
+
+				lfsClient := lfs.NewClient(endpoint, migrations.NewMigrationHTTPTransport())
+				if err := pushAllLFSObjects(ctx, gitRepo, lfsClient); err != nil {
+					return util.SanitizeErrorCredentialURLs(err)
+				}
 			}
 		}
 

--- a/services/repository/migrate.go
+++ b/services/repository/migrate.go
@@ -160,6 +160,10 @@ func MigrateRepositoryGitData(ctx context.Context, u *user_model.User,
 
 		if opts.LFS {
 			endpoint := lfs.DetermineEndpoint(opts.CloneAddr, opts.LFSEndpoint)
+			if endpoint == nil {
+				// unlike mirror sync, migration explicitly requested LFS, so a missing endpoint is an error, not a skip
+				return repo, errors.New("no LFS endpoint could be determined, only http(s), git and local file endpoints are supported")
+			}
 			lfsClient := lfs.NewClient(endpoint, httpTransport)
 			if err = repo_module.StoreMissingLfsObjectsInRepository(ctx, repo, gitRepo, lfsClient); err != nil {
 				log.Error("Failed to store missing LFS objects for repository: %v", err)


### PR DESCRIPTION
Fixes #38016

`lfs.DetermineEndpoint` returns `nil` for remotes it cannot derive an LFS endpoint from (e.g. `ssh://` URLs — they fall through to the `default` branch of `endpointFromURL`), and `lfs.NewClient` dereferences the endpoint unconditionally. Three call sites passed the result through unchecked, so syncing an SSH push mirror with LFS enabled panicked:

```
modules/lfs/endpoint.go:70:endpointFromURL() [E] lfs.endpointFromUrl: unknown url
services/mirror/mirror_push.go:90:SyncPushMirror.1() [E] PANIC whilst syncPushMirror[1] Panic: runtime error: invalid memory address or nil pointer dereference
```

This PR nil-guards all three call sites:

- `services/mirror/mirror_push.go` — log a warning and skip LFS sync, but still push the git data. The LFS client only supports http(s) and file endpoints, so LFS-over-SSH cannot work anyway; failing the whole mirror sync for it left SSH push mirrors broken even though `git push --mirror` itself succeeds. `OpenRepository` moves inside the guarded branch since the handle was only used for LFS.
- `services/mirror/mirror_pull.go` — same guard, consistent with the file's existing log-and-continue handling of LFS errors.
- `services/repository/migrate.go` — return a handled error instead of skipping: LFS migration was explicitly requested, so silently skipping it would drop data.
- `modules/lfs/endpoint_test.go` — pin the nil contract for `ssh://` and scp-style clone URLs.

Remote URLs in the new warnings are passed through `util.SanitizeCredentialURLs` so embedded credentials don't reach the logs.

AI-assisted: investigated and drafted with Claude Code (claude-fable-5); reviewed, tested and signed off by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)