### PR TITLE
fix: separate squash commit message from Reviewed-on/Reviewed-by trailers

### DIFF
--- a/routers/web/repo/pull_merge_form.go
+++ b/routers/web/repo/pull_merge_form.go
@@ -17,6 +17,16 @@ import (
 	pull_service "gitea.dev/services/pull"
 )
 
+// joinSquashMergeMessage joins the squash commit messages with the merge body
+// (Reviewed-on/Reviewed-by trailers) using a newline separator, so the trailers
+// are not appended to the last line of the commit messages.
+func joinSquashMergeMessage(commitMessages, mergeBody string) string {
+	if commitMessages != "" && mergeBody != "" {
+		return commitMessages + "\n" + mergeBody
+	}
+	return commitMessages + mergeBody
+}
+
 func (prInfo *pullRequestViewInfo) prepareMergeBoxFormProps(ctx *context.Context) {
 	pull := prInfo.issue.PullRequest
 	if pull.HasMerged || prInfo.issue.IsClosed {
@@ -78,6 +88,8 @@ func (prInfo *pullRequestViewInfo) prepareMergeBoxFormProps(ctx *context.Context
 		defaultSquashMergeCommitMessages = pull_service.GetSquashMergeCommitMessages(ctx, pull)
 	}
 
+	defaultSquashMergeMessage := joinSquashMergeMessage(defaultSquashMergeCommitMessages, defaultSquashMergeBody)
+
 	allOverridableChecksOk := !prInfo.MergeBoxData.hasOverridableBlockers
 	mergeFormProps := map[string]any{
 		"baseLink":                       prInfo.issue.Link(),
@@ -138,7 +150,7 @@ func (prInfo *pullRequestViewInfo) prepareMergeBoxFormProps(ctx *context.Context
 				"allowed":               prConfig.AllowSquash,
 				"textDoMerge":           ctx.Locale.Tr("repo.pulls.squash_merge_pull_request"),
 				"mergeTitleFieldText":   defaultSquashMergeTitle,
-				"mergeMessageFieldText": defaultSquashMergeCommitMessages + defaultSquashMergeBody,
+				"mergeMessageFieldText": defaultSquashMergeMessage,
 				"hideAutoMerge":         generalHideAutoMerge,
 			},
 			map[string]any{

--- a/routers/web/repo/pull_merge_form_test.go
+++ b/routers/web/repo/pull_merge_form_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package repo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJoinSquashMergeMessage(t *testing.T) {
+	const mergeBody = "Reviewed-on: https://gitea.com/gitea/runner/pulls/1084\nReviewed-by: Zettat123 <39446+zettat123@noreply.gitea.com>"
+
+	// commit messages without a trailing newline must not be concatenated onto the trailers
+	assert.Equal(t,
+		"Fixes #496\nFixes #552\n"+mergeBody,
+		joinSquashMergeMessage("Fixes #496\nFixes #552", mergeBody),
+	)
+
+	// empty commit messages: only the merge body, no leading newline
+	assert.Equal(t, mergeBody, joinSquashMergeMessage("", mergeBody))
+
+	// empty merge body: only the commit messages, no trailing newline
+	assert.Equal(t, "Fixes #496", joinSquashMergeMessage("Fixes #496", ""))
+
+	// both empty
+	assert.Empty(t, joinSquashMergeMessage("", ""))
+}


### PR DESCRIPTION
When building the default squash commit message in the merge form, the PR's commit messages were concatenated directly with the merge body (the `Reviewed-on` / `Reviewed-by` trailers) with no separator:

```go
"mergeMessageFieldText": defaultSquashMergeCommitMessages + defaultSquashMergeBody,
```

When the commit-messages part does not end in a newline — which happens when `PopulateSquashCommentWithCommitMessages` is disabled (the default, so the trimmed PR description is used) and the PR has no additional co-authors — the trailers get appended onto the last line of the description:

```
Fixes #496
Fixes #552Reviewed-on: https://gitea.com/gitea/runner/pulls/1084
Reviewed-by: Zettat123 <...>
```

This bug is long-standing: the same separator-less concatenation lived in the Vue merge form template for years and was ported into Go unchanged during the pull request view refactor (#37451). It stayed hidden because the other code paths (`formatSquashMergeCommitMessages`, co-authored commits) already emit a trailing newline.

This PR extracts the join into `joinSquashMergeMessage`, which inserts a newline between the two parts when both are present, and adds a regression test.

After the fix:

```
Fixes #496
Fixes #552
Reviewed-on: https://gitea.com/gitea/runner/pulls/1084
Reviewed-by: Zettat123 <...>
```