### PR TITLE
fix(api): align Swagger schemas for UserSettings and TopicListResponse

### DIFF
--- a/modules/structs/repo_topic.go
+++ b/modules/structs/repo_topic.go
@@ -32,3 +32,8 @@ type RepoTopicOptions struct {
 	// list of topic names
 	Topics []string `json:"topics"`
 }
+
+// TopicListResponse returns a list of TopicResponse
+type TopicListResponse struct {
+	Topics []*TopicResponse `json:"topics"`
+}

--- a/routers/api/v1/repo/topic.go
+++ b/routers/api/v1/repo/topic.go
@@ -300,7 +300,7 @@ func TopicSearch(ctx *context.APIContext) {
 	}
 
 	ctx.SetTotalCountHeader(total)
-	ctx.JSON(http.StatusOK, map[string]any{
-		"topics": topicResponses,
+	ctx.JSON(http.StatusOK, api.TopicListResponse{
+		Topics: topicResponses,
 	})
 }

--- a/routers/api/v1/swagger/repo.go
+++ b/routers/api/v1/swagger/repo.go
@@ -341,7 +341,7 @@ type swaggerFileDeleteResponse struct {
 // swagger:response TopicListResponse
 type swaggerTopicListResponse struct {
 	// in: body
-	Body []api.TopicResponse `json:"body"`
+	Body api.TopicListResponse `json:"body"`
 }
 
 // TopicNames

--- a/routers/api/v1/swagger/user.go
+++ b/routers/api/v1/swagger/user.go
@@ -46,7 +46,7 @@ type swaggerResponseUserHeatmapData struct {
 // swagger:response UserSettings
 type swaggerResponseUserSettings struct {
 	// in:body
-	Body []api.UserSettings `json:"body"`
+	Body api.UserSettings `json:"body"`
 }
 
 // BadgeList

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -30208,6 +30208,20 @@
       },
       "x-go-package": "gitea.dev/modules/structs"
     },
+    "TopicListResponse": {
+      "description": "TopicListResponse returns a list of TopicResponse",
+      "type": "object",
+      "properties": {
+        "topics": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TopicResponse"
+          },
+          "x-go-name": "Topics"
+        }
+      },
+      "x-go-package": "gitea.dev/modules/structs"
+    },
     "TopicName": {
       "description": "TopicName a list of repo topic names",
       "type": "object",
@@ -31804,10 +31818,7 @@
     "TopicListResponse": {
       "description": "TopicListResponse",
       "schema": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/TopicResponse"
-        }
+        "$ref": "#/definitions/TopicListResponse"
       }
     },
     "TopicNames": {
@@ -31858,10 +31869,7 @@
     "UserSettings": {
       "description": "UserSettings",
       "schema": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/UserSettings"
-        }
+        "$ref": "#/definitions/UserSettings"
       }
     },
     "VariableList": {

--- a/templates/swagger/v1_openapi3_json.tmpl
+++ b/templates/swagger/v1_openapi3_json.tmpl
@@ -1402,10 +1402,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "items": {
-                "$ref": "#/components/schemas/TopicResponse"
-              },
-              "type": "array"
+              "$ref": "#/components/schemas/TopicListResponse"
             }
           }
         },
@@ -1484,10 +1481,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "items": {
-                "$ref": "#/components/schemas/UserSettings"
-              },
-              "type": "array"
+              "$ref": "#/components/schemas/UserSettings"
             }
           }
         },
@@ -9958,6 +9952,20 @@
           },
           "user": {
             "$ref": "#/components/schemas/User"
+          }
+        },
+        "type": "object",
+        "x-go-package": "gitea.dev/modules/structs"
+      },
+      "TopicListResponse": {
+        "description": "TopicListResponse returns a list of TopicResponse",
+        "properties": {
+          "topics": {
+            "items": {
+              "$ref": "#/components/schemas/TopicResponse"
+            },
+            "type": "array",
+            "x-go-name": "Topics"
           }
         },
         "type": "object",


### PR DESCRIPTION
Corrects the Swagger/OpenAPI schemas for `/user/settings` and `/topics/search` to match the actual JSON objects returned by the API. Previously, the spec incorrectly declared these responses as bare arrays, breaking typed client generation and schema validation.
Fixes https://github.com/go-gitea/gitea/issues/38581
### Mismatches Fixed
* **`GET /user/settings`**: Changed Swagger response type from `[]api.UserSettings` (array) to `api.UserSettings` (object).
* **`GET /topics/search`**: Defined `api.TopicListResponse` to wrap the topics array, and updated the Go handler and Swagger spec to use it.

### Verification
* Validated swagger spec against 2.0 schema via `make swagger-validate` (Passed).
* Ran and passed topic search integration tests: `go test -run '^TestAPITopicSearch$' ./tests/integration/`
* Ran and passed user settings integration tests: `go test -run '^TestAPIUpdateUser$|^TestAPIPublicOnlySelfUserRoutes$' ./tests/integration/`