### PR TITLE
fix(git): regenerate missing packfile index to recover orphaned packs

### DIFF
--- a/modules/git/repo_base_gogit.go
+++ b/modules/git/repo_base_gogit.go
@@ -8,8 +8,11 @@ package git
 
 import (
 	"context"
+	"os"
 	"path/filepath"
+	"strings"
 
+	"gitea.dev/modules/git/gitcmd"
 	gitealog "gitea.dev/modules/log"
 	"gitea.dev/modules/setting"
 	"gitea.dev/modules/util"
@@ -53,13 +56,20 @@ func OpenRepository(ctx context.Context, repoPath string) (*Repository, error) {
 	}
 
 	fs := osfs.New(repoPath)
-	_, err = fs.Stat(".git")
-	if err == nil {
+	gitDirPath := repoPath
+	if _, err = fs.Stat(".git"); err == nil {
+		gitDirPath = filepath.Join(repoPath, ".git")
 		fs, err = fs.Chroot(".git")
 		if err != nil {
 			return nil, err
 		}
 	}
+
+	// Regenerate any orphan packfile index before go-git tries to read it, otherwise a single
+	// pack without its ".idx" makes the whole repository unreadable with "packfile not found".
+	// This happens on Windows (issue #38359): the gogit storage keeps ".pack" descriptors open,
+	// so git's repack cleanup can delete the ".idx" while failing to unlink the locked ".pack".
+	repairOrphanPackIndexes(ctx, gitDirPath)
 	// the "clone --shared" repo doesn't work well with go-git AlternativeFS, https://github.com/go-git/go-git/issues/1006
 	// so use "/" for AlternatesFS, I guess it is the same behavior as current nogogit (no limitation or check for the "objects/info/alternates" paths), trust the "clone" command executed by the server.
 	var altFs billy.Filesystem
@@ -101,4 +111,31 @@ func (repo *Repository) Close() error {
 // GoGitRepo gets the go-git repo representation
 func (repo *Repository) GoGitRepo() *gogit.Repository {
 	return repo.gogitRepo
+}
+
+// repairOrphanPackIndexes finds packfiles that lost their ".idx" and regenerates it with
+// "git index-pack". It is a no-op for healthy repositories (the common case) and never
+// returns an error: a repository that cannot be repaired is left for go-git to report.
+func repairOrphanPackIndexes(ctx context.Context, gitDirPath string) {
+	packDir := filepath.Join(gitDirPath, "objects", "pack")
+	entries, err := os.ReadDir(packDir)
+	if err != nil {
+		return // no pack dir (e.g. empty repo) or unreadable; nothing to repair
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".pack") {
+			continue
+		}
+		idxPath := filepath.Join(packDir, strings.TrimSuffix(name, ".pack")+".idx")
+		if _, err = os.Stat(idxPath); err == nil || !os.IsNotExist(err) {
+			continue // index present, or an unexpected stat error we should not act on
+		}
+		packPath := filepath.Join(packDir, name)
+		if err = gitcmd.NewCommand("index-pack").AddDynamicArguments(packPath).WithDir(gitDirPath).Run(ctx); err != nil {
+			gitealog.Error("Failed to regenerate missing index for orphan packfile %q: %v", packPath, err)
+		} else {
+			gitealog.Warn("Regenerated missing index for orphan packfile %q", packPath)
+		}
+	}
 }

--- a/modules/git/repo_base_gogit_test.go
+++ b/modules/git/repo_base_gogit_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+//go:build gogit
+
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOpenRepositoryRepairsOrphanPack reproduces issue #38359: a packfile whose ".idx"
+// is missing (e.g. on Windows, git's repack cleanup deletes the ".idx" but cannot delete
+// the ".pack" that the gogit storage keeps open) makes the whole repository unreadable with
+// "packfile not found". Opening the repository should regenerate the missing index instead.
+func TestOpenRepositoryRepairsOrphanPack(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, os.CopyFS(tmpDir, os.DirFS(filepath.Join(testReposDir, "repo5_pulls"))))
+
+	// c83380d... only lives inside the packfile, so reading it requires the pack index.
+	const packedCommit = "c83380d7056593c51a699d12b9c00627bd5743e9"
+	packIdx := filepath.Join(tmpDir, "objects", "pack", "pack-81423f591973f5d9dab89cc45afa1c544448133e.idx")
+	require.FileExists(t, packIdx)
+	require.NoError(t, os.Remove(packIdx)) // turn the pack into an orphan
+
+	repo, err := OpenRepository(t.Context(), tmpDir)
+	require.NoError(t, err)
+	defer repo.Close()
+
+	commit, err := repo.GetCommit(packedCommit)
+	require.NoError(t, err)
+	assert.Equal(t, packedCommit, commit.ID.String())
+
+	// the missing index must have been regenerated while opening the repository
+	assert.FileExists(t, packIdx)
+}


### PR DESCRIPTION
Fixes #38359.

On Windows, the official Gitea binary is built with the `gogit` tag, so git objects are read through go-git instead of the git CLI. go-git opens repositories with `KeepDescriptors: true` (`modules/git/repo_base_gogit.go`), which keeps every `.pack` file descriptor open for the lifetime of the cached repository.

When a subsequent `git push` triggers auto-gc / `repack -d`, git consolidates packfiles and unlinks the redundant ones. On Windows an open handle blocks deletion — but go-git only holds the `.pack` open (it opens `.idx` files transiently and closes them). So git succeeds in deleting the `.idx` while failing to unlink the still-locked `.pack`, leaving an **orphan packfile with no index**.

The next time a fresh go-git storage opens that repository, `ObjectStorage.requireIndex()` scans for `*.pack` files and tries to load each `.idx`. The orphan's missing index returns `ErrPackfileNotFound` ("packfile not found"), and because `requireIndex` aborts on the first failure, **every** object read then fails with a `500 Internal Server Error` — on the web UI, the API, and actions (`GetBranchCommit`, `ListBranches`, `CreateCommitStatusForRunJobs`, etc.), exactly as seen in the reported logs.

The reporter's manual workaround (regenerating the missing `.idx`) is `git index-pack` under the hood, so this is safe to automate — the packfile still contains all objects, only the index is gone.
