### PR TITLE
chore(typo): fix grammar in comments, API docs and error messages

### DIFF
--- a/modules/git/object_format.go
+++ b/modules/git/object_format.go
@@ -10,10 +10,10 @@ import (
 	"strconv"
 )
 
-// sha1Pattern can be used to determine if a string is an valid sha
+// sha1Pattern can be used to determine if a string is a valid sha
 var sha1Pattern = regexp.MustCompile(`^[0-9a-f]{4,40}$`)
 
-// sha256Pattern can be used to determine if a string is an valid sha
+// sha256Pattern can be used to determine if a string is a valid sha
 var sha256Pattern = regexp.MustCompile(`^[0-9a-f]{4,64}$`)
 
 type ObjectFormat interface {

--- a/modules/issue/template/template.go
+++ b/modules/issue/template/template.go
@@ -167,7 +167,7 @@ func validateOptions(field *api.IssueFormField, idx int) error {
 
 	options, ok := field.Attributes["options"].([]any)
 	if !ok || len(options) == 0 {
-		return position.Errorf("'options' is required and should be a array")
+		return position.Errorf("'options' is required and should be an array")
 	}
 
 	for optIdx, option := range options {
@@ -270,7 +270,7 @@ func validateDropdownDefault(position errorPosition, attributes map[string]any) 
 	options, ok := attributes["options"].([]any)
 	if !ok {
 		// should not happen
-		return position.Errorf("'options' is required and should be a array")
+		return position.Errorf("'options' is required and should be an array")
 	}
 	if defaultValue < 0 || defaultValue >= len(options) {
 		return position.Errorf("the value of 'default' is out of range")

--- a/modules/issue/template/template_test.go
+++ b/modules/issue/template/template_test.go
@@ -268,7 +268,7 @@ body:
     attributes:
       label: "a"
 `,
-			wantErr: "body[0](dropdown): 'options' is required and should be a array",
+			wantErr: "body[0](dropdown): 'options' is required and should be an array",
 		},
 		{
 			name: "dropdown invalid options",

--- a/modules/markup/html.go
+++ b/modules/markup/html.go
@@ -51,7 +51,7 @@ var globalVars = sync.OnceValue(func() *globalVarsType {
 	v := &globalVarsType{}
 	// NOTE: All below regex matching do not perform any extra validation.
 	// Thus a link is produced even if the linked entity does not exist.
-	// While fast, this is also incorrect and lead to false positives.
+	// While fast, this is also incorrect and leads to false positives.
 	// TODO: fix invalid linking issue (update: stale TODO, what issues? maybe no TODO anymore)
 
 	// valid chars in encoded path and parameter: [-+~_%.a-zA-Z0-9/]

--- a/modules/references/references.go
+++ b/modules/references/references.go
@@ -24,7 +24,7 @@ var (
 
 	// NOTE: All below regex matching do not perform any extra validation.
 	// Thus a link is produced even if the linked entity does not exist.
-	// While fast, this is also incorrect and lead to false positives.
+	// While fast, this is also incorrect and leads to false positives.
 	// TODO: fix invalid linking issue
 
 	// mentionPattern matches all mentions in the form of "@user" or "@org/team"

--- a/modules/structs/notifications.go
+++ b/modules/structs/notifications.go
@@ -68,7 +68,7 @@ const (
 type NotifySubjectType string
 
 const (
-	// NotifySubjectIssue a issue is subject of an notification
+	// NotifySubjectIssue an issue is subject of a notification
 	NotifySubjectIssue NotifySubjectType = "Issue"
 	// NotifySubjectPull a pull is subject of an notification
 	NotifySubjectPull NotifySubjectType = "Pull"

--- a/routers/api/v1/repo/action.go
+++ b/routers/api/v1/repo/action.go
@@ -36,11 +36,11 @@ import (
 	"gitea.com/gitea/runner/act/model"
 )
 
-// ListActionsSecrets list an repo's actions secrets
+// ListActionsSecrets list a repo's actions secrets
 func (Action) ListActionsSecrets(ctx *context.APIContext) {
 	// swagger:operation GET /repos/{owner}/{repo}/actions/secrets repository repoListActionsSecrets
 	// ---
-	// summary: List an repo's actions secrets
+	// summary: List a repo's actions secrets
 	// produces:
 	// - application/json
 	// parameters:

--- a/routers/api/v1/repo/avatar.go
+++ b/routers/api/v1/repo/avatar.go
@@ -13,7 +13,7 @@ import (
 	repo_service "gitea.dev/services/repository"
 )
 
-// UpdateVatar updates the Avatar of an Repo
+// UpdateAvatar updates the Avatar of a Repo
 func UpdateAvatar(ctx *context.APIContext) {
 	// swagger:operation POST /repos/{owner}/{repo}/avatar repository repoUpdateAvatar
 	// ---
@@ -56,7 +56,7 @@ func UpdateAvatar(ctx *context.APIContext) {
 	ctx.Status(http.StatusNoContent)
 }
 
-// UpdateAvatar deletes the Avatar of an Repo
+// DeleteAvatar deletes the Avatar of a Repo
 func DeleteAvatar(ctx *context.APIContext) {
 	// swagger:operation DELETE /repos/{owner}/{repo}/avatar repository repoDeleteAvatar
 	// ---

--- a/routers/api/v1/repo/git_ref.go
+++ b/routers/api/v1/repo/git_ref.go
@@ -14,7 +14,7 @@ import (
 	"gitea.dev/services/context"
 )
 
-// GetGitAllRefs get ref or an list all the refs of a repository
+// GetGitAllRefs get ref or a list of all the refs of a repository
 func GetGitAllRefs(ctx *context.APIContext) {
 	// swagger:operation GET /repos/{owner}/{repo}/git/refs repository repoListAllGitRefs
 	// ---

--- a/services/migrations/dump.go
+++ b/services/migrations/dump.go
@@ -49,7 +49,7 @@ type RepositoryDumper struct {
 	prHeadCache map[string]string
 }
 
-// NewRepositoryDumper creates an gitea Uploader
+// NewRepositoryDumper creates a gitea Uploader
 func NewRepositoryDumper(ctx context.Context, baseDir, repoOwner, repoName string, opts base.MigrateOptions) (*RepositoryDumper, error) {
 	baseDir = filepath.Join(baseDir, repoOwner, repoName)
 	if err := os.MkdirAll(baseDir, os.ModePerm); err != nil {

--- a/services/migrations/gitea_uploader.go
+++ b/services/migrations/gitea_uploader.go
@@ -56,7 +56,7 @@ type GiteaLocalUploader struct {
 	gitServiceType structs.GitServiceType
 }
 
-// NewGiteaLocalUploader creates an gitea Uploader via gitea API v1
+// NewGiteaLocalUploader creates a gitea Uploader via gitea API v1
 func NewGiteaLocalUploader(_ context.Context, doer *user_model.User, repoOwner, repoName string) *GiteaLocalUploader {
 	return &GiteaLocalUploader{
 		doer:        doer,

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -28066,7 +28066,7 @@
             "Commit",
             "Repository"
           ],
-          "x-go-enum-desc": "Issue NotifySubjectIssue an issue is subject of an notification\nPull NotifySubjectPull a pull is subject of an notification\nCommit NotifySubjectCommit a commit is subject of an notification\nRepository NotifySubjectRepository a repository is subject of an notification",
+          "x-go-enum-desc": "Issue NotifySubjectIssue an issue is subject of a notification\nPull NotifySubjectPull a pull is subject of an notification\nCommit NotifySubjectCommit a commit is subject of an notification\nRepository NotifySubjectRepository a repository is subject of an notification",
           "x-go-name": "Type"
         },
         "url": {

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -28066,7 +28066,7 @@
             "Commit",
             "Repository"
           ],
-          "x-go-enum-desc": "Issue NotifySubjectIssue a issue is subject of an notification\nPull NotifySubjectPull a pull is subject of an notification\nCommit NotifySubjectCommit a commit is subject of an notification\nRepository NotifySubjectRepository a repository is subject of an notification",
+          "x-go-enum-desc": "Issue NotifySubjectIssue an issue is subject of an notification\nPull NotifySubjectPull a pull is subject of an notification\nCommit NotifySubjectCommit a commit is subject of an notification\nRepository NotifySubjectRepository a repository is subject of an notification",
           "x-go-name": "Type"
         },
         "url": {

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -5889,7 +5889,7 @@
         "tags": [
           "repository"
         ],
-        "summary": "List an repo's actions secrets",
+        "summary": "List a repo's actions secrets",
         "operationId": "repoListActionsSecrets",
         "parameters": [
           {

--- a/templates/swagger/v1_openapi3_json.tmpl
+++ b/templates/swagger/v1_openapi3_json.tmpl
@@ -7782,7 +7782,7 @@
               "Repository"
             ],
             "type": "string",
-            "x-go-enum-desc": "Issue NotifySubjectIssue a issue is subject of an notification\nPull NotifySubjectPull a pull is subject of an notification\nCommit NotifySubjectCommit a commit is subject of an notification\nRepository NotifySubjectRepository a repository is subject of an notification",
+            "x-go-enum-desc": "Issue NotifySubjectIssue an issue is subject of an notification\nPull NotifySubjectPull a pull is subject of an notification\nCommit NotifySubjectCommit a commit is subject of an notification\nRepository NotifySubjectRepository a repository is subject of an notification",
             "x-go-name": "Type"
           },
           "url": {

--- a/templates/swagger/v1_openapi3_json.tmpl
+++ b/templates/swagger/v1_openapi3_json.tmpl
@@ -16954,7 +16954,7 @@
             "$ref": "#/components/responses/notFound"
           }
         },
-        "summary": "List an repo's actions secrets",
+        "summary": "List a repo's actions secrets",
         "tags": [
           "repository"
         ]

--- a/templates/swagger/v1_openapi3_json.tmpl
+++ b/templates/swagger/v1_openapi3_json.tmpl
@@ -7782,7 +7782,7 @@
               "Repository"
             ],
             "type": "string",
-            "x-go-enum-desc": "Issue NotifySubjectIssue an issue is subject of an notification\nPull NotifySubjectPull a pull is subject of an notification\nCommit NotifySubjectCommit a commit is subject of an notification\nRepository NotifySubjectRepository a repository is subject of an notification",
+            "x-go-enum-desc": "Issue NotifySubjectIssue an issue is subject of a notification\nPull NotifySubjectPull a pull is subject of an notification\nCommit NotifySubjectCommit a commit is subject of an notification\nRepository NotifySubjectRepository a repository is subject of an notification",
             "x-go-name": "Type"
           },
           "url": {


### PR DESCRIPTION
Fix wrong function names in doc comments (UpdateVatar, UpdateAvatar on DeleteAvatar), 'a array' in issue template validation errors, 'an repo's' in a swagger summary, and several article/agreement errors in comments.