### PR TITLE
fix(cli): default must-change-password to false for bot users

### DIFF
--- a/cmd/admin_user_create.go
+++ b/cmd/admin_user_create.go
@@ -158,7 +158,8 @@ func runCreateUser(ctx context.Context, c *cli.Command) error {
 	}
 
 	isAdmin := c.Bool("admin")
-	mustChangePassword := true // always default to true
+	// bot users are non-interactive, so they never need to change password
+	mustChangePassword := userType == user_model.UserTypeIndividual
 	if c.IsSet("must-change-password") {
 		if userType != user_model.UserTypeIndividual {
 			return errors.New("must-change-password flag can only be set for individual users")

--- a/cmd/admin_user_create.go
+++ b/cmd/admin_user_create.go
@@ -158,7 +158,7 @@ func runCreateUser(ctx context.Context, c *cli.Command) error {
 	}
 
 	isAdmin := c.Bool("admin")
-	// bot users are non-interactive, so they never need to change password
+	// Only local, existing, regular users should be forced to update their password. Bot users for example are non-interactive
 	mustChangePassword := userType == user_model.UserTypeIndividual
 	if c.IsSet("must-change-password") {
 		if userType != user_model.UserTypeIndividual {

--- a/cmd/admin_user_create_test.go
+++ b/cmd/admin_user_create_test.go
@@ -63,6 +63,7 @@ func TestAdminUserCreate(t *testing.T) {
 		u := unittest.AssertExistsAndLoadBean(t, &user_model.User{LowerName: "u"})
 		assert.Equal(t, user_model.UserTypeBot, u.Type)
 		assert.Empty(t, u.Passwd)
+		assert.False(t, u.MustChangePassword, "bot users should not be forced to change password")
 	})
 
 	t.Run("AccessToken", func(t *testing.T) {


### PR DESCRIPTION
Fixes #38174

## Problem

When creating a bot user with `gitea admin user create --user-type bot`, the account ends up with `must_change_password=true`. Since bot accounts are non-interactive (Git over HTTPS, API access, tokens, CI/CD), the forced password change breaks these automation flows until an admin manually clears the flag — and the resulting failures look like authentication/token problems rather than a forced-change requirement.

The `--must-change-password` flag cannot even be set for bot users, so previously there was no way to avoid this default.

## Fix

Default `must_change_password` to `false` for bot users (it remains `true` for individual users, except the first user, as before).