### PR TITLE
fix(indexer): recover from panic on corrupted issue index search

### DIFF
--- a/modules/indexer/issues/bleve/bleve.go
+++ b/modules/indexer/issues/bleve/bleve.go
@@ -5,12 +5,14 @@ package bleve
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"gitea.dev/modules/indexer"
 	indexer_internal "gitea.dev/modules/indexer/internal"
 	inner_bleve "gitea.dev/modules/indexer/internal/bleve"
 	"gitea.dev/modules/indexer/issues/internal"
+	"gitea.dev/modules/log"
 	"gitea.dev/modules/util"
 
 	"github.com/blevesearch/bleve/v2"
@@ -159,6 +161,21 @@ func (b *Indexer) Delete(_ context.Context, ids ...int64) error {
 	return batch.Flush()
 }
 
+// searchWithPanicRecover runs a bleve search and converts any panic into an
+// error. A corrupted on-disk index (e.g. a truncated zapx posting list) makes
+// the underlying bleve search panic with "index out of range" (see #38210);
+// recovering here keeps a single corrupted segment from crashing the request
+// and points operators at rebuilding the index.
+func searchWithPanicRecover(fn func() (*bleve.SearchResult, error)) (result *bleve.SearchResult, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("PANIC during issue indexer search, the index files may be corrupted and need to be rebuilt: %v\nStacktrace: %s", r, log.Stack(2))
+			result, err = nil, fmt.Errorf("issue indexer search failed, the index may be corrupted: %v", r)
+		}
+	}()
+	return fn()
+}
+
 // Search searches for issues by given conditions.
 // Returns the matching issue IDs
 func (b *Indexer) Search(ctx context.Context, options *internal.SearchOptions) (*internal.SearchResult, error) {
@@ -305,7 +322,9 @@ func (b *Indexer) Search(ctx context.Context, options *internal.SearchOptions) (
 
 	search.SortBy([]string{string(options.SortBy), "-_id"})
 
-	result, err := b.inner.Indexer.SearchInContext(ctx, search)
+	result, err := searchWithPanicRecover(func() (*bleve.SearchResult, error) {
+		return b.inner.Indexer.SearchInContext(ctx, search)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/modules/indexer/issues/bleve/bleve_test.go
+++ b/modules/indexer/issues/bleve/bleve_test.go
@@ -4,11 +4,13 @@
 package bleve
 
 import (
+	"errors"
 	"testing"
 
 	"gitea.dev/modules/indexer/issues/internal"
 	"gitea.dev/modules/indexer/issues/internal/tests"
 
+	"github.com/blevesearch/bleve/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -75,6 +77,36 @@ func TestBleveIndexerNoAssignee(t *testing.T) {
 			assert.ElementsMatch(t, testCase.expectedIDs, searchResultIDs(result))
 		})
 	}
+}
+
+func TestSearchWithPanicRecover(t *testing.T) {
+	t.Run("passes through results", func(t *testing.T) {
+		want := &bleve.SearchResult{}
+		got, err := searchWithPanicRecover(func() (*bleve.SearchResult, error) {
+			return want, nil
+		})
+		require.NoError(t, err)
+		assert.Same(t, want, got)
+	})
+
+	t.Run("passes through errors", func(t *testing.T) {
+		wantErr := errors.New("boom")
+		got, err := searchWithPanicRecover(func() (*bleve.SearchResult, error) {
+			return nil, wantErr
+		})
+		require.ErrorIs(t, err, wantErr)
+		assert.Nil(t, got)
+	})
+
+	t.Run("recovers from a panic", func(t *testing.T) {
+		// A corrupted on-disk index makes the underlying bleve search panic
+		// with "index out of range" (#38210); it must become an error.
+		got, err := searchWithPanicRecover(func() (*bleve.SearchResult, error) {
+			panic("index out of range [8] with length 8")
+		})
+		require.Error(t, err)
+		assert.Nil(t, got)
+	})
 }
 
 func searchResultIDs(result *internal.SearchResult) []int64 {


### PR DESCRIPTION
## Fixes #38210

Searching issues (`GET /issues?...&q=...`) can panic with `runtime error: index out of range [N] with length N`, crashing the request with a 500 panic page. The panic originates in the Bleve `zapx` storage engine while decoding a term posting list (`zapx/v17/memuvarint.go` `ReadUvarint`, which reads `S[C]` with no bounds check), indicating a **corrupted on-disk issue index segment**.

### Regression

This surfaced after #37525, which bumped `bleve v2.5.7 -> v2.6.0` and introduced `zapx/v17 v17.1.2` — the exact version in the reported stack trace. The new v17 segment format is what panics on the corrupt posting list. Bumping the dependency does not help: `memuvarint.go` is byte-for-byte identical in the current `v17.1.6`, so the missing bounds check is still upstream.

### Change

The init path already recovers from corruption panics and logs guidance to rebuild the index, but the **search path had no `recover()`**. This wraps the Bleve search in `searchWithPanicRecover`, converting a panic into a returned error and logging the rebuild hint, so a single corrupted segment degrades that search instead of crashing the request. A regression test covers the wrapper.

Operators still need to rebuild the index (delete `ISSUE_INDEXER_PATH` and restart) to clear the corruption.

*Authored with assistance from Claude Code (Opus 4.8).*