### PR TITLE
fix(web): enforce repository token scope on diff and patch downloads

### DIFF
--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -616,6 +616,10 @@ func DownloadComparePatch(ctx *context.Context) {
 }
 
 func downloadCompareDiffOrPatch(ctx *context.Context, patch bool) {
+	if !checkDownloadTokenScope(ctx) {
+		return
+	}
+
 	// The route captures `basehead` separately so the `.diff`/`.patch` suffix is
 	// stripped from the catch-all `*` param parseCompareInfo would otherwise read.
 	cpi := newComparePageInfo()

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -1480,6 +1480,10 @@ func DownloadPullPatch(ctx *context.Context) {
 
 // DownloadPullDiffOrPatch render a pull's raw diff or patch
 func DownloadPullDiffOrPatch(ctx *context.Context, patch bool) {
+	if !checkDownloadTokenScope(ctx) {
+		return
+	}
+
 	pr, err := issues_model.GetPullRequestByIndex(ctx, ctx.Repo.Repository.ID, ctx.PathParamInt64("index"))
 	if err != nil {
 		if issues_model.IsErrPullRequestNotExist(err) {

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1616,8 +1616,8 @@ func registerWebRoutes(m *web.Router, webAuth *AuthMiddleware) {
 		m.Get("/{type:pulls}", repo.Issues)
 		m.Group("/{type:pulls}/{index}", func() {
 			m.Get("", repo.SetEditorconfigIfExists, repo.SetWhitespaceBehavior, repo.GetPullDiffStats, repo.ViewIssue)
-			m.Get(".diff", repo.DownloadPullDiff)
-			m.Get(".patch", repo.DownloadPullPatch)
+			m.Get(".diff", webAuth.AllowBasic, webAuth.AllowOAuth2, repo.DownloadPullDiff)
+			m.Get(".patch", webAuth.AllowBasic, webAuth.AllowOAuth2, repo.DownloadPullPatch)
 			m.Get("/merge_box", repo.ViewPullMergeBox)
 			m.Group("/commits", func() {
 				m.Get("", repo.SetWhitespaceBehavior, repo.GetPullDiffStats, repo.ViewPullCommits)

--- a/tests/integration/download_test.go
+++ b/tests/integration/download_test.go
@@ -194,6 +194,20 @@ func TestDownloadRepoContentTokenScopes(t *testing.T) {
 			withScope:    http.StatusOK,
 			publicOnlyOK: false,
 		},
+		{
+			name:         "PublicPullDiff",
+			method:       http.MethodGet,
+			url:          "/user2/repo1/pulls/2.diff",
+			withScope:    http.StatusOK,
+			publicOnlyOK: true,
+		},
+		{
+			name:         "PublicPullPatch",
+			method:       http.MethodGet,
+			url:          "/user2/repo1/pulls/2.patch",
+			withScope:    http.StatusOK,
+			publicOnlyOK: true,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

This PR closes a token-scope enforcement gap in web diff/patch download endpoints.

An earlier fix added `checkDownloadTokenScope()` to archive, raw, and media downloads, but missed the pull request and compare diff/patch handlers. As a result, an API token without `read:repository` could still access raw diff content through those endpoints.

## What changed

- add `checkDownloadTokenScope()` to:
  - pull request diff downloads
  - pull request patch downloads
  - compare diff downloads
  - compare patch downloads
- enable sessionless token auth for pull request `.diff` / `.patch` web routes so scoped PATs are evaluated consistently
- add integration coverage for pull diff/patch token-scope enforcement

## Why

Raw diff and patch responses expose repository content and should follow the same repository scope rules as other download-style endpoints.

This fixes an incomplete variant of the earlier download scope enforcement change.