### PR TITLE
fix(api): deny private org member enumeration via /members

### DIFF
--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -1719,7 +1719,7 @@ func Routes() *web.Router {
 				m.Get("", reqToken(), org.ListMembers)
 				m.Combo("/{username}").Get(reqToken(), org.IsMember).
 					Delete(reqToken(), reqOrgOwnership(), org.DeleteMember)
-			})
+			}, reqOrgVisible())
 			addActionsRoutes(
 				m,
 				reqOrgMembership(),
@@ -1731,7 +1731,7 @@ func Routes() *web.Router {
 				m.Combo("/{username}").Get(org.IsPublicMember).
 					Put(reqToken(), reqOrgMembership(), org.PublicizeMember).
 					Delete(reqToken(), reqOrgMembership(), org.ConcealMember)
-			})
+			}, reqOrgVisible())
 			m.Group("/teams", func() {
 				m.Get("", org.ListTeams)
 				m.Post("", reqOrgOwnership(), bind(api.CreateTeamOption{}), org.CreateTeam)

--- a/routers/api/v1/org/member.go
+++ b/routers/api/v1/org/member.go
@@ -77,6 +77,12 @@ func ListMembers(ctx *context.APIContext) {
 	//   "404":
 	//     "$ref": "#/responses/notFound"
 
+	// don't disclose membership of organizations the doer cannot see
+	if !organization.HasOrgOrUserVisible(ctx, ctx.Org.Organization.AsUser(), ctx.Doer) {
+		ctx.APIErrorNotFound()
+		return
+	}
+
 	var (
 		isMember bool
 		err      error

--- a/routers/api/v1/org/member.go
+++ b/routers/api/v1/org/member.go
@@ -77,12 +77,6 @@ func ListMembers(ctx *context.APIContext) {
 	//   "404":
 	//     "$ref": "#/responses/notFound"
 
-	// don't disclose membership of organizations the doer cannot see
-	if !organization.HasOrgOrUserVisible(ctx, ctx.Org.Organization.AsUser(), ctx.Doer) {
-		ctx.APIErrorNotFound()
-		return
-	}
-
 	var (
 		isMember bool
 		err      error
@@ -124,12 +118,6 @@ func ListPublicMembers(ctx *context.APIContext) {
 	//     "$ref": "#/responses/UserList"
 	//   "404":
 	//     "$ref": "#/responses/notFound"
-
-	// don't disclose membership of organizations the doer cannot see
-	if !organization.HasOrgOrUserVisible(ctx, ctx.Org.Organization.AsUser(), ctx.Doer) {
-		ctx.APIErrorNotFound()
-		return
-	}
 
 	listMembers(ctx, false)
 }
@@ -211,11 +199,6 @@ func IsPublicMember(ctx *context.APIContext) {
 
 	userToCheck := user.GetContextUserByPathParam(ctx)
 	if ctx.Written() {
-		return
-	}
-	// don't disclose membership of organizations the doer cannot see
-	if !organization.HasOrgOrUserVisible(ctx, ctx.Org.Organization.AsUser(), ctx.Doer) {
-		ctx.APIErrorNotFound()
 		return
 	}
 	is, err := organization.IsPublicMembership(ctx, ctx.Org.Organization.ID, userToCheck.ID)

--- a/tests/integration/api_org_test.go
+++ b/tests/integration/api_org_test.go
@@ -284,10 +284,16 @@ func TestAPIOrgPrivateMembersNotLeaked(t *testing.T) {
 	MakeRequest(t, req, http.StatusNotFound)
 	req = NewRequest(t, "GET", "/api/v1/orgs/"+orgName+"/public_members").AddTokenAuth(outsiderToken)
 	MakeRequest(t, req, http.StatusNotFound)
+	// the full member list of a private org must not be enumerable by an outsider either
+	req = NewRequest(t, "GET", "/api/v1/orgs/"+orgName+"/members").AddTokenAuth(outsiderToken)
+	MakeRequest(t, req, http.StatusNotFound)
 
 	// the member can still see the public membership of their own org
 	req = NewRequest(t, "GET", "/api/v1/orgs/"+orgName+"/public_members/"+memberName).AddTokenAuth(memberToken)
 	MakeRequest(t, req, http.StatusNoContent)
+	// and the member can still list the org's members
+	req = NewRequest(t, "GET", "/api/v1/orgs/"+orgName+"/members").AddTokenAuth(memberToken)
+	MakeRequest(t, req, http.StatusOK)
 }
 
 func testAPIDeleteOrgRepos(t *testing.T) {


### PR DESCRIPTION
## Summary

The `GET /orgs/{org}/members` endpoint (`ListMembers`) did not verify that the requesting user is allowed to see the organization. As a result, any authenticated user could enumerate **all** members of a **private** organization, not just public ones.

A previous change added the org-visibility guard to the `public_members` endpoints but missed `ListMembers`. This applies the same `HasOrgOrUserVisible` check so outsiders receive a `404` for orgs they cannot see, while members, admins, and public-org access are unaffected.