### PR TITLE
feat(repo): add inline comments on commit diff pages

### DIFF
--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -420,6 +420,7 @@ func prepareMigrationTasks() []*migration {
 		newMigration(340, "Add ContinueOnError column to ActionRunJob", v1_27.AddContinueOnErrorToActionRunJob),
 		newMigration(341, "Convert legacy MSSQL DATETIME columns to DATETIME2", v1_27.FixLegacyMSSQLDateTimeColumns),
 		newMigration(342, "Add scoped workflows schema", v1_27.AddScopedWorkflowsSchema),
+		newMigration(343, "Add commit comment table", v1_27.AddCommitCommentTable),
 	}
 	return preparedMigrations
 }

--- a/models/migrations/v1_27/v343.go
+++ b/models/migrations/v1_27/v343.go
@@ -6,8 +6,6 @@ package v1_27
 import (
 	"gitea.dev/models/db"
 	"gitea.dev/modules/timeutil"
-
-	"xorm.io/xorm"
 )
 
 func AddCommitCommentTable(x db.EngineMigration) error {

--- a/models/migrations/v1_27/v343.go
+++ b/models/migrations/v1_27/v343.go
@@ -1,0 +1,27 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v1_27
+
+import (
+	"gitea.dev/models/db"
+	"gitea.dev/modules/timeutil"
+
+	"xorm.io/xorm"
+)
+
+func AddCommitCommentTable(x db.EngineMigration) error {
+	type CommitComment struct {
+		ID        int64             `xorm:"pk autoincr"`
+		RepoID    int64             `xorm:"INDEX NOT NULL DEFAULT 0"`
+		CommitSHA string            `xorm:"VARCHAR(64) INDEX NOT NULL DEFAULT ''"`
+		TreePath  string            `xorm:"VARCHAR(4000) NOT NULL DEFAULT ''"`
+		Line      int64             `xorm:"NOT NULL DEFAULT 0"`
+		Content   string            `xorm:"LONGTEXT NOT NULL"`
+		Patch     string            `xorm:"LONGTEXT"`
+		PosterID  int64             `xorm:"INDEX NOT NULL DEFAULT 0"`
+		CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
+		UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
+	}
+	return x.Sync(new(CommitComment))
+}

--- a/models/repo/commit_comment.go
+++ b/models/repo/commit_comment.go
@@ -1,0 +1,161 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package repo
+
+import (
+	"fmt"
+	"html/template"
+
+	"gitea.dev/models/db"
+	user_model "gitea.dev/models/user"
+	"gitea.dev/modules/container"
+	"gitea.dev/modules/structs"
+	"gitea.dev/modules/timeutil"
+)
+
+// CommitComment represents a comment on a line of code in a commit diff.
+// This is a standalone model unrelated to the issue/PR Comment system.
+type CommitComment struct {
+	ID        int64            `xorm:"pk autoincr"`
+	RepoID    int64            `xorm:"INDEX NOT NULL DEFAULT 0"`
+	CommitSHA string           `xorm:"VARCHAR(64) INDEX NOT NULL DEFAULT ''"`
+	TreePath  string           `xorm:"VARCHAR(4000) NOT NULL DEFAULT ''"`
+	Line      int64            `xorm:"NOT NULL DEFAULT 0"` // + is right, - is left
+	Content   string           `xorm:"LONGTEXT NOT NULL"`
+	Patch     string           `xorm:"LONGTEXT"`
+	PosterID  int64            `xorm:"INDEX NOT NULL DEFAULT 0"`
+	Poster    *user_model.User `xorm:"-"`
+
+	CreatedUnix     timeutil.TimeStamp `xorm:"INDEX created"`
+	UpdatedUnix     timeutil.TimeStamp `xorm:"INDEX updated"`
+	RenderedContent template.HTML      `xorm:"-"`
+}
+
+func init() {
+	db.RegisterModel(new(CommitComment))
+}
+
+// DiffSide returns "previous" if Line is a LOC of the previous contents and "proposed" if it is a LOC of the proposed contents.
+func (c *CommitComment) DiffSide() string {
+	if c.Line < 0 {
+		return "previous"
+	}
+	return "proposed"
+}
+
+// UnsignedLine returns the LOC of the code comment without + or -
+func (c *CommitComment) UnsignedLine() uint64 {
+	if c.Line < 0 {
+		return uint64(c.Line * -1)
+	}
+	return uint64(c.Line)
+}
+
+// HashTag returns unique hash tag for the commit comment.
+func (c *CommitComment) HashTag() string {
+	return fmt.Sprintf("commitcomment-%d", c.ID)
+}
+
+// CommitCommentList provides helpers for CommitComment slices
+type CommitCommentList []*CommitComment
+
+func (l CommitCommentList) LoadPosters(ctx context.Context) error {
+	if len(l) == 0 {
+		return nil
+	}
+	posterIDs := container.FilterSlice(l, func(c *CommitComment) (int64, bool) {
+		return c.PosterID, c.Poster == nil && c.PosterID > 0
+	})
+	posterMaps, err := user_model.GetUsersMapByIDs(ctx, posterIDs)
+	if err != nil {
+		return err
+	}
+	for _, comment := range l {
+		if comment.Poster == nil {
+			comment.Poster = user_model.GetPossibleUserFromMap(comment.PosterID, posterMaps)
+		}
+	}
+	return nil
+}
+
+var ErrInvalidCommitCommentLine = structs.ErrInvalidArgument{Argument: "line", Message: "line must be non-zero, negative for left side or positive for right side"}
+
+func CreateCommitComment(ctx context.Context, doerID int64, repoID int64, commitSHA string, treePath string, line int64, content string, patch string) (*CommitComment, error) {
+	if line == 0 {
+		return nil, ErrInvalidCommitCommentLine
+	}
+	comment := &CommitComment{
+		RepoID:    repoID,
+		CommitSHA: commitSHA,
+		TreePath:  treePath,
+		Line:      line,
+		Patch:     patch,
+		Content:   content,
+		PosterID:  doerID,
+	}
+	if err := db.Insert(ctx, comment); err != nil {
+		return nil, fmt.Errorf("CreateCommitComment: %w", err)
+	}
+	return comment, nil
+}
+
+func DeleteCommitComment(ctx context.Context, id int64, repoID int64) error {
+	affected, err := db.GetEngine(ctx).Where("id = ? AND repo_id = ?", id, repoID).Delete(new(CommitComment))
+	if err != nil {
+		return fmt.Errorf("DeleteCommitComment: %w", err)
+	}
+	if affected == 0 {
+		return fmt.Errorf("commit comment %d not found in repo %d", id, repoID)
+	}
+	return nil
+}
+
+func FindCommitCommentByID(ctx context.Context, id int64) (*CommitComment, error) {
+	comment := new(CommitComment)
+	has, err := db.GetEngine(ctx).ID(id).Get(comment)
+	if err != nil {
+		return nil, fmt.Errorf("FindCommitCommentByID: %w", err)
+	}
+	if !has {
+		return nil, fmt.Errorf("commit comment %d not found", id)
+	}
+	return comment, nil
+}
+
+// FindCommitCommentsByCommitSHA returns all commit comments for a given commit.
+func FindCommitCommentsByCommitSHA(ctx context.Context, repoID int64, commitSHA string) (CommitCommentList, error) {
+	comments := make([]*CommitComment, 0, 10)
+	err := db.GetEngine(ctx).Where("repo_id = ? AND commit_sha = ?", repoID, commitSHA).
+		Find(&comments)
+	if err != nil {
+		return nil, fmt.Errorf("FindCommitCommentsByCommitSHA: %w", err)
+	}
+	return comments, nil
+}
+
+// FindCommitCommentsForDiff returns commit comments organized by file -> line -> comments.
+func FindCommitCommentsForDiff(ctx context.Context, repoID int64, commitSHA string) (map[string]map[int64][]*CommitComment, error) {
+	allComments, err := FindCommitCommentsByCommitSHA(ctx, repoID, commitSHA)
+	if err != nil {
+		return nil, err
+	}
+	err = CommitCommentList(allComments).LoadPosters(ctx)
+	if err != nil {
+		return nil, err
+	}
+	fileMap := make(map[string]map[int64][]*CommitComment)
+	for _, c := range allComments {
+		if fileMap[c.TreePath] == nil {
+			fileMap[c.TreePath] = make(map[int64][]*CommitComment)
+		}
+		var lineKey int64
+		if c.Line < 0 {
+			lineKey = int64(c.UnsignedLine()) * -1
+		} else {
+			lineKey = int64(c.UnsignedLine())
+		}
+		fileMap[c.TreePath][lineKey] = append(fileMap[c.TreePath][lineKey], c)
+	}
+	return fileMap, nil
+}

--- a/models/repo/commit_comment.go
+++ b/models/repo/commit_comment.go
@@ -4,14 +4,15 @@
 package repo
 
 import (
+	"context"
 	"fmt"
 	"html/template"
 
 	"gitea.dev/models/db"
 	user_model "gitea.dev/models/user"
 	"gitea.dev/modules/container"
-	"gitea.dev/modules/structs"
 	"gitea.dev/modules/timeutil"
+	"gitea.dev/modules/util"
 )
 
 // CommitComment represents a comment on a line of code in a commit diff.
@@ -79,7 +80,7 @@ func (l CommitCommentList) LoadPosters(ctx context.Context) error {
 	return nil
 }
 
-var ErrInvalidCommitCommentLine = structs.ErrInvalidArgument{Argument: "line", Message: "line must be non-zero, negative for left side or positive for right side"}
+var ErrInvalidCommitCommentLine = util.ErrInvalidArgument
 
 func CreateCommitComment(ctx context.Context, doerID int64, repoID int64, commitSHA string, treePath string, line int64, content string, patch string) (*CommitComment, error) {
 	if line == 0 {

--- a/routers/web/repo/commit.go
+++ b/routers/web/repo/commit.go
@@ -426,6 +426,13 @@ func Diff(ctx *context.Context) {
 		ctx.Data["MergedPRIssueNumber"] = pr.Index
 	}
 
+	// Load commit comments into the diff
+	if diff != nil {
+		if err := diff.LoadCommitComments(ctx, ctx.Repo.Repository.ID, commitID); err != nil {
+			log.Error("LoadCommitComments: %v", err)
+		}
+	}
+
 	ctx.HTML(http.StatusOK, tplCommitPage)
 }
 

--- a/routers/web/repo/commit_comment.go
+++ b/routers/web/repo/commit_comment.go
@@ -13,7 +13,6 @@ import (
 	repo_model "gitea.dev/models/repo"
 	unit_model "gitea.dev/models/unit"
 	"gitea.dev/modules/git"
-	"gitea.dev/modules/gitrepo"
 	"gitea.dev/modules/log"
 	"gitea.dev/modules/markup/markdown"
 	"gitea.dev/modules/setting"
@@ -67,14 +66,6 @@ func CreateCommitComment(ctx *context.Context) {
 
 	var patch string
 	gitRepo := ctx.Repo.GitRepo
-	gitRepoStore := ctx.Repo.Repository
-	if ctx.Data["PageIsWiki"] != nil {
-		var err error
-		gitRepoStore = ctx.Repo.Repository.WikiStorageRepo()
-		gitRepo, _ = gitrepo.RepositoryFromRequestContextOrOpen(ctx, gitRepoStore)
-	} else {
-		gitRepo = ctx.Repo.GitRepo
-	}
 
 	if gitRepo != nil {
 		patch, _ = git.GetFileDiffCutAroundLine(
@@ -114,12 +105,12 @@ func DeleteCommitComment(ctx *context.Context) {
 
 	comment, err := repo_model.FindCommitCommentByID(ctx, commentID)
 	if err != nil {
-		ctx.NotFound("FindCommitCommentByID", err)
+		ctx.NotFound(err)
 		return
 	}
 
 	if comment.RepoID != ctx.Repo.Repository.ID {
-		ctx.NotFound("comment's repoID is incorrect", fmt.Errorf("comment's repoID is incorrect"))
+		ctx.NotFound(fmt.Errorf("commit comment repoID mismatch"))
 		return
 	}
 

--- a/routers/web/repo/commit_comment.go
+++ b/routers/web/repo/commit_comment.go
@@ -1,0 +1,176 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package repo
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+	"strconv"
+
+	"gitea.dev/models/renderhelper"
+	repo_model "gitea.dev/models/repo"
+	unit_model "gitea.dev/models/unit"
+	"gitea.dev/modules/git"
+	"gitea.dev/modules/gitrepo"
+	"gitea.dev/modules/log"
+	"gitea.dev/modules/markup/markdown"
+	"gitea.dev/modules/setting"
+	"gitea.dev/modules/templates"
+	"gitea.dev/services/context"
+	"gitea.dev/services/context/upload"
+	"gitea.dev/services/gitdiff"
+)
+
+const (
+	tplNewCommitComment   templates.TplName = "repo/diff/new_commit_comment"
+	tplCommitConversation templates.TplName = "repo/diff/commit_conversation"
+)
+
+// RenderNewCommitCommentForm renders the form for creating a new comment on a commit
+func RenderNewCommitCommentForm(ctx *context.Context) {
+	ctx.Data["PageIsPullFiles"] = true
+	ctx.Data["IsAttachmentEnabled"] = setting.Attachment.Enabled
+	upload.AddUploadContext(ctx, "comment")
+	ctx.HTML(http.StatusOK, tplNewCommitComment)
+}
+
+// CreateCommitComment creates a new inline comment on a commit
+func CreateCommitComment(ctx *context.Context) {
+	commitID := ctx.PathParam("sha")
+
+	side := ctx.FormString("side")
+	line := ctx.FormInt64("line")
+	treePath := ctx.FormString("path")
+	content := ctx.FormString("content")
+
+	signedLine := line
+	if side == "previous" {
+		signedLine *= -1
+	}
+
+	if signedLine == 0 {
+		ctx.JSONError("line must be non-zero")
+		return
+	}
+
+	if content == "" {
+		ctx.JSONError("content is required")
+		return
+	}
+
+	if treePath == "" {
+		ctx.JSONError("path is required")
+		return
+	}
+
+	var patch string
+	gitRepo := ctx.Repo.GitRepo
+	gitRepoStore := ctx.Repo.Repository
+	if ctx.Data["PageIsWiki"] != nil {
+		var err error
+		gitRepoStore = ctx.Repo.Repository.WikiStorageRepo()
+		gitRepo, _ = gitrepo.RepositoryFromRequestContextOrOpen(ctx, gitRepoStore)
+	} else {
+		gitRepo = ctx.Repo.GitRepo
+	}
+
+	if gitRepo != nil {
+		patch, _ = git.GetFileDiffCutAroundLine(
+			gitRepo, commitID, commitID, treePath,
+			int64((&repo_model.CommitComment{Line: signedLine}).UnsignedLine()), signedLine < 0, setting.UI.CodeCommentLines,
+		)
+
+		if patch == "" {
+			p, err := gitdiff.GeneratePatchForUnchangedLine(gitRepo, commitID, treePath, signedLine, setting.UI.CodeCommentLines)
+			if err == nil {
+				patch = p
+			} else {
+				log.Debug("Unable to generate patch for commit comment (file=%s, line=%d, commit=%s): %v", treePath, signedLine, commitID, err)
+			}
+		}
+	}
+
+	comment, err := repo_model.CreateCommitComment(ctx, ctx.Doer.ID, ctx.Repo.Repository.ID, commitID, treePath, signedLine, content, patch)
+	if err != nil {
+		ctx.ServerError("CreateCommitComment", err)
+		return
+	}
+
+	log.Trace("Commit comment created: %-v Comment[%d]", ctx.Repo.Repository, comment.ID)
+
+	renderCommitConversation(ctx, comment)
+}
+
+// DeleteCommitComment deletes a commit comment
+func DeleteCommitComment(ctx *context.Context) {
+	commentIDStr := ctx.PathParam("id")
+	commentID, err := strconv.ParseInt(commentIDStr, 10, 64)
+	if err != nil {
+		ctx.ServerError("Invalid comment ID", err)
+		return
+	}
+
+	comment, err := repo_model.FindCommitCommentByID(ctx, commentID)
+	if err != nil {
+		ctx.NotFound("FindCommitCommentByID", err)
+		return
+	}
+
+	if comment.RepoID != ctx.Repo.Repository.ID {
+		ctx.NotFound("comment's repoID is incorrect", fmt.Errorf("comment's repoID is incorrect"))
+		return
+	}
+
+	if comment.PosterID != ctx.Doer.ID && !ctx.Repo.Permission.CanWrite(unit_model.TypeCode) {
+		ctx.HTTPError(http.StatusForbidden)
+		return
+	}
+
+	if err := repo_model.DeleteCommitComment(ctx, commentID, ctx.Repo.Repository.ID); err != nil {
+		ctx.ServerError("DeleteCommitComment", err)
+		return
+	}
+
+	ctx.JSONOK()
+}
+
+func renderCommitConversation(ctx *context.Context, comment *repo_model.CommitComment) {
+	comments, err := repo_model.FindCommitCommentsByCommitSHA(ctx, ctx.Repo.Repository.ID, comment.CommitSHA)
+	if err != nil {
+		ctx.ServerError("FindCommitCommentsByCommitSHA", err)
+		return
+	}
+
+	if err := comments.LoadPosters(ctx); err != nil {
+		ctx.ServerError("LoadPosters", err)
+		return
+	}
+
+	rctx := renderhelper.NewRenderContextRepoComment(ctx, ctx.Repo.Repository, renderhelper.RepoCommentOptions{
+		CurrentRefSubURL: "commit/" + comment.CommitSHA,
+	})
+
+	for _, c := range comments {
+		rendered, err := markdown.RenderString(rctx, c.Content)
+		if err != nil {
+			log.Error("RenderString: %v", err)
+			c.RenderedContent = template.HTML(template.HTMLEscapeString(c.Content))
+		} else {
+			c.RenderedContent = rendered
+		}
+	}
+
+	var lineComments []*repo_model.CommitComment
+	for _, c := range comments {
+		if c.TreePath == comment.TreePath && c.Line == comment.Line {
+			lineComments = append(lineComments, c)
+		}
+	}
+
+	ctx.Data["IsAttachmentEnabled"] = setting.Attachment.Enabled
+	upload.AddUploadContext(ctx, "comment")
+	ctx.Data["comments"] = lineComments
+	ctx.HTML(http.StatusOK, tplCommitConversation)
+}

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1713,6 +1713,12 @@ func registerWebRoutes(m *web.Router, webAuth *AuthMiddleware) {
 			m.Get("/commit/{sha:([a-f0-9]{7,64})$}", repo.SetEditorconfigIfExists, repo.SetDiffViewStyle, repo.SetWhitespaceBehavior, repo.Diff)
 			m.Get("/commit/{sha:([a-f0-9]{7,64})$}/load-branches-and-tags", repo.LoadBranchesAndTags)
 
+			m.Group("/commit/{sha:[a-f0-9]{7,64}}/comment", func() {
+				m.Get("", repo.RenderNewCommitCommentForm)
+				m.Post("", repo.CreateCommitComment)
+				m.Post("/{id:[0-9]+}/delete", repo.DeleteCommitComment)
+			}, context.RepoMustNotBeArchived())
+
 			// FIXME: this route `/cherry-pick/{sha}` doesn't seem useful or right, the new code always uses `/_cherrypick/` which could handle branch name correctly
 			m.Get("/cherry-pick/{sha:([a-f0-9]{7,64})$}", repo.SetEditorconfigIfExists, context.RepoRefByDefaultBranch(), repo.CherryPick)
 		}, repo.MustBeNotEmpty)

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -22,6 +22,7 @@ import (
 	git_model "gitea.dev/models/git"
 	issues_model "gitea.dev/models/issues"
 	pull_model "gitea.dev/models/pull"
+	repo_model "gitea.dev/models/repo"
 	user_model "gitea.dev/models/user"
 	"gitea.dev/modules/analyze"
 	"gitea.dev/modules/base"
@@ -77,7 +78,8 @@ type DiffLine struct {
 	Match       int // the diff matched index. -1: no match. 0: plain and no need to match. >0: for add/del, "Lines" slice index of the other side
 	Type        DiffLineType
 	Content     string
-	Comments    issues_model.CommentList // related PR code comments
+	CommitComments repo_model.CommitCommentList // related commit comments (non-PR)
+	Comments       issues_model.CommentList // related PR code comments
 	SectionInfo *DiffLineSectionInfo
 }
 
@@ -624,6 +626,32 @@ func (diff *Diff) LoadComments(ctx context.Context, issue *issues_model.Issue, c
 	}
 	return nil
 }
+
+// LoadCommitComments loads commit comments into each diff line
+func (diff *Diff) LoadCommitComments(ctx context.Context, repoID int64, commitSHA string) error {
+	allComments, err := repo_model.FindCommitCommentsForDiff(ctx, repoID, commitSHA)
+	if err != nil {
+		return err
+	}
+	for _, file := range diff.Files {
+		if lineCommits, ok := allComments[file.Name]; ok {
+			for _, section := range file.Sections {
+				for _, line := range section.Lines {
+					comments := lineCommits[int64(line.LeftIdx*-1)]
+					comments = append(comments, lineCommits[int64(line.RightIdx)]...)
+					if len(comments) > 0 {
+						sort.SliceStable(comments, func(i, j int) bool {
+							return comments[i].CreatedUnix < comments[j].CreatedUnix
+						})
+						line.CommitComments = comments
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
 
 const cmdDiffHead = "diff --git "
 

--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -184,7 +184,7 @@
 										{{end}}
 									</div>
 								{{else}}
-									<table class="chroma" data-new-comment-url="{{$.Issue.Link}}/files/reviews/new_comment" data-path="{{$file.Name}}">
+									<table class="chroma" data-new-comment-url="{{if $.PageIsPullFiles}}{{$.Issue.Link}}/files/reviews/new_comment{{else if $.PageIsDiff}}{{$.RepoLink}}/commit/{{$.CommitID}}/comment{{end}}" data-path="{{$file.Name}}">
 										{{if $.IsSplitStyle}}
 											{{template "repo/diff/section_split" dict "file" . "root" $}}
 										{{else}}

--- a/templates/repo/diff/commit_comment_form.tmpl
+++ b/templates/repo/diff/commit_comment_form.tmpl
@@ -1,0 +1,31 @@
+{{$root0 := or $.root $}}
+{{if and ctx.RootData.SignedUserID (not ctx.RootData.Repository.IsArchived)}}
+	<form class="ui form {{if $.hidden}}tw-hidden comment-form{{end}}" action="{{$root0.RepoLink}}/commit/{{$root0.CommitID}}/comment" method="post">
+		{{ctx.CsrfTokenHtml}}
+		<input type="hidden" name="side" value="">
+		<input type="hidden" name="line" value="">
+		<input type="hidden" name="path" value="">
+		<div class="field">
+		{{template "shared/combomarkdowneditor" (dict
+			"CustomInit" true
+			"MarkdownEditorContext" (ctx.MiscUtils.MarkdownEditorComment ctx.RootData.Repository)
+			"TextareaName" "content"
+			"TextareaPlaceholder" (ctx.Locale.Tr "repo.diff.comment.placeholder")
+			"DropzoneParentContainer" "form"
+			"DisableAutosize" "true"
+		)}}
+		</div>
+		{{if $root0.IsAttachmentEnabled}}
+			<div class="field">
+				{{template "repo/upload" $root0}}
+			</div>
+		{{end}}
+
+		<div class="field footer">
+			<div class="flex-text-block tw-justify-end">
+				<button type="submit" class="ui submit primary tiny button btn-add-comment">{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}</button>
+				<button type="button" class="ui submit tiny basic button btn-cancel cancel-code-comment">{{ctx.Locale.Tr "cancel"}}</button>
+			</div>
+		</div>
+	</form>
+{{end}}

--- a/templates/repo/diff/commit_comments.tmpl
+++ b/templates/repo/diff/commit_comments.tmpl
@@ -1,0 +1,35 @@
+{{$root := or $.root $}}
+{{range .comments}}
+
+{{$createdStr:= DateUtils.TimeSince .CreatedUnix}}
+<div class="comment" id="{{.HashTag}}">
+	<div class="tw-mt-2 tw-mr-4">
+		{{template "shared/user/avatarlink" dict "user" .Poster}}
+	</div>
+	<div class="content comment-container">
+		<div class="comment-header avatar-content-left-arrow">
+			<div class="comment-header-left">
+				<span class="tw-text-text-light muted-links">
+					{{template "shared/user/namelink" .Poster}}
+					{{ctx.Locale.Tr "repo.issues.commented_at" .HashTag $createdStr}}
+				</span>
+			</div>
+			<div class="comment-header-right">
+				{{if and $root.SignedUserID (not $root.Repository.IsArchived)}}
+					{{template "repo/issue/view_content/context_menu" dict "item" . "delete" false "issue" false "diff" true "IsCommentPoster" (and $root.IsSigned (eq $root.SignedUserID .PosterID))}}
+				{{end}}
+			</div>
+		</div>
+		<div class="ui attached segment comment-body">
+			<div class="render-content markup" {{if or $root.IsAdmin (and $root.IsSigned (eq $root.SignedUserID .PosterID))}}data-can-edit="true"{{end}}>
+			{{if .RenderedContent}}
+				{{.RenderedContent}}
+			{{else}}
+				<span class="no-content">{{ctx.Locale.Tr "repo.issues.no_content"}}</span>
+			{{end}}
+			</div>
+			<div id="{{.HashTag}}-raw" class="raw-content tw-hidden">{{.Content}}</div>
+		</div>
+	</div>
+</div>
+{{end}}

--- a/templates/repo/diff/commit_conversation.tmpl
+++ b/templates/repo/diff/commit_conversation.tmpl
@@ -1,0 +1,23 @@
+{{$root := or .root $}}
+{{if len .comments}}
+	{{$comment := index .comments 0}}
+	<div class="conversation-holder" data-path="{{$comment.TreePath}}" data-side="{{if lt $comment.Line 0}}left{{else}}right{{end}}" data-idx="{{$comment.UnsignedLine}}">
+		<div id="code-comments-{{$comment.ID}}" class="field comment-code-cloud">
+			<div class="comment-list">
+				<div class="ui comments">
+					{{template "repo/diff/commit_comments" dict "root" $root "comments" .comments}}
+				</div>
+			</div>
+			<div class="flex-text-block tw-mt-2 tw-flex-wrap tw-justify-end">
+				{{if and $root.SignedUserID (not $root.Repository.IsArchived)}}
+					<button class="comment-form-reply ui primary icon tiny button">
+						{{svg "octicon-reply" 12}}{{ctx.Locale.Tr "repo.diff.comment.reply"}}
+					</button>
+				{{end}}
+			</div>
+			{{template "repo/diff/commit_comment_form" dict "root" $root "hidden" true}}
+		</div>
+	</div>
+{{else}}
+	{{template "repo/diff/conversation_outdated"}}
+{{end}}

--- a/templates/repo/diff/new_commit_comment.tmpl
+++ b/templates/repo/diff/new_commit_comment.tmpl
@@ -1,0 +1,5 @@
+<div class="conversation-holder">
+	<div class="field comment-code-cloud">
+		{{template "repo/diff/commit_comment_form" .}}
+	</div>
+</div>

--- a/templates/repo/diff/section_split.tmpl
+++ b/templates/repo/diff/section_split.tmpl
@@ -28,7 +28,7 @@
 					<td class="lines-escape del-code lines-escape-old">{{if $line.LeftIdx}}{{ctx.RenderUtils.RenderUnicodeEscapeToggleButton $leftDiff.EscapeStatus}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-old del-code"><span class="tw-font-mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span></td>
 					<td class="lines-code lines-code-old del-code">
-						{{- if and $.root.SignedUserID $.root.PageIsPullFiles -}}
+						{{- if and $.root.SignedUserID (or $.root.PageIsPullFiles $.root.PageIsDiff) -}}
 							<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-left{{if (not $line.CanComment)}} tw-invisible{{end}}" data-side="left" data-idx="{{$line.LeftIdx}}">
 								{{- svg "octicon-plus" -}}
 							</button>
@@ -43,7 +43,7 @@
 					<td class="lines-escape add-code lines-escape-new">{{if $match.RightIdx}}{{ctx.RenderUtils.RenderUnicodeEscapeToggleButton $rightDiff.EscapeStatus}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-new add-code">{{if $match.RightIdx}}<span class="tw-font-mono" data-type-marker="{{$match.GetLineTypeMarker}}"></span>{{end}}</td>
 					<td class="lines-code lines-code-new add-code">
-						{{- if and $.root.SignedUserID $.root.PageIsPullFiles -}}
+						{{- if and $.root.SignedUserID (or $.root.PageIsPullFiles $.root.PageIsDiff) -}}
 							<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-right{{if (not $match.CanComment)}} tw-invisible{{end}}" data-side="right" data-idx="{{$match.RightIdx}}">
 								{{- svg "octicon-plus" -}}
 							</button>
@@ -60,7 +60,7 @@
 					<td class="lines-escape lines-escape-old">{{if $line.LeftIdx}}{{ctx.RenderUtils.RenderUnicodeEscapeToggleButton $inlineDiff.EscapeStatus}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-old">{{if $line.LeftIdx}}<span class="tw-font-mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
 					<td class="lines-code lines-code-old">
-						{{- if and $.root.SignedUserID $.root.PageIsPullFiles (not (eq .GetType 2)) -}}
+						{{- if and $.root.SignedUserID (or $.root.PageIsPullFiles $.root.PageIsDiff) (not (eq .GetType 2)) -}}
 							<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-left{{if (not $line.CanComment)}} tw-invisible{{end}}" data-side="left" data-idx="{{$line.LeftIdx}}">
 								{{- svg "octicon-plus" -}}
 							</button>
@@ -75,7 +75,7 @@
 					<td class="lines-escape lines-escape-new">{{if $line.RightIdx}}{{ctx.RenderUtils.RenderUnicodeEscapeToggleButton $inlineDiff.EscapeStatus}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-new">{{if $line.RightIdx}}<span class="tw-font-mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
 					<td class="lines-code lines-code-new">
-						{{- if and $.root.SignedUserID $.root.PageIsPullFiles (not (eq .GetType 3)) -}}
+						{{- if and $.root.SignedUserID (or $.root.PageIsPullFiles $.root.PageIsDiff) (not (eq .GetType 3)) -}}
 							<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-right{{if (not $line.CanComment)}} tw-invisible{{end}}" data-side="right" data-idx="{{$line.RightIdx}}">
 								{{- svg "octicon-plus" -}}
 							</button>
@@ -90,7 +90,7 @@
 			</tr>
 			{{if and (eq .GetType 3) $hasmatch}}
 				{{$match := index $section.Lines $line.Match}}
-				{{if or $line.Comments $match.Comments}}
+				{{if or $line.Comments $match.Comments $line.CommitComments $match.CommitComments}}
 					<tr class="add-comment" data-line-type="{{.GetHTMLDiffLineType}}">
 						<td class="add-comment-left" colspan="4">
 							{{if $line.Comments}}
@@ -102,6 +102,12 @@
 								{{if eq $match.GetCommentSide "previous"}}
 									{{template "repo/diff/conversation" dict "." $.root "comments" $match.Comments}}
 								{{end}}
+							{{end}}
+							{{if $line.CommitComments}}
+								{{template "repo/diff/commit_conversation" dict "root" $.root "comments" $line.CommitComments}}
+							{{end}}
+							{{if $match.CommitComments}}
+								{{template "repo/diff/commit_conversation" dict "root" $.root "comments" $match.CommitComments}}
 							{{end}}
 						</td>
 						<td class="add-comment-right" colspan="4">
@@ -115,19 +121,31 @@
 									{{template "repo/diff/conversation" dict "." $.root "comments" $match.Comments}}
 								{{end}}
 							{{end}}
+							{{if $line.CommitComments}}
+								{{template "repo/diff/commit_conversation" dict "root" $.root "comments" $line.CommitComments}}
+							{{end}}
+							{{if $match.CommitComments}}
+								{{template "repo/diff/commit_conversation" dict "root" $.root "comments" $match.CommitComments}}
+							{{end}}
 						</td>
 					</tr>
 				{{end}}
-			{{else if $line.Comments}}
+			{{else if or $line.Comments $line.CommitComments}}
 				<tr class="add-comment" data-line-type="{{.GetHTMLDiffLineType}}">
 					<td class="add-comment-left" colspan="4">
 						{{if eq $line.GetCommentSide "previous"}}
 							{{template "repo/diff/conversation" dict "." $.root "comments" $line.Comments}}
 						{{end}}
+						{{if $line.CommitComments}}
+							{{template "repo/diff/commit_conversation" dict "root" $.root "comments" $line.CommitComments}}
+						{{end}}
 					</td>
 					<td class="add-comment-right" colspan="4">
 						{{if eq $line.GetCommentSide "proposed"}}
 							{{template "repo/diff/conversation" dict "." $.root "comments" $line.Comments}}
+						{{end}}
+						{{if $line.CommitComments}}
+							{{template "repo/diff/commit_conversation" dict "root" $.root "comments" $line.CommitComments}}
 						{{end}}
 					</td>
 				</tr>

--- a/templates/repo/diff/section_unified.tmpl
+++ b/templates/repo/diff/section_unified.tmpl
@@ -31,7 +31,7 @@
 				<td class="chroma lines-code blob-hunk">{{template "repo/diff/section_code" dict "diff" $inlineDiff}}</td>
 			{{else}}
 				<td class="chroma lines-code{{if (not $line.RightIdx)}} lines-code-old{{end}}">
-					{{- if and $.root.SignedUserID $.root.PageIsPullFiles -}}
+					{{- if and $.root.SignedUserID (or $.root.PageIsPullFiles $.root.PageIsDiff) -}}
 						<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-{{if $line.RightIdx}}right{{else}}left{{end}}{{if (not $line.CanComment)}} tw-invisible{{end}}" data-side="{{if $line.RightIdx}}right{{else}}left{{end}}" data-idx="{{if $line.RightIdx}}{{$line.RightIdx}}{{else}}{{$line.LeftIdx}}{{end}}">
 							{{- svg "octicon-plus" -}}
 						</button>
@@ -44,6 +44,12 @@
 			<tr class="add-comment" data-line-type="{{.GetHTMLDiffLineType}}">
 				<td class="add-comment-left add-comment-right" colspan="5">
 					{{template "repo/diff/conversation" dict "." $.root "comments" $line.Comments}}
+				</td>
+			</tr>
+		{{else if $line.CommitComments}}
+			<tr class="add-comment" data-line-type="{{.GetHTMLDiffLineType}}">
+				<td class="add-comment-left add-comment-right" colspan="5">
+					{{template "repo/diff/commit_conversation" dict "root" $.root "comments" $line.CommitComments}}
 				</td>
 			</tr>
 		{{end}}


### PR DESCRIPTION
Add the ability to leave comments on individual lines of commit
diff pages, extending the existing code review comment system to
non-PR commit views. Uses a standalone `CommitComment` model to
keep concerns separate from the issue/PR Comment system.

Fixes #4898

Features:
- New CommitComment model with CRUD and v343 migration
- Load commit comments into DiffLine for inline rendering
- Support for unified and split diff views
- CREATE/DELETE endpoints under /commit/{sha}/comment
- New templates for comment form, comments, conversation
- [+] button and reply button work on commit diff pages
