### PR TITLE
enhance(packages): show package count in profile tabs

### DIFF
--- a/models/packages/package.go
+++ b/models/packages/package.go
@@ -351,6 +351,19 @@ func HasOwnerPackages(ctx context.Context, ownerID int64) (bool, error) {
 		Exist(&PackageVersion{})
 }
 
+// CountOwnerPackages counts a user/org's accessible packages
+func CountOwnerPackages(ctx context.Context, ownerID int64) (int64, error) {
+	return db.GetEngine(ctx).
+		Table("package_version").
+		Join("INNER", "package", "package.id = package_version.package_id").
+		Where(builder.Eq{
+			"package_version.is_internal": false,
+			"package.owner_id":            ownerID,
+		}).
+		Distinct("package.id").
+		Count(&Package{})
+}
+
 // HasRepositoryPackages tests if a repository has packages
 func HasRepositoryPackages(ctx context.Context, repositoryID int64) (bool, error) {
 	return db.GetEngine(ctx).Where("repo_id = ?", repositoryID).Exist(&Package{})

--- a/models/packages/package_test.go
+++ b/models/packages/package_test.go
@@ -64,3 +64,67 @@ func TestHasOwnerPackages(t *testing.T) {
 	assert.True(t, has)
 	assert.NoError(t, err)
 }
+
+func TestCountOwnerPackages(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	owner := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 1})
+
+	count, err := packages_model.CountOwnerPackages(t.Context(), owner.ID)
+	assert.EqualValues(t, 0, count)
+	assert.NoError(t, err)
+
+	p1, err := packages_model.TryInsertPackage(t.Context(), &packages_model.Package{
+		OwnerID:   owner.ID,
+		LowerName: "package-1",
+	})
+	assert.NotNil(t, p1)
+	assert.NoError(t, err)
+
+	count, err = packages_model.CountOwnerPackages(t.Context(), owner.ID)
+	assert.EqualValues(t, 0, count)
+	assert.NoError(t, err)
+
+	pv, err := packages_model.GetOrInsertVersion(t.Context(), &packages_model.PackageVersion{
+		PackageID:    p1.ID,
+		LowerVersion: "internal",
+		IsInternal:   true,
+	})
+	assert.NotNil(t, pv)
+	assert.NoError(t, err)
+
+	count, err = packages_model.CountOwnerPackages(t.Context(), owner.ID)
+	assert.EqualValues(t, 0, count)
+	assert.NoError(t, err)
+
+	for _, version := range []string{"1.0.0", "1.0.1"} {
+		pv, err = packages_model.GetOrInsertVersion(t.Context(), &packages_model.PackageVersion{
+			PackageID:    p1.ID,
+			LowerVersion: version,
+		})
+		assert.NotNil(t, pv)
+		assert.NoError(t, err)
+	}
+
+	count, err = packages_model.CountOwnerPackages(t.Context(), owner.ID)
+	assert.EqualValues(t, 1, count)
+	assert.NoError(t, err)
+
+	p2, err := packages_model.TryInsertPackage(t.Context(), &packages_model.Package{
+		OwnerID:   owner.ID,
+		LowerName: "package-2",
+	})
+	assert.NotNil(t, p2)
+	assert.NoError(t, err)
+
+	pv, err = packages_model.GetOrInsertVersion(t.Context(), &packages_model.PackageVersion{
+		PackageID:    p2.ID,
+		LowerVersion: "1.0.0",
+	})
+	assert.NotNil(t, pv)
+	assert.NoError(t, err)
+
+	count, err = packages_model.CountOwnerPackages(t.Context(), owner.ID)
+	assert.EqualValues(t, 2, count)
+	assert.NoError(t, err)
+}

--- a/routers/web/shared/user/header.go
+++ b/routers/web/shared/user/header.go
@@ -9,6 +9,7 @@ import (
 
 	"gitea.dev/models/db"
 	"gitea.dev/models/organization"
+	packages_model "gitea.dev/models/packages"
 	access_model "gitea.dev/models/perm/access"
 	project_model "gitea.dev/models/project"
 	repo_model "gitea.dev/models/repo"
@@ -191,6 +192,14 @@ func loadHeaderCount(ctx *context.Context) error {
 		return err
 	}
 	ctx.Data["ProjectCount"] = projectCount
+
+	if setting.Packages.Enabled {
+		packageCount, err := packages_model.CountOwnerPackages(ctx, ctx.ContextUser.ID)
+		if err != nil {
+			return err
+		}
+		ctx.Data["PackageCount"] = packageCount
+	}
 
 	return nil
 }

