### PR TITLE
fix(actions): align status icon span for Safari rendering

### DIFF
--- a/web_src/js/components/ActionStatusIcon.vue
+++ b/web_src/js/components/ActionStatusIcon.vue
@@ -28,7 +28,18 @@ const iconClass = computed(() => {
 </script>
 
 <template>
-  <span :data-tooltip-content="localeStatus ?? status" v-if="status">
+  <span class="action-status-icon" :data-tooltip-content="localeStatus ?? status" v-if="status">
     <SvgIcon :name="icon.name" :class="iconClass" :size="size"/>
   </span>
 </template>
+
+<style scoped>
+/* Safari renders inline <span> baseline differently from Chrome/Firefox, causing
+   SVG icons to appear misaligned. inline-flex + align-items centers the icon
+   vertically within the span regardless of browser baseline handling. */
+.action-status-icon {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+}
+</style>

--- a/web_src/js/components/ActionStatusIcon.vue
+++ b/web_src/js/components/ActionStatusIcon.vue
@@ -32,14 +32,3 @@ const iconClass = computed(() => {
     <SvgIcon :name="icon.name" :class="iconClass" :size="size"/>
   </span>
 </template>
-
-<style scoped>
-/* Safari renders inline <span> baseline differently from Chrome/Firefox, causing
-   SVG icons to appear misaligned. inline-flex + align-items centers the icon
-   vertically within the span regardless of browser baseline handling. */
-.action-status-icon {
-  display: inline-flex;
-  align-items: center;
-  vertical-align: middle;
-}
-</style>

--- a/web_src/js/components/ActionStatusIcon.vue
+++ b/web_src/js/components/ActionStatusIcon.vue
@@ -28,7 +28,7 @@ const iconClass = computed(() => {
 </script>
 
 <template>
-  <span class="action-status-icon" :data-tooltip-content="localeStatus ?? status" v-if="status">
+  <span class="flex-text-inline" :data-tooltip-content="localeStatus ?? status" v-if="status">
     <SvgIcon :name="icon.name" :class="iconClass" :size="size"/>
   </span>
 </template>


### PR DESCRIPTION
Fixes #38553

The `<span>` wrapping the SVG in `ActionStatusIcon.vue` had no explicit display or alignment styles. Safari computes baseline alignment for inline spans differently from Chrome/Firefox, causing the icon to shift vertically in the action matrix build status list.

**Fix:** make it inline-flex