### PR TITLE
fix(actions): show retention info on hover for expired artifacts

### DIFF
--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -124,6 +124,7 @@
   "artifacts": "Artifacts",
   "expired": "Expired",
   "artifact_expires_at": "Expires at %s",
+  "artifact_expired_at": "Expired at %s",
   "confirm_delete_artifact": "Are you sure you want to delete the artifact '%s'?",
   "archived": "Archived",
   "concept_system_global": "Global",

--- a/routers/web/repo/actions/view.go
+++ b/routers/web/repo/actions/view.go
@@ -716,9 +716,10 @@ func fillViewRunResponseSummary(ctx *context_module.Context, resp *ViewResponse,
 	resp.Artifacts = make([]*ArtifactsViewItem, 0, len(arts))
 	for _, art := range arts {
 		resp.Artifacts = append(resp.Artifacts, &ArtifactsViewItem{
-			Name:   art.ArtifactName,
-			Size:   art.FileSize,
-			Status: util.Iif(art.Status == actions_model.ArtifactStatusExpired, "expired", "completed"),
+			Name:        art.ArtifactName,
+			Size:        art.FileSize,
+			Status:      util.Iif(art.Status == actions_model.ArtifactStatusExpired, "expired", "completed"),
+			ExpiresUnix: int64(art.ExpiredUnix),
 		})
 	}
 }

--- a/templates/repo/actions/view_component.tmpl
+++ b/templates/repo/actions/view_component.tmpl
@@ -39,6 +39,7 @@
 		data-locale-artifacts-title="{{ctx.Locale.Tr "artifacts"}}"
 		data-locale-artifact-expired="{{ctx.Locale.Tr "expired"}}"
 		data-locale-artifact-expires-at="{{ctx.Locale.Tr "artifact_expires_at"}}"
+		data-locale-artifact-expired-at="{{ctx.Locale.Tr "artifact_expired_at"}}"
 		data-locale-confirm-delete-artifact="{{ctx.Locale.Tr "confirm_delete_artifact"}}"
 		data-locale-show-timestamps="{{ctx.Locale.Tr "show_timestamps"}}"
 		data-locale-show-log-seconds="{{ctx.Locale.Tr "show_log_seconds"}}"

--- a/web_src/js/components/RepoActionView.vue
+++ b/web_src/js/components/RepoActionView.vue
@@ -274,7 +274,12 @@ onBeforeUnmount(() => {
                   <SvgIcon name="octicon-trash"/>
                 </a>
               </template>
-              <span v-else class="flex-text-block tw-flex-1 tw-min-w-0 tw-text-text-light-2">
+              <span
+                v-else class="flex-text-block tw-flex-1 tw-min-w-0 tw-text-text-light-2"
+                :data-tooltip-content="buildArtifactTooltipHtml(artifact, locale.artifactExpiredAt)"
+                data-tooltip-render="html"
+                data-tooltip-placement="top-end"
+              >
                 <SvgIcon name="octicon-file-removed"/>
                 <span class="tw-flex-1 gt-ellipsis">{{ artifact.name }}</span>
                 <span class="ui label tw-flex-shrink-0">{{ locale.artifactExpired }}</span>

--- a/web_src/js/features/repo-actions.ts
+++ b/web_src/js/features/repo-actions.ts
@@ -71,6 +71,7 @@ function initRepositoryActionsView() {
       artifactsTitle: el.getAttribute('data-locale-artifacts-title'),
       artifactExpired: el.getAttribute('data-locale-artifact-expired'),
       artifactExpiresAt: el.getAttribute('data-locale-artifact-expires-at'),
+      artifactExpiredAt: el.getAttribute('data-locale-artifact-expired-at'),
       confirmDeleteArtifact: el.getAttribute('data-locale-confirm-delete-artifact'),
       showTimeStamps: el.getAttribute('data-locale-show-timestamps'),
       showLogSeconds: el.getAttribute('data-locale-show-log-seconds'),


### PR DESCRIPTION
The artifact info hover tooltip (#37100) only worked for live artifacts. Hovering an expired/deleted artifact showed nothing, and even on live artifacts the retention date was missing on real runs.

Two root causes:

1. **Expired artifacts had no tooltip.** In the run view sidebar, expired artifacts render in a separate branch that omitted `data-tooltip-content` entirely, so there was nothing to hover.
2. **`ExpiresUnix` was no longer sent.** The `ActionRunAttempt` refactor (#37119) dropped `ExpiresUnix` from `fillViewRunResponseArtifacts`, so real runs always returned `0` and the tooltip fell back to size-only. Only the devtest mock still populated it, which masked the regression.

Artifacts without a recorded expiry (`expiresUnix <= 0`) still degrade gracefully to a size-only tooltip. Both states can be previewed on the `/devtest/mock/*` actions run page.
