### PR TITLE
fix(auth): use the session's actual login method for sign-out redirect

### DIFF
--- a/modules/session/key.go
+++ b/modules/session/key.go
@@ -4,8 +4,9 @@
 package session
 
 const (
-	KeyUID   = "uid"
-	KeyUname = "uname"
+	KeyUID       = "uid"
+	KeyUname     = "uname"
+	KeyLoginType = "loginType"
 
 	KeyUserHasTwoFactorAuth = "userHasTwoFactorAuth"
 )

--- a/routers/web/auth/auth.go
+++ b/routers/web/auth/auth.go
@@ -319,6 +319,10 @@ func SignInPost(ctx *context.Context) {
 		}
 		return
 	}
+	if err := ctx.Session.Set(session.KeyLoginType, auth.Plain); err != nil {
+		ctx.ServerError("UserSignIn: Unable to update session", err)
+		return
+	}
 
 	// Now handle 2FA:
 	// First of all if the source can skip local two fa we're done
@@ -484,14 +488,19 @@ func SignOut(ctx *context.Context) {
 }
 
 func buildSignOutRedirectURL(ctx *context.Context) string {
-	if ctx.Doer != nil && ctx.Doer.LoginType == auth.OAuth2 {
+	loginType := auth.NoType
+	if sessionLoginType := ctx.Session.Get(session.KeyLoginType); sessionLoginType != nil {
+		loginType, _ = sessionLoginType.(auth.Type)
+	} else if ctx.Doer != nil {
+		loginType = ctx.Doer.LoginType
+	}
+	if ctx.Doer != nil && loginType == auth.OAuth2 {
 		if s := buildOIDCEndSessionURL(ctx, ctx.Doer); s != "" {
 			return s
 		}
 	}
 
 	// The assumption is: if reverse proxy auth is enabled, then the users should only sign-in via reverse proxy auth.
-	// TODO: in the future, if we need to distinguish different sign-in methods, we need to save the sign-in method in session and check here
 	if setting.Service.EnableReverseProxyAuth && setting.ReverseProxyLogoutRedirect != "" {
 		return setting.ReverseProxyLogoutRedirect
 	}

--- a/routers/web/auth/auth_test.go
+++ b/routers/web/auth/auth_test.go
@@ -165,5 +165,19 @@ func TestWebAuthOAuth2(t *testing.T) {
 		assert.Equal(t, expectedValues, u.Query())
 		u.RawQuery = ""
 		assert.Equal(t, "https://example.com/oidc-logout", u.String())
+
+		t.Run("SessionOAuth2OverridesUserLoginType", func(t *testing.T) {
+			ctx, _ := contexttest.MockContext(t, "/user/logout", contexttest.MockContextOption{SessionStore: session.NewMockMemStore("oauth2-sid")})
+			ctx.Doer = &user_model.User{ID: 1, LoginType: auth_model.Plain, LoginSource: authSource.ID}
+			require.NoError(t, ctx.Session.Set(session.KeyLoginType, auth_model.OAuth2))
+			assert.Contains(t, buildSignOutRedirectURL(ctx), "https://example.com/oidc-logout")
+		})
+
+		t.Run("SessionPlainOverridesUserLoginType", func(t *testing.T) {
+			ctx, _ := contexttest.MockContext(t, "/user/logout", contexttest.MockContextOption{SessionStore: session.NewMockMemStore("plain-sid")})
+			ctx.Doer = &user_model.User{ID: 1, LoginType: auth_model.OAuth2, LoginSource: authSource.ID}
+			require.NoError(t, ctx.Session.Set(session.KeyLoginType, auth_model.Plain))
+			assert.Equal(t, setting.AppSubURL+"/", buildSignOutRedirectURL(ctx))
+		})
 	})
 }

--- a/routers/web/auth/oauth.go
+++ b/routers/web/auth/oauth.go
@@ -275,6 +275,7 @@ type LinkAccountData struct {
 }
 
 func init() {
+	gob.Register(auth.Type(0))      // TODO: CHI-SESSION-GOB-REGISTER
 	gob.Register(LinkAccountData{}) // TODO: CHI-SESSION-GOB-REGISTER
 }
 
@@ -356,6 +357,10 @@ func oauth2UpdateAvatarIfNeed(ctx *context.Context, avatarURL string, u *user_mo
 func handleOAuth2SignIn(ctx *context.Context, authSource *auth.Source, u *user_model.User, gothUser goth.User) {
 	oauth2SignInSync(ctx, authSource.ID, u, gothUser)
 	if ctx.Written() {
+		return
+	}
+	if err := ctx.Session.Set(session.KeyLoginType, auth.OAuth2); err != nil {
+		ctx.ServerError("handleOAuth2SignIn: Unable to update session", err)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- `buildSignOutRedirectURL()` decided whether to redirect to the OIDC provider's `end_session_endpoint` using `ctx.Doer.LoginType` — the account's permanently configured login type, not how the *current session* actually authenticated.
- An OAuth2/OIDC-registered account that also signs in through Gitea's own password form still got redirected to the OIDC logout endpoint on sign-out. That endpoint has no active SSO session for the browser in this flow, and returns a bare JSON status response instead of completing logout cleanly (as reported in #38209).
- This was already flagged by a TODO at the exact call site: *"if we need to distinguish different sign-in methods, we need to save the sign-in method in session and check here."*

## Change
- Added `session.KeyLoginType`.
- Set to `auth.Plain` on a successful password sign-in (`SignInPost`, right after `UserSignIn` succeeds and before the 2FA branch — so it survives whatever 2FA/WebAuthn hop follows, since `regenerateSession` only deletes keys explicitly listed).
- Set to `auth.OAuth2` in `handleOAuth2SignIn`, the single entry point for both direct OAuth2 sign-in and the link-account flow.
- `buildSignOutRedirectURL` now reads the session value first, falling back to `ctx.Doer.LoginType` only when the session doesn't have it — covers older sessions predating this change, and sign-in paths intentionally left untouched (WebAuthn-only, OpenID, SSPI/reverse-proxy), which is exactly the incremental scope the TODO comment describes.
- Registered `auth.Type` with `gob` so it round-trips through the session store's encoding (same pattern as the existing `LinkAccountData` registration in the same `init()`).
- Removed the now-resolved TODO comment; left the reverse-proxy-auth logic right below it untouched.

## Test plan
- `go build ./...` — clean
- `go vet ./routers/web/auth/... ./modules/session/...` — clean
- `go test ./routers/web/auth/... ./modules/session/...` — pass
- Extended the existing `OIDCLogout` test (which already covers the account-`LoginType`-only fallback path) with two new subtests: session `OAuth2` overrides an account `LoginType` of `Plain` (redirects to OIDC logout), and session `Plain` overrides an account `LoginType` of `OAuth2` (redirects to the normal post-logout page) — covering both directions of the fix.