### PR TITLE
fix(project): prevent database mutations on invalid MoveIssues payload

### DIFF
--- a/routers/web/repo/projects.go
+++ b/routers/web/repo/projects.go
@@ -742,6 +742,7 @@ func MoveIssues(ctx *context.Context) {
 	form := &movedIssuesForm{}
 	if err = json.NewDecoder(ctx.Req.Body).Decode(&form); err != nil {
 		ctx.ServerError("DecodeMovedIssuesForm", err)
+		return
 	}
 
 	issueIDs := make([]int64, 0, len(form.Issues))


### PR DESCRIPTION
This PR resolves a logic leak in Gitea's project board issue reordering handler (`MoveIssues`).

When the JSON payload in the request body failed to decode (e.g. due to truncated bodies, network connection termination, or proxy timeout), Gitea logged an internal server error using `ctx.ServerError("DecodeMovedIssuesForm", err)`. 

However, because the code was missing a `return` statement in this check, Gitea continued to execute the handler using an empty payload. This led to database transactions running updates (`MoveIssuesOnProjectColumn`) on invalid/empty targets, followed by duplicate HTTP write header conflicts (`http: superfluous response.WriteHeader call`).

### Solution
Added the missing `return` statement directly after `ctx.ServerError(...)` when JSON decoding fails, terminating handler execution immediately.

### Automated Tests
Ran integration/unit tests for `routers/web/repo` package:
```bash
go test -run 'Test' ./routers/web/repo/...