### PR TITLE
fix: handle invalid mirror LFS endpoints

### DIFF
--- a/services/mirror/mirror_pull.go
+++ b/services/mirror/mirror_pull.go
@@ -25,7 +25,6 @@ import (
 	"gitea.dev/modules/setting"
 	"gitea.dev/modules/timeutil"
 	"gitea.dev/modules/util"
-	"gitea.dev/services/migrations"
 	notify_service "gitea.dev/services/notify"
 	repo_service "gitea.dev/services/repository"
 )
@@ -173,8 +172,10 @@ func runSync(ctx context.Context, m *repo_model.Mirror) ([]*repo_module.SyncResu
 	if m.LFS && setting.LFS.StartServer {
 		log.Trace("SyncMirrors [repo: %-v]: syncing LFS objects...", m.Repo)
 		endpoint := lfs.DetermineEndpoint(remoteURL.String(), m.LFSEndpoint)
-		lfsClient := lfs.NewClient(endpoint, migrations.NewMigrationHTTPTransport())
-		if err = repo_module.StoreMissingLfsObjectsInRepository(ctx, m.Repo, gitRepo, lfsClient); err != nil {
+		lfsClient, err := newLFSClient(endpoint)
+		if err != nil {
+			log.Error("SyncMirrors [repo: %-v]: failed to determine LFS endpoint: %v", m.Repo.FullName(), err)
+		} else if err = repo_module.StoreMissingLfsObjectsInRepository(ctx, m.Repo, gitRepo, lfsClient); err != nil {
 			log.Error("SyncMirrors [repo: %-v]: failed to synchronize LFS objects for repository: %v", m.Repo.FullName(), err)
 		}
 	}

--- a/services/mirror/mirror_pull_test.go
+++ b/services/mirror/mirror_pull_test.go
@@ -4,9 +4,11 @@
 package mirror
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_checkRecoverableSyncError(t *testing.T) {
@@ -35,4 +37,18 @@ func Test_checkRecoverableSyncError(t *testing.T) {
 	for _, c := range cases {
 		assert.Equal(t, c.recoverable, checkRecoverableSyncError(c.message), "test case: %s", c.message)
 	}
+}
+
+func Test_newLFSClient(t *testing.T) {
+	client, err := newLFSClient(nil)
+	require.Error(t, err)
+	assert.Nil(t, client)
+	assert.EqualError(t, err, "the LFS endpoint is not valid")
+
+	endpoint, err := url.Parse("https://example.com/repo.git/info/lfs")
+	require.NoError(t, err)
+
+	client, err = newLFSClient(endpoint)
+	require.NoError(t, err)
+	assert.NotNil(t, client)
 }

--- a/services/mirror/mirror_push.go
+++ b/services/mirror/mirror_push.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"regexp"
 	"time"
 
@@ -28,6 +29,13 @@ import (
 )
 
 var stripExitStatus = regexp.MustCompile(`exit status \d+ - `)
+
+func newLFSClient(endpoint *url.URL) (lfs.Client, error) {
+	if endpoint == nil {
+		return nil, errors.New("the LFS endpoint is not valid")
+	}
+	return lfs.NewClient(endpoint, migrations.NewMigrationHTTPTransport()), nil
+}
 
 // AddPushMirrorRemote registers the push mirror remote.
 func AddPushMirrorRemote(ctx context.Context, m *repo_model.PushMirror, addr string) error {
@@ -145,7 +153,10 @@ func runPushSync(ctx context.Context, m *repo_model.PushMirror) error {
 			defer gitRepo.Close()
 
 			endpoint := lfs.DetermineEndpoint(remoteURL.String(), "")
-			lfsClient := lfs.NewClient(endpoint, migrations.NewMigrationHTTPTransport())
+			lfsClient, err := newLFSClient(endpoint)
+			if err != nil {
+				return err
+			}
 			if err := pushAllLFSObjects(ctx, gitRepo, lfsClient); err != nil {
 				return util.SanitizeErrorCredentialURLs(err)
 			}


### PR DESCRIPTION
## Summary
- Validate derived LFS endpoints before creating mirror LFS clients.
- Return/log a clear invalid endpoint error instead of panicking when SSH remote endpoint parsing fails.
- Add unit coverage for nil and valid LFS endpoints.

Fixes #38016

## Test plan
- go test -vet=off ./services/mirror