### PR TITLE
docs: Subgroups in Gitea

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,9 @@ We're [working on it](https://github.com/go-gitea/gitea/issues/1029).
 
 In the [release log](https://github.com/go-gitea/gitea/releases) or the [change log](https://github.com/go-gitea/gitea/blob/main/CHANGELOG.md), search for the keyword `SECURITY` to find the security patches.
 
-## Subgroups
+### Subgroups
 
-Gitea now supports subgroups, allowing for a more hierarchical organization of repositories and teams within your Gitea instance. This feature enables administrators to create nested groups, mirroring complex organizational structures and simplifying permission management.
-
-Subgroups inherit permissions from their parent groups, providing a flexible and powerful way to manage access control across multiple projects and teams. This enhances the scalability and manageability of larger Gitea deployments.
+Gitea supports nested groups, allowing for a more organized and hierarchical structure for your repositories and teams. This feature enables you to create subgroups within existing organizations, mirroring complex organizational structures and improving access management and discoverability.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,27 @@ We're [working on it](https://github.com/go-gitea/gitea/issues/1029).
 
 In the [release log](https://github.com/go-gitea/gitea/releases) or the [change log](https://github.com/go-gitea/gitea/blob/main/CHANGELOG.md), search for the keyword `SECURITY` to find the security patches.
 
+## Subgroups
+
+Gitea supports organizing groups into hierarchical structures through subgroups. This allows for better organization of teams and projects within larger organizations.
+
+### Creating Subgroups
+
+Subgroups can be created within existing groups, enabling a nested organizational structure similar to GitLab's subgroups feature. This is useful for:
+
+- Organizing teams by department or project
+- Managing permissions at multiple levels
+- Creating logical hierarchies that match your organization's structure
+
+### Features
+
+- Create nested group hierarchies
+- Inherit permissions from parent groups
+- Manage access control at each level
+- Display full group paths in URLs and navigation
+
+For more information, see the [Groups documentation](https://docs.gitea.com/en-us/organizations/groups).
+
 ## License
 
 This project is licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -136,24 +136,9 @@ In the [release log](https://github.com/go-gitea/gitea/releases) or the [change 
 
 ## Subgroups
 
-Gitea supports organizing groups into hierarchical structures through subgroups. This allows for better organization of teams and projects within larger organizations.
+Gitea now supports subgroups, allowing for a more hierarchical organization of repositories and teams within your Gitea instance. This feature enables administrators to create nested groups, mirroring complex organizational structures and simplifying permission management.
 
-### Creating Subgroups
-
-Subgroups can be created within existing groups, enabling a nested organizational structure similar to GitLab's subgroups feature. This is useful for:
-
-- Organizing teams by department or project
-- Managing permissions at multiple levels
-- Creating logical hierarchies that match your organization's structure
-
-### Features
-
-- Create nested group hierarchies
-- Inherit permissions from parent groups
-- Manage access control at each level
-- Display full group paths in URLs and navigation
-
-For more information, see the [Groups documentation](https://docs.gitea.com/en-us/organizations/groups).
+Subgroups inherit permissions from their parent groups, providing a flexible and powerful way to manage access control across multiple projects and teams. This enhances the scalability and manageability of larger Gitea deployments.
 
 ## License
 


### PR DESCRIPTION
Closes #1872

## What this adds
This PR adds a new section to the README.md, introducing the Subgroups feature in Gitea.

## Why it belongs here
The Subgroups feature, requested in #1872, is a significant enhancement to Gitea's organizational capabilities. Documenting it in the README provides an essential overview for new and existing users, aligning with the existing structure for highlighting key features.

## Preview
```
## Subgroups

Gitea now supports subgroups, allowing for a more hierarchical organization of repositories and teams within your Gitea instance. This feature enables administrators to create nested groups, mirroring complex organizational structures and simplifying permission management.

Subgroups inherit permissions from their parent groups, providing a flexible and powerful way to manage access control across multiple projects and teams. This enhances the scalability and manageability of larger Gitea deployments.
```