### PR TITLE
fix(actions): group reusable-workflow matrix legs in the workflow graph

### DIFF
--- a/routers/web/devtest/mock_actions.go
+++ b/routers/web/devtest/mock_actions.go
@@ -383,7 +383,7 @@ func MockActionsRunsJobs(ctx *context.Context) {
 		//   cross_caller      (caller, cross-repo, expanded)
 		//     └ external_job  (regular)
 		//   build (linux|windows|macos)       (regular matrix; graph folds into one "build" node)
-		//   build-call (linux|windows|macos)  (caller matrix, each calls build.yml; should fold like "build")
+		//   build-call (linux|windows|macos)  (caller matrix, each calls build.yml; folds into one "build-call" node like "build")
 		//   final             (regular, needs local_caller + cross_caller)
 		const (
 			prepareID     = int64(400)
@@ -400,8 +400,9 @@ func MockActionsRunsJobs(ctx *context.Context) {
 			buildWindowsID = int64(411)
 			buildMacosID   = int64(412)
 
-			// Caller matrix set – each matrix leg calls a reusable workflow. #38466: these are NOT
-			// folded into one "build-call" node the way the regular "build" matrix above is.
+			// Caller matrix set – each matrix leg calls the same reusable workflow. #38466: like the
+			// regular "build" matrix above, these fold into one "build-call" node. Matrix legs share a
+			// single JobID, so the legs below use JobID "build-call" and differ only by their name suffix.
 			buildCallLinuxID    = int64(420)
 			buildCallWindowsID  = int64(421)
 			buildCallMacosID    = int64(422)
@@ -449,24 +450,26 @@ func MockActionsRunsJobs(ctx *context.Context) {
 				ParentJobID: crossCallerID,
 			},
 
-			// Regular matrix "build" – these fold into one matrix node in the graph.
+			// Regular matrix "build" – these fold into one matrix node in the graph. The matrix legs
+			// share a single JobID ("build"); the " (variant)" name suffix distinguishes the legs.
 			{
-				ID: buildLinuxID, Link: jobLink(buildLinuxID), JobID: "build_linux", Name: "build (linux)",
+				ID: buildLinuxID, Link: jobLink(buildLinuxID), JobID: "build", Name: "build (linux)",
 				Status: actions_model.StatusSuccess.String(), Duration: "1m", Needs: []string{"prepare"},
 			},
 			{
-				ID: buildWindowsID, Link: jobLink(buildWindowsID), JobID: "build_windows", Name: "build (windows)",
+				ID: buildWindowsID, Link: jobLink(buildWindowsID), JobID: "build", Name: "build (windows)",
 				Status: actions_model.StatusSuccess.String(), Duration: "2m", Needs: []string{"prepare"},
 			},
 			{
-				ID: buildMacosID, Link: jobLink(buildMacosID), JobID: "build_macos", Name: "build (macos)",
+				ID: buildMacosID, Link: jobLink(buildMacosID), JobID: "build", Name: "build (macos)",
 				Status: actions_model.StatusSuccess.String(), Duration: "90s", Needs: []string{"prepare"},
 			},
 
-			// Caller matrix "build-call" – each leg calls a reusable workflow. #38466: unlike the
-			// regular "build" matrix above, these are rendered as separate nodes instead of grouped.
+			// Caller matrix "build-call" – each leg calls the same reusable workflow. #38466: like the
+			// regular "build" matrix above, these fold into one node. The matrix legs share a single
+			// JobID ("build-call"); the " (variant)" name suffix distinguishes the legs.
 			{
-				ID: buildCallLinuxID, Link: jobLink(buildCallLinuxID), JobID: "build_call_linux", Name: "build-call (linux)",
+				ID: buildCallLinuxID, Link: jobLink(buildCallLinuxID), JobID: "build-call", Name: "build-call (linux)",
 				Status: actions_model.StatusSuccess.String(), Duration: "1m", Needs: []string{"prepare"},
 				IsReusableCaller: true, CallUses: "./.gitea/workflows/build.yml",
 			},
@@ -475,7 +478,7 @@ func MockActionsRunsJobs(ctx *context.Context) {
 				Status: actions_model.StatusSuccess.String(), Duration: "1m", ParentJobID: buildCallLinuxID,
 			},
 			{
-				ID: buildCallWindowsID, Link: jobLink(buildCallWindowsID), JobID: "build_call_windows", Name: "build-call (windows)",
+				ID: buildCallWindowsID, Link: jobLink(buildCallWindowsID), JobID: "build-call", Name: "build-call (windows)",
 				Status: actions_model.StatusSuccess.String(), Duration: "2m", Needs: []string{"prepare"},
 				IsReusableCaller: true, CallUses: "./.gitea/workflows/build.yml",
 			},
@@ -484,7 +487,7 @@ func MockActionsRunsJobs(ctx *context.Context) {
 				Status: actions_model.StatusSuccess.String(), Duration: "2m", ParentJobID: buildCallWindowsID,
 			},
 			{
-				ID: buildCallMacosID, Link: jobLink(buildCallMacosID), JobID: "build_call_macos", Name: "build-call (macos)",
+				ID: buildCallMacosID, Link: jobLink(buildCallMacosID), JobID: "build-call", Name: "build-call (macos)",
 				Status: actions_model.StatusSuccess.String(), Duration: "90s", Needs: []string{"prepare"},
 				IsReusableCaller: true, CallUses: "./.gitea/workflows/build.yml",
 			},

--- a/routers/web/devtest/mock_actions.go
+++ b/routers/web/devtest/mock_actions.go
@@ -382,6 +382,8 @@ func MockActionsRunsJobs(ctx *context.Context) {
 		//       └ deep_job    (regular)
 		//   cross_caller      (caller, cross-repo, expanded)
 		//     └ external_job  (regular)
+		//   build (linux|windows|macos)       (regular matrix; graph folds into one "build" node)
+		//   build-call (linux|windows|macos)  (caller matrix, each calls build.yml; should fold like "build")
 		//   final             (regular, needs local_caller + cross_caller)
 		const (
 			prepareID     = int64(400)
@@ -392,6 +394,20 @@ func MockActionsRunsJobs(ctx *context.Context) {
 			crossCallerID = int64(405)
 			externalJobID = int64(406)
 			finalID       = int64(407)
+
+			// Regular matrix set – the graph already folds these into a single "build" node.
+			buildLinuxID   = int64(410)
+			buildWindowsID = int64(411)
+			buildMacosID   = int64(412)
+
+			// Caller matrix set – each matrix leg calls a reusable workflow. #38466: these are NOT
+			// folded into one "build-call" node the way the regular "build" matrix above is.
+			buildCallLinuxID    = int64(420)
+			buildCallWindowsID  = int64(421)
+			buildCallMacosID    = int64(422)
+			buildCallLinuxJobID = int64(423)
+			buildCallWinJobID   = int64(424)
+			buildCallMacJobID   = int64(425)
 		)
 
 		resp.State.Run.Jobs = []*actions.ViewJob{
@@ -432,6 +448,51 @@ func MockActionsRunsJobs(ctx *context.Context) {
 				Status: actions_model.StatusWaiting.String(), Duration: "0s",
 				ParentJobID: crossCallerID,
 			},
+
+			// Regular matrix "build" – these fold into one matrix node in the graph.
+			{
+				ID: buildLinuxID, Link: jobLink(buildLinuxID), JobID: "build_linux", Name: "build (linux)",
+				Status: actions_model.StatusSuccess.String(), Duration: "1m", Needs: []string{"prepare"},
+			},
+			{
+				ID: buildWindowsID, Link: jobLink(buildWindowsID), JobID: "build_windows", Name: "build (windows)",
+				Status: actions_model.StatusSuccess.String(), Duration: "2m", Needs: []string{"prepare"},
+			},
+			{
+				ID: buildMacosID, Link: jobLink(buildMacosID), JobID: "build_macos", Name: "build (macos)",
+				Status: actions_model.StatusSuccess.String(), Duration: "90s", Needs: []string{"prepare"},
+			},
+
+			// Caller matrix "build-call" – each leg calls a reusable workflow. #38466: unlike the
+			// regular "build" matrix above, these are rendered as separate nodes instead of grouped.
+			{
+				ID: buildCallLinuxID, Link: jobLink(buildCallLinuxID), JobID: "build_call_linux", Name: "build-call (linux)",
+				Status: actions_model.StatusSuccess.String(), Duration: "1m", Needs: []string{"prepare"},
+				IsReusableCaller: true, CallUses: "./.gitea/workflows/build.yml",
+			},
+			{
+				ID: buildCallLinuxJobID, Link: jobLink(buildCallLinuxJobID), JobID: "bc_linux_build", Name: "build",
+				Status: actions_model.StatusSuccess.String(), Duration: "1m", ParentJobID: buildCallLinuxID,
+			},
+			{
+				ID: buildCallWindowsID, Link: jobLink(buildCallWindowsID), JobID: "build_call_windows", Name: "build-call (windows)",
+				Status: actions_model.StatusSuccess.String(), Duration: "2m", Needs: []string{"prepare"},
+				IsReusableCaller: true, CallUses: "./.gitea/workflows/build.yml",
+			},
+			{
+				ID: buildCallWinJobID, Link: jobLink(buildCallWinJobID), JobID: "bc_windows_build", Name: "build",
+				Status: actions_model.StatusSuccess.String(), Duration: "2m", ParentJobID: buildCallWindowsID,
+			},
+			{
+				ID: buildCallMacosID, Link: jobLink(buildCallMacosID), JobID: "build_call_macos", Name: "build-call (macos)",
+				Status: actions_model.StatusSuccess.String(), Duration: "90s", Needs: []string{"prepare"},
+				IsReusableCaller: true, CallUses: "./.gitea/workflows/build.yml",
+			},
+			{
+				ID: buildCallMacJobID, Link: jobLink(buildCallMacJobID), JobID: "bc_macos_build", Name: "build",
+				Status: actions_model.StatusSuccess.String(), Duration: "90s", ParentJobID: buildCallMacosID,
+			},
+
 			{
 				ID: finalID, Link: jobLink(finalID), JobID: "final", Name: "final",
 				Status: actions_model.StatusBlocked.String(), Duration: "0s",

--- a/web_src/js/components/WorkflowGraph.utils.test.ts
+++ b/web_src/js/components/WorkflowGraph.utils.test.ts
@@ -157,16 +157,18 @@ test('reusable callers with identical dependency signature are kept as separate 
   expect(graph.nodes.find((n) => n.id === 'job:3')?.name).toBe('cross-repo caller');
 });
 
-test('reusable caller with matrix-pattern name does not get absorbed into a sibling matrix node', () => {
+test('matrix legs that call a reusable workflow are folded into a single matrix node', () => {
   const jobs: ActionsJob[] = [
-    {id: 1, link: '', jobId: 'deploy_dev', name: 'deploy (dev)', status: 'success', canRerun: false, isReusableCaller: false, parentJobID: 0, duration: '1s'},
-    {id: 2, link: '', jobId: 'deploy_qa', name: 'deploy (qa)', status: 'success', canRerun: false, isReusableCaller: false, parentJobID: 0, duration: '1s'},
-    {id: 3, link: '', jobId: 'deploy_staging', name: 'deploy (staging)', status: 'running', canRerun: false, isReusableCaller: true, parentJobID: 0, duration: '2s', callUses: './.gitea/workflows/deploy.yml'},
+    {id: 1, link: '', jobId: 'prepare', name: 'prepare', status: 'success', canRerun: false, isReusableCaller: false, parentJobID: 0, duration: '30s'},
+    {id: 2, link: '', jobId: 'build_call_linux', name: 'build-call (linux)', status: 'success', canRerun: false, isReusableCaller: true, parentJobID: 0, duration: '1m', needs: ['prepare'], callUses: './.gitea/workflows/build.yml'},
+    {id: 3, link: '', jobId: 'build_call_windows', name: 'build-call (windows)', status: 'success', canRerun: false, isReusableCaller: true, parentJobID: 0, duration: '2m', needs: ['prepare'], callUses: './.gitea/workflows/build.yml'},
+    {id: 4, link: '', jobId: 'build_call_macos', name: 'build-call (macos)', status: 'success', canRerun: false, isReusableCaller: true, parentJobID: 0, duration: '90s', needs: ['prepare'], callUses: './.gitea/workflows/build.yml'},
   ];
   const graph = createWorkflowGraphModel(jobs);
-  expect(graph.nodes.find((n) => n.id === 'job:3')?.name).toBe('deploy (staging)');
-  const matrixNode = graph.nodes.find((n) => n.type === 'matrix');
-  expect(matrixNode?.jobs.map((j) => j.id).sort()).toEqual([1, 2]);
+  const matrixNodes = graph.nodes.filter((n) => n.type === 'matrix');
+  expect(matrixNodes).toHaveLength(1);
+  expect(matrixNodes[0].matrixKey).toBe('build-call');
+  expect(matrixNodes[0].jobs.map((j) => j.id).sort()).toEqual([2, 3, 4]);
 });
 
 test('directed highlight state covers ancestors and descendants of the hovered node', () => {

--- a/web_src/js/components/WorkflowGraph.utils.ts
+++ b/web_src/js/components/WorkflowGraph.utils.ts
@@ -264,9 +264,8 @@ function buildVisualGraph(
 
   const matrixJobsByKey = new Map<string, ActionsJob[]>();
   for (const job of jobs) {
-    // Reusable callers are distinct workflow files — never fold them into a matrix bucket
-    // even if their display name happens to look like "name (variant)".
-    if (job.isReusableCaller) continue;
+    // Matrix legs that call a reusable workflow are still one logical job (a single `uses:`
+    // expanded over the matrix), so fold them into a matrix node like any other matrix job.
     const matrixKey = matrixKeyFromJobName(job.name);
     if (!matrixKey) continue;
     if (!matrixJobsByKey.has(matrixKey)) matrixJobsByKey.set(matrixKey, []);
@@ -322,10 +321,8 @@ function buildVisualGraph(
   const visualIdByJobId = new Map<number, string>();
   for (const job of jobs) {
     const matrixKey = matrixKeyFromJobName(job.name);
-    // Symmetric with the matrix-bucket loop above: a reusable caller whose display name
-    // happens to look like "name (variant)" must never be folded into the matrix node, or it
-    // would silently vanish (its visualId would point at a matrix node it isn't part of).
-    if (matrixKey && !job.isReusableCaller && (matrixJobsByKey.get(matrixKey)?.length ?? 0) > 1) {
+    // Symmetric with the matrix-bucket loop above (callers included).
+    if (matrixKey && (matrixJobsByKey.get(matrixKey)?.length ?? 0) > 1) {
       visualIdByJobId.set(job.id, `matrix:${matrixKey}`);
       continue;
     }


### PR DESCRIPTION
Fixes the UI issue reported in #38466: matrix jobs that invoke a reusable workflow (`build-call (linux)`, `build-call (windows)`, …) were rendered as separate nodes in the run's workflow graph, while an equivalent regular matrix
(`build (linux)`, `build (windows)`, …) collapsed neatly into a single matrix node.

### Cause

When #37497 introduced matrix folding, reusable callers were explicitly excluded from it (`WorkflowGraph.utils.ts`) on the assumption that every caller is a distinct workflow file. But a matrix `uses:` is defined once at the job level and expanded over the matrix — all legs are the *same* logical job, so they should fold like any other matrix.

### Change

- Fold matrix legs that call a reusable workflow into a single matrix node, the same as regular matrix jobs.
- Genuinely distinct callers — different `uses:` files that merely share a parents/children dependency signature — are still kept as their own nodes (that grouping guard is unchanged).
- Added a matrix-of-callers scenario to the devtest run (`/devtest/repo-action-view/runs/40`) so the regular-vs-caller matrix contrast is reproducible side by side.

### Before / After

Before: three loose `build-call (...)` boxes next to one grouped `build` box.
After: both matrices collapse into a single node.
