### PR TITLE
fix: download dropdown menu clipped on the branches page

### DIFF
--- a/web_src/css/modules/table.css
+++ b/web_src/css/modules/table.css
@@ -161,15 +161,6 @@
 .ui.fixed.table {
   table-layout: fixed;
 }
-.ui.fixed.table th,
-.ui.fixed.table td {
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-/* while a dropdown in the cell is open, its absolutely-positioned menu must not be clipped by the cell */
-.ui.fixed.table td:has(.ui.dropdown.active) {
-  overflow: visible;
-}
 
 .ui.selectable.table > tbody > tr:hover,
 .ui.table tbody tr td.selectable:hover {

--- a/web_src/css/modules/table.css
+++ b/web_src/css/modules/table.css
@@ -166,6 +166,10 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+/* while a dropdown in the cell is open, its absolutely-positioned menu must not be clipped by the cell */
+.ui.fixed.table td:has(.ui.dropdown.active) {
+  overflow: visible;
+}
 
 .ui.selectable.table > tbody > tr:hover,
 .ui.table tbody tr td.selectable:hover {


### PR DESCRIPTION
Fixes #38603

On the branches page, opening the per-branch download dropdown shows only a small sliver of the menu's top edge — the rest is clipped (screenshots in the issue; reproducible on gitea.com).

**Root cause:** the branches tables are `ui fixed table`, and the `.ui.fixed.table td { overflow: hidden }` rule in `web_src/css/modules/table.css` clips the absolutely-positioned dropdown menu to the cell, so the menu's `z-index` never comes into play.

**Fix:** lift the clipping only while a dropdown inside the cell is open (`td:has(.ui.dropdown.active)`). Cell content keeps its `text-overflow: ellipsis` behavior whenever no menu is open. Verified by injecting the rule on gitea.com's branches page — the menu renders fully above the rows below it.
