### PR TITLE
feat(metrics): Add histogram of mirror sync steps by labels user/repo/step

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -2707,6 +2707,8 @@ LEVEL = Info
 ;ENABLED_ISSUE_BY_LABEL = false
 ;; Enable issue by repository metrics; default is false
 ;ENABLED_ISSUE_BY_REPOSITORY = false
+;; Enable mirror sync duration metrics; default is true
+;ENABLED_MIRROR_SYNC_DURATION = true
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -2750,6 +2750,8 @@ LEVEL = Info
 ;ENABLED_ISSUE_BY_LABEL = false
 ;; Enable issue by repository metrics; default is false
 ;ENABLED_ISSUE_BY_REPOSITORY = false
+;; Enable mirror sync duration metrics (high-cardinality: owner+repo+step); default is false
+;ENABLED_MIRROR_SYNC_DURATION = false
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -2734,6 +2734,8 @@ LEVEL = Info
 ;ENABLED_ISSUE_BY_LABEL = false
 ;; Enable issue by repository metrics; default is false
 ;ENABLED_ISSUE_BY_REPOSITORY = false
+;; Enable mirror sync duration metrics (high-cardinality: owner+repo+step); default is false
+;ENABLED_MIRROR_SYNC_DURATION = false
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pquerna/otp v1.5.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/quasoft/websspi v1.1.2
 	github.com/redis/go-redis/v9 v9.20.0
 	github.com/robfig/cron/v3 v3.0.1
@@ -240,7 +241,6 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.68.1 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pquerna/otp v1.5.0
 	github.com/prometheus/client_golang v1.24.1
+	github.com/prometheus/client_model v0.6.2
 	github.com/quasoft/websspi v1.1.2
 	github.com/redis/go-redis/v9 v9.22.0
 	github.com/rhysd/actionlint v1.7.12
@@ -235,7 +236,6 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/go.mod
+++ b/go.mod
@@ -87,6 +87,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pquerna/otp v1.5.0
 	github.com/prometheus/client_golang v1.24.1
