### PR TITLE
fix(ui): restore commits table column widths

### DIFF
--- a/templates/repo/commits_list.tmpl
+++ b/templates/repo/commits_list.tmpl
@@ -2,9 +2,9 @@
 	<table class="ui very basic table unstackable" id="commits-table">
 		<thead>
 			<tr>
-				<th class="four wide">{{ctx.Locale.Tr "repo.commits.author"}}</th>
+				<th class="three wide">{{ctx.Locale.Tr "repo.commits.author"}}</th>
 				<th class="two wide sha">{{StringUtils.ToUpper $.Repository.ObjectFormatName}}</th>
-				<th class="seven wide message">{{ctx.Locale.Tr "repo.commits.message"}}</th>
+				<th class="eight wide message">{{ctx.Locale.Tr "repo.commits.message"}}</th>
 				<th class="two wide tw-text-right">{{ctx.Locale.Tr "repo.commits.date"}}</th>
 				<th class="one wide"></th>
 			</tr>


### PR DESCRIPTION
https://github.com/go-gitea/gitea/pull/37594 widened the author column from `three wide` to `four wide`, leaving a large empty gap around the SHA column in the common single-author case. The old author cell was capped at 180px, so the wider column only adds whitespace: avatar-stack names ellipsize at 240px each, and wider multi-author rows still expand naturally in the auto-layout table. Restore the pre-existing `three`/`eight` widths.

Before:

<img width="1332" height="230" alt="Screenshot 2026-07-09 at 14 07 55" src="https://github.com/user-attachments/assets/5e68e7c5-bc5a-4c06-a5f9-035408558160" />

After:

<img width="1331" height="240" alt="Screenshot 2026-07-09 at 14 06 39" src="https://github.com/user-attachments/assets/342ee031-d6fe-4fca-8e58-f6d753a75fc8" />
