### PR TITLE
fix(admin): exit dev test queue producer loop when context is cancelled

### DIFF
--- a/routers/web/admin/queue_tester.go
+++ b/routers/web/admin/queue_tester.go
@@ -56,6 +56,7 @@ func initTestQueueOnce() {
 			for {
 				select {
 				case <-ctx.Done():
+					return
 				case <-time.After(500 * time.Millisecond):
 					if adding {
 						if testQueue.GetQueueItemNumber() == qs.Length {


### PR DESCRIPTION
The dev-mode test queue producer goroutine's `select` had an empty `<-ctx.Done()` case with no `return`. Once the context is cancelled, that case is permanently ready, so the loop busy-spins and allocates a new `time.After` timer on every iteration instead of exiting. Add the missing `return` so the goroutine stops on shutdown.