### PR TITLE
fix(actions): don't show branch-filtered push workflows as skipped in pull requests

### DIFF
--- a/modules/actions/workflows.go
+++ b/modules/actions/workflows.go
@@ -363,7 +363,14 @@ func matchPushEvent(commit *git.Commit, pushPayload *api.PushPayload, evt *jobpa
 		return detectMatched
 	}
 
-	matchTimes := 0
+	// Branch/tag filters gate whether the workflow applies to this ref at all: a mismatch means
+	// the workflow is not applicable (like GitHub) and must not emit a skipped commit status.
+	// Paths/paths-ignore filters instead only skip a run whose ref already matched, so a paths
+	// mismatch is reported as filtered-out to keep required status checks satisfied.
+	// Branch and tag filters are counted (rather than a bool) because when both are present only
+	// one needs to match; the paths filters have no such rule so a single bool suffices.
+	refMatchCount, refFilterCount := 0, 0
+	pathMatched := true
 	hasBranchFilter := false
 	hasTagFilter := false
 	refName := git.RefName(pushPayload.Ref)
@@ -372,6 +379,7 @@ func matchPushEvent(commit *git.Commit, pushPayload *api.PushPayload, evt *jobpa
 		switch cond {
 		case "branches":
 			hasBranchFilter = true
+			refFilterCount++
 			if !refName.IsBranch() {
 				break
 			}
@@ -380,10 +388,11 @@ func matchPushEvent(commit *git.Commit, pushPayload *api.PushPayload, evt *jobpa
 				break
 			}
 			if !workflowpattern.Skip(patterns, []string{refName.BranchName()}) {
-				matchTimes++
+				refMatchCount++
 			}
 		case "branches-ignore":
 			hasBranchFilter = true
+			refFilterCount++
 			if !refName.IsBranch() {
 				break
 			}
@@ -392,10 +401,11 @@ func matchPushEvent(commit *git.Commit, pushPayload *api.PushPayload, evt *jobpa
 				break
 			}
 			if !workflowpattern.Filter(patterns, []string{refName.BranchName()}) {
-				matchTimes++
+				refMatchCount++
 			}
 		case "tags":
 			hasTagFilter = true
+			refFilterCount++
 			if !refName.IsTag() {
 				break
 			}
@@ -404,10 +414,11 @@ func matchPushEvent(commit *git.Commit, pushPayload *api.PushPayload, evt *jobpa
 				break
 			}
 			if !workflowpattern.Skip(patterns, []string{refName.TagName()}) {
-				matchTimes++
+				refMatchCount++
 			}
 		case "tags-ignore":
 			hasTagFilter = true
+			refFilterCount++
 			if !refName.IsTag() {
 				break
 			}
@@ -416,11 +427,10 @@ func matchPushEvent(commit *git.Commit, pushPayload *api.PushPayload, evt *jobpa
 				break
 			}
 			if !workflowpattern.Filter(patterns, []string{refName.TagName()}) {
-				matchTimes++
+				refMatchCount++
 			}
 		case "paths":
 			if refName.IsTag() {
-				matchTimes++
 				break
 			}
 			filesChanged, err := commit.GetFilesChangedSinceCommit(pushPayload.Before)
@@ -429,15 +439,11 @@ func matchPushEvent(commit *git.Commit, pushPayload *api.PushPayload, evt *jobpa
 				return detectNotApplicable
 			}
 			patterns, err := workflowpattern.CompilePatterns(vals...)
-			if err != nil {
-				break
-			}
-			if !workflowpattern.Skip(patterns, filesChanged) {
-				matchTimes++
+			if err != nil || workflowpattern.Skip(patterns, filesChanged) {
+				pathMatched = false
 			}
 		case "paths-ignore":
 			if refName.IsTag() {
-				matchTimes++
 				break
 			}
 			filesChanged, err := commit.GetFilesChangedSinceCommit(pushPayload.Before)
@@ -446,11 +452,8 @@ func matchPushEvent(commit *git.Commit, pushPayload *api.PushPayload, evt *jobpa
 				return detectNotApplicable
 			}
 			patterns, err := workflowpattern.CompilePatterns(vals...)
-			if err != nil {
-				break
-			}
-			if !workflowpattern.Filter(patterns, filesChanged) {
-				matchTimes++
+			if err != nil || workflowpattern.Filter(patterns, filesChanged) {
+				pathMatched = false
 			}
 		default:
 			log.Warn("push event unsupported condition %q", cond)
@@ -458,12 +461,17 @@ func matchPushEvent(commit *git.Commit, pushPayload *api.PushPayload, evt *jobpa
 	}
 	// if both branch and tag filter are defined in the workflow only one needs to match
 	if hasBranchFilter && hasTagFilter {
-		matchTimes++
+		refMatchCount++
 	}
-	if matchTimes == len(evt.Acts()) {
-		return detectMatched
+	// a branch/tag filter mismatch means the workflow does not apply to this ref
+	if refMatchCount != refFilterCount {
+		return detectNotApplicable
 	}
-	return detectFilteredOut
+	// the ref matched; a paths filter mismatch skips the run but keeps the required check satisfied
+	if !pathMatched {
+		return detectFilteredOut
+	}
+	return detectMatched
 }
 
 func matchIssuesEvent(issuePayload *api.IssuePayload, evt *jobparser.Event) bool {
@@ -517,7 +525,12 @@ func matchIssuesEvent(issuePayload *api.IssuePayload, evt *jobparser.Event) bool
 func matchPullRequestEvent(gitRepo *git.Repository, commit *git.Commit, prPayload *api.PullRequestPayload, evt *jobparser.Event) detectResult {
 	acts := evt.Acts()
 	activityTypeMatched := false
-	matchTimes := 0
+	// Branch filters gate whether the workflow applies to this pull request's base branch: a
+	// mismatch means the workflow is not applicable (like GitHub) and must not emit a skipped
+	// commit status. Paths/paths-ignore filters instead only skip a run whose branch already
+	// matched, so a paths mismatch is reported as filtered-out to keep required checks satisfied.
+	refMatched := true
+	pathMatched := true
 
 	if vals, ok := acts["types"]; !ok {
 		// defaultly, only pull request `opened`, `reopened` and `synchronized` will trigger workflow
@@ -547,7 +560,6 @@ func matchPullRequestEvent(gitRepo *git.Repository, commit *git.Commit, prPayloa
 		for _, val := range vals {
 			if glob.MustCompile(val, '/').Match(string(action)) {
 				activityTypeMatched = true
-				matchTimes++
 				break
 			}
 		}
@@ -574,20 +586,14 @@ func matchPullRequestEvent(gitRepo *git.Repository, commit *git.Commit, prPayloa
 		case "branches":
 			refName := git.RefName(prPayload.PullRequest.Base.Ref)
 			patterns, err := workflowpattern.CompilePatterns(vals...)
-			if err != nil {
-				break
-			}
-			if !workflowpattern.Skip(patterns, []string{refName.ShortName()}) {
-				matchTimes++
+			if err != nil || workflowpattern.Skip(patterns, []string{refName.ShortName()}) {
+				refMatched = false
 			}
 		case "branches-ignore":
 			refName := git.RefName(prPayload.PullRequest.Base.Ref)
 			patterns, err := workflowpattern.CompilePatterns(vals...)
-			if err != nil {
-				break
-			}
-			if !workflowpattern.Filter(patterns, []string{refName.ShortName()}) {
-				matchTimes++
+			if err != nil || workflowpattern.Filter(patterns, []string{refName.ShortName()}) {
+				refMatched = false
 			}
 		case "paths":
 			filesChanged, err := headCommit.GetFilesChangedSinceCommit(prPayload.PullRequest.MergeBase)
@@ -596,11 +602,8 @@ func matchPullRequestEvent(gitRepo *git.Repository, commit *git.Commit, prPayloa
 				return detectNotApplicable
 			}
 			patterns, err := workflowpattern.CompilePatterns(vals...)
-			if err != nil {
-				break
-			}
-			if !workflowpattern.Skip(patterns, filesChanged) {
-				matchTimes++
+			if err != nil || workflowpattern.Skip(patterns, filesChanged) {
+				pathMatched = false
 			}
 		case "paths-ignore":
 			filesChanged, err := headCommit.GetFilesChangedSinceCommit(prPayload.PullRequest.MergeBase)
@@ -609,11 +612,8 @@ func matchPullRequestEvent(gitRepo *git.Repository, commit *git.Commit, prPayloa
 				return detectNotApplicable
 			}
 			patterns, err := workflowpattern.CompilePatterns(vals...)
-			if err != nil {
-				break
-			}
-			if !workflowpattern.Filter(patterns, filesChanged) {
-				matchTimes++
+			if err != nil || workflowpattern.Filter(patterns, filesChanged) {
+				pathMatched = false
 			}
 		default:
 			log.Warn("pull request event unsupported condition %q", cond)
@@ -622,7 +622,12 @@ func matchPullRequestEvent(gitRepo *git.Repository, commit *git.Commit, prPayloa
 	if !activityTypeMatched {
 		return detectNotApplicable
 	}
-	if matchTimes != len(evt.Acts()) {
+	// the base branch does not match the branches filter: the workflow does not apply
+	if !refMatched {
+		return detectNotApplicable
+	}
+	// the branch matched; a paths filter mismatch skips the run but keeps the required check satisfied
+	if !pathMatched {
 		return detectFilteredOut
 	}
 	return detectMatched

--- a/modules/actions/workflows_test.go
+++ b/modules/actions/workflows_test.go
@@ -225,7 +225,9 @@ func TestDetectMatched(t *testing.T) {
 			expected: detectMatched,
 		},
 		{
-			desc:         "push branch filter excludes -> filtered out",
+			// A branch filter mismatch means the workflow does not apply to this ref (like GitHub),
+			// so it must not post a skipped commit status that would leak into a pull request.
+			desc:         "push branch filter excludes -> not applicable",
 			triggedEvent: webhook_module.HookEventPush,
 			payload: &api.PushPayload{
 				Ref:     "refs/heads/feature/x",
@@ -234,7 +236,33 @@ func TestDetectMatched(t *testing.T) {
 			},
 			commit:   nil,
 			yamlOn:   "on:\n  push:\n    branches: [main]",
-			expected: detectFilteredOut,
+			expected: detectNotApplicable,
+		},
+		{
+			desc:         "push branches-ignore excludes -> not applicable",
+			triggedEvent: webhook_module.HookEventPush,
+			payload: &api.PushPayload{
+				Ref:     "refs/heads/main",
+				Before:  "0000000",
+				Commits: []*api.PayloadCommit{{ID: "abc", Added: []string{"a.go"}, Message: "x"}},
+			},
+			commit:   nil,
+			yamlOn:   "on:\n  push:\n    branches-ignore: [main]",
+			expected: detectNotApplicable,
+		},
+		{
+			// The base branch of the pull request does not match the branches filter,
+			// so the workflow does not apply (no skipped status).
+			desc:         "pull_request base branch filter excludes -> not applicable",
+			triggedEvent: webhook_module.HookEventPullRequest,
+			payload: &api.PullRequestPayload{
+				Action: api.HookIssueOpened,
+				PullRequest: &api.PullRequest{
+					Base: &api.PRBranchInfo{Ref: "refs/heads/dev"},
+				},
+			},
+			yamlOn:   "on:\n  pull_request:\n    branches: [main]",
+			expected: detectNotApplicable,
 		},
 	}
 

--- a/tests/integration/actions_trigger_test.go
+++ b/tests/integration/actions_trigger_test.go
@@ -339,9 +339,10 @@ jobs:
 		})
 		assert.NoError(t, err)
 		assert.NotEmpty(t, addFileToBranchResp)
-		// the push to test-skip-ci is filtered by branches, so no run is created; a skipped commit status is posted instead
+		// the push to test-skip-ci does not match the workflow's `branches: [master]`, so the push
+		// workflow does not apply: no run and no skipped commit status (it must not leak into the PR)
 		assert.Equal(t, 1, unittest.GetCount(t, &actions_model.ActionRun{RepoID: repo.ID}))
-		assertSkippedCommitStatusExists(t, repo.ID, addFileToBranchResp.Commit.SHA, "push")
+		assertNoSkippedCommitStatusExists(t, repo.ID, addFileToBranchResp.Commit.SHA, "push")
 
 		resp := testPullCreate(t, session, "user2", "skip-ci", true, "master", "test-skip-ci", "[skip ci] test-skip-ci")
 
@@ -1884,15 +1885,28 @@ jobs:
 	})
 }
 
-// assertSkippedCommitStatusExists asserts that a filtered-out workflow posted a skipped commit status on sha
-func assertSkippedCommitStatusExists(t *testing.T, repoID int64, sha, eventSuffix string) {
+// hasSkippedCommitStatus reports whether a skipped commit status for the given event was posted on sha.
+func hasSkippedCommitStatus(t *testing.T, repoID int64, sha, eventSuffix string) bool {
 	t.Helper()
 	statuses, err := git_model.GetLatestCommitStatus(t.Context(), repoID, sha, db.ListOptionsAll)
 	require.NoError(t, err)
 	for _, s := range statuses {
 		if s.State == commitstatus.CommitStatusSkipped && strings.Contains(s.Context, "("+eventSuffix+")") {
-			return
+			return true
 		}
 	}
-	assert.Failf(t, "missing skipped commit status", "no skipped commit status with event %q on %s (found %d statuses)", eventSuffix, sha, len(statuses))
+	return false
+}
+
+// assertSkippedCommitStatusExists asserts that a filtered-out workflow posted a skipped commit status on sha
+func assertSkippedCommitStatusExists(t *testing.T, repoID int64, sha, eventSuffix string) {
+	t.Helper()
+	assert.Truef(t, hasSkippedCommitStatus(t, repoID, sha, eventSuffix), "missing skipped commit status with event %q on %s", eventSuffix, sha)
+}
+
+// assertNoSkippedCommitStatusExists asserts that no skipped commit status for the given event was posted on sha,
+// e.g. a workflow whose branch filter excludes the ref must not leak a skipped status into a pull request.
+func assertNoSkippedCommitStatusExists(t *testing.T, repoID int64, sha, eventSuffix string) {
+	t.Helper()
+	assert.Falsef(t, hasSkippedCommitStatus(t, repoID, sha, eventSuffix), "unexpected skipped commit status with event %q on %s", eventSuffix, sha)
 }


### PR DESCRIPTION
Closes #38351

## Problem

A `push`-only workflow shows up as **Skipped** inside pull requests, where it should not appear at all.

Given two workflows:

```yaml
# .gitea/workflows/push.yml
on:
  push:
    branches: [main]
```
```yaml
# .gitea/workflows/pull.yml
on:
  pull_request:
```

Opening a PR from a feature branch surfaces the `push` workflow as a skipped check in the PR.

## Cause

#38237 fixed required status checks getting stuck *Pending* when a workflow is excluded by a `paths` filter, by posting a `CommitStatusSkipped` status for filtered-out workflows. But `matchPushEvent` / `matchPullRequestEvent` returned `detectFilteredOut` for **any** filter mismatch — including a **branch/tag** mismatch.

So pushing to a feature branch, where the `push` workflow's `branches: [main]` filter excludes the ref, posted a skipped `push` status on that commit. Because the commit is the PR's head, the status leaked into the PR's checks.
