### PR TITLE
chore(snap): drop `armhf` build

### DIFF
--- a/.github/workflows/release-nightly-snapcraft.yml
+++ b/.github/workflows/release-nightly-snapcraft.yml
@@ -34,7 +34,7 @@ jobs:
           chmod 600 "$HOME/.local/share/snapcraft/launchpad-credentials"
           snapcraft remote-build \
             --launchpad-accept-public-upload \
-            --build-for=amd64,arm64,armhf
+            --build-for=amd64,arm64
 
       - name: List built snaps
         run: find . -maxdepth 1 -type f -name '*.snap' -print

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,9 +12,6 @@ base: core24
 adopt-info: gitea
 
 platforms:
-  armhf:
-    build-on: [armhf]
-    build-for: [armhf]
   amd64:
     build-on: [amd64]
     build-for: [amd64]


### PR DESCRIPTION
Launchpad no longer builds `core24` snaps for `armhf`. Since `snapcraft remote-build` submits a single request for all platforms, the `armhf` rejection fails with `snapcraft internal error: BadRequest()` and takes the `amd64` and `arm64` builds down with it, so nothing gets published.

Dropping 32-bit ARM from `snap/snapcraft.yaml` and the workflow's `--build-for` restores nightly snap publishing for the remaining architectures.