--- a/routers/web/shared/user/header.go
+++ b/routers/web/shared/user/header.go
@@ -9,6 +9,7 @@ import (
 
 	"gitea.dev/models/db"
 	"gitea.dev/models/organization"
+	packages_model "gitea.dev/models/packages"
 	access_model "gitea.dev/models/perm/access"
 	project_model "gitea.dev/models/project"
 	repo_model "gitea.dev/models/repo"
@@ -190,6 +191,14 @@ func loadHeaderCount(ctx *context.Context) error {
 		return err
 	}
 	ctx.Data["ProjectCount"] = projectCount
+
+	if setting.Packages.Enabled {
+		packageCount, err := packages_model.CountOwnerPackages(ctx, ctx.ContextUser.ID)
+		if err != nil {
+			return err
+		}
+		ctx.Data["PackageCount"] = packageCount
+	}
 
 	return nil
 }

--- a/routers/web/user/package.go
+++ b/routers/web/user/package.go
@@ -49,10 +49,6 @@ const (
 
 // ListPackages displays a list of all packages of the context user
 func ListPackages(ctx *context.Context) {
-	if _, err := shared_user.RenderUserOrgHeader(ctx); err != nil {
-		ctx.ServerError("RenderUserOrgHeader", err)
-		return
-	}
 	page := max(ctx.FormInt("page"), 1)
 	query := ctx.FormTrim("q")
 	packageType := ctx.FormTrim("type")

--- a/templates/org/menu.tmpl
+++ b/templates/org/menu.tmpl
@@ -23,6 +23,9 @@
 			{{if and .IsPackageEnabled .CanReadPackages}}
 			<a class="{{if .IsPackagesPage}}active {{end}}item" href="{{$.Org.HomeLink}}/-/packages">
 				{{svg "octicon-package"}} {{ctx.Locale.Tr "packages.title"}}
+				{{if .PackageCount}}
+					<div class="ui small label">{{.PackageCount}}</div>
+				{{end}}
 			</a>
 			{{end}}
 			{{if and .IsRepoIndexerEnabled .CanReadCode}}

--- a/templates/user/overview/header.tmpl
+++ b/templates/user/overview/header.tmpl
@@ -22,6 +22,9 @@
 		{{if and .IsPackageEnabled (or .ContextUser.IsIndividual .CanReadPackages)}}
 			<a href="{{.ContextUser.HomeLink}}/-/packages" class="{{if .IsPackagesPage}}active {{end}}item">
 				{{svg "octicon-package"}} {{ctx.Locale.Tr "packages.title"}}
+				{{if .PackageCount}}
+					<div class="ui small label">{{.PackageCount}}</div>
+				{{end}}
 			</a>
 		{{end}}
 		{{if and .IsRepoIndexerEnabled (or .ContextUser.IsIndividual .CanReadCode)}}


### PR DESCRIPTION
## Summary

- Show package counts on user and organization package tabs, matching the existing repository and project tab counters.
- Count distinct owner packages that have at least one non-internal version.
- Hide the package count badge when the count is zero.

## Screenshots

Captured locally with Podman and Playwright/Chrome:

- Before: 
<img width="1365" height="768" alt="package-tab-before" src="https://github.com/user-attachments/assets/239db75e-9940-4504-9ca3-5c010ed38921" />

- After: 
<img width="1365" height="768" alt="package-tab-after" src="https://github.com/user-attachments/assets/22441eac-fd70-41e0-9158-48c705b79d42" />


## Testing

- `make GO=/home/ahanoff/.local/bin/go fmt`
- `/home/ahanoff/.local/bin/go test -run '^TestCountOwnerPackages$|^TestHasOwnerPackages$' ./models/packages/`
- `git diff --check`
- `make deps-frontend`
- `make frontend`
- `pnpm exec playwright screenshot --browser=chromium --channel=chrome --viewport-size=1365,768 --wait-for-timeout=1000 http://127.0.0.1:3101/demo/-/packages screenshots/package-tab-before.png`
- `pnpm exec playwright screenshot --browser=chromium --channel=chrome --viewport-size=1365,768 --wait-for-selector=".ui.secondary.pointing.menu .item .ui.small.label" --wait-for-timeout=500 http://127.0.0.1:3102/demo/-/packages screenshots/package-tab-after.png`

## AI Assistance

This PR was prepared with assistance from Codex:GPT-5.5 xhigh and reviewed before submission.