+	github.com/prometheus/client_model v0.6.2
 	github.com/quasoft/websspi v1.1.2
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/rhysd/actionlint v1.7.12
@@ -241,7 +242,6 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/modules/setting/metrics.go
+++ b/modules/setting/metrics.go
@@ -5,15 +5,17 @@ package setting
 
 // Metrics settings
 var Metrics = struct {
-	Enabled                  bool
-	Token                    string
-	EnabledIssueByLabel      bool
-	EnabledIssueByRepository bool
+	Enabled                   bool
+	Token                     string
+	EnabledIssueByLabel       bool
+	EnabledIssueByRepository  bool
+	EnabledMirrorSyncDuration bool
 }{
-	Enabled:                  false,
-	Token:                    "",
-	EnabledIssueByLabel:      false,
-	EnabledIssueByRepository: false,
+	Enabled:                   false,
+	Token:                     "",
+	EnabledIssueByLabel:       false,
+	EnabledIssueByRepository:  false,
+	EnabledMirrorSyncDuration: false,
 }
 
 func loadMetricsFrom(rootCfg ConfigProvider) {

--- a/modules/setting/metrics.go
+++ b/modules/setting/metrics.go
@@ -5,15 +5,17 @@ package setting
 
 // Metrics settings
 var Metrics = struct {
-	Enabled                  bool
-	Token                    string
-	EnabledIssueByLabel      bool
-	EnabledIssueByRepository bool
+	Enabled                   bool
+	Token                     string
+	EnabledIssueByLabel       bool
+	EnabledIssueByRepository  bool
+	EnabledMirrorSyncDuration bool
 }{
-	Enabled:                  false,
-	Token:                    "",
-	EnabledIssueByLabel:      false,
-	EnabledIssueByRepository: false,
+	Enabled:                   false,
+	Token:                     "",
+	EnabledIssueByLabel:       false,
+	EnabledIssueByRepository:  false,
+	EnabledMirrorSyncDuration: true,
 }
 
 func loadMetricsFrom(rootCfg ConfigProvider) {

--- a/services/mirror/mirror_pull.go
+++ b/services/mirror/mirror_pull.go
@@ -107,6 +107,11 @@ func checkRecoverableSyncError(stderrMessage string) bool {
 
 // runSync returns true if sync finished without error.
 func runSync(ctx context.Context, m *repo_model.Mirror) ([]*repo_module.SyncResult, bool) {
+	totalStart := time.Now()
+	defer func() {
+		recordMirrorSyncStep(m.Repo.OwnerName, m.Repo.Name, syncSteps.Total, totalStart)
+	}()
+
 	log.Trace("SyncMirrors [repo: %-v]: running git remote update...", m.Repo)
 
 	remoteURL, remoteErr := gitrepo.GitRemoteGetURL(ctx, m.Repo, m.GetRemoteName())
@@ -127,6 +132,7 @@ func runSync(ctx context.Context, m *repo_model.Mirror) ([]*repo_module.SyncResu
 	}
 
 	var err error
+	fetchStart := time.Now()
 	fetchStdout, fetchStderr, err := gitrepo.RunCmdString(ctx, m.Repo, cmdFetch())
 	if err != nil {
 		// sanitize the output, since it may contain the remote address, which may contain a password
@@ -160,9 +166,13 @@ func runSync(ctx context.Context, m *repo_model.Mirror) ([]*repo_module.SyncResu
 			return nil, false
 		}
 	}
+	recordMirrorSyncStep(m.Repo.OwnerName, m.Repo.Name, syncSteps.Fetch, fetchStart)
+
+	commitGraphStart := time.Now()
 	if err := gitrepo.WriteCommitGraph(ctx, m.Repo); err != nil {
 		log.Error("SyncMirrors [repo: %-v]: %v", m.Repo, err)
 	}
+	recordMirrorSyncStep(m.Repo.OwnerName, m.Repo.Name, syncSteps.CommitGraph, commitGraphStart)
 
 	gitRepo, err := gitrepo.OpenRepository(ctx, m.Repo)
 	if err != nil {
@@ -170,6 +180,7 @@ func runSync(ctx context.Context, m *repo_model.Mirror) ([]*repo_module.SyncResu
 		return nil, false
 	}
 
+	lfsStart := time.Now()
 	if m.LFS && setting.LFS.StartServer {
 		log.Trace("SyncMirrors [repo: %-v]: syncing LFS objects...", m.Repo)
 		lfsClient, err := lfs.NewClientFromEndpoint(remoteURL.String(), m.LFSEndpoint, migrations.NewMigrationHTTPTransport())
@@ -179,31 +190,39 @@ func runSync(ctx context.Context, m *repo_model.Mirror) ([]*repo_module.SyncResu
 			log.Error("SyncMirrors [repo: %-v]: failed to synchronize LFS objects for repository: %v", m.Repo.FullName(), err)
 		}
 	}
+	recordMirrorSyncStep(m.Repo.OwnerName, m.Repo.Name, syncSteps.LFS, lfsStart)
 
 	log.Trace("SyncMirrors [repo: %-v]: syncing branches...", m.Repo)
+	branchesStart := time.Now()
 	_, results, err := repo_module.SyncRepoBranchesWithRepo(ctx, m.Repo, gitRepo, 0)
 	if err != nil {
 		log.Error("SyncMirrors [repo: %-v]: failed to synchronize branches: %v", m.Repo, err)
 	}
+	recordMirrorSyncStep(m.Repo.OwnerName, m.Repo.Name, syncSteps.Branches, branchesStart)
 
 	log.Trace("SyncMirrors [repo: %-v]: syncing releases with tags...", m.Repo)
+	releasesStart := time.Now()
 	tagResults, err := repo_module.SyncReleasesWithTags(ctx, m.Repo, gitRepo)
 	if err != nil {
 		log.Error("SyncMirrors [repo: %-v]: failed to synchronize tags to releases: %v", m.Repo, err)
 	}
 	results = append(results, tagResults...)
 	gitRepo.Close()
+	recordMirrorSyncStep(m.Repo.OwnerName, m.Repo.Name, syncSteps.Releases, releasesStart)
 
 	log.Trace("SyncMirrors [repo: %-v]: updating size of repository", m.Repo)
+	repoSizeStart := time.Now()
 	if err := repo_module.UpdateRepoSize(ctx, m.Repo); err != nil {
 		log.Error("SyncMirrors [repo: %-v]: failed to update size for mirror repository: %v", m.Repo.FullName(), err)
 	}
+	recordMirrorSyncStep(m.Repo.OwnerName, m.Repo.Name, syncSteps.RepoSize, repoSizeStart)
 
 	cmdRemoteUpdatePrune := func() *gitcmd.Command {
 		return gitcmd.NewCommand("remote", "update", "--prune").
 			AddDynamicArguments(m.GetRemoteName()).WithTimeout(timeout).WithEnv(envs)
 	}
 
+	wikiStart := time.Now()
 	if repo_service.HasWiki(ctx, m.Repo) {
 		log.Trace("SyncMirrors [repo: %-v Wiki]: running git remote update...", m.Repo)
 		// the result of "git remote update" is in stderr
@@ -246,6 +265,7 @@ func runSync(ctx context.Context, m *repo_model.Mirror) ([]*repo_module.SyncResu
 		}
 		log.Trace("SyncMirrors [repo: %-v Wiki]: git remote update complete", m.Repo)
 	}
+	recordMirrorSyncStep(m.Repo.OwnerName, m.Repo.Name, syncSteps.Wiki, wikiStart)
 
 	log.Trace("SyncMirrors [repo: %-v]: invalidating mirror branch caches...", m.Repo)
 	branches, _, err := gitrepo.GetBranchesByPath(ctx, m.Repo, 0, 0)
@@ -294,6 +314,11 @@ func SyncPullMirror(ctx context.Context, repoID int64) bool {
 
 	ctx, _, finished := process.GetManager().AddContext(ctx, fmt.Sprintf("Syncing Mirror %s/%s", m.Repo.OwnerName, m.Repo.Name))
 	defer finished()
+
+	syncSuccess := false
+	defer func() {
+		recordMirrorSyncStatus(m.Repo.OwnerName, m.Repo.Name, syncSuccess)
+	}()
 
 	log.Trace("SyncMirrors [repo: %-v]: Running Sync", m.Repo)
 	results, ok := runSync(ctx, m)
@@ -410,6 +435,7 @@ func SyncPullMirror(ctx context.Context, repoID int64) bool {
 
 	log.Trace("SyncMirrors [repo: %-v]: Successfully updated", m.Repo)
 
+	syncSuccess = true
 	return true
 }
 

--- a/services/mirror/mirror_pull.go
+++ b/services/mirror/mirror_pull.go
@@ -106,6 +106,11 @@ func checkRecoverableSyncError(stderrMessage string) bool {
 
 // runSync returns true if sync finished without error.
 func runSync(ctx context.Context, m *repo_model.Mirror) ([]*repo_module.SyncResult, bool) {
+	totalStart := time.Now()
+	defer func() {
+		recordMirrorSyncStep(m.Repo.OwnerName, m.Repo.Name, syncSteps.Total, totalStart)
+	}()
+
 	log.Trace("SyncMirrors [repo: %-v]: running git remote update...", m.Repo)
 
 	remoteURL, remoteErr := git.ParseRemoteAddressURL(ctx, m.Repo, m.GetRemoteName())
@@ -136,6 +141,7 @@ func runSync(ctx context.Context, m *repo_model.Mirror) ([]*repo_module.SyncResu
 	}
 
 	var err error
+	fetchStart := time.Now()
 	fetchStdout, fetchStderr, err := cmdFetch().WithRepo(m.Repo).RunStdString(ctx)
 	if err != nil {
 		// sanitize the output, since it may contain the remote address, which may contain a password
@@ -169,9 +175,13 @@ func runSync(ctx context.Context, m *repo_model.Mirror) ([]*repo_module.SyncResu
 			return nil, false
 		}
 	}
+	recordMirrorSyncStep(m.Repo.OwnerName, m.Repo.Name, syncSteps.Fetch, fetchStart)
+
+	commitGraphStart := time.Now()
 	if err := git.WriteCommitGraph(ctx, m.Repo); err != nil {
 		log.Error("SyncMirrors [repo: %-v]: %v", m.Repo, err)
 	}
+	recordMirrorSyncStep(m.Repo.OwnerName, m.Repo.Name, syncSteps.CommitGraph, commitGraphStart)
 
 	gitRepo, err := git.OpenRepository(ctx, m.Repo)
 	if err != nil {
@@ -179,6 +189,7 @@ func runSync(ctx context.Context, m *repo_model.Mirror) ([]*repo_module.SyncResu
 		return nil, false
 	}
 
+	lfsStart := time.Now()
 	if m.LFS && setting.LFS.StartServer {
 		log.Trace("SyncMirrors [repo: %-v]: syncing LFS objects...", m.Repo)
 		lfsClient, err := lfs.NewClientFromEndpoint(remoteURL.String(), m.LFSEndpoint, migrations.NewMigrationHTTPTransport())
@@ -188,25 +199,32 @@ func runSync(ctx context.Context, m *repo_model.Mirror) ([]*repo_module.SyncResu
 			log.Error("SyncMirrors [repo: %-v]: failed to synchronize LFS objects for repository: %v", m.Repo.FullName(), err)
 		}
 	}
+	recordMirrorSyncStep(m.Repo.OwnerName, m.Repo.Name, syncSteps.LFS, lfsStart)
 
 	log.Trace("SyncMirrors [repo: %-v]: syncing branches...", m.Repo)
+	branchesStart := time.Now()
 	_, results, err := repo_module.SyncRepoBranchesWithRepo(ctx, m.Repo, gitRepo, 0)
 	if err != nil {
 		log.Error("SyncMirrors [repo: %-v]: failed to synchronize branches: %v", m.Repo, err)
 	}
+	recordMirrorSyncStep(m.Repo.OwnerName, m.Repo.Name, syncSteps.Branches, branchesStart)
 
 	log.Trace("SyncMirrors [repo: %-v]: syncing releases with tags...", m.Repo)
+	releasesStart := time.Now()
 	tagResults, err := repo_module.SyncReleasesWithTags(ctx, m.Repo, gitRepo)
 	if err != nil {
 		log.Error("SyncMirrors [repo: %-v]: failed to synchronize tags to releases: %v", m.Repo, err)
 	}
 	results = append(results, tagResults...)
 	gitRepo.Close()
+	recordMirrorSyncStep(m.Repo.OwnerName, m.Repo.Name, syncSteps.Releases, releasesStart)
 
 	log.Trace("SyncMirrors [repo: %-v]: updating size of repository", m.Repo)
+	repoSizeStart := time.Now()
 	if err := repo_module.UpdateRepoSize(ctx, m.Repo); err != nil {
 		log.Error("SyncMirrors [repo: %-v]: failed to update size for mirror repository: %v", m.Repo.FullName(), err)
 	}
+	recordMirrorSyncStep(m.Repo.OwnerName, m.Repo.Name, syncSteps.RepoSize, repoSizeStart)
 
 	cmdRemoteUpdatePrune := func() *gitcmd.Command {
 		cmd := gitcmd.NewCommand("remote", "update", "--prune").AddDynamicArguments(m.GetRemoteName()).WithTimeout(timeout).WithEnv(envs)
@@ -214,6 +232,7 @@ func runSync(ctx context.Context, m *repo_model.Mirror) ([]*repo_module.SyncResu
 		return cmd
 	}
 
+	wikiStart := time.Now()
 	if repo_service.HasWiki(ctx, m.Repo) {
 		log.Trace("SyncMirrors [repo: %-v Wiki]: running git remote update...", m.Repo)
 		// the result of "git remote update" is in stderr
@@ -256,6 +275,7 @@ func runSync(ctx context.Context, m *repo_model.Mirror) ([]*repo_module.SyncResu
 		}
 		log.Trace("SyncMirrors [repo: %-v Wiki]: git remote update complete", m.Repo)
 	}
+	recordMirrorSyncStep(m.Repo.OwnerName, m.Repo.Name, syncSteps.Wiki, wikiStart)
 
 	log.Trace("SyncMirrors [repo: %-v]: invalidating mirror branch caches...", m.Repo)
 	branches, _, err := git.GetBranchesByPath(ctx, m.Repo, 0, 0)
@@ -304,6 +324,11 @@ func SyncPullMirror(ctx context.Context, repoID int64) bool {
 
 	ctx, _, finished := process.GetManager().AddContext(ctx, fmt.Sprintf("Syncing Mirror %s/%s", m.Repo.OwnerName, m.Repo.Name))
 	defer finished()
+
+	syncSuccess := false
+	defer func() {
+		recordMirrorSyncStatus(m.Repo.OwnerName, m.Repo.Name, syncSuccess)
+	}()
 
 	log.Trace("SyncMirrors [repo: %-v]: Running Sync", m.Repo)
 	results, ok := runSync(ctx, m)
@@ -420,6 +445,7 @@ func SyncPullMirror(ctx context.Context, repoID int64) bool {
 
 	log.Trace("SyncMirrors [repo: %-v]: Successfully updated", m.Repo)
 
+	syncSuccess = true
 	return true
 }
 

--- a/services/mirror/mirror_pull_metrics.go
+++ b/services/mirror/mirror_pull_metrics.go
@@ -1,0 +1,78 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package mirror
+
+import (
+	"time"
+
+	"gitea.dev/modules/log"
+	"gitea.dev/modules/setting"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type syncStep struct{ label string }
+
+var syncSteps = struct {
+	Fetch, CommitGraph, LFS, Branches, Releases, RepoSize, Wiki, Total syncStep
+}{
+	Fetch:       syncStep{"fetch"},
+	CommitGraph: syncStep{"commit_graph"},
+	LFS:         syncStep{"lfs"},
+	Branches:    syncStep{"branches"},
+	Releases:    syncStep{"releases"},
+	RepoSize:    syncStep{"repo_size"},
+	Wiki:        syncStep{"wiki"},
+	Total:       syncStep{"total"},
+}
+
+var mirrorSyncDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: "gitea",
+	Subsystem: "mirror",
+	Name:      "sync_duration_ms",
+	Help:      "Duration in milliseconds of mirror pull sync steps.",
+	Buckets:   []float64{5, 1000, 5000, 10000, 30000, 60000, 300000},
+}, []string{"owner", "repo", "step"})
+
+var mirrorSyncStatus = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: "gitea",
+	Subsystem: "mirror",
+	Name:      "sync_status",
+	Help:      "Count of mirror pull sync completions, labeled by success/failure.",
+	Buckets:   []float64{0, 1},
+}, []string{"owner", "repo", "success"})
+
+func init() {
+	prometheus.MustRegister(mirrorSyncDuration)
+	prometheus.MustRegister(mirrorSyncStatus)
+}
+
+func recordMirrorSyncStep(owner, repo string, step syncStep, start time.Time) {
+	if !setting.Metrics.Enabled || !setting.Metrics.EnabledMirrorSyncDuration {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("panic in recordMirrorSyncStep: %v", r)
+		}
+	}()
+	elapsed := float64(time.Since(start).Milliseconds())
+	mirrorSyncDuration.WithLabelValues(owner, repo, step.label).Observe(elapsed)
+}
+
+func recordMirrorSyncStatus(owner, repo string, success bool) {
+	if !setting.Metrics.Enabled || !setting.Metrics.EnabledMirrorSyncDuration {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("panic in recordMirrorSyncStatus: %v", r)
+		}
+	}()
+	s := "false"
+	if success {
+		s = "true"
+	}
+	mirrorSyncStatus.WithLabelValues(owner, repo, s).Observe(1)
+}

--- a/services/mirror/mirror_pull_metrics.go
+++ b/services/mirror/mirror_pull_metrics.go
@@ -1,0 +1,97 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package mirror
+
+import (
+	"time"
+
+	"gitea.dev/modules/log"
+	"gitea.dev/modules/setting"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type syncStep struct{ label string }
+
+var syncSteps = struct {
+	Fetch, CommitGraph, LFS, Branches, Releases, RepoSize, Wiki, Total syncStep
+}{
+	Fetch:       syncStep{"fetch"},
+	CommitGraph: syncStep{"commit_graph"},
+	LFS:         syncStep{"lfs"},
+	Branches:    syncStep{"branches"},
+	Releases:    syncStep{"releases"},
+	RepoSize:    syncStep{"repo_size"},
+	Wiki:        syncStep{"wiki"},
+	Total:       syncStep{"total"},
+}
+
+var mirrorSyncDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: "gitea",
+	Subsystem: "mirror",
+	Name:      "sync_duration_ms",
+	Help:      "Duration in milliseconds of mirror pull sync steps.",
+	Buckets:   []float64{5, 1000, 5000, 10000, 30000, 60000, 300000},
+}, []string{"owner", "repo", "step"})
+
+var mirrorSyncStatus = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: "gitea",
+	Subsystem: "mirror",
+	Name:      "sync_total",
+	Help:      "Count of mirror pull sync completions, labeled by success/failure.",
+}, []string{"owner", "repo", "success"})
+
+func init() {
+	prometheus.MustRegister(mirrorSyncDuration)
+	prometheus.MustRegister(mirrorSyncStatus)
+}
+
+type mirrorMetricsConfig struct {
+	Enabled                   bool
+	EnabledMirrorSyncDuration bool
+}
+
+func defaultMetricsConfig() mirrorMetricsConfig {
+	return mirrorMetricsConfig{
+		Enabled:                   setting.Metrics.Enabled,
+		EnabledMirrorSyncDuration: setting.Metrics.EnabledMirrorSyncDuration,
+	}
+}
+
+func recordMirrorSyncStep(owner, repo string, step syncStep, start time.Time) {
+	recordMirrorSyncStepWith(defaultMetricsConfig(), owner, repo, step, start)
+}
+
+func recordMirrorSyncStepWith(cfg mirrorMetricsConfig, owner, repo string, step syncStep, start time.Time) {
+	if !cfg.Enabled || !cfg.EnabledMirrorSyncDuration {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("panic in recordMirrorSyncStep: %v", r)
+		}
+	}()
+	elapsed := float64(time.Since(start).Milliseconds())
+	mirrorSyncDuration.WithLabelValues(owner, repo, step.label).Observe(elapsed)
+}
+
+func recordMirrorSyncStatus(owner, repo string, success bool) {
+	recordMirrorSyncStatusWith(defaultMetricsConfig(), owner, repo, success)
+}
+
+func recordMirrorSyncStatusWith(cfg mirrorMetricsConfig, owner, repo string, success bool) {
+	if !cfg.Enabled || !cfg.EnabledMirrorSyncDuration {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("panic in recordMirrorSyncStatus: %v", r)
+		}
+	}()
+	s := "false"
+	if success {
+		s = "true"
+	}
+	mirrorSyncStatus.WithLabelValues(owner, repo, s).Inc()
+}

--- a/services/mirror/mirror_pull_metrics_test.go
+++ b/services/mirror/mirror_pull_metrics_test.go
@@ -1,0 +1,171 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package mirror
+
+import (
+	"testing"
+	"time"
+
+	"gitea.dev/modules/setting"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+)
+
+func getHistogramSampleCount(h *dto.Histogram) uint64 {
+	if h == nil {
+		return 0
+	}
+	return h.GetSampleCount()
+}
+
+func getHistogramSum(h *dto.Histogram) float64 {
+	if h == nil {
+		return 0
+	}
+	return h.GetSampleSum()
+}
+
+func collectHistogram(owner, repo, step string) *dto.Histogram {
+	observer := mirrorSyncDuration.WithLabelValues(owner, repo, step)
+	m := &dto.Metric{}
+	if metric, ok := observer.(interface{ Write(*dto.Metric) error }); ok {
+		_ = metric.Write(m)
+	}
+	return m.GetHistogram()
+}
+
+func collectStatusHistogram(owner, repo, success string) *dto.Histogram {
+	observer := mirrorSyncStatus.WithLabelValues(owner, repo, success)
+	m := &dto.Metric{}
+	if metric, ok := observer.(interface{ Write(*dto.Metric) error }); ok {
+		_ = metric.Write(m)
+	}
+	return m.GetHistogram()
+}
+
+func TestRecordMirrorSyncStep_DisabledMetrics(t *testing.T) {
+	setting.Metrics.Enabled = false
+	setting.Metrics.EnabledMirrorSyncDuration = true
+
+	before := collectHistogram("disabled-org", "disabled-repo", syncSteps.Fetch.label)
+	beforeCount := getHistogramSampleCount(before)
+
+	recordMirrorSyncStep("disabled-org", "disabled-repo", syncSteps.Fetch, time.Now().Add(-100*time.Millisecond))
+
+	after := collectHistogram("disabled-org", "disabled-repo", syncSteps.Fetch.label)
+	afterCount := getHistogramSampleCount(after)
+
+	assert.Equal(t, beforeCount, afterCount, "metrics should not be recorded when Metrics.Enabled is false")
+}
+
+func TestRecordMirrorSyncStep_DisabledMirrorSyncDuration(t *testing.T) {
+	setting.Metrics.Enabled = true
+	setting.Metrics.EnabledMirrorSyncDuration = false
+
+	before := collectHistogram("disabled-mirror-org", "disabled-mirror-repo", syncSteps.Fetch.label)
+	beforeCount := getHistogramSampleCount(before)
+
+	recordMirrorSyncStep("disabled-mirror-org", "disabled-mirror-repo", syncSteps.Fetch, time.Now().Add(-50*time.Millisecond))
+
+	after := collectHistogram("disabled-mirror-org", "disabled-mirror-repo", syncSteps.Fetch.label)
+	afterCount := getHistogramSampleCount(after)
+
+	assert.Equal(t, beforeCount, afterCount, "metrics should not be recorded when EnabledMirrorSyncDuration is false")
+}
+
+func TestRecordMirrorSyncStep_Enabled(t *testing.T) {
+	setting.Metrics.Enabled = true
+	setting.Metrics.EnabledMirrorSyncDuration = true
+
+	start := time.Now().Add(-200 * time.Millisecond)
+	recordMirrorSyncStep("my-org", "my-repo", syncSteps.Fetch, start)
+
+	// Prometheus metric name: gitea_mirror_sync_duration_ms
+	// With labels: {owner="my-org", repo="my-repo", step="fetch"}
+	h := collectHistogram("my-org", "my-repo", syncSteps.Fetch.label)
+	assert.GreaterOrEqual(t, getHistogramSampleCount(h), uint64(1))
+	assert.Greater(t, getHistogramSum(h), float64(0))
+}
+
+func TestRecordMirrorSyncStep_AllSteps(t *testing.T) {
+	setting.Metrics.Enabled = true
+	setting.Metrics.EnabledMirrorSyncDuration = true
+
+	steps := []syncStep{
+		syncSteps.Fetch,
+		syncSteps.CommitGraph,
+		syncSteps.LFS,
+		syncSteps.Branches,
+		syncSteps.Releases,
+		syncSteps.RepoSize,
+		syncSteps.Wiki,
+		syncSteps.Total,
+	}
+
+	for _, step := range steps {
+		recordMirrorSyncStep("step-org", "step-repo", step, time.Now().Add(-10*time.Millisecond))
+	}
+
+	// Verify all steps recorded: gitea_mirror_sync_duration_ms_bucket, gitea_mirror_sync_duration_ms_sum, gitea_mirror_sync_duration_ms_count
+	for _, step := range steps {
+		h := collectHistogram("step-org", "step-repo", step.label)
+		assert.GreaterOrEqual(t, getHistogramSampleCount(h), uint64(1), "step %q should have at least one observation", step.label)
+	}
+}
+
+func TestRecordMirrorSyncStatus_Success(t *testing.T) {
+	setting.Metrics.Enabled = true
+	setting.Metrics.EnabledMirrorSyncDuration = true
+
+	recordMirrorSyncStatus("status-org", "status-repo", true)
+
+	// Prometheus metric name: gitea_mirror_sync_status
+	// With labels: {owner="status-org", repo="status-repo", success="true"}
+	h := collectStatusHistogram("status-org", "status-repo", "true")
+	assert.GreaterOrEqual(t, getHistogramSampleCount(h), uint64(1))
+}
+
+func TestRecordMirrorSyncStatus_Failure(t *testing.T) {
+	setting.Metrics.Enabled = true
+	setting.Metrics.EnabledMirrorSyncDuration = true
+
+	recordMirrorSyncStatus("fail-org", "fail-repo", false)
+
+	// Prometheus metric name: gitea_mirror_sync_status
+	// With labels: {owner="fail-org", repo="fail-repo", success="false"}
+	h := collectStatusHistogram("fail-org", "fail-repo", "false")
+	assert.GreaterOrEqual(t, getHistogramSampleCount(h), uint64(1))
+}
+
+func TestRecordMirrorSyncStatus_BothStates(t *testing.T) {
+	setting.Metrics.Enabled = true
+	setting.Metrics.EnabledMirrorSyncDuration = true
+
+	recordMirrorSyncStatus("both-org", "both-repo", true)
+	recordMirrorSyncStatus("both-org", "both-repo", false)
+
+	// gitea_mirror_sync_status_count{owner="both-org", repo="both-repo", success="true"} == 1
+	hTrue := collectStatusHistogram("both-org", "both-repo", "true")
+	assert.GreaterOrEqual(t, getHistogramSampleCount(hTrue), uint64(1))
+
+	// gitea_mirror_sync_status_count{owner="both-org", repo="both-repo", success="false"} == 1
+	hFalse := collectStatusHistogram("both-org", "both-repo", "false")
+	assert.GreaterOrEqual(t, getHistogramSampleCount(hFalse), uint64(1))
+}
+
+func TestRecordMirrorSyncStatus_DisabledMetrics(t *testing.T) {
+	setting.Metrics.Enabled = false
+	setting.Metrics.EnabledMirrorSyncDuration = true
+
+	before := collectStatusHistogram("status-disabled-org", "status-disabled-repo", "true")
+	beforeCount := getHistogramSampleCount(before)
+
+	recordMirrorSyncStatus("status-disabled-org", "status-disabled-repo", true)
+
+	after := collectStatusHistogram("status-disabled-org", "status-disabled-repo", "true")
+	afterCount := getHistogramSampleCount(after)
+
+	assert.Equal(t, beforeCount, afterCount, "status metrics should not be recorded when Metrics.Enabled is false")
+}

--- a/services/mirror/mirror_pull_metrics_test.go
+++ b/services/mirror/mirror_pull_metrics_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package mirror
+
+import (
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+)
+
+func getHistogramSampleCount(h *dto.Histogram) uint64 {
+	if h == nil {
+		return 0
+	}
+	return h.GetSampleCount()
+}
+
+func getHistogramSum(h *dto.Histogram) float64 {
+	if h == nil {
+		return 0
+	}
+	return h.GetSampleSum()
+}
+
+func collectHistogram(owner, repo, step string) *dto.Histogram {
+	observer := mirrorSyncDuration.WithLabelValues(owner, repo, step)
+	m := &dto.Metric{}
+	if metric, ok := observer.(interface{ Write(*dto.Metric) error }); ok {
+		_ = metric.Write(m)
+	}
+	return m.GetHistogram()
+}
+
+func collectCounter(owner, repo, success string) float64 {
+	counter := mirrorSyncStatus.WithLabelValues(owner, repo, success)
+	m := &dto.Metric{}
+	if metric, ok := counter.(interface{ Write(*dto.Metric) error }); ok {
+		_ = metric.Write(m)
+	}
+	return m.GetCounter().GetValue()
+}
+
+func TestRecordMirrorSyncStep_DisabledMetrics(t *testing.T) {
+	cfg := mirrorMetricsConfig{Enabled: false, EnabledMirrorSyncDuration: true}
+
+	before := collectHistogram("disabled-org", "disabled-repo", syncSteps.Fetch.label)
+	beforeCount := getHistogramSampleCount(before)
+
+	recordMirrorSyncStepWith(cfg, "disabled-org", "disabled-repo", syncSteps.Fetch, time.Now().Add(-100*time.Millisecond))
+
+	after := collectHistogram("disabled-org", "disabled-repo", syncSteps.Fetch.label)
+	afterCount := getHistogramSampleCount(after)
+
+	assert.Equal(t, beforeCount, afterCount, "metrics should not be recorded when Enabled is false")
+}
+
+func TestRecordMirrorSyncStep_DisabledMirrorSyncDuration(t *testing.T) {
+	cfg := mirrorMetricsConfig{Enabled: true, EnabledMirrorSyncDuration: false}
+
+	before := collectHistogram("disabled-mirror-org", "disabled-mirror-repo", syncSteps.Fetch.label)
+	beforeCount := getHistogramSampleCount(before)
+
+	recordMirrorSyncStepWith(cfg, "disabled-mirror-org", "disabled-mirror-repo", syncSteps.Fetch, time.Now().Add(-50*time.Millisecond))
+
+	after := collectHistogram("disabled-mirror-org", "disabled-mirror-repo", syncSteps.Fetch.label)
+	afterCount := getHistogramSampleCount(after)
+
+	assert.Equal(t, beforeCount, afterCount, "metrics should not be recorded when EnabledMirrorSyncDuration is false")
+}
+
+func TestRecordMirrorSyncStep_Enabled(t *testing.T) {
+	cfg := mirrorMetricsConfig{Enabled: true, EnabledMirrorSyncDuration: true}
+
+	start := time.Now().Add(-200 * time.Millisecond)
+	recordMirrorSyncStepWith(cfg, "my-org", "my-repo", syncSteps.Fetch, start)
+
+	h := collectHistogram("my-org", "my-repo", syncSteps.Fetch.label)
+	assert.GreaterOrEqual(t, getHistogramSampleCount(h), uint64(1))
+	assert.Greater(t, getHistogramSum(h), float64(0))
+}
+
+func TestRecordMirrorSyncStep_AllSteps(t *testing.T) {
+	cfg := mirrorMetricsConfig{Enabled: true, EnabledMirrorSyncDuration: true}
+
+	steps := []syncStep{
+		syncSteps.Fetch,
+		syncSteps.CommitGraph,
+		syncSteps.LFS,
+		syncSteps.Branches,
+		syncSteps.Releases,
+		syncSteps.RepoSize,
+		syncSteps.Wiki,
+		syncSteps.Total,
+	}
+
+	for _, step := range steps {
+		recordMirrorSyncStepWith(cfg, "step-org", "step-repo", step, time.Now().Add(-10*time.Millisecond))
+	}
+
+	for _, step := range steps {
+		h := collectHistogram("step-org", "step-repo", step.label)
+		assert.GreaterOrEqual(t, getHistogramSampleCount(h), uint64(1), "step %q should have at least one observation", step.label)
+	}
+}
+
+func TestRecordMirrorSyncStatus_Success(t *testing.T) {
+	cfg := mirrorMetricsConfig{Enabled: true, EnabledMirrorSyncDuration: true}
+
+	before := collectCounter("status-org", "status-repo", "true")
+	recordMirrorSyncStatusWith(cfg, "status-org", "status-repo", true)
+	after := collectCounter("status-org", "status-repo", "true")
+
+	assert.Greater(t, after, before)
+}
+
+func TestRecordMirrorSyncStatus_Failure(t *testing.T) {
+	cfg := mirrorMetricsConfig{Enabled: true, EnabledMirrorSyncDuration: true}
+
+	before := collectCounter("fail-org", "fail-repo", "false")
+	recordMirrorSyncStatusWith(cfg, "fail-org", "fail-repo", false)
+	after := collectCounter("fail-org", "fail-repo", "false")
+
+	assert.Greater(t, after, before)
+}
+
+func TestRecordMirrorSyncStatus_BothStates(t *testing.T) {
+	cfg := mirrorMetricsConfig{Enabled: true, EnabledMirrorSyncDuration: true}
+
+	beforeTrue := collectCounter("both-org", "both-repo", "true")
+	beforeFalse := collectCounter("both-org", "both-repo", "false")
+
+	recordMirrorSyncStatusWith(cfg, "both-org", "both-repo", true)
+	recordMirrorSyncStatusWith(cfg, "both-org", "both-repo", false)
+
+	afterTrue := collectCounter("both-org", "both-repo", "true")
+	afterFalse := collectCounter("both-org", "both-repo", "false")
+
+	assert.Greater(t, afterTrue, beforeTrue)
+	assert.Greater(t, afterFalse, beforeFalse)
+}
+
+func TestRecordMirrorSyncStatus_DisabledMetrics(t *testing.T) {
+	cfg := mirrorMetricsConfig{Enabled: false, EnabledMirrorSyncDuration: true}
+
+	before := collectCounter("status-disabled-org", "status-disabled-repo", "true")
+	recordMirrorSyncStatusWith(cfg, "status-disabled-org", "status-disabled-repo", true)
+	after := collectCounter("status-disabled-org", "status-disabled-repo", "true")
+
+	assert.InDelta(t, before, after, 0, "status metrics should not be recorded when Enabled is false")
+}


### PR DESCRIPTION
I had need of some visibility into mirror sync timings, so this adds a prometheus histogram for each of the mirror_pull steps as well as a general success/failure and total time. They are labelled by user/repository so folks can drill down into *which* repos might be taking longer.