### PR TITLE
feat(profile): enhance contribution heatmap with year selector and pr…

### DIFF
--- a/models/activities/action.go
+++ b/models/activities/action.go
@@ -433,6 +433,7 @@ type GetFeedsOptions struct {
 	OnlyPerformedBy bool                   // only actions performed by requested user
 	IncludeDeleted  bool                   // include deleted actions
 	Date            string                 // the day we want activity for: YYYY-MM-DD
+	Year            int                    // the year we want activity for: YYYY
 	DontCount       bool                   // do counting in GetFeeds
 }
 
@@ -450,18 +451,22 @@ func ActivityReadable(user, doer *user_model.User) bool {
 
 func FeedDateCond(opts GetFeedsOptions) builder.Cond {
 	cond := builder.NewCond()
-	if opts.Date == "" {
-		return cond
-	}
+	if opts.Date != "" {
+		dateLow, err := time.ParseInLocation("2006-01-02", opts.Date, setting.DefaultUILocation)
+		if err != nil {
+			log.Warn("Unable to parse %s, filter not applied: %v", opts.Date, err)
+		} else {
+			dateHigh := dateLow.Add(86399000000000) // 23h59m59s
 
-	dateLow, err := time.ParseInLocation("2006-01-02", opts.Date, setting.DefaultUILocation)
-	if err != nil {
-		log.Warn("Unable to parse %s, filter not applied: %v", opts.Date, err)
-	} else {
-		dateHigh := dateLow.Add(86399000000000) // 23h59m59s
-
-		cond = cond.And(builder.Gte{"`action`.created_unix": dateLow.Unix()})
-		cond = cond.And(builder.Lte{"`action`.created_unix": dateHigh.Unix()})
+			cond = cond.And(builder.Gte{"`action`.created_unix": dateLow.Unix()})
+			cond = cond.And(builder.Lte{"`action`.created_unix": dateHigh.Unix()})
+		}
+	} else if opts.Year > 0 {
+		loc := setting.DefaultUILocation
+		start := time.Date(opts.Year, time.January, 1, 0, 0, 0, 0, loc)
+		end := time.Date(opts.Year, time.December, 31, 23, 59, 59, 999999999, loc)
+		cond = cond.And(builder.Gte{"`action`.created_unix": start.Unix()})
+		cond = cond.And(builder.Lte{"`action`.created_unix": end.Unix()})
 	}
 	return cond
 }

--- a/models/activities/user_heatmap.go
+++ b/models/activities/user_heatmap.go
@@ -5,6 +5,7 @@ package activities
 
 import (
 	"context"
+	"time"
 
 	"gitea.dev/models/db"
 	"gitea.dev/models/organization"
@@ -20,16 +21,16 @@ type UserHeatmapData struct {
 }
 
 // GetUserHeatmapDataByUser returns an array of UserHeatmapData, it checks whether doer can access user's activity
-func GetUserHeatmapDataByUser(ctx context.Context, user, doer *user_model.User) ([]*UserHeatmapData, error) {
-	return getUserHeatmapData(ctx, user, nil, doer)
+func GetUserHeatmapDataByUser(ctx context.Context, user, doer *user_model.User, year int, showPrivate bool) ([]*UserHeatmapData, error) {
+	return getUserHeatmapData(ctx, user, nil, doer, year, showPrivate)
 }
 
 // GetUserHeatmapDataByOrgTeam returns an array of UserHeatmapData, it checks whether doer can access org's activity
-func GetUserHeatmapDataByOrgTeam(ctx context.Context, org *organization.Organization, team *organization.Team, doer *user_model.User) ([]*UserHeatmapData, error) {
-	return getUserHeatmapData(ctx, org.AsUser(), team, doer)
+func GetUserHeatmapDataByOrgTeam(ctx context.Context, org *organization.Organization, team *organization.Team, doer *user_model.User, year int, showPrivate bool) ([]*UserHeatmapData, error) {
+	return getUserHeatmapData(ctx, org.AsUser(), team, doer, year, showPrivate)
 }
 
-func getUserHeatmapData(ctx context.Context, user *user_model.User, team *organization.Team, doer *user_model.User) ([]*UserHeatmapData, error) {
+func getUserHeatmapData(ctx context.Context, user *user_model.User, team *organization.Team, doer *user_model.User, year int, showPrivate bool) ([]*UserHeatmapData, error) {
 	hdata := make([]*UserHeatmapData, 0)
 
 	if !ActivityReadable(user, doer) {
@@ -51,7 +52,7 @@ func getUserHeatmapData(ctx context.Context, user *user_model.User, team *organi
 		RequestedUser:  user,
 		RequestedTeam:  team,
 		Actor:          doer,
-		IncludePrivate: true, // don't filter by private, as we already filter by repo access
+		IncludePrivate: showPrivate,
 		IncludeDeleted: true,
 		// * Heatmaps for individual users only include actions that the user themself did.
 		// * For organizations actions by all users that were made in owned
@@ -62,12 +63,29 @@ func getUserHeatmapData(ctx context.Context, user *user_model.User, team *organi
 		return nil, err
 	}
 
-	// HINT: USER-ACTIVITY-PUSH-COMMITS: it only uses the doer's action time, it doesn't use git commit's time
-	return hdata, db.GetEngine(ctx).
+	var startTime, endTime int64
+	if year > 0 {
+		loc := setting.DefaultUILocation
+		start := time.Date(year-1, time.December, 25, 0, 0, 0, 0, loc)
+		end := time.Date(year, time.December, 31, 23, 59, 59, 999999999, loc)
+		startTime = start.Unix()
+		endTime = end.Unix()
+	} else {
+		startTime = int64(timeutil.TimeStampNow() - (366+7)*86400)
+	}
+
+	query := db.GetEngine(ctx).
 		Select(groupBy+" AS timestamp, count(user_id) as contributions").
 		Table("action").
 		Where(cond).
-		And("created_unix > ?", timeutil.TimeStampNow()-(366+7)*86400). // (366+7) days to include the first week for the heatmap
+		And("created_unix > ?", startTime)
+
+	if endTime > 0 {
+		query = query.And("created_unix <= ?", endTime)
+	}
+
+	// HINT: USER-ACTIVITY-PUSH-COMMITS: it only uses the doer's action time, it doesn't use git commit's time
+	return hdata, query.
 		GroupBy(groupByName).
 		OrderBy("timestamp").
 		Find(&hdata)

--- a/models/activities/user_heatmap_test.go
+++ b/models/activities/user_heatmap_test.go
@@ -79,7 +79,7 @@ func TestGetUserHeatmapDataByUser(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Get the heatmap and compare
-		heatmap, err := activities_model.GetUserHeatmapDataByUser(t.Context(), user, doer)
+		heatmap, err := activities_model.GetUserHeatmapDataByUser(t.Context(), user, doer, 0, true)
 		var contributions int
 		for _, hm := range heatmap {
 			contributions += int(hm.Contributions)

--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -198,6 +198,8 @@
   "heatmap.no_contributions": "No contributions",
   "heatmap.less": "Less",
   "heatmap.more": "More",
+  "heatmap.last_12_months": "Last 12 months",
+  "heatmap.show_private": "Show private contributions",
   "editor.buttons.heading.tooltip": "Add heading",
   "editor.buttons.bold.tooltip": "Add bold text",
   "editor.buttons.italic.tooltip": "Add italic text",

--- a/routers/api/v1/user/user.go
+++ b/routers/api/v1/user/user.go
@@ -156,7 +156,13 @@ func GetUserHeatmapData(ctx *context.APIContext) {
 	//   "404":
 	//     "$ref": "#/responses/notFound"
 
-	heatmap, err := activities_model.GetUserHeatmapDataByUser(ctx, ctx.ContextUser, ctx.Doer)
+	year := ctx.FormInt("year")
+	showPrivate := true
+	if ctx.FormString("show-private") != "" {
+		showPrivate = ctx.FormBool("show-private")
+	}
+
+	heatmap, err := activities_model.GetUserHeatmapDataByUser(ctx, ctx.ContextUser, ctx.Doer, year, showPrivate)
 	if err != nil {
 		ctx.APIErrorInternal(err)
 		return

--- a/routers/web/user/heatmap.go
+++ b/routers/web/user/heatmap.go
@@ -51,12 +51,19 @@ func DashboardHeatmap(ctx *context.Context) {
 		ctx.NotFound(nil)
 		return
 	}
+
+	year := ctx.FormInt("year")
+	showPrivate := true
+	if ctx.FormString("show-private") != "" {
+		showPrivate = ctx.FormBool("show-private")
+	}
+
 	var data []*activities_model.UserHeatmapData
 	var err error
 	if ctx.Org.Organization == nil {
-		data, err = activities_model.GetUserHeatmapDataByUser(ctx, ctx.ContextUser, ctx.Doer)
+		data, err = activities_model.GetUserHeatmapDataByUser(ctx, ctx.ContextUser, ctx.Doer, year, showPrivate)
 	} else {
-		data, err = activities_model.GetUserHeatmapDataByOrgTeam(ctx, ctx.Org.Organization, ctx.Org.Team, ctx.Doer)
+		data, err = activities_model.GetUserHeatmapDataByOrgTeam(ctx, ctx.Org.Organization, ctx.Org.Team, ctx.Doer, year, showPrivate)
 	}
 	if err != nil {
 		ctx.ServerError("GetUserHeatmapData", err)

--- a/routers/web/user/home.go
+++ b/routers/web/user/home.go
@@ -111,15 +111,22 @@ func Dashboard(ctx *context.Context) {
 
 	prepareHeatmapURL(ctx)
 
+	year := ctx.FormInt("year")
+	showPrivate := true
+	if ctx.FormString("show-private") != "" {
+		showPrivate = ctx.FormBool("show-private")
+	}
+
 	pageSize := setting.UI.User.RepoPagingNum
 	feeds, count, err := feed_service.GetFeedsForDashboard(ctx, activities_model.GetFeedsOptions{
 		RequestedUser:   ctxUser,
 		RequestedTeam:   ctx.Org.Team,
 		Actor:           ctx.Doer,
-		IncludePrivate:  true,
+		IncludePrivate:  showPrivate,
 		OnlyPerformedBy: false,
 		IncludeDeleted:  false,
 		Date:            ctx.FormString("date"),
+		Year:            year,
 		ListOptions:     db.ListOptions{Page: page, PageSize: pageSize},
 	})
 	if err != nil {

--- a/routers/web/user/profile.go
+++ b/routers/web/user/profile.go
@@ -168,8 +168,12 @@ func prepareUserProfileTabData(ctx *context.Context, profileDbRepo *repo_model.R
 		}
 
 		date := ctx.FormString("date")
+		year := ctx.FormInt("year")
 		pagingNum = setting.UI.FeedPagingNum
 		showPrivate := ctx.IsSigned && (ctx.Doer.IsAdmin || ctx.Doer.ID == ctx.ContextUser.ID)
+		if ctx.FormString("show-private") != "" {
+			showPrivate = showPrivate && ctx.FormBool("show-private")
+		}
 		// a public-only API token must not surface private activity, even for its own owner
 		if showPrivate && context.TokenIsPublicOnly(ctx) {
 			showPrivate = false
@@ -181,6 +185,7 @@ func prepareUserProfileTabData(ctx *context.Context, profileDbRepo *repo_model.R
 			OnlyPerformedBy: true,
 			IncludeDeleted:  false,
 			Date:            date,
+			Year:            year,
 			ListOptions: db.ListOptions{
 				PageSize: pagingNum,
 				Page:     page,

--- a/templates/user/heatmap.tmpl
+++ b/templates/user/heatmap.tmpl
@@ -7,6 +7,10 @@
 		data-locale-no-contributions="{{ctx.Locale.Tr "heatmap.no_contributions"}}"
 		data-locale-more="{{ctx.Locale.Tr "heatmap.more"}}"
 		data-locale-less="{{ctx.Locale.Tr "heatmap.less"}}"
+		data-locale-last-12-months="{{ctx.Locale.Tr "heatmap.last_12_months"}}"
+		data-locale-show-private="{{ctx.Locale.Tr "heatmap.show_private"}}"
+		data-user-created-year="{{if .ContextUser}}{{.ContextUser.CreatedUnix.Year}}{{end}}"
+		data-show-private-toggle="{{if and .SignedUser (not .ContextUser.IsOrganization) (or .SignedUser.IsAdmin (eq .SignedUser.ID .ContextUser.ID))}}true{{else}}false{{end}}"
 	></div>
 </div>
 <div class="divider"></div>

--- a/web_src/css/features/heatmap.css
+++ b/web_src/css/features/heatmap.css
@@ -9,7 +9,7 @@
 }
 
 @container (width > 0) {
-  #user-heatmap {
+  #user-heatmap.is-loading {
     /* Set element to fixed height so that it does not resize after load. The calculation is complex
        because the element does not scale with a fixed aspect ratio. */
     height: calc((100cqw / 5) - (100cqw / 25) + 20px);
@@ -57,4 +57,21 @@
 
 #user-heatmap .heatmap-day:hover {
   outline: 1.5px solid var(--color-text);
+}
+
+.heatmap-select {
+  font-size: 14px !important;
+  padding: 8px 30px 8px 12px !important;
+  height: 38px !important;
+  line-height: 20px !important;
+}
+
+.heatmap-controls {
+  margin-bottom: 16px;
+}
+
+@media (min-width: 768px) {
+  .heatmap-controls {
+    margin-bottom: 0;
+  }
 }

--- a/web_src/js/components/ActivityHeatmap.vue
+++ b/web_src/js/components/ActivityHeatmap.vue
@@ -1,20 +1,25 @@
 <script lang="ts" setup>
-import {computed, onBeforeUnmount, onMounted} from 'vue';
+import {ref, computed, watch, onBeforeUnmount, onMounted} from 'vue';
 import tippy, {createSingleton} from 'tippy.js';
 import type {CreateSingletonInstance, Instance} from 'tippy.js';
 import {getCurrentLocale} from '../utils.ts';
+import {GET} from '../modules/fetch.ts';
 
 type HeatmapValue = {date: Date; count: number};
 type HeatmapCell = {date: Date; colorIndex: number; ariaLabel: string; tooltip: string};
 type MonthLabel = {monthIdx: number; weekIdx: number};
 
 const props = defineProps<{
-  values: HeatmapValue[];
+  heatmapUrl: string;
+  userCreatedYear?: number;
+  showPrivateToggle?: boolean;
   locale: {
     textTotalContributions: string;
     heatMapLocale: {months: string[]; days: string[]; on: string; more: string; less: string};
     noDataText: string;
     tooltipUnit: string;
+    last12Months: string;
+    showPrivate: string;
   };
 }>();
 
@@ -36,6 +41,85 @@ const gridLeft = Math.ceil(squareSize * 2.5);
 const gridTop = squareSize + squareSize / 2;
 
 const now = new Date();
+const currentYear = now.getFullYear();
+
+const params = new URLSearchParams(document.location.search);
+const initialYear = parseInt(params.get('year') || '0', 10) || 0;
+const initialShowPrivate = params.get('show-private') !== 'false';
+
+const values = ref<HeatmapValue[]>([]);
+const totalContributions = ref(0);
+const selectedYear = ref(initialYear);
+const showPrivate = ref(initialShowPrivate);
+const isLoading = ref(true);
+
+const startYear = props.userCreatedYear ? Math.min(props.userCreatedYear, currentYear) : currentYear;
+const years = computed(() => {
+  const list = [0]; // 0 represents "Last 12 months"
+  for (let y = currentYear; y >= startYear; y--) {
+    list.push(y);
+  }
+  return list;
+});
+
+async function fetchData() {
+  isLoading.value = true;
+  try {
+    const url = new URL(props.heatmapUrl, window.location.origin);
+    if (selectedYear.value > 0) {
+      url.searchParams.set('year', String(selectedYear.value));
+    }
+    url.searchParams.set('show-private', String(showPrivate.value));
+
+    const resp = await GET(url.toString());
+    if (!resp.ok) throw new Error(`Failed to load heatmap data: ${resp.status} ${resp.statusText}`);
+    const {heatmapData, totalContributions: total} = await resp.json();
+
+    const heatmap: Record<string, number> = {};
+    for (const [timestamp, contributions] of heatmapData) {
+      // Convert to user timezone and sum contributions by date
+      const dateStr = new Date(timestamp * 1000).toDateString();
+      heatmap[dateStr] = (heatmap[dateStr] || 0) + contributions;
+    }
+
+    values.value = Object.entries(heatmap).map(([dateStr, count]) => {
+      return {date: new Date(dateStr), count};
+    });
+    totalContributions.value = total;
+  } catch (err) {
+    console.error('Heatmap failed to load', err);
+  } finally {
+    isLoading.value = false;
+  }
+}
+
+onMounted(() => {
+  fetchData();
+});
+
+function selectYear(y: number) {
+  selectedYear.value = y;
+  const params = new URLSearchParams(document.location.search);
+  if (y > 0) {
+    params.set('year', String(y));
+  } else {
+    params.delete('year');
+  }
+  params.delete('date'); // clear date filter when changing year
+  params.delete('page');
+
+  const newSearch = params.toString();
+  window.location.search = newSearch.length ? `?${newSearch}` : '';
+}
+
+watch(showPrivate, (val) => {
+  const params = new URLSearchParams(document.location.search);
+  params.set('show-private', String(val));
+  params.delete('page');
+
+  const newSearch = params.toString();
+  window.location.search = newSearch.length ? `?${newSearch}` : '';
+});
 
 function dateKey(d: Date): string {
   return `${d.getFullYear()}${String(d.getMonth()).padStart(2, '0')}${String(d.getDate()).padStart(2, '0')}`;
@@ -47,17 +131,35 @@ function shiftDate(d: Date, days: number): Date {
   return out;
 }
 
-const grid = computed(() => {
-  const start = shiftDate(now, -trailingDays);
-  const padStart = start.getDay();
-  const padEnd = daysInWeek - 1 - now.getDay();
-  const weekCount = (trailingDays + 1 + padStart + padEnd) / daysInWeek;
+const limitDate = computed(() => {
+  if (selectedYear.value === 0) return now;
+  return new Date(selectedYear.value, 11, 31, 23, 59, 59, 999);
+});
 
-  const maxCount = props.values.length ? Math.max(...props.values.map((v) => v.count)) : 0;
+const grid = computed(() => {
+  let start: Date;
+  let end: Date;
+  let daysCount: number;
+
+  if (selectedYear.value === 0) {
+    start = shiftDate(now, -trailingDays);
+    end = now;
+    daysCount = trailingDays + 1;
+  } else {
+    start = new Date(selectedYear.value, 0, 1);
+    end = new Date(selectedYear.value, 11, 31);
+    daysCount = Math.round((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+  }
+
+  const padStart = start.getDay();
+  const padEnd = daysInWeek - 1 - end.getDay();
+  const weekCount = (daysCount + padStart + padEnd) / daysInWeek;
+
+  const maxCount = values.value.length ? Math.max(...values.value.map((v) => v.count)) : 0;
   const max = maxCount > 0 ? Math.ceil(maxCount / 5 * 4) : 1;
 
   const activities = new Map<string, {count: number; colorIndex: number}>();
-  for (const {date, count} of props.values) {
+  for (const {date, count} of values.value) {
     const colorIndex = count >= max ? 4 : Math.max(1, Math.ceil((count / max) * 3));
     activities.set(dateKey(date), {count, colorIndex});
   }
@@ -122,6 +224,12 @@ onBeforeUnmount(() => {
   cellInstances.clear();
 });
 
+watch(values, () => {
+  for (const instance of cellInstances.values()) instance.destroy();
+  cellInstances.clear();
+  singleton?.setInstances([]);
+});
+
 function lazyInitTooltip(e: MouseEvent) {
   const el = e.target as Element;
   if (!singleton || cellInstances.has(el) || !el.classList.contains('heatmap-day')) return;
@@ -146,64 +254,108 @@ function handleDayClick(date: Date) {
   const newSearch = params.toString();
   window.location.search = newSearch.length ? `?${newSearch}` : '';
 }
+
+const totalContributionsText = computed(() => {
+  const totalFormatted = totalContributions.value.toLocaleString();
+  const baseText = props.locale.textTotalContributions.replace('%s', totalFormatted);
+  if (selectedYear.value === 0) {
+    return baseText;
+  }
+  const last12MonthsPattern = new RegExp(props.locale.last12Months, 'gi');
+  if (last12MonthsPattern.test(baseText)) {
+    return baseText.replace(last12MonthsPattern, String(selectedYear.value));
+  }
+  return baseText.replace(/last 12 months/gi, String(selectedYear.value));
+});
 </script>
+
 <template>
-  <div>
-    <svg class="heatmap-svg" :viewBox="`0 0 ${grid.width} ${grid.height}`">
-      <g class="heatmap-month-labels" :transform="`translate(${gridLeft}, 0)`">
-        <text
-          v-for="m in grid.monthLabels"
-          :key="m.weekIdx"
-          class="heatmap-month-label"
-          :x="cellSize * m.weekIdx"
-          :y="cellSize - squareBorder"
-        >
-          {{ locale.heatMapLocale.months[m.monthIdx] }}
-        </text>
-      </g>
-      <g class="heatmap-day-labels" :transform="`translate(0, ${gridTop})`">
-        <text class="heatmap-day-label" :x="0" :y="20">{{ locale.heatMapLocale.days[1] }}</text>
-        <text class="heatmap-day-label" :x="0" :y="44">{{ locale.heatMapLocale.days[3] }}</text>
-        <text class="heatmap-day-label" :x="0" :y="69">{{ locale.heatMapLocale.days[5] }}</text>
-      </g>
-      <g class="heatmap-grid" :transform="`translate(${gridLeft}, ${gridTop})`" @mouseover="lazyInitTooltip">
-        <g
-          v-for="(week, w) in grid.calendar"
-          :key="w"
-          class="heatmap-week"
-          :transform="`translate(${w * cellSize}, 0)`"
-        >
-          <template v-for="(day, d) in week" :key="d">
-            <rect
-              v-if="day.date < now"
-              class="heatmap-day"
-              :transform="`translate(0, ${d * cellSize})`"
-              :width="squareSize"
-              :height="squareSize"
-              :style="{fill: colorRange[day.colorIndex]}"
-              :aria-label="day.ariaLabel"
-              :data-tooltip="day.tooltip"
-              @click="handleDayClick(day.date)"
-            />
-          </template>
-        </g>
-      </g>
-    </svg>
-    <div class="heatmap-footer">
-      <div>{{ locale.textTotalContributions }}</div>
-      <div class="heatmap-legend">
-        <div>{{ locale.heatMapLocale.less }}</div>
-        <svg class="heatmap-legend-svg" :viewBox="legendViewBox" :height="squareSize">
-          <rect
-            v-for="(color, i) in colorRange"
-            :key="i"
-            :width="squareSize"
-            :height="squareSize"
-            :x="(i + 1) * cellSize"
-            :style="{fill: color}"
-          />
+  <div class="tw-flex tw-flex-col md:tw-flex-row tw-gap-4">
+    <div class="tw-flex-1 tw-min-w-0">
+      <div v-if="isLoading" class="tw-flex tw-items-center tw-justify-center tw-h-32">
+        <div class="ui active centered inline loader"/>
+      </div>
+      <div v-else>
+        <svg class="heatmap-svg" :viewBox="`0 0 ${grid.width} ${grid.height}`">
+          <g class="heatmap-month-labels" :transform="`translate(${gridLeft}, 0)`">
+            <text
+              v-for="m in grid.monthLabels"
+              :key="m.weekIdx"
+              class="heatmap-month-label"
+              :x="cellSize * m.weekIdx"
+              :y="cellSize - squareBorder"
+            >
+              {{ locale.heatMapLocale.months[m.monthIdx] }}
+            </text>
+          </g>
+          <g class="heatmap-day-labels" :transform="`translate(0, ${gridTop})`">
+            <text class="heatmap-day-label" :x="0" :y="20">{{ locale.heatMapLocale.days[1] }}</text>
+            <text class="heatmap-day-label" :x="0" :y="44">{{ locale.heatMapLocale.days[3] }}</text>
+            <text class="heatmap-day-label" :x="0" :y="69">{{ locale.heatMapLocale.days[5] }}</text>
+          </g>
+          <g class="heatmap-grid" :transform="`translate(${gridLeft}, ${gridTop})`" @mouseover="lazyInitTooltip">
+            <g
+              v-for="(week, w) in grid.calendar"
+              :key="w"
+              class="heatmap-week"
+              :transform="`translate(${w * cellSize}, 0)`"
+            >
+              <template v-for="(day, d) in week" :key="d">
+                <rect
+                  v-if="day.date.getTime() <= limitDate.getTime()"
+                  class="heatmap-day"
+                  :transform="`translate(0, ${d * cellSize})`"
+                  :width="squareSize"
+                  :height="squareSize"
+                  :style="{fill: colorRange[day.colorIndex]}"
+                  :aria-label="day.ariaLabel"
+                  :data-tooltip="day.tooltip"
+                  @click="handleDayClick(day.date)"
+                />
+              </template>
+            </g>
+          </g>
         </svg>
-        <div>{{ locale.heatMapLocale.more }}</div>
+        <div class="heatmap-footer">
+          <div>{{ totalContributionsText }}</div>
+          <div class="heatmap-legend">
+            <div>{{ locale.heatMapLocale.less }}</div>
+            <svg class="heatmap-legend-svg" :viewBox="legendViewBox" :height="squareSize">
+              <rect
+                v-for="(color, i) in colorRange"
+                :key="i"
+                :width="squareSize"
+                :height="squareSize"
+                :x="(i + 1) * cellSize"
+                :style="{fill: color}"
+              />
+            </svg>
+            <div>{{ locale.heatMapLocale.more }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="heatmap-controls tw-flex tw-flex-col tw-gap-4 tw-shrink-0 tw-w-full md:tw-w-44">
+      <div class="native-select tw-w-full">
+        <select
+          v-model="selectedYear"
+          class="tw-w-full heatmap-select"
+          @change="selectYear(selectedYear)"
+        >
+          <option
+            v-for="y in years"
+            :key="y"
+            :value="y"
+          >
+            {{ y === 0 ? locale.last12Months : y }}
+          </option>
+        </select>
+      </div>
+
+      <div v-if="showPrivateToggle" class="ui checkbox tw-ml-2">
+        <input type="checkbox" v-model="showPrivate" id="heatmap-private-toggle">
+        <label for="heatmap-private-toggle" class="tw-cursor-pointer">{{ locale.showPrivate }}</label>
       </div>
     </div>
   </div>

--- a/web_src/js/features/heatmap.ts
+++ b/web_src/js/features/heatmap.ts
@@ -1,56 +1,41 @@
 import {createApp} from 'vue';
 import {translateMonth, translateDay} from '../utils.ts';
-import {GET} from '../modules/fetch.ts';
-
-type HeatmapResponse = {
-  heatmapData: Array<[number, number]>; // [[1617235200, 2]] = [unix timestamp, count]
-  totalContributions: number;
-};
 
 export async function initHeatmap() {
   const el = document.querySelector<HTMLElement>('#user-heatmap');
   if (!el) return;
 
   try {
-    const url = el.getAttribute('data-heatmap-url')!;
-    const resp = await GET(url);
-    if (!resp.ok) throw new Error(`Failed to load heatmap data: ${resp.status} ${resp.statusText}`);
-    const {heatmapData, totalContributions} = await resp.json() as HeatmapResponse;
+    const heatmapUrl = el.getAttribute('data-heatmap-url')!;
+    const userCreatedYear = parseInt(el.getAttribute('data-user-created-year') || '0', 10) || 0;
+    const showPrivateToggle = el.getAttribute('data-show-private-toggle') === 'true';
 
-    const heatmap: Record<string, number> = {};
-    for (const [timestamp, contributions] of heatmapData) {
-      // Convert to user timezone and sum contributions by date
-      const dateStr = new Date(timestamp * 1000).toDateString();
-      heatmap[dateStr] = (heatmap[dateStr] || 0) + contributions;
-    }
-
-    const values = Object.entries(heatmap).map(([dateStr, count]) => {
-      return {date: new Date(dateStr), count};
-    });
-
-    const totalFormatted = totalContributions.toLocaleString();
-    const textTotalContributions = el.getAttribute('data-locale-total-contributions')!.replace('%s', totalFormatted);
-
-    // last heatmap tooltip localization attempt https://github.com/go-gitea/gitea/pull/24131/commits/a83761cbbae3c2e3b4bced71e680f44432073ac8
     const locale = {
       heatMapLocale: {
         months: new Array(12).fill(undefined).map((_, idx) => translateMonth(idx)),
         days: new Array(7).fill(undefined).map((_, idx) => translateDay(idx)),
-        on: ' - ', // no correct locale support for it, because in many languages the sentence is not "something on someday"
+        on: ' - ',
         more: el.getAttribute('data-locale-more'),
         less: el.getAttribute('data-locale-less'),
       },
       tooltipUnit: 'contributions',
-      textTotalContributions,
+      textTotalContributions: el.getAttribute('data-locale-total-contributions'),
       noDataText: el.getAttribute('data-locale-no-contributions'),
+      last12Months: el.getAttribute('data-locale-last-12-months'),
+      showPrivate: el.getAttribute('data-locale-show-private'),
     };
 
     const {default: ActivityHeatmap} = await import('../components/ActivityHeatmap.vue');
-    const View = createApp(ActivityHeatmap, {values, locale});
+    const View = createApp(ActivityHeatmap, {
+      heatmapUrl,
+      userCreatedYear,
+      showPrivateToggle,
+      locale,
+    });
     View.mount(el);
     el.classList.remove('is-loading');
   } catch (err) {
-    console.error('Heatmap failed to load', err);
-    el.textContent = 'Heatmap failed to load';
+    console.error('Heatmap failed to initialize', err);
+    el.textContent = 'Heatmap failed to initialize';
   }
 }


### PR DESCRIPTION
This PR completes the enhancement of the user profile contribution heatmap in Gitea. It implements historical year selection navigation (similar to GitHub) and adds a user-visibility toggle for private repository contributions to authenticated owners and administrators.

Fixes https://github.com/go-gitea/gitea/issues/5439 
Partially fixes https://github.com/go-gitea/gitea/issues/38450
### Key Features & Implementations

#### 1. Backend Service Layer & Filtering
* **SQL Date Boundary Querying (`models/activities/`)**: Added `year` filtering into `GetUserHeatmapDataByUser` and `GetUserHeatmapDataByOrgTeam`. Enforced boundaries beginning on Dec 25 of the previous year to prevent rendering gaps in the week-grid.
* **Activity Feed Time Integration (`models/activities/action.go`)**: Updated `FeedDateCond` to apply year-based filtering boundaries when retrieving the dashboard activity feed.
* **Access Control Check (`routers/web/user/profile.go`)**: Restricted visibility of private activity logs to authorized viewers (signed-in profile owner or Gitea administrator).

#### 2. Frontend Components & CSS Layout
* **Dropdown Selection Control (`ActivityHeatmap.vue`)**: Refactored the year selector to use Gitea's `.native-select` styling for a clean, professional, and responsive dropdown menu.
* **Private Toggle State Integration**: Implemented client-side state mapping for the "Show private contributions" checkbox, dynamically reading Gitea template permissions.
* **Grid Rendering and Synchronization**: Synchronized year selection and privacy toggles via URL query parameters, automatically updating both the heatmap grid and the activity feed timeline dynamically on load.
* **Responsive Spacing Fixes (`web_src/css/features/heatmap.css`)**: Restricted container-query height limits to the loading state to allow the heatmap to resize dynamically, and introduced margin-bottom spacing to prevent overlapping elements on mobile browsers.

### Screenshots
Before
<img width="1246" height="651" alt="image" src="https://github.com/user-attachments/assets/89b5ec13-fe0e-45b6-9b90-041ddd169c57" />
After
<img width="1246" height="651" alt="image" src="https://github.com/user-attachments/assets/caab2a7e-acec-46c9-8cbe-850d1375ac12" />

### Verification & Testing

#### 1. Manual Verification
* Verified that selecting a year reloads the timeline feed to match the chosen year's contribution history.
* Verified that checking/unchecking **"Show private contributions"** correctly toggles the contribution visibility on the heatmap and feed.
* Confirmed that anonymous/unauthenticated visitors do not see the private toggle option or private contributions.

