### PR TITLE
fix(actions): fix 500 error when canceling a canceling task

### DIFF
--- a/services/convert/action_test.go
+++ b/services/convert/action_test.go
@@ -177,3 +177,13 @@ func TestToActionWorkflowJob_StepStatusIsIndependentOfJobStatus(t *testing.T) {
 	assert.Equal(t, "completed", apiJob.Steps[1].Status, "step 1 status")
 	assert.Equal(t, "failure", apiJob.Steps[1].Conclusion, "step 1 conclusion")
 }
+
+func TestToActionsStatus_Cancelling(t *testing.T) {
+	action, conclusion := ToActionsStatus(actions_model.StatusCancelling)
+	assert.Equal(t, "in_progress", action)
+	assert.Empty(t, conclusion)
+}
+
+func TestToWorkflowRunAction_Cancelling(t *testing.T) {
+	assert.Equal(t, "in_progress", ToWorkflowRunAction(actions_model.StatusCancelling))
+}

--- a/services/convert/convert.go
+++ b/services/convert/convert.go
@@ -412,7 +412,7 @@ func ToWorkflowRunAction(status actions_model.Status) (action string) {
 	switch status {
 	case actions_model.StatusWaiting, actions_model.StatusBlocked:
 		action = "requested"
-	case actions_model.StatusRunning:
+	case actions_model.StatusRunning, actions_model.StatusCancelling:
 		action = "in_progress"
 	default:
 		if status.IsDone() {
@@ -430,7 +430,7 @@ func ToActionsStatus(status actions_model.Status) (action, conclusion string) {
 		action = "queued" // "waiting" is a naming conflict of the webhook between Gitea and GitHub Actions
 	case actions_model.StatusBlocked:
 		action = "waiting" // naming conflict (as above)
-	case actions_model.StatusRunning:
+	case actions_model.StatusRunning, actions_model.StatusCancelling:
 		action = "in_progress"
 	default:
 		action = "completed"


### PR DESCRIPTION
Resolves #38221 

## Summary
Cancelling a workflow run that was already in `cancelling` status caused a 500 because `ToActionsStatus` and `ToWorkflowRunAction` did not handle `StatusCancelling` and panicked with `unknown action status: cancelling`.

### Fix
Map `StatusCancelling` to `in_progress` in both converters, matching GitHub’s Actions API, which has no separate cancelling status.

### Tests
Added unit tests asserting `ToActionsStatus` and `ToWorkflowRunAction` return `in_progress` for `StatusCancelling` without panicking.

DISCLAIMER: I used AI to find the issue causing this bug