### PR TITLE
fix: restore markdown heading anchor links in comments

### DIFF
--- a/models/renderhelper/repo_comment.go
+++ b/models/renderhelper/repo_comment.go
@@ -69,6 +69,7 @@ func NewRenderContextRepoComment(ctx context.Context, repo *repo_model.Repositor
 		metas["markupAllowShortIssuePattern"] = "true"
 	}
 	metas["footnoteContextId"] = helper.opts.FootnoteContextID
-	rctx = rctx.WithMetas(metas).WithHelper(helper)
+	// comments support markdown headings, so anchor links like "[x](#section)" can jump to them
+	rctx = rctx.WithMetas(metas).WithHelper(helper).WithEnableHeadingIDGeneration(true)
 	return rctx
 }

--- a/models/renderhelper/repo_comment_test.go
+++ b/models/renderhelper/repo_comment_test.go
@@ -72,6 +72,31 @@ func TestRepoComment(t *testing.T) {
 `, rendered)
 	})
 
+	t.Run("HeadingAnchor", func(t *testing.T) {
+		// markdown headings in comments must get an id so anchor links like "[x](#section-name)" can jump to them.
+		// The per-comment context ID keeps the heading id and its link unique across comments on the same page,
+		// so a link resolves to the heading in its own comment instead of the first matching one.
+		input := "## Section Name\n\n[jump](#section-name)\n"
+
+		rctx1 := NewRenderContextRepoComment(t.Context(), repo1, RepoCommentOptions{FootnoteContextID: "11"}).
+			WithMarkupType(markdown.MarkupName)
+		rendered1, err := testRenderString(rctx1, input)
+		assert.NoError(t, err)
+		assert.Equal(t,
+			`<h2 id="user-content-section-name-11">Section Name</h2>
+<p><a href="#user-content-section-name-11" rel="nofollow">jump</a></p>
+`, rendered1)
+
+		rctx2 := NewRenderContextRepoComment(t.Context(), repo1, RepoCommentOptions{FootnoteContextID: "22"}).
+			WithMarkupType(markdown.MarkupName)
+		rendered2, err := testRenderString(rctx2, input)
+		assert.NoError(t, err)
+		assert.Equal(t,
+			`<h2 id="user-content-section-name-22">Section Name</h2>
+<p><a href="#user-content-section-name-22" rel="nofollow">jump</a></p>
+`, rendered2)
+	})
+
 	t.Run("NoRepo", func(t *testing.T) {
 		rctx := NewRenderContextRepoComment(t.Context(), nil).WithMarkupType(markdown.MarkupName)
 		rendered, err := testRenderString(rctx, "any")

--- a/modules/markup/html_node.go
+++ b/modules/markup/html_node.go
@@ -17,6 +17,18 @@ func isAnchorIDUserContent(s string) bool {
 	return strings.HasPrefix(s, "user-content-") || strings.Contains(s, ":user-content-") || isAnchorIDFootnote(s)
 }
 
+// anchorContextSuffix returns a per-render-context suffix (e.g. "-1234" for a comment ID) appended to
+// generated anchor IDs and their "#" links. It keeps anchors unique across multiple user contents on the
+// same page (for example, several issue comments that each contain a heading with the same text), so a
+// link resolves to the heading in its own comment instead of the first matching one on the page.
+// It reuses the same context ID already used to disambiguate footnotes.
+func anchorContextSuffix(ctx *RenderContext) string {
+	if contextID := ctx.RenderOptions.Metas["footnoteContextId"]; contextID != "" {
+		return "-" + contextID
+	}
+	return ""
+}
+
 func isAnchorIDFootnote(s string) bool {
 	return strings.HasPrefix(s, "fnref:user-content-") || strings.HasPrefix(s, "fn:user-content-")
 }
@@ -58,12 +70,13 @@ func processNodeHeadingAndID(ctx *RenderContext, node *html.Node) {
 	// TODO: handle duplicate IDs, need to track existing IDs in the document
 	// Add user-content- to IDs and "#" links if they don't already have them,
 	// and convert the link href to a relative link to the host root
+	contextSuffix := anchorContextSuffix(ctx)
 	attrIDVal := ""
 	for idx, attr := range node.Attr {
 		if attr.Key == "id" {
 			attrIDVal = attr.Val
 			if !isAnchorIDUserContent(attrIDVal) {
-				attrIDVal = "user-content-" + attrIDVal
+				attrIDVal = "user-content-" + attrIDVal + contextSuffix
 				node.Attr[idx].Val = attrIDVal
 			}
 		}
@@ -84,7 +97,7 @@ func processNodeHeadingAndID(ctx *RenderContext, node *html.Node) {
 			// Use the same CleanValue function used by Markdown heading ID generation
 			attrIDVal = string(common.CleanValue([]byte(nodeText)))
 			if attrIDVal != "" {
-				attrIDVal = "user-content-" + attrIDVal
+				attrIDVal = "user-content-" + attrIDVal + contextSuffix
 				node.Attr = append(node.Attr, html.Attribute{Key: "id", Val: attrIDVal})
 			}
 		}
@@ -118,7 +131,8 @@ func processNodeA(ctx *RenderContext, node *html.Node) {
 		if attr.Key == "href" {
 			if anchorID, ok := strings.CutPrefix(attr.Val, "#"); ok {
 				if !isAnchorIDUserContent(attr.Val) {
-					node.Attr[idx].Val = "#user-content-" + anchorID
+					// match the suffix added to the heading ID so the link resolves within its own context (e.g. comment)
+					node.Attr[idx].Val = "#user-content-" + anchorID + anchorContextSuffix(ctx)
 				}
 			} else {
 				node.Attr[idx].Val = ctx.RenderHelper.ResolveLink(attr.Val, LinkTypeDefault)


### PR DESCRIPTION
Fixes #38083

### Problem

Anchor links to markdown headings in issue/PR comments stopped jumping to their target in 1.26:

```md
## Section Name

[jump](#section-name)
```

Clicking the link updates the URL bar but no scroll happens.

### Regression

In 1.25, goldmark was configured with `parser.WithAutoHeadingID()`, so **every** markdown heading got an `id` — including in comments.

#36284 removed `parser.WithAutoHeadingID()` and moved heading-ID generation into the HTML post-processor (`processNodeHeadingAndID`), gated behind `EnableHeadingIDGeneration`. That flag is only enabled for repo files and wikis, so markdown headings in comments no longer get an `id`. The link href is still rewritten to `#user-content-<slug>`, but no matching heading `id` exists, so the browser/`anchors.ts` has nothing to scroll to.

Before (comment render):
```html
<h2>Section Name</h2>                                <!-- no id -->
<p><a href="#user-content-section-name">jump</a></p> <!-- points to nothing -->
```

### Fix

- Enable heading-ID generation for comment rendering.
- Append the per-comment context ID (the same one already used to disambiguate **footnotes**) to both the heading `id` and the anchor `href`.

This also fixes a second issue: with multiple comments on one page, two comments containing the same heading text would otherwise produce duplicate IDs and a link would jump to the *first* match. The context suffix keeps each comment self-contained:

```html
<!-- comment 11 -->  <h2 id="user-content-section-name-11">…  link → #user-content-section-name-11
<!-- comment 22 -->  <h2 id="user-content-section-name-22">…  link → #user-content-section-name-22
```

### Note

Heading anchor IDs in comments/issue bodies now include the context suffix (e.g. `#section-name-0` for the issue body), consistent with how footnote anchors already behave. Old bookmarks to a bare `#section` anchor in a comment won't resolve, but those IDs already changed in the 1.25→1.26 refactor.

_Investigated and implemented with assistance from Claude_