### PR TITLE
fix(actions): keep workflow run trailing on one row with long branch names

### DIFF
--- a/models/actions/run.go
+++ b/models/actions/run.go
@@ -121,7 +121,7 @@ func (run *ActionRun) PrettyRef() string {
 	return refName.ShortName()
 }
 
-// RefTooltip return a tooltop of run's ref. For pull request, it's the title of the PR, otherwise it's the ShortName.
+// RefTooltip return a tooltip of run's ref. For pull request, it's the title of the PR, otherwise it's the ShortName.
 func (run *ActionRun) RefTooltip() string {
 	payload, err := run.GetPullRequestEventPayload()
 	if err == nil && payload != nil && payload.PullRequest != nil {

--- a/templates/repo/actions/runs_list.tmpl
+++ b/templates/repo/actions/runs_list.tmpl
@@ -38,7 +38,7 @@
 					{{end}}
 				</div>
 			</div>
-			<div class="item-trailing">
+			<div class="run-list-item-trailing">
 				{{if $run.IsRefDeleted}}
 					<span class="ui label run-list-ref gt-ellipsis tw-line-through" data-tooltip-content="{{$run.RefTooltip}}">{{$run.PrettyRef}}</span>
 				{{else}}

--- a/web_src/css/actions.css
+++ b/web_src/css/actions.css
@@ -53,20 +53,19 @@
   flex: 0 0 280px;
 }
 
-.run-list-ref {
-  display: inline-block !important;
-  max-width: 105px;
+.ui.label.run-list-ref {
+  display: inline-block;
+  max-width: 110px;
 }
 
 @media (max-width: 767.98px) {
   .run-list-item-trailing {
     flex-direction: column;
     align-items: flex-end;
-    width: auto;
-    flex-basis: auto;
+    max-width: 30%;
+    flex: 0 0 30%;
   }
-  .run-list-item-right,
-  .run-list-ref {
+  .run-list-item-right {
     max-width: 110px;
   }
 }

--- a/web_src/css/actions.css
+++ b/web_src/css/actions.css
@@ -43,7 +43,7 @@
   align-items: center;
 }
 
-.run-list .item-trailing {
+.run-list.items-with-main > .item .item-trailing {
   flex-wrap: nowrap;
   width: 280px;
   flex: 0 0 280px;
@@ -55,7 +55,7 @@
 }
 
 @media (max-width: 767.98px) {
-  .run-list .item-trailing {
+  .run-list.items-with-main > .item .item-trailing {
     flex-direction: column;
     align-items: flex-end;
     width: auto;

--- a/web_src/css/actions.css
+++ b/web_src/css/actions.css
@@ -43,7 +43,11 @@
   align-items: center;
 }
 
-.run-list.items-with-main > .item .item-trailing {
+.run-list-item-trailing {
+  display: flex;
+  gap: var(--gap-block);
+  align-items: center;
+  justify-content: end;
   flex-wrap: nowrap;
   width: 280px;
   flex: 0 0 280px;
@@ -55,7 +59,7 @@
 }
 
 @media (max-width: 767.98px) {
-  .run-list.items-with-main > .item .item-trailing {
+  .run-list-item-trailing {
     flex-direction: column;
     align-items: flex-end;
     width: auto;


### PR DESCRIPTION
The flex-list refactor (#37505) raised the shared `.item-trailing` selector's specificity, so its `flex-wrap: wrap` started overriding the run list's intended `flex-wrap: nowrap` — a long branch name pushed the trailing content past its fixed 280px width and wrapped the kebab menu onto its own line.