### PR TITLE
feat: Add inline comments on commits

### DIFF
--- a/models/issues/comment.go
+++ b/models/issues/comment.go
@@ -837,11 +837,16 @@ func CreateComment(ctx context.Context, opts *CreateCommentOptions) (_ *Comment,
 			}
 		}
 
+		var issueID int64
+		if opts.Issue != nil {
+			issueID = opts.Issue.ID
+		}
+
 		comment := &Comment{
 			Type:             opts.Type,
 			PosterID:         opts.Doer.ID,
 			Poster:           opts.Doer,
-			IssueID:          opts.Issue.ID,
+			IssueID:          issueID,
 			LabelID:          LabelID,
 			OldMilestoneID:   opts.OldMilestoneID,
 			MilestoneID:      opts.MilestoneID,
@@ -910,8 +915,10 @@ func updateCommentInfos(ctx context.Context, opts *CreateCommentOptions, comment
 		}
 		fallthrough
 	case CommentTypeComment:
-		if err := UpdateIssueNumComments(ctx, opts.Issue.ID); err != nil {
-			return err
+		if opts.Issue != nil {
+			if err := UpdateIssueNumComments(ctx, opts.Issue.ID); err != nil {
+				return err
+			}
 		}
 		fallthrough
 	case CommentTypeReview:
@@ -921,7 +928,10 @@ func updateCommentInfos(ctx context.Context, opts *CreateCommentOptions, comment
 		// comment type reopen and close event have their own logic to update numbers but not here
 	}
 	// update the issue's updated_unix column
-	return UpdateIssueCols(ctx, opts.Issue, "updated_unix")
+	if opts.Issue != nil {
+		return UpdateIssueCols(ctx, opts.Issue, "updated_unix")
+	}
+	return nil
 }
 
 func createDeadlineComment(ctx context.Context, doer *user_model.User, issue *Issue, newDeadlineUnix timeutil.TimeStamp) (*Comment, error) {
@@ -1073,6 +1083,7 @@ type FindCommentsOptions struct {
 	TreePath    string
 	Type        CommentType
 	IssueIDs    []int64
+	CommitSHA   string
 	Invalidated optional.Option[bool]
 	IsPull      optional.Option[bool]
 }
@@ -1105,6 +1116,9 @@ func (opts FindCommentsOptions) ToConds() builder.Cond {
 	}
 	if len(opts.TreePath) > 0 {
 		cond = cond.And(builder.Eq{"comment.tree_path": opts.TreePath})
+	}
+	if len(opts.CommitSHA) > 0 {
+		cond = cond.And(builder.Eq{"comment.commit_sha": opts.CommitSHA})
 	}
 	if opts.Invalidated.Has() {
 		cond = cond.And(builder.Eq{"comment.invalidated": opts.Invalidated.Value()})

--- a/models/issues/comment_code.go
+++ b/models/issues/comment_code.go
@@ -20,21 +20,20 @@ type CodeComments map[string]map[int64][]*Comment
 
 // FetchCodeComments will return a 2d-map: ["Path"]["Line"] = Comments at line
 func FetchCodeComments(ctx context.Context, issue *Issue, currentUser *user_model.User, showOutdatedComments bool) (CodeComments, error) {
-	return fetchCodeCommentsByReview(ctx, issue, currentUser, nil, showOutdatedComments)
+	return fetchCodeCommentsByReview(ctx, issue.Repo, issue, currentUser, nil, showOutdatedComments)
 }
 
-func fetchCodeCommentsByReview(ctx context.Context, issue *Issue, currentUser *user_model.User, review *Review, showOutdatedComments bool) (CodeComments, error) {
+// FetchCommitCodeComments will return a 2d-map: ["Path"]["Line"] = Comments at line for a commit
+func FetchCommitCodeComments(ctx context.Context, repo *repo_model.Repository, commitSHA string) (CodeComments, error) {
 	pathToLineToComment := make(CodeComments)
-	if review == nil {
-		review = &Review{ID: 0}
-	}
 	opts := FindCommentsOptions{
-		Type:     CommentTypeCode,
-		IssueID:  issue.ID,
-		ReviewID: review.ID,
+		Type:      CommentTypeCode,
+		RepoID:    repo.ID,
+		CommitSHA: commitSHA,
+		IssueID:   0, // No issue for commit comments
 	}
 
-	comments, err := findCodeComments(ctx, opts, issue, currentUser, review, showOutdatedComments)
+	comments, err := findCodeComments(ctx, opts, repo, nil, nil, nil, true)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +47,32 @@ func fetchCodeCommentsByReview(ctx context.Context, issue *Issue, currentUser *u
 	return pathToLineToComment, nil
 }
 
-func findCodeComments(ctx context.Context, opts FindCommentsOptions, issue *Issue, currentUser *user_model.User, review *Review, showOutdatedComments bool) ([]*Comment, error) {
+func fetchCodeCommentsByReview(ctx context.Context, repo *repo_model.Repository, issue *Issue, currentUser *user_model.User, review *Review, showOutdatedComments bool) (CodeComments, error) {
+	pathToLineToComment := make(CodeComments)
+	if review == nil {
+		review = &Review{ID: 0}
+	}
+	opts := FindCommentsOptions{
+		Type:     CommentTypeCode,
+		IssueID:  issue.ID,
+		ReviewID: review.ID,
+	}
+
+	comments, err := findCodeComments(ctx, opts, repo, issue, currentUser, review, showOutdatedComments)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, comment := range comments {
+		if pathToLineToComment[comment.TreePath] == nil {
+			pathToLineToComment[comment.TreePath] = make(map[int64][]*Comment)
+		}
+		pathToLineToComment[comment.TreePath][comment.Line] = append(pathToLineToComment[comment.TreePath][comment.Line], comment)
+	}
+	return pathToLineToComment, nil
+}
+
+func findCodeComments(ctx context.Context, opts FindCommentsOptions, repo *repo_model.Repository, issue *Issue, currentUser *user_model.User, review *Review, showOutdatedComments bool) ([]*Comment, error) {
 	var comments CommentList
 	if review == nil {
 		review = &Review{ID: 0}
@@ -67,8 +91,11 @@ func findCodeComments(ctx context.Context, opts FindCommentsOptions, issue *Issu
 		return nil, err
 	}
 
-	if err := issue.LoadRepo(ctx); err != nil {
-		return nil, err
+	if issue != nil {
+		if err := issue.LoadRepo(ctx); err != nil {
+			return nil, err
+		}
+		repo = issue.Repo
 	}
 
 	if err := comments.LoadPosters(ctx); err != nil {
@@ -83,7 +110,7 @@ func findCodeComments(ctx context.Context, opts FindCommentsOptions, issue *Issu
 		return nil, err
 	}
 
-	if err := comments.loadReactions(ctx, issue.Repo); err != nil {
+	if err := comments.loadReactions(ctx, repo); err != nil {
 		return nil, err
 	}
 
@@ -116,7 +143,7 @@ func findCodeComments(ctx context.Context, opts FindCommentsOptions, issue *Issu
 		n++
 
 		var err error
-		rctx := renderhelper.NewRenderContextRepoComment(ctx, issue.Repo, renderhelper.RepoCommentOptions{
+		rctx := renderhelper.NewRenderContextRepoComment(ctx, repo, renderhelper.RepoCommentOptions{
 			FootnoteContextID: strconv.FormatInt(comment.ID, 10),
 		})
 		if comment.RenderedContent, err = markdown.RenderString(rctx, comment.Content); err != nil {
@@ -134,5 +161,17 @@ func FetchCodeCommentsByLine(ctx context.Context, issue *Issue, currentUser *use
 		TreePath: treePath,
 		Line:     line,
 	}
-	return findCodeComments(ctx, opts, issue, currentUser, nil, showOutdatedComments)
+	return findCodeComments(ctx, opts, issue.Repo, issue, currentUser, nil, showOutdatedComments)
+}
+
+// FetchCommitCodeCommentsByLine fetches the code comments for a given treePath and line number for a commit
+func FetchCommitCodeCommentsByLine(ctx context.Context, repo *repo_model.Repository, commitSHA string, currentUser *user_model.User, treePath string, line int64, showOutdatedComments bool) (CommentList, error) {
+	opts := FindCommentsOptions{
+		Type:      CommentTypeCode,
+		RepoID:    repo.ID,
+		CommitSHA: commitSHA,
+		TreePath:  treePath,
+		Line:      line,
+	}
+	return findCodeComments(ctx, opts, repo, nil, currentUser, nil, showOutdatedComments)
 }

--- a/routers/web/repo/commit.go
+++ b/routers/web/repo/commit.go
@@ -30,8 +30,11 @@ import (
 	"gitea.dev/modules/setting"
 	"gitea.dev/modules/templates"
 	"gitea.dev/modules/util"
+	"gitea.dev/modules/web"
 	asymkey_service "gitea.dev/services/asymkey"
 	"gitea.dev/services/context"
+	"gitea.dev/services/context/upload"
+	"gitea.dev/services/forms"
 	git_service "gitea.dev/services/git"
 	"gitea.dev/services/gitdiff"
 	repo_service "gitea.dev/services/repository"
@@ -334,6 +337,11 @@ func Diff(ctx *context.Context) {
 		ctx.NotFound(err)
 		return
 	}
+
+	if err := diff.LoadCommitComments(ctx, ctx.Repo.Repository, commitID); err != nil {
+		log.Error("LoadCommitComments failed: %v", err)
+	}
+
 	diffShortStat, err := gitdiff.GetDiffShortStat(ctx, gitRepoStore, gitRepo, "", commitID)
 	if err != nil {
 		ctx.ServerError("GetDiffShortStat", err)
@@ -477,4 +485,100 @@ func processGitCommits(ctx *context.Context, gitCommits []*git.Commit) ([]*git_m
 		}
 	}
 	return commits, nil
+}
+
+// RenderNewCommitCodeCommentForm renders the form for creating a new commit comment
+func RenderNewCommitCodeCommentForm(ctx *context.Context) {
+	commitID := ctx.Params(":sha")
+	if len(commitID) != 40 {
+		ctx.NotFound(nil)
+		return
+	}
+
+	ctx.Data["PageIsCommitFiles"] = true
+	ctx.Data["AfterCommitID"] = commitID
+	ctx.Data["IsAttachmentEnabled"] = setting.Attachment.Enabled
+	upload.AddUploadContext(ctx, "comment")
+	ctx.HTML(http.StatusOK, "repo/diff/new_comment")
+}
+
+// CreateCommitCodeComment will create a code comment on a commit
+func CreateCommitCodeComment(ctx *context.Context) {
+	form := web.GetForm(ctx).(*forms.CodeCommentForm)
+	commitID := ctx.Params(":sha")
+	if len(commitID) != 40 {
+		ctx.NotFound(nil)
+		return
+	}
+
+	if ctx.HasError() {
+		ctx.Flash.Error(ctx.GetErrMsg())
+		ctx.Redirect(fmt.Sprintf("%s/commit/%s", ctx.Repo.RepoLink, commitID))
+		return
+	}
+
+	signedLine := form.Line
+	if form.Side == "previous" {
+		signedLine *= -1
+	}
+
+	var attachments []string
+	if setting.Attachment.Enabled {
+		attachments = form.Files
+	}
+
+	comment, err := repo_service.CreateCommitCodeComment(ctx,
+		ctx.Doer,
+		ctx.Repo.Repository,
+		ctx.Repo.GitRepo,
+		commitID,
+		signedLine,
+		form.Content,
+		form.TreePath,
+		attachments,
+	)
+	if err != nil {
+		ctx.ServerError("CreateCommitCodeComment", err)
+		return
+	}
+
+	if comment == nil {
+		ctx.Redirect(fmt.Sprintf("%s/commit/%s", ctx.Repo.RepoLink, commitID))
+		return
+	}
+
+	renderCommitConversation(ctx, comment, form.Origin)
+}
+
+func renderCommitConversation(ctx *context.Context, comment *issues_model.Comment, origin string) {
+	ctx.Data["PageIsCommitFiles"] = true
+
+	showOutdatedComments := origin == "timeline" || GetShowOutdatedComments(ctx)
+	comments, err := issues_model.FetchCommitCodeCommentsByLine(ctx, ctx.Repo.Repository, comment.CommitSHA, ctx.Doer, comment.TreePath, comment.Line, showOutdatedComments)
+	if err != nil {
+		ctx.ServerError("FetchCommitCodeCommentsByLine", err)
+		return
+	}
+	if len(comments) == 0 {
+		ctx.HTML(http.StatusOK, "repo/diff/conversation_outdated")
+		return
+	}
+
+	if err := comments.LoadAttachments(ctx); err != nil {
+		ctx.ServerError("LoadAttachments", err)
+		return
+	}
+
+	ctx.Data["IsAttachmentEnabled"] = setting.Attachment.Enabled
+	upload.AddUploadContext(ctx, "comment")
+
+	ctx.Data["comments"] = comments
+	ctx.Data["AfterCommitID"] = comment.CommitSHA
+
+	// Add missing bits that might be needed by the template
+	ctx.Data["CanBlockUser"] = func(blocker, blockee *user_model.User) bool {
+		return false // Or implement properly
+	}
+
+	ctx.HTML(http.StatusOK, "repo/diff/conversation")
 }

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -821,6 +821,22 @@ func ExcerptBlob(ctx *context.Context) {
 				}
 			}
 		}
+	} else if diffBlobExcerptData.AfterCommitID != "" {
+		ctx.Data["PageIsCommitFiles"] = true
+		ctx.Data["AfterCommitID"] = diffBlobExcerptData.AfterCommitID
+		ctx.Data["CanBlockUser"] = func(blocker, blockee *user_model.User) bool {
+			return false // No-op for now unless user_service is imported and reachable
+		}
+
+		allComments, err := issues_model.FetchCommitCodeComments(ctx, ctx.Repo.Repository, diffBlobExcerptData.AfterCommitID)
+		if err != nil {
+			log.Error("FetchCommitCodeComments error: %v", err)
+		} else {
+			if lineComments, ok := allComments[filePath]; ok {
+				attachCommentsToLines(section, lineComments)
+				attachHiddenCommentIDs(section, lineComments)
+			}
+		}
 	}
 
 	ctx.Data["section"] = section

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1713,6 +1713,11 @@ func registerWebRoutes(m *web.Router, webAuth *AuthMiddleware) {
 			m.Get("/commit/{sha:([a-f0-9]{7,64})$}", repo.SetEditorconfigIfExists, repo.SetDiffViewStyle, repo.SetWhitespaceBehavior, repo.Diff)
 			m.Get("/commit/{sha:([a-f0-9]{7,64})$}/load-branches-and-tags", repo.LoadBranchesAndTags)
 
+			m.Group("/commit/{sha:([a-f0-9]{7,64})$}/comments", func() {
+				m.Get("/new", repo.RenderNewCommitCodeCommentForm)
+				m.Post("", web.Bind(forms.CodeCommentForm{}), repo.CreateCommitCodeComment)
+			}, optSignIn, context.RepoMustNotBeArchived())
+
 			// FIXME: this route `/cherry-pick/{sha}` doesn't seem useful or right, the new code always uses `/_cherrypick/` which could handle branch name correctly
 			m.Get("/cherry-pick/{sha:([a-f0-9]{7,64})$}", repo.SetEditorconfigIfExists, context.RepoRefByDefaultBranch(), repo.CherryPick)
 		}, repo.MustBeNotEmpty)

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -1640,3 +1640,31 @@ func GetWhitespaceFlag(whitespaceBehavior string) gitcmd.TrustedCmdArgs {
 	}
 	return nil
 }
+
+// LoadCommitComments loads comments into each line for a commit diff
+func (diff *Diff) LoadCommitComments(ctx context.Context, repo *repo_model.Repository, commitSHA string) error {
+	allComments, err := issues_model.FetchCommitCodeComments(ctx, repo, commitSHA)
+	if err != nil {
+		return err
+	}
+	for _, file := range diff.Files {
+		if lineCommits, ok := allComments[file.Name]; ok {
+			for _, section := range file.Sections {
+				for _, line := range section.Lines {
+					if comments, ok := lineCommits[int64(line.LeftIdx*-1)]; ok {
+						line.Comments = append(line.Comments, comments...)
+					}
+					if comments, ok := lineCommits[int64(line.RightIdx)]; ok {
+						line.Comments = append(line.Comments, comments...)
+					}
+					sort.SliceStable(line.Comments, func(i, j int) bool {
+						return line.Comments[i].CreatedUnix < line.Comments[j].CreatedUnix
+					})
+					// Mark expand buttons that have comments in hidden lines
+					FillHiddenCommentIDsForDiffLine(line, lineCommits)
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/services/repository/commit_comment.go
+++ b/services/repository/commit_comment.go
@@ -1,0 +1,52 @@
+package repository
+
+import (
+	"context"
+
+	"gitea.dev/models/issues"
+	repo_model "gitea.dev/models/repo"
+	user_model "gitea.dev/models/user"
+	"gitea.dev/modules/git"
+	"gitea.dev/modules/setting"
+)
+
+// CreateCommitCodeComment creates a code comment on a commit
+func CreateCommitCodeComment(ctx context.Context, doer *user_model.User, repo *repo_model.Repository, gitRepo *git.Repository, commitID string, line int64, content, treePath string, attachments []string) (*issues.Comment, error) {
+	commit, err := gitRepo.GetCommit(commitID)
+	if err != nil {
+		return nil, err
+	}
+
+	objectFormat, err := gitRepo.GetObjectFormat()
+	if err != nil {
+		return nil, err
+	}
+	parentCommitID := objectFormat.EmptyTree().String()
+
+	if commit.ParentCount() > 0 {
+		parentCommit, err := commit.Parent(0)
+		if err == nil && parentCommit != nil {
+			parentCommitID = parentCommit.ID.String()
+		}
+	}
+
+	patch, err := git.GetFileDiffCutAroundLine(
+		gitRepo, parentCommitID, commitID, treePath,
+		int64((&issues.Comment{Line: line}).UnsignedLine()), line < 0, setting.UI.CodeCommentLines,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return issues.CreateComment(ctx, &issues.CreateCommentOptions{
+		Type:        issues.CommentTypeCode,
+		Doer:        doer,
+		Repo:        repo,
+		Content:     content,
+		LineNum:     line,
+		TreePath:    treePath,
+		CommitSHA:   commitID,
+		Patch:       patch,
+		Attachments: attachments,
+	})
+}

--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -184,7 +184,7 @@
 										{{end}}
 									</div>
 								{{else}}
-									<table class="chroma" data-new-comment-url="{{$.Issue.Link}}/files/reviews/new_comment" data-path="{{$file.Name}}">
+									<table class="chroma" data-new-comment-url="{{if $.Issue}}{{$.Issue.Link}}/files/reviews/new_comment{{else}}{{$.RepoLink}}/commit/{{$.AfterCommitID}}/comments/new{{end}}" data-path="{{$file.Name}}">
 										{{if $.IsSplitStyle}}
 											{{template "repo/diff/section_split" dict "file" . "root" $}}
 										{{else}}

--- a/templates/repo/diff/comment_form.tmpl
+++ b/templates/repo/diff/comment_form.tmpl
@@ -1,5 +1,5 @@
 {{if and ctx.RootData.SignedUserID (not ctx.RootData.Repository.IsArchived)}}
-	<form class="ui form {{if $.hidden}}tw-hidden comment-form{{end}}" action="{{$.root.Issue.Link}}/files/reviews/comments" method="post">
+	<form class="ui form {{if $.hidden}}tw-hidden comment-form{{end}}" action="{{if $.root.Issue}}{{$.root.Issue.Link}}/files/reviews/comments{{else}}{{$.root.RepoLink}}/commit/{{$.root.AfterCommitID}}/comments{{end}}" method="post">
 		<input type="hidden" name="origin" value="{{if $.root.PageIsPullFiles}}diff{{else}}timeline{{end}}">
 		<input type="hidden" name="latest_commit_id" value="{{$.root.AfterCommitID}}">
 		<input type="hidden" name="side" value="{{if $.Side}}{{$.Side}}{{end}}">

--- a/templates/repo/diff/comments.tmpl
+++ b/templates/repo/diff/comments.tmpl
@@ -34,7 +34,7 @@
 			</div>
 			<div class="comment-header-right">
 				{{if .Invalidated}}
-					{{$referenceUrl := printf "%s#%s" $.root.Issue.Link .HashTag}}
+					{{$referenceUrl := printf "%s#%s" (if $.root.Issue $.root.Issue.Link (printf "%s/commit/%s" $.root.RepoLink $.root.AfterCommitID)) .HashTag}}
 					<a href="{{$referenceUrl}}" class="ui label basic small" data-tooltip-content="{{ctx.Locale.Tr "repo.issues.review.outdated_description"}}">
 						{{ctx.Locale.Tr "repo.issues.review.outdated"}}
 					</a>

--- a/templates/repo/diff/conversation.tmpl
+++ b/templates/repo/diff/conversation.tmpl
@@ -5,7 +5,7 @@
 	{{$resolveDoer := $comment.ResolveDoer}}
 	{{$hasReview := and $comment.Review}}
 	{{$isReviewPending := and $hasReview (eq $comment.Review.Type 0)}}
-	{{$referenceUrl := printf "%s#%s" $.Issue.Link $comment.HashTag}}
+	{{$referenceUrl := printf "%s#%s" (if $.Issue $.Issue.Link (printf "%s/commit/%s" $.RepoLink $.AfterCommitID)) $comment.HashTag}}
 	<div class="conversation-holder" data-path="{{$comment.TreePath}}" data-side="{{if lt $comment.Line 0}}left{{else}}right{{end}}" data-idx="{{$comment.UnsignedLine}}">
 		{{if $resolved}}
 			<div class="resolved-placeholder">


### PR DESCRIPTION
Fixes #4898

Allows users to add inline code comments on regular commit diffs, similar to Pull Request diffs. Adds backend API support for `CreateCommitCodeComment` and modifies PR-centric UI templates to work effectively for individual commits.