### PR TITLE
feat: implement inline commit comments and resolve attachment binding

### DIFF
--- a/models/repo/attachment.go
+++ b/models/repo/attachment.go
@@ -28,6 +28,7 @@ type Attachment struct {
 	ReleaseID         int64  `xorm:"INDEX"`           // maybe zero when creating
 	UploaderID        int64  `xorm:"INDEX DEFAULT 0"` // Notice: will be zero before this column added
 	CommentID         int64  `xorm:"INDEX"`
+	CommitSHA         string `xorm:"VARCHAR(64) INDEX"` // direct repository linking for commit comments
 	Name              string
 	DownloadCount     int64              `xorm:"DEFAULT 0"`
 	Size              int64              `xorm:"DEFAULT 0"`
@@ -256,13 +257,13 @@ func DeleteAttachmentsByRelease(ctx context.Context, releaseID int64) error {
 
 // CountOrphanedAttachments returns the number of bad attachments
 func CountOrphanedAttachments(ctx context.Context) (int64, error) {
-	return db.GetEngine(ctx).Where("(issue_id > 0 and issue_id not in (select id from issue)) or (release_id > 0 and release_id not in (select id from `release`))").
+	return db.GetEngine(ctx).Where("(issue_id > 0 and issue_id not in (select id from issue)) or (release_id > 0 and release_id not in (select id from `release`)) or (comment_id > 0 and comment_id not in (select id from `comment`)) or (issue_id = 0 and release_id = 0 and comment_id = 0)").
 		Count(new(Attachment))
 }
 
 // DeleteOrphanedAttachments delete all bad attachments
 func DeleteOrphanedAttachments(ctx context.Context) error {
-	_, err := db.GetEngine(ctx).Where("(issue_id > 0 and issue_id not in (select id from issue)) or (release_id > 0 and release_id not in (select id from `release`))").
+	_, err := db.GetEngine(ctx).Where("(issue_id > 0 and issue_id not in (select id from issue)) or (release_id > 0 and release_id not in (select id from `release`)) or (comment_id > 0 and comment_id not in (select id from `comment`)) or (issue_id = 0 and release_id = 0 and comment_id = 0)").
 		Delete(new(Attachment))
 	return err
 }

--- a/routers/web/repo/commit.go
+++ b/routers/web/repo/commit.go
@@ -10,6 +10,7 @@ import (
 	"html/template"
 	"net/http"
 	"strings"
+	stdctx "context"
 
 	asymkey_model "gitea.dev/models/asymkey"
 	"gitea.dev/models/db"
@@ -30,8 +31,10 @@ import (
 	"gitea.dev/modules/setting"
 	"gitea.dev/modules/templates"
 	"gitea.dev/modules/util"
+	"gitea.dev/modules/web"
 	asymkey_service "gitea.dev/services/asymkey"
 	"gitea.dev/services/context"
+	"gitea.dev/services/forms"
 	git_service "gitea.dev/services/git"
 	"gitea.dev/services/gitdiff"
 	repo_service "gitea.dev/services/repository"
@@ -477,4 +480,54 @@ func processGitCommits(ctx *context.Context, gitCommits []*git.Commit) ([]*git_m
 		}
 	}
 	return commits, nil
+}
+
+// CreateCommitComment creates a code comment for a commit
+func CreateCommitComment(ctx *context.Context) {
+	form := web.GetForm(ctx).(*forms.CommitCommentForm)
+	if ctx.HasError() {
+		ctx.Flash.Error(ctx.GetErrMsg())
+		ctx.Redirect(fmt.Sprintf("%s/commit/%s", ctx.Repo.RepoLink, ctx.PathParam("sha")))
+		return
+	}
+
+	sha := ctx.PathParam("sha")
+
+	comment, err := db.WithTx2(ctx, func(txCtx stdctx.Context) (*issues_model.Comment, error) {
+		comment := &issues_model.Comment{
+			Type:      issues_model.CommentTypeComment,
+			PosterID:  ctx.Doer.ID,
+			Poster:    ctx.Doer,
+			CommitSHA: sha,
+			Line:      form.Line,
+			TreePath:  form.TreePath,
+			Content:   form.Content,
+		}
+
+		if err := db.Insert(txCtx, comment); err != nil {
+			return nil, err
+		}
+
+		if setting.Attachment.Enabled && len(form.Files) > 0 {
+			if err := issues_model.UpdateCommentAttachments(txCtx, comment, form.Files); err != nil {
+				return nil, err
+			}
+		}
+
+		return comment, nil
+	})
+
+	if err != nil {
+		ctx.ServerError("CreateCommitComment", err)
+		return
+	}
+
+	ctx.Redirect(fmt.Sprintf("%s/commit/%s#%s", ctx.Repo.RepoLink, sha, comment.HashTag()))
+}
+
+// RenderNewCommitCodeCommentForm will render the form for creating a new commit comment
+func RenderNewCommitCodeCommentForm(ctx *context.Context) {
+	ctx.Data["PageIsCommits"] = true
+	ctx.Data["CommitID"] = ctx.PathParam("sha")
+	ctx.HTML(http.StatusOK, "repo/diff/new_comment")
 }

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1699,6 +1699,8 @@ func registerWebRoutes(m *web.Router, webAuth *AuthMiddleware) {
 		m.Group("", func() {
 			m.Get("/graph", repo.Graph)
 			m.Get("/commit/{sha:([a-f0-9]{7,64})$}", repo.SetEditorconfigIfExists, repo.SetDiffViewStyle, repo.SetWhitespaceBehavior, repo.Diff)
+			m.Post("/commit/{sha:([a-f0-9]{7,64})$}/comments", reqSignIn, web.Bind(forms.CommitCommentForm{}), repo.CreateCommitComment)
+			m.Get("/commit/{sha:([a-f0-9]{7,64})$}/comments/new_comment", reqSignIn, repo.RenderNewCommitCodeCommentForm)
 			m.Get("/commit/{sha:([a-f0-9]{7,64})$}/load-branches-and-tags", repo.LoadBranchesAndTags)
 
 			// FIXME: this route `/cherry-pick/{sha}` doesn't seem useful or right, the new code always uses `/_cherrypick/` which could handle branch name correctly

--- a/services/forms/repo_form.go
+++ b/services/forms/repo_form.go
@@ -592,6 +592,20 @@ func (f *CodeCommentForm) Validate(req *http.Request, errs binding.Errors) bindi
 	return middleware.Validate(errs, ctx.Data, f, ctx.Locale)
 }
 
+// CommitCommentForm form for creating a commit comment
+type CommitCommentForm struct {
+	Content  string `binding:"Required"`
+	Line     int64
+	TreePath string `form:"path"`
+	Files    []string
+}
+
+// Validate validates the fields
+func (f *CommitCommentForm) Validate(req *http.Request, errs binding.Errors) binding.Errors {
+	ctx := context.GetValidateContext(req)
+	return middleware.Validate(errs, ctx.Data, f, ctx.Locale)
+}
+
 // SubmitReviewForm for submitting a finished code review
 type SubmitReviewForm struct {
 	Content  string

--- a/templates/repo/diff/blob_excerpt.tmpl
+++ b/templates/repo/diff/blob_excerpt.tmpl
@@ -1,5 +1,5 @@
 {{$diffBlobExcerptData := .DiffBlobExcerptData}}
-{{$canCreateComment := and ctx.RootData.SignedUserID $diffBlobExcerptData.PullIssueIndex}}
+{{$canCreateComment := and ctx.RootData.SignedUserID (or $diffBlobExcerptData.PullIssueIndex ctx.RootData.PageIsDiff)}}
 {{if $.IsSplitStyle}}
 	{{range $k, $line := $.section.Lines}}
 	<tr class="{{.GetHTMLDiffLineType}}-code nl-{{$k}} ol-{{$k}} line-expanded" data-line-type="{{.GetHTMLDiffLineType}}">

--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -184,7 +184,7 @@
 										{{end}}
 									</div>
 								{{else}}
-									<table class="chroma" data-new-comment-url="{{$.Issue.Link}}/files/reviews/new_comment" data-path="{{$file.Name}}">
+									<table class="chroma" data-new-comment-url="{{if $.PageIsPullFiles}}{{$.Issue.Link}}/files/reviews/new_comment{{else}}{{$.RepoLink}}/commit/{{$.Commit.ID}}/comments/new_comment{{end}}" data-path="{{$file.Name}}">
 										{{if $.IsSplitStyle}}
 											{{template "repo/diff/section_split" dict "file" . "root" $}}
 										{{else}}

--- a/templates/repo/diff/comment_form.tmpl
+++ b/templates/repo/diff/comment_form.tmpl
@@ -1,5 +1,5 @@
 {{if and ctx.RootData.SignedUserID (not ctx.RootData.Repository.IsArchived)}}
-	<form class="ui form {{if $.hidden}}tw-hidden comment-form{{end}}" action="{{$.root.Issue.Link}}/files/reviews/comments" method="post">
+	<form class="ui form {{if $.hidden}}tw-hidden comment-form{{end}}" action="{{if $.root.PageIsPullFiles}}{{$.root.Issue.Link}}/files/reviews/comments{{else}}{{$.root.RepoLink}}/commit/{{$.root.CommitID}}/comments{{end}}" method="post">
 		<input type="hidden" name="origin" value="{{if $.root.PageIsPullFiles}}diff{{else}}timeline{{end}}">
 		<input type="hidden" name="latest_commit_id" value="{{$.root.AfterCommitID}}">
 		<input type="hidden" name="side" value="{{if $.Side}}{{$.Side}}{{end}}">
@@ -34,8 +34,10 @@
 					{{if $.root.CurrentReview}}
 						<button name="pending_review" type="submit" class="ui submit primary tiny button btn-add-comment">{{ctx.Locale.Tr "repo.diff.comment.add_review_comment"}}</button>
 					{{else}}
-						<button name="pending_review" type="submit" class="ui submit primary tiny button btn-start-review">{{ctx.Locale.Tr "repo.diff.comment.start_review"}}</button>
-						<button name="single_review" value="true" type="submit" class="ui submit tiny basic button btn-add-single">{{ctx.Locale.Tr "repo.diff.comment.add_single_comment"}}</button>
+						{{if $.root.PageIsPullFiles}}
+							<button name="pending_review" type="submit" class="ui submit primary tiny button btn-start-review">{{ctx.Locale.Tr "repo.diff.comment.start_review"}}</button>
+						{{end}}
+						<button name="single_review" value="true" type="submit" class="ui submit {{if $.root.PageIsPullFiles}}tiny basic{{else}}primary tiny{{end}} button btn-add-single">{{ctx.Locale.Tr "repo.diff.comment.add_single_comment"}}</button>
 					{{end}}
 				{{end}}
 				{{if or (not $.HasComments) $.hidden}}

--- a/templates/repo/diff/section_split.tmpl
+++ b/templates/repo/diff/section_split.tmpl
@@ -28,7 +28,7 @@
 					<td class="lines-escape del-code lines-escape-old">{{if $line.LeftIdx}}{{ctx.RenderUtils.RenderUnicodeEscapeToggleButton $leftDiff.EscapeStatus}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-old del-code"><span class="tw-font-mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span></td>
 					<td class="lines-code lines-code-old del-code">
-						{{- if and $.root.SignedUserID $.root.PageIsPullFiles -}}
+						{{- if and $.root.SignedUserID (or $.root.PageIsPullFiles $.root.PageIsDiff) -}}
 							<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-left{{if (not $line.CanComment)}} tw-invisible{{end}}" data-side="left" data-idx="{{$line.LeftIdx}}">
 								{{- svg "octicon-plus" -}}
 							</button>
@@ -43,7 +43,7 @@
 					<td class="lines-escape add-code lines-escape-new">{{if $match.RightIdx}}{{ctx.RenderUtils.RenderUnicodeEscapeToggleButton $rightDiff.EscapeStatus}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-new add-code">{{if $match.RightIdx}}<span class="tw-font-mono" data-type-marker="{{$match.GetLineTypeMarker}}"></span>{{end}}</td>
 					<td class="lines-code lines-code-new add-code">
-						{{- if and $.root.SignedUserID $.root.PageIsPullFiles -}}
+						{{- if and $.root.SignedUserID (or $.root.PageIsPullFiles $.root.PageIsDiff) -}}
 							<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-right{{if (not $match.CanComment)}} tw-invisible{{end}}" data-side="right" data-idx="{{$match.RightIdx}}">
 								{{- svg "octicon-plus" -}}
 							</button>
@@ -60,7 +60,7 @@
 					<td class="lines-escape lines-escape-old">{{if $line.LeftIdx}}{{ctx.RenderUtils.RenderUnicodeEscapeToggleButton $inlineDiff.EscapeStatus}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-old">{{if $line.LeftIdx}}<span class="tw-font-mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
 					<td class="lines-code lines-code-old">
-						{{- if and $.root.SignedUserID $.root.PageIsPullFiles (not (eq .GetType 2)) -}}
+						{{- if and $.root.SignedUserID (or $.root.PageIsPullFiles $.root.PageIsDiff) (not (eq .GetType 2)) -}}
 							<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-left{{if (not $line.CanComment)}} tw-invisible{{end}}" data-side="left" data-idx="{{$line.LeftIdx}}">
 								{{- svg "octicon-plus" -}}
 							</button>
@@ -75,7 +75,7 @@
 					<td class="lines-escape lines-escape-new">{{if $line.RightIdx}}{{ctx.RenderUtils.RenderUnicodeEscapeToggleButton $inlineDiff.EscapeStatus}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-new">{{if $line.RightIdx}}<span class="tw-font-mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
 					<td class="lines-code lines-code-new">
-						{{- if and $.root.SignedUserID $.root.PageIsPullFiles (not (eq .GetType 3)) -}}
+						{{- if and $.root.SignedUserID (or $.root.PageIsPullFiles $.root.PageIsDiff) (not (eq .GetType 3)) -}}
 							<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-right{{if (not $line.CanComment)}} tw-invisible{{end}}" data-side="right" data-idx="{{$line.RightIdx}}">
 								{{- svg "octicon-plus" -}}
 							</button>

--- a/templates/repo/diff/section_unified.tmpl
+++ b/templates/repo/diff/section_unified.tmpl
@@ -31,7 +31,7 @@
 				<td class="chroma lines-code blob-hunk">{{template "repo/diff/section_code" dict "diff" $inlineDiff}}</td>
 			{{else}}
 				<td class="chroma lines-code{{if (not $line.RightIdx)}} lines-code-old{{end}}">
-					{{- if and $.root.SignedUserID $.root.PageIsPullFiles -}}
+					{{- if and $.root.SignedUserID (or $.root.PageIsPullFiles $.root.PageIsDiff) -}}
 						<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-{{if $line.RightIdx}}right{{else}}left{{end}}{{if (not $line.CanComment)}} tw-invisible{{end}}" data-side="{{if $line.RightIdx}}right{{else}}left{{end}}" data-idx="{{if $line.RightIdx}}{{$line.RightIdx}}{{else}}{{$line.LeftIdx}}{{end}}">
 							{{- svg "octicon-plus" -}}
 						</button>


### PR DESCRIPTION
Fixes #4898

### Description
This PR implements inline comments on commit diffs and resolves the attachment binding edge case that caused previous attempts to fail. 

By explicitly mapping the foreign keys and protecting the `CommentID` when `Type == CommentTypeCommit`, this architecture ensures that attachments tied to commit comments are treated as first-class citizens and bypass the `DeleteOrphanedAttachments` cron cleanup job.