### PR TITLE
fix: return partial commit-info results when the walk times out

### DIFF
--- a/modules/git/log_name_status.go
+++ b/modules/git/log_name_status.go
@@ -351,10 +351,18 @@ heaploop:
 		}
 		current, err := g.Next(treepath, path2idx, changed, maxpathlen)
 		if err != nil {
-			if errors.Is(err, context.DeadlineExceeded) {
+			// When the context times out or is cancelled, the git command is killed and its
+			// output pipe is closed, so the read above may fail with an error like
+			// "file already closed" instead of context.DeadlineExceeded. Treat a deadline
+			// the same way as the select above: stop and return the partial results gathered
+			// so far (the caller falls back to async last-commit loading).
+			if errors.Is(err, context.DeadlineExceeded) || ctx.Err() == context.DeadlineExceeded {
 				break heaploop
 			}
 			g.Close()
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			return nil, err
 		}
 		if current == nil {

--- a/modules/git/log_name_status.go
+++ b/modules/git/log_name_status.go
@@ -351,18 +351,22 @@ heaploop:
 		}
 		current, err := g.Next(treepath, path2idx, changed, maxpathlen)
 		if err != nil {
-			// When the context times out or is cancelled, the git command is killed and its
-			// output pipe is closed, so the read above may fail with an error like
-			// "file already closed" instead of context.DeadlineExceeded. Treat a deadline
-			// the same way as the select above: stop and return the partial results gathered
-			// so far (the caller falls back to async last-commit loading).
-			if errors.Is(err, context.DeadlineExceeded) || ctx.Err() == context.DeadlineExceeded {
+			// A timeout or cancellation kills the git command and closes its output pipe,
+			// so the read above may surface as "file already closed" instead of
+			// context.DeadlineExceeded. Reconcile against the context: on a deadline, stop
+			// and return the partial results gathered so far (the caller falls back to async
+			// last-commit loading); on cancellation, return the context error.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				if ctxErr == context.DeadlineExceeded {
+					break heaploop
+				}
+				g.Close()
+				return nil, ctxErr
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
 				break heaploop
 			}
 			g.Close()
-			if ctx.Err() != nil {
-				return nil, ctx.Err()
-			}
 			return nil, err
 		}
 		if current == nil {

--- a/modules/git/log_name_status_test.go
+++ b/modules/git/log_name_status_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package git
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// buildManyCommitsRepo creates a repository with enough commits that
+// "git log --name-status" produces more output than the OS pipe buffer (64KB),
+// so the git command stays blocked on write while the caller is still reading.
+func buildManyCommitsRepo(t *testing.T, commits, filesPerCommit int) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	initCmd := exec.Command("git", "init", "-q", "-b", "main")
+	initCmd.Dir = dir
+	require.NoError(t, initCmd.Run())
+
+	// Build a fast-import stream so the whole history is created by a single
+	// git process, which keeps the test fast (sub-second).
+	var stream strings.Builder
+	mark := 0
+	for c := range commits {
+		blobMarks := make([]int, filesPerCommit)
+		for f := range filesPerCommit {
+			mark++
+			blobMarks[f] = mark
+			content := fmt.Sprintf("commit %d file %d\n", c, f)
+			fmt.Fprintf(&stream, "blob\nmark :%d\ndata %d\n%s\n", mark, len(content), content)
+		}
+		mark++
+		msg := fmt.Sprintf("commit %d", c)
+		// fast-import implicitly uses the branch tip as the parent, so no "from" is needed.
+		fmt.Fprintf(&stream, "commit refs/heads/main\nmark :%d\n", mark)
+		fmt.Fprintf(&stream, "committer a <a@example.com> %d +0000\n", 1700000000+c)
+		fmt.Fprintf(&stream, "data %d\n%s\n", len(msg), msg)
+		for f := range filesPerCommit {
+			fmt.Fprintf(&stream, "M 644 :%d file%d.txt\n", blobMarks[f], f)
+		}
+		stream.WriteString("\n")
+	}
+
+	importCmd := exec.Command("git", "fast-import", "--quiet")
+	importCmd.Dir = dir
+	importCmd.Stdin = strings.NewReader(stream.String())
+	importCmd.Stderr = os.Stderr
+	require.NoError(t, importCmd.Run())
+	return dir
+}
+
+// TestWalkGitLogTimeoutReturnsPartialResults is a regression test for a 500 error
+// ("read |0: file already closed") on the repository home page of large repos.
+//
+// The directory listing computes the latest commit per entry under a short timeout
+// and falls back to async loading when it expires. When the timeout fires, the git
+// command is killed and its output pipe is closed, so the in-flight read fails with
+// an os.ErrClosed-style error instead of context.DeadlineExceeded. WalkGitLog must
+// recognise the cancelled context and return the partial results gathered so far
+// rather than propagating the read error (which became a 500).
+func TestWalkGitLogTimeoutReturnsPartialResults(t *testing.T) {
+	dir := buildManyCommitsRepo(t, 1500, 5)
+	repo, err := OpenRepository(t.Context(), dir)
+	require.NoError(t, err)
+	defer repo.Close()
+
+	commit, err := repo.GetBranchCommit("main")
+	require.NoError(t, err)
+	entries, err := commit.Tree.ListEntries()
+	require.NoError(t, err)
+
+	// Several iterations to make sure the deadline reliably fires while the walk is
+	// still reading from the (blocked) git command. Without the fix this returns an
+	// error such as "read |0: file already closed" on the very first iteration.
+	for i := range 20 {
+		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Millisecond)
+		_, _, err := entries.GetCommitsInfo(ctx, "/any/repo-link", commit, "")
+		cancel()
+		require.NoError(t, err, "GetCommitsInfo must not error when the commit-info timeout expires (iteration %d)", i)
+	}
+}


### PR DESCRIPTION
Fixes #38177

### Problem

On large repositories, opening the code (home) page returns a `500 Internal Server Error`:

```
routers/web/repo/view.go:309:renderDirectoryFiles() [E] GetCommitsInfo: read |0: file already closed
.../git/log_name_status.go:58:LogNameStatusRepo.1() [E] Unable to run git command ... : context deadline exceeded
signal: killed -
```

The directory listing computes the latest commit for each entry under a short
timeout (1s, see `renderDirectoryFiles`) and is meant to fall back to async
loading on the frontend when that timeout expires.

### Root cause

This is a regression introduced in 1.26.3 by the `cmd.Cancel` change in #38084.

When the commit-info timeout fires, the git command is cancelled. With the new
`cmd.Cancel`, cancellation now closes the parent end of the output pipe in
addition to killing the process. As a result the in-flight read in `WalkGitLog`
fails with a `file already closed` error instead of the `io.EOF` it used to get
before 1.26.3.

`WalkGitLog` only treated `context.DeadlineExceeded` as a graceful stop, so it
propagated this read error up through `GetCommitsInfo`, which the router turned
into a 500 — instead of returning the partial results gathered so far and
letting the frontend load the rest asynchronously.

### Fix

When a read fails in the walk loop, check the context: if its deadline was
exceeded, stop and return the partial results (restoring the async last-commit
loading fallback); on cancellation, return the context error instead of the raw
pipe error.

