### PR TITLE
chore: remove eslint-plugin-array-func

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,4 +1,3 @@
-import arrayFunc from 'eslint-plugin-array-func';
 import comments from '@eslint-community/eslint-plugin-eslint-comments';
 import globals from 'globals';
 import importPlugin from 'eslint-plugin-import-x';
@@ -62,7 +61,6 @@ export default defineConfig([
       '@eslint-community/eslint-comments': comments,
       '@stylistic': stylistic,
       '@typescript-eslint': typescriptPlugin.plugin,
-      'array-func': arrayFunc,
       'gitea': {rules: {'unescaped-html-literal': unescapedHtmlLiteral}},
       'import-x': importPlugin,
       regexp,
@@ -275,12 +273,6 @@ export default defineConfig([
       '@typescript-eslint/unified-signatures': [2],
       'accessor-pairs': [2],
       'array-callback-return': [2, {checkForEach: true}],
-      'array-func/avoid-reverse': [2],
-      'array-func/from-map': [2],
-      'array-func/no-unnecessary-this-arg': [2],
-      'array-func/prefer-array-from': [2],
-      'array-func/prefer-flat-map': [0], // handled by unicorn/prefer-array-flat-map
-      'array-func/prefer-flat': [0], // handled by unicorn/prefer-array-flat
       'arrow-body-style': [0],
       'block-scoped-var': [2],
       'camelcase': [0],

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "@vitest/eslint-plugin": "1.6.20",
     "eslint": "10.6.0",
     "eslint-import-resolver-typescript": "4.4.5",
-    "eslint-plugin-array-func": "5.1.1",
     "eslint-plugin-import-x": "4.17.1",
     "eslint-plugin-playwright": "2.10.4",
     "eslint-plugin-regexp": "3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,9 +261,6 @@ importers:
       eslint-import-resolver-typescript:
         specifier: 4.4.5
         version: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.62.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.6.0(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@10.6.0(jiti@2.7.0))
-      eslint-plugin-array-func:
-        specifier: 5.1.1
-        version: 5.1.1(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-import-x:
         specifier: 4.17.1
         version: 4.17.1(@typescript-eslint/utils@8.62.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.6.0(jiti@2.7.0))
@@ -2430,12 +2427,6 @@ packages:
         optional: true
       eslint-import-resolver-webpack:
         optional: true
-
-  eslint-plugin-array-func@5.1.1:
-    resolution: {integrity: sha512-TbVGk+yLqXHgtrS4DnYzg2Ycuk5y+lYFy5NgT748neQdJvNIYUucxp2QQjPU7dwbs9xp9fyktgtK069y9rNdig==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '>=8.51.0'
 
   eslint-plugin-import-x@4.17.1:
     resolution: {integrity: sha512-4cdstYkKCyjumM2Q9NSI03K8D2a9F4Ssz33K2lv2hQa4KmR9jPLwk3uWGtNvclfqBrPGfGuMBwsGMbe6dMRbfg==}
@@ -6779,10 +6770,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
-
-  eslint-plugin-array-func@5.1.1(eslint@10.6.0(jiti@2.7.0)):
-    dependencies:
-      eslint: 10.6.0(jiti@2.7.0)
 
   eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.62.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.6.0(jiti@2.7.0)):
     dependencies:

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,9 +1,3 @@
-declare module 'eslint-plugin-array-func' {
-  import type {Eslint} from 'eslint';
-  const plugin: Eslint.Plugin;
-  export = plugin;
-}
-
 declare module '*.svg' {
   const value: string;
   export default value;


### PR DESCRIPTION
The rules from `eslint-plugin-array-func` are redundant with `eslint-plugin-unicorn`:

- `from-map` → `unicorn/prefer-array-from-map`
- `no-unnecessary-this-arg` → `unicorn/no-array-method-this-argument`
- `prefer-flat` / `prefer-flat-map` → `unicorn/prefer-array-flat` / `unicorn/prefer-array-flat-map` (already disabled here)

The two remaining rules (`avoid-reverse`, `prefer-array-from`) are niche and not worth carrying an extra dependency for.