### PR TITLE
fix(markup): remove double strikethrough line on inline code

### DIFF
--- a/web_src/css/markup/content.css
+++ b/web_src/css/markup/content.css
@@ -366,10 +366,6 @@ html[data-gitea-theme-dark="false"] .markup img[src*="#gh-dark-mode-only"] {
   display: none;
 }
 
-.markup del code {
-  text-decoration: inherit;
-}
-
 .markup pre > code {
   font-size: 100%;
 }


### PR DESCRIPTION
## Summary
- `.markup del code { text-decoration: inherit; }` forces inline `<code>` elements nested inside `<del>` (i.e. markdown `~~`code`~~`) to inherit the line-through decoration, but this renders as two visually overlapping strikethrough lines instead of one — reported and screenshotted in #34786 (also reproducible on the demo instance, confirmed by a second commenter).
- Removed the rule. `grep -rn "markup del code"` across `web_src/` and `templates/` confirms nothing else depends on it — the only match was the removed rule itself.

## Test plan
- `pnpm exec stylelint --color --max-warnings=0 web_src/css/markup/content.css` — clean
- Manually confirmed via `grep` that no other selector or template relies on `.markup del code`