### PR TITLE
enhance: marshal JSON maps deterministically

### DIFF
--- a/modules/json/jsonv2.go
+++ b/modules/json/jsonv2.go
@@ -28,7 +28,6 @@ func init() {
 	commonMarshalOptions := []jsonv2.Options{
 		jsonv2.FormatNilSliceAsNull(true),
 		jsonv2.FormatNilMapAsNull(true),
-		// v1 marshals maps in a deterministic order, v2 doesn't unless this option is set
 		jsonv2.Deterministic(true),
 	}
 	jsonV2.marshalOptions = jsonv2.JoinOptions(commonMarshalOptions...)

--- a/modules/json/jsonv2.go
+++ b/modules/json/jsonv2.go
@@ -28,6 +28,8 @@ func init() {
 	commonMarshalOptions := []jsonv2.Options{
 		jsonv2.FormatNilSliceAsNull(true),
 		jsonv2.FormatNilMapAsNull(true),
+		// v1 marshals maps in a deterministic order, v2 doesn't unless this option is set
+		jsonv2.Deterministic(true),
 	}
 	jsonV2.marshalOptions = jsonv2.JoinOptions(commonMarshalOptions...)
 	jsonV2.unmarshalOptions = jsonv2.DefaultOptionsV2()


### PR DESCRIPTION
`encoding/json/v2` iterates maps in random order unless `Deterministic` is set, while v1 always sorted them. `marshalOptions` is built from scratch, so the switch to v2 made all map output unstable between renders, e.g. `data-merge-form-props` in the PR merge box, which also defeats any caching or diffing of such responses.