### PR TITLE
Update pull request head reference when possible

### DIFF
--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -555,6 +555,34 @@ func PushToBaseRepo(ctx context.Context, pr *issues_model.PullRequest) (err erro
 	return pushToBaseRepoHelper(ctx, pr, "")
 }
 
+func updatePullHeadRefIfObjectExists(ctx context.Context, pr *issues_model.PullRequest) (bool, error) {
+	if pr.HeadCommitID == "" {
+		return false, nil
+	}
+
+	if err := pr.LoadBaseRepo(ctx); err != nil {
+		return false, err
+	}
+
+	baseGitRepo, err := gitrepo.OpenRepository(ctx, pr.BaseRepo)
+	if err != nil {
+		return false, fmt.Errorf("OpenRepository: %w", err)
+	}
+	defer baseGitRepo.Close()
+
+	// `IsReferenceExist` also accepts full object IDs here, which lets us cheaply
+	// detect whether mergeability checks already imported the head commit.
+	if !baseGitRepo.IsReferenceExist(pr.HeadCommitID) {
+		return false, nil
+	}
+
+	if err := gitrepo.UpdateRef(ctx, pr.BaseRepo, pr.GetGitHeadRefName(), pr.HeadCommitID); err != nil {
+		return false, fmt.Errorf("UpdateRef: %w", err)
+	}
+
+	return true, nil
+}
+
 func pushToBaseRepoHelper(ctx context.Context, pr *issues_model.PullRequest, prefixHeadBranch string) (err error) {
 	log.Trace("PushToBaseRepo[%d]: pushing commits to base repo '%s'", pr.BaseRepoID, pr.GetGitHeadRefName())
 
@@ -576,6 +604,12 @@ func pushToBaseRepoHelper(ctx context.Context, pr *issues_model.PullRequest, pre
 	}
 
 	gitRefName := pr.GetGitHeadRefName()
+	if updated, err := updatePullHeadRefIfObjectExists(ctx, pr); err != nil {
+		log.Info("Unable to update PR head ref directly for %s#%d (%-v:%s), falling back to push: %v", pr.BaseRepo.FullName(), pr.Index, pr.BaseRepo, gitRefName, err)
+	} else if updated {
+		log.Trace("PushToBaseRepo[%d]: updated PR head ref directly in base repo '%s'", pr.BaseRepoID, gitRefName)
+		return nil
+	}
 
 	if err := gitrepo.Push(ctx, pr.HeadRepo, pr.BaseRepo, git.PushOptions{
 		Branch: prefixHeadBranch + pr.HeadBranch + ":" + gitRefName,

--- a/services/pull/pull_test.go
+++ b/services/pull/pull_test.go
@@ -5,6 +5,7 @@
 package pull
 
 import (
+	"context"
 	"testing"
 
 	issues_model "gitea.dev/models/issues"
@@ -14,9 +15,49 @@ import (
 	"gitea.dev/modules/gitrepo"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TODO TestPullRequest_PushToBaseRepo
+
+func TestUpdatePullHeadRefIfObjectExists(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	pr := unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{ID: 1})
+	require.NoError(t, pr.LoadBaseRepo(t.Context()))
+	pr.Index = 987654
+
+	gitRepo, err := gitrepo.OpenRepository(t.Context(), pr.BaseRepo)
+	require.NoError(t, err)
+	defer gitRepo.Close()
+
+	pr.HeadCommitID, err = gitRepo.GetBranchCommitID(pr.BaseBranch)
+	require.NoError(t, err)
+
+	updated, err := updatePullHeadRefIfObjectExists(t.Context(), pr)
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	refCommitID, err := gitRepo.GetRefCommitID(pr.GetGitHeadRefName())
+	require.NoError(t, err)
+	assert.Equal(t, pr.HeadCommitID, refCommitID)
+
+	t.Cleanup(func() {
+		assert.NoError(t, gitrepo.RemoveRef(context.Background(), pr.BaseRepo, pr.GetGitHeadRefName()))
+	})
+}
+
+func TestUpdatePullHeadRefIfObjectExistsMissingObject(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	pr := unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{ID: 1})
+	pr.Index = 987654
+	pr.HeadCommitID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	updated, err := updatePullHeadRefIfObjectExists(t.Context(), pr)
+	require.NoError(t, err)
+	assert.False(t, updated)
+}
 
 func TestPullRequest_CommitMessageTrailersPattern(t *testing.T) {
 	// Not a valid trailer section


### PR DESCRIPTION
Instead of pushing the commit to remote, use update reference to create the pull request reference when possible.