### PR TITLE
test(e2e): fix race in pdf file render test

### DIFF
--- a/tests/e2e/file-view-render.test.ts
+++ b/tests/e2e/file-view-render.test.ts
@@ -35,7 +35,8 @@ test('pdf file', async ({page, request}) => {
   await page.goto(`/${owner}/${repoName}/src/branch/main/test.pdf`);
   const container = page.locator('.file-view-render-container');
   await expect(container).toHaveAttribute('data-render-name', 'pdf-viewer');
-  expect((await container.boundingBox())!.height).toBeGreaterThan(300);
+  // the attribute is set before the plugin's async render completes, so poll until the height is applied
+  await expect.poll(async () => (await container.boundingBox())!.height).toBeGreaterThan(300);
   await assertFlushWithParent(container, page.locator('.file-view'));
 });
 

--- a/tests/e2e/file-view-render.test.ts
+++ b/tests/e2e/file-view-render.test.ts
@@ -35,7 +35,6 @@ test('pdf file', async ({page, request}) => {
   await page.goto(`/${owner}/${repoName}/src/branch/main/test.pdf`);
   const container = page.locator('.file-view-render-container');
   await expect(container).toHaveAttribute('data-render-name', 'pdf-viewer');
-  // the attribute is set before the plugin's async render completes, so poll until the height is applied
   await expect.poll(async () => (await container.boundingBox())!.height).toBeGreaterThan(300);
   await assertFlushWithParent(container, page.locator('.file-view'));
 });


### PR DESCRIPTION
`data-render-name` is set before the plugin's async render runs, so measuring the container height right after the attribute appears can observe the pre-render 48px height when the `pdfobject` chunk loads slowly (flaked in CI). Poll for the height instead, like the asciicast test in the same file does.