### PR TITLE
fix(actions): resolve workflow runs by run_number in API

### DIFF
--- a/routers/api/v1/repo/action.go
+++ b/routers/api/v1/repo/action.go
@@ -1275,11 +1275,24 @@ func ActionsEnableWorkflow(ctx *context.APIContext) {
 }
 
 func getCurrentRepoActionRunByID(ctx *context.APIContext) *actions_model.ActionRun {
-	runID := ctx.PathParamInt64("run")
-	run, err := actions_model.GetRunByRepoAndID(ctx, ctx.Repo.Repository.ID, runID)
-	if err != nil {
+	repoID := ctx.Repo.Repository.ID
+	runNum := ctx.PathParamInt64("run")
+	if runNum <= 0 {
+		ctx.APIError(http.StatusBadRequest, "run must be a positive integer")
+		return nil
+	}
+
+	run, err := actions_model.GetRunByRepoAndID(ctx, repoID, runNum)
+	if err != nil && !errors.Is(err, util.ErrNotExist) {
 		ctx.APIErrorAuto(err)
 		return nil
+	}
+	if errors.Is(err, util.ErrNotExist) {
+		run, err = actions_model.GetRunByRepoAndIndex(ctx, repoID, runNum)
+		if err != nil {
+			ctx.APIErrorAuto(err)
+			return nil
+		}
 	}
 	run.Repo = ctx.Repo.Repository
 	return run
@@ -1663,22 +1676,11 @@ func ListWorkflowRunJobs(ctx *context.APIContext) {
 	//   "422":
 	//     "$ref": "#/responses/validationError"
 
-	repoID, runID := ctx.Repo.Repository.ID, ctx.PathParamInt64("run")
-
-	// Avoid the list all jobs functionality for this api route to be used with a runID == 0.
-	if runID <= 0 {
-		ctx.APIError(http.StatusBadRequest, "runID must be a positive integer")
+	run := getCurrentRepoActionRunByID(ctx)
+	if ctx.Written() {
 		return
 	}
-
-	run, err := actions_model.GetRunByRepoAndID(ctx, repoID, runID)
-	if err != nil {
-		ctx.APIErrorAuto(err)
-		return
-	}
-	// runID is used as an additional filter next to repoID to ensure that we only list jobs for the specified repoID and runID.
-	// no additional checks for runID are needed here
-	shared.ListJobs(ctx, 0, repoID, runID, optional.Some(run.LatestAttemptID))
+	shared.ListJobs(ctx, 0, run.RepoID, run.ID, optional.Some(run.LatestAttemptID))
 }
 
 // ListWorkflowRunAttemptJobs Lists all jobs for a workflow run attempt.

--- a/tests/integration/api_actions_run_test.go
+++ b/tests/integration/api_actions_run_test.go
@@ -84,6 +84,20 @@ func testAPIActionsGetWorkflowRun(t *testing.T) {
 		require.NotEmpty(t, job198.Steps, "job must return at least one step when task has steps")
 		assert.Equal(t, "main", job198.Steps[0].Name, "first step name")
 	})
+
+	t.Run("ListRunJobsByRunNumber", func(t *testing.T) {
+		run := unittest.AssertExistsAndLoadBean(t, &actions_model.ActionRun{ID: 795})
+		require.NotEqual(t, run.ID, run.Index, "fixture must have distinct run id and run_number")
+
+		req := NewRequest(t, "GET", fmt.Sprintf("/api/v1/repos/%s/actions/runs/%d/jobs", repo.FullName(), run.Index)).
+			AddTokenAuth(token)
+		resp := MakeRequest(t, req, http.StatusOK)
+		jobList := DecodeJSON(t, resp, &api.ActionWorkflowJobsResponse{})
+
+		require.NotZero(t, jobList.TotalCount)
+		job198Idx := slices.IndexFunc(jobList.Entries, func(job *api.ActionWorkflowJob) bool { return job.ID == 198 })
+		require.NotEqual(t, -1, job198Idx, "expected to find job 198 when resolving run by run_number")
+	})
 }
 
 func testAPIActionsGetWorkflowJob(t *testing.T) {


### PR DESCRIPTION
## Summary

Run-scoped Actions API handlers only resolved `{run}` by database ID, while the web UI also accepts the repo-scoped `run_number` (index). Callers who used `run_number` from `/actions/tasks` or the UI URL could get an empty job list from GET `/api/v1/repos/{owner}/{repo}/actions/runs/{run}/jobs` even when jobs were visible in the browser. This PR adds the same ID-then-index fallback to `getCurrentRepoActionRunByID`, which is shared by run-scoped API endpoints including job listing.

## Test

`ListRunJobsByRunNumber` loads fixture run 795, which has `id` 795 and `run_number` 191, and calls `GET /api/v1/repos/user2/repo2/actions/runs/191/jobs`. It asserts the response is HTTP 200 with a non-zero `total_count` and that job 198 is present in the list.

Closes #38286 