### PR TITLE
fix(pull): filter reviewer candidates by profile visibility

### DIFF
--- a/services/pull/reviewer.go
+++ b/services/pull/reviewer.go
@@ -61,12 +61,28 @@ func GetReviewers(ctx context.Context, repo *repo_model.Repository, doerID, post
 		}
 	}
 
+	var doer *user_model.User
+	if doerID > 0 {
+		var err error
+		doer, err = user_model.GetUserByID(ctx, doerID)
+		if err != nil && !user_model.IsErrUserNotExist(err) {
+			return nil, err
+		}
+	}
+
 	// add owner after all users are loaded because we can avoid load owner twice
 	if repo.OwnerID != posterID && !repo.Owner.IsOrganization() && !uniqueUserIDs.Contains(repo.OwnerID) {
 		users = append(users, repo.Owner)
 	}
 
-	return users, nil
+	visibleUsers := users[:0]
+	for _, user := range users {
+		if user_model.IsUserVisibleToViewer(ctx, user, doer) {
+			visibleUsers = append(visibleUsers, user)
+		}
+	}
+
+	return visibleUsers, nil
 }
 
 // GetReviewerTeams get all teams can be requested to review

--- a/services/pull/reviewer_test.go
+++ b/services/pull/reviewer_test.go
@@ -6,11 +6,15 @@ package pull_test
 import (
 	"testing"
 
+	"gitea.dev/models/db"
+	"gitea.dev/models/perm"
 	repo_model "gitea.dev/models/repo"
 	"gitea.dev/models/unittest"
+	user_model "gitea.dev/models/user"
 	pull_service "gitea.dev/services/pull"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRepoGetReviewers(t *testing.T) {
@@ -54,6 +58,39 @@ func TestRepoGetReviewers(t *testing.T) {
 	reviewers, err = pull_service.GetReviewers(ctx, repo3, 2, 2)
 	assert.NoError(t, err)
 	assert.Len(t, reviewers, 1)
+}
+
+func TestRepoGetReviewersPrivateVisibility(t *testing.T) {
+	require.NoError(t, unittest.PrepareTestDatabase())
+
+	ctx := t.Context()
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+	privateUser := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 31})
+	collaboration := &repo_model.Collaboration{
+		RepoID: repo.ID,
+		UserID: privateUser.ID,
+		Mode:   perm.AccessModeRead,
+	}
+	require.NoError(t, db.Insert(ctx, collaboration))
+	defer db.DeleteByBean(ctx, collaboration)
+
+	t.Run("UnrelatedDoer", func(t *testing.T) {
+		reviewers, err := pull_service.GetReviewers(ctx, repo, 4, 0)
+		require.NoError(t, err)
+		require.Len(t, reviewers, 1)
+		assert.EqualValues(t, 2, reviewers[0].ID)
+	})
+
+	t.Run("DoerInSameOrganization", func(t *testing.T) {
+		reviewers, err := pull_service.GetReviewers(ctx, repo, 20, 0)
+		require.NoError(t, err)
+
+		reviewerIDs := make([]int64, 0, len(reviewers))
+		for _, reviewer := range reviewers {
+			reviewerIDs = append(reviewerIDs, reviewer.ID)
+		}
+		assert.ElementsMatch(t, []int64{2, 31}, reviewerIDs)
+	})
 }
 
 func TestRepoGetReviewerTeams(t *testing.T) {


### PR DESCRIPTION
## Summary
- `GetReviewers()` built its candidate list with only an `is_active = true` SQL filter, never checking the candidate's `Visibility`. A user who set their profile to private (or limited) was still returned as a reviewer-request candidate — name, avatar, and account existence exposed via the reviewer picker — to any non-admin caller with no organizational relationship to them and no mutual follow. That's exactly the audience `IsUserVisibleToViewer` exists to keep such users hidden from.
- Reported and root-caused in #37371 (already public, including a reproduction report), which pinned it to this exact function and missing filter.
- Loads the doer (falling back to an anonymous/nil viewer when `doerID` is absent or doesn't resolve to an existing user) and filters both the DB-queried candidates and the separately-appended repo owner through the existing `user_model.IsUserVisibleToViewer(ctx, candidate, doer)` policy check — the same function Gitea already uses elsewhere to decide profile visibility, so this doesn't introduce new policy, just applies the existing one here too.
- **Deliberately out of scope:** candidate `IsRestricted` filtering, mentioned in the original report alongside visibility, has no equivalent existing policy helper to point to and would need its own judgment call on intended semantics (e.g., a restricted user who's a legitimate team member of the repo's own org) — left untouched pending separate discussion rather than guessing.

## Test plan
- `go build ./...` — clean
- `go vet ./services/pull/...` — clean
- `go test ./services/pull/...` — pass (existing `TestRepoGetReviewers`/`TestRepoGetReviewerTeams` unaffected)
- Added `TestRepoGetReviewersPrivateVisibility` with two subtests using existing fixture data (private-visibility user id 31, `visibility: 2`) plus a temporary read collaboration on repo 1:
  - an unrelated non-admin doer (user 4, no org/follow relationship) does **not** see the private user in results
  - a doer in the same organization (user 20, org 19/team 6) **does** still see them — confirms the filter isn't overly aggressive