### PR TITLE
fix(issue): make dependency search local-first

### DIFF
--- a/routers/web/repo/issue_dependency.go
+++ b/routers/web/repo/issue_dependency.go
@@ -4,13 +4,116 @@
 package repo
 
 import (
+	"errors"
 	"net/http"
+	"regexp"
+	"strconv"
 
 	issues_model "gitea.dev/models/issues"
 	access_model "gitea.dev/models/perm/access"
+	repo_model "gitea.dev/models/repo"
 	"gitea.dev/modules/setting"
+	"gitea.dev/modules/util"
 	"gitea.dev/services/context"
+	"gitea.dev/services/convert"
 )
+
+var dependencyRefPattern = regexp.MustCompile(`^\s*(?:(?P<owner>[0-9a-zA-Z_.-]+)/(?P<repo>[0-9a-zA-Z_.-]+))?(?P<type>[#!])(?P<index>[0-9]+)\s*$`)
+
+func parseDependencyRef(ref string) (owner, repo string, index int64, isPull, ok bool) {
+	match := dependencyRefPattern.FindStringSubmatch(ref)
+	if match == nil {
+		return "", "", 0, false, false
+	}
+
+	for i, name := range dependencyRefPattern.SubexpNames() {
+		switch name {
+		case "owner":
+			owner = match[i]
+		case "repo":
+			repo = match[i]
+		case "type":
+			isPull = match[i] == "!"
+		case "index":
+			var err error
+			index, err = strconv.ParseInt(match[i], 10, 64)
+			if err != nil {
+				return "", "", 0, false, false
+			}
+		}
+	}
+
+	return owner, repo, index, isPull, true
+}
+
+func dependencySearchTypeAllows(searchType string, isPull bool) bool {
+	switch searchType {
+	case "pulls":
+		return isPull
+	case "issues":
+		return !isPull
+	case "", "all":
+		return true
+	default:
+		return false
+	}
+}
+
+func getDependencyByRef(ctx *context.Context, currentIssueID int64, ref, searchType string) (*issues_model.Issue, error) {
+	owner, repoName, index, isPull, ok := parseDependencyRef(ref)
+	if !ok || !dependencySearchTypeAllows(searchType, isPull) {
+		return nil, util.ErrNotExist
+	}
+
+	depRepo := ctx.Repo.Repository
+	if owner != "" || repoName != "" {
+		var err error
+		depRepo, err = repo_model.GetRepositoryByOwnerAndName(ctx, owner, repoName)
+		if err != nil {
+			return nil, err
+		}
+		if depRepo.ID != ctx.Repo.Repository.ID && !setting.Service.AllowCrossRepositoryDependencies {
+			return nil, util.ErrNotExist
+		}
+	}
+
+	dep, err := issues_model.GetIssueByIndex(ctx, depRepo.ID, index)
+	if err != nil {
+		return nil, err
+	}
+	if dep.IsPull != isPull || dep.ID == currentIssueID {
+		return nil, util.ErrNotExist
+	}
+	dep.Repo = depRepo
+
+	depRepoPerm := ctx.Repo.Permission
+	if depRepo.ID != ctx.Repo.Repository.ID {
+		depRepoPerm, err = access_model.GetDoerRepoPermission(ctx, depRepo, ctx.Doer)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if !depRepoPerm.CanReadIssuesOrPulls(dep.IsPull) {
+		return nil, util.ErrNotExist
+	}
+
+	return dep, nil
+}
+
+// SearchDependencyByRef resolves exact dependency references for the dependency dropdown.
+func SearchDependencyByRef(ctx *context.Context) {
+	dep, err := getDependencyByRef(ctx, ctx.FormInt64("issue_id"), ctx.FormTrim("ref"), ctx.FormString("type"))
+	if err != nil {
+		if errors.Is(err, util.ErrNotExist) || issues_model.IsErrIssueNotExist(err) || repo_model.IsErrRepoNotExist(err) {
+			ctx.JSON(http.StatusOK, convert.ToIssueList(ctx, ctx.Doer, issues_model.IssueList{}))
+			return
+		}
+		ctx.ServerError("getDependencyByRef", err)
+		return
+	}
+
+	ctx.JSON(http.StatusOK, convert.ToIssueList(ctx, ctx.Doer, issues_model.IssueList{dep}))
+}
 
 // AddDependency adds new dependencies
 func AddDependency(ctx *context.Context) {
@@ -27,8 +130,6 @@ func AddDependency(ctx *context.Context) {
 		return
 	}
 
-	depID := ctx.FormInt64("newDependency")
-
 	if err = issue.LoadRepo(ctx); err != nil {
 		ctx.ServerError("LoadRepo", err)
 		return
@@ -37,11 +138,24 @@ func AddDependency(ctx *context.Context) {
 	// Redirect
 	defer ctx.Redirect(issue.Link())
 
-	// Dependency
-	dep, err := issues_model.GetIssueByID(ctx, depID)
-	if err != nil {
-		ctx.Flash.Error(ctx.Tr("repo.issues.dependency.add_error_dep_issue_not_exist"))
-		return
+	depRef := ctx.FormTrim("newDependency")
+	var dep *issues_model.Issue
+	if depID, err := strconv.ParseInt(depRef, 10, 64); err == nil {
+		dep, err = issues_model.GetIssueByID(ctx, depID)
+		if err != nil {
+			ctx.Flash.Error(ctx.Tr("repo.issues.dependency.add_error_dep_issue_not_exist"))
+			return
+		}
+	} else {
+		dep, err = getDependencyByRef(ctx, issue.ID, depRef, "all")
+		if err != nil {
+			if errors.Is(err, util.ErrNotExist) || issues_model.IsErrIssueNotExist(err) || repo_model.IsErrRepoNotExist(err) {
+				ctx.Flash.Error(ctx.Tr("repo.issues.dependency.add_error_dep_issue_not_exist"))
+				return
+			}
+			ctx.ServerError("getDependencyByRef", err)
+			return
+		}
 	}
 
 	// Check if both issues are in the same repo if cross repository dependencies is not enabled

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1332,6 +1332,7 @@ func registerWebRoutes(m *web.Router, webAuth *AuthMiddleware) {
 					Post(web.Bind(forms.CreateIssueForm{}), repo.NewIssuePost)
 				m.Get("/choose", repo.NewIssueChooseTemplate)
 			})
+			m.Get("/dependency-search", repo.SearchDependencyByRef)
 			m.Get("/search", repo.SearchRepoIssuesJSON)
 		}, reqUnitIssuesReader)
 

--- a/tests/integration/issue_test.go
+++ b/tests/integration/issue_test.go
@@ -575,6 +575,97 @@ func TestSearchIssues(t *testing.T) {
 	assert.Len(t, apiIssues, 2)
 }
 
+func TestSearchDependencyByRef(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	session := loginUser(t, "user2")
+
+	t.Run("same repo issue", func(t *testing.T) {
+		query := url.Values{"ref": {"#1"}, "issue_id": {"2"}, "type": {"all"}}
+		req := NewRequest(t, "GET", "/user2/repo1/issues/dependency-search?"+query.Encode())
+		resp := session.MakeRequest(t, req, http.StatusOK)
+		apiIssues := DecodeJSON(t, resp, []*api.Issue{})
+		assert.Len(t, apiIssues, 1)
+		assert.EqualValues(t, 1, apiIssues[0].Index)
+		assert.Equal(t, "user2/repo1", apiIssues[0].Repo.FullName)
+	})
+
+	t.Run("same repo pull", func(t *testing.T) {
+		query := url.Values{"ref": {"!3"}, "issue_id": {"2"}, "type": {"pulls"}}
+		req := NewRequest(t, "GET", "/user2/repo1/issues/dependency-search?"+query.Encode())
+		resp := session.MakeRequest(t, req, http.StatusOK)
+		apiIssues := DecodeJSON(t, resp, []*api.Issue{})
+		assert.Len(t, apiIssues, 1)
+		assert.EqualValues(t, 3, apiIssues[0].Index)
+		assert.NotNil(t, apiIssues[0].PullRequest)
+	})
+
+	t.Run("cross repo private readable", func(t *testing.T) {
+		query := url.Values{"ref": {"org3/repo3!2"}, "issue_id": {"2"}, "type": {"pulls"}}
+		req := NewRequest(t, "GET", "/user2/repo1/issues/dependency-search?"+query.Encode())
+		resp := session.MakeRequest(t, req, http.StatusOK)
+		apiIssues := DecodeJSON(t, resp, []*api.Issue{})
+		assert.Len(t, apiIssues, 1)
+		assert.Equal(t, "org3/repo3", apiIssues[0].Repo.FullName)
+		assert.EqualValues(t, 2, apiIssues[0].Index)
+	})
+
+	t.Run("type filter mismatch", func(t *testing.T) {
+		query := url.Values{"ref": {"!3"}, "issue_id": {"2"}, "type": {"issues"}}
+		req := NewRequest(t, "GET", "/user2/repo1/issues/dependency-search?"+query.Encode())
+		resp := session.MakeRequest(t, req, http.StatusOK)
+		apiIssues := DecodeJSON(t, resp, []*api.Issue{})
+		assert.Empty(t, apiIssues)
+	})
+
+	t.Run("self dependency", func(t *testing.T) {
+		query := url.Values{"ref": {"!2"}, "issue_id": {"2"}, "type": {"all"}}
+		req := NewRequest(t, "GET", "/user2/repo1/issues/dependency-search?"+query.Encode())
+		resp := session.MakeRequest(t, req, http.StatusOK)
+		apiIssues := DecodeJSON(t, resp, []*api.Issue{})
+		assert.Empty(t, apiIssues)
+	})
+
+	t.Run("cross repo private not readable", func(t *testing.T) {
+		query := url.Values{"ref": {"org3/repo3!2"}, "issue_id": {"2"}, "type": {"pulls"}}
+		req := NewRequest(t, "GET", "/user2/repo1/issues/dependency-search?"+query.Encode())
+		resp := loginUser(t, "user40").MakeRequest(t, req, http.StatusOK)
+		apiIssues := DecodeJSON(t, resp, []*api.Issue{})
+		assert.Empty(t, apiIssues)
+	})
+
+	t.Run("cross repo disabled", func(t *testing.T) {
+		oldAllowCrossRepo := setting.Service.AllowCrossRepositoryDependencies
+		setting.Service.AllowCrossRepositoryDependencies = false
+		defer func() { setting.Service.AllowCrossRepositoryDependencies = oldAllowCrossRepo }()
+
+		query := url.Values{"ref": {"org3/repo3!2"}, "issue_id": {"2"}, "type": {"pulls"}}
+		req := NewRequest(t, "GET", "/user2/repo1/issues/dependency-search?"+query.Encode())
+		resp := session.MakeRequest(t, req, http.StatusOK)
+		apiIssues := DecodeJSON(t, resp, []*api.Issue{})
+		assert.Empty(t, apiIssues)
+	})
+}
+
+func TestAddDependencyByRef(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	targetIssue := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{RepoID: 1, Index: 2})
+	dependencyIssue := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{RepoID: 3, Index: 2})
+	enableRepoDependencies(t, targetIssue.RepoID)
+	enableRepoDependencies(t, dependencyIssue.RepoID)
+
+	session := loginUser(t, "user2")
+	req := NewRequestWithValues(t, "POST", "/user2/repo1/pulls/2/dependency/add", map[string]string{
+		"newDependency": "org3/repo3!2",
+	})
+	session.MakeRequest(t, req, http.StatusSeeOther)
+	unittest.AssertExistsAndLoadBean(t, &issues_model.IssueDependency{
+		IssueID:      targetIssue.ID,
+		DependencyID: dependencyIssue.ID,
+	})
+}
+
 func TestSearchIssuesWithLabels(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
 

--- a/web_src/js/features/repo-issue-sidebar.ts
+++ b/web_src/js/features/repo-issue-sidebar.ts
@@ -7,7 +7,7 @@ import {html} from '../utils/html.ts';
 import {fomanticQuery} from '../modules/fomantic/base.ts';
 import {showTemporaryTooltip} from '../modules/tippy.ts';
 
-const {appSubUrl} = window.config;
+const dependencyReferencePattern = /^\s*(?:[0-9a-zA-Z_.-]+\/[0-9a-zA-Z_.-]+)?[#!][0-9]+\s*$/;
 
 function initRepoIssueBranchSelector(elSidebar: HTMLElement) {
   // TODO: RemoveIssueRef: see "repo/issue/branch_selector_field.tmpl"
@@ -54,17 +54,21 @@ export function initRepoIssueSidebarDependency(elSidebar: HTMLElement) {
   if (!elDropdown) return;
 
   const issuePageInfo = parseIssuePageInfo();
-  const crossRepoSearch = elDropdown.getAttribute('data-issue-cross-repo-search');
-  let issueSearchUrl = `${issuePageInfo.repoLink}/issues/search?q={query}&type=${issuePageInfo.issueDependencySearchType}`;
-  if (crossRepoSearch === 'true') {
-    issueSearchUrl = `${appSubUrl}/issues/search?q={query}&priority_repo_id=${issuePageInfo.repoId}&type=${issuePageInfo.issueDependencySearchType}`;
-  }
+  const localIssueSearchUrl = `${issuePageInfo.repoLink}/issues/search?q={query}&type=${issuePageInfo.issueDependencySearchType}&state=open`;
+  const dependencyRefSearchUrl = `${issuePageInfo.repoLink}/issues/dependency-search?ref={query}&issue_id=${elDropdown.getAttribute('data-issue-id')}&type=${issuePageInfo.issueDependencySearchType}`;
   fomanticQuery(elDropdown).dropdown({
+    allowAdditions: true,
+    forceSelection: false,
     fullTextSearch: true,
     apiSettings: {
       cache: false,
       rawResponse: true,
-      url: issueSearchUrl,
+      url: localIssueSearchUrl,
+      beforeSend(this: any, settings: any) {
+        const query = String(this.urlData.query || '');
+        settings.url = dependencyReferencePattern.test(query) ? dependencyRefSearchUrl : localIssueSearchUrl;
+        return settings;
+      },
       onResponse(response: any) {
         const filteredResponse = {success: true, results: [] as Array<Record<string, any>>};
         const currIssueId = elDropdown.getAttribute('data-issue-id');


### PR DESCRIPTION
Avoid broad instance-wide dependency suggestions on large installations by keeping normal dependency picker queries scoped to the current repository. Add exact reference resolution for same-instance issue and pull dependencies so users can still add cross-repository dependencies explicitly with refs like #123, !123, owner/repo#123, or owner/repo!123.

The resolver preserves existing permission checks, cross-repository dependency settings, type filtering, and self-dependency protection. It also lets the existing dependency add endpoint accept typed refs directly, so dependency submission does not require a dropdown suggestion to exist.

Add integration coverage for exact dependency lookup, permission denial, disabled cross-repo dependencies, and adding a cross-repo PR dependency by typed ref.

Assisted-by: OpenCode:github-copilot/gpt-5.5