### PR TITLE
feat(migrations): add repository migration from bitbucket.org

### DIFF
--- a/modules/structs/repo.go
+++ b/modules/structs/repo.go
@@ -354,6 +354,7 @@ const (
 	GitBucketService                        // 7 gitbucket service
 	CodebaseService                         // 8 codebase service
 	CodeCommitService                       // 9 codecommit service
+	BitbucketService                        // 10 bitbucket.org service
 )
 
 // Name represents the service type's name
@@ -381,6 +382,8 @@ func (gt GitServiceType) Title() string {
 		return "Codebase"
 	case CodeCommitService:
 		return "CodeCommit"
+	case BitbucketService:
+		return "Bitbucket"
 	case PlainGitService:
 		return "Git"
 	}
@@ -399,7 +402,7 @@ type MigrateRepoOptions struct {
 	// required: true
 	RepoName string `json:"repo_name" binding:"Required;AlphaDashDot;MaxSize(100)"`
 
-	// enum: ["git","github","gitea","gitlab","gogs","onedev","gitbucket","codebase","codecommit"]
+	// enum: ["git","github","gitea","gitlab","gogs","onedev","gitbucket","codebase","codecommit","bitbucket"]
 	Service      string `json:"service"`
 	AuthUsername string `json:"auth_username"`
 	AuthPassword string `json:"auth_password"`
@@ -425,7 +428,7 @@ type MigrateRepoOptions struct {
 // TokenAuth represents whether a service type supports token-based auth
 func (gt GitServiceType) TokenAuth() bool {
 	switch gt {
-	case GithubService, GiteaService, GitlabService:
+	case GithubService, GiteaService, GitlabService, BitbucketService:
 		return true
 	}
 	return false
@@ -437,6 +440,7 @@ var SupportedFullGitService = []GitServiceType{
 	GithubService,
 	GitlabService,
 	GiteaService,
+	BitbucketService,
 	GogsService,
 	OneDevService,
 	GitBucketService,

--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -1132,6 +1132,8 @@
   "repo.migrate.onedev.description": "Migrate data from code.onedev.io or other OneDev instances.",
   "repo.migrate.codebase.description": "Migrate data from codebasehq.com.",
   "repo.migrate.gitbucket.description": "Migrate data from GitBucket instances.",
+  "repo.migrate.bitbucket.description": "Migrate data from bitbucket.org.",
+  "repo.migrate.bitbucket_token_desc": "Enter a Bitbucket username and app password (or an access token) so private repositories and metadata can be migrated. Leave blank for public repositories.",
   "repo.migrate.codecommit.description": "Migrate data from AWS CodeCommit.",
   "repo.migrate.codecommit.aws_access_key_id": "AWS Access Key ID",
   "repo.migrate.codecommit.aws_secret_access_key": "AWS Secret Access Key",

--- a/services/convert/utils.go
+++ b/services/convert/utils.go
@@ -40,6 +40,8 @@ func ToGitServiceType(value string) structs.GitServiceType {
 		return structs.CodebaseService
 	case "codecommit":
 		return structs.CodeCommitService
+	case "bitbucket":
+		return structs.BitbucketService
 	default:
 		return structs.PlainGitService
 	}

--- a/services/convert/utils_test.go
+++ b/services/convert/utils_test.go
@@ -38,6 +38,8 @@ func TestToGitServiceType(t *testing.T) {
 		typ: "codebase", enum: 8,
 	}, {
 		typ: "codecommit", enum: 9,
+	}, {
+		typ: "bitbucket", enum: 10,
 	}}
 	for _, test := range tc {
 		assert.EqualValues(t, test.enum, ToGitServiceType(test.typ))

--- a/services/migrations/bitbucket.go
+++ b/services/migrations/bitbucket.go
@@ -20,6 +20,7 @@ import (
 	"gitea.dev/modules/log"
 	base "gitea.dev/modules/migration"
 	"gitea.dev/modules/structs"
+	"gitea.dev/modules/util"
 )
 
 var (
@@ -462,30 +463,16 @@ func bitbucketClosedTime(state string, updated time.Time) *time.Time {
 func bitbucketIssueLabels(issue bitbucketIssue) []*base.Label {
 	labels := make([]*base.Label, 0, 4)
 	for _, label := range []string{
-		bitbucketPrefixedLabel("kind", issue.Kind),
-		bitbucketPrefixedLabel("priority", issue.Priority),
-		bitbucketNamedLabel("component", issue.Component),
-		bitbucketNamedLabel("version", issue.Version),
+		util.Iif(issue.Kind == "", "", "kind/"+issue.Kind),
+		util.Iif(issue.Priority == "", "", "priority/"+issue.Priority),
+		util.Iif(issue.Component == nil || issue.Component.Name == "", "", "component/"+issue.Component.Name),
+		util.Iif(issue.Version == nil || issue.Version.Name == "", "", "version/"+issue.Version.Name),
 	} {
 		if label != "" {
 			labels = append(labels, &base.Label{Name: label, Color: bitbucketLabelColor(label)})
 		}
 	}
 	return labels
-}
-
-func bitbucketPrefixedLabel(prefix, value string) string {
-	if value == "" {
-		return ""
-	}
-	return prefix + "/" + value
-}
-
-func bitbucketNamedLabel(prefix string, value *bitbucketNamedValue) string {
-	if value == nil || value.Name == "" {
-		return ""
-	}
-	return bitbucketPrefixedLabel(prefix, value.Name)
 }
 
 func bitbucketLabelColor(name string) string {
@@ -535,13 +522,8 @@ func (b *BitbucketDownloader) fetchAllIssues(ctx context.Context) ([]bitbucketIs
 	return all, nil
 }
 
-func (b *BitbucketDownloader) ensureIssueIDs(ctx context.Context) error {
-	_, err := b.fetchAllIssues(ctx)
-	return err
-}
-
 func (b *BitbucketDownloader) bitbucketPRNumber(ctx context.Context, prID int64) (int64, error) {
-	if err := b.ensureIssueIDs(ctx); err != nil {
+	if _, err := b.fetchAllIssues(ctx); err != nil {
 		return 0, err
 	}
 	b.prIDFrozen = true

--- a/services/migrations/bitbucket.go
+++ b/services/migrations/bitbucket.go
@@ -1,0 +1,768 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package migrations
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"gitea.dev/modules/json"
+	"gitea.dev/modules/log"
+	base "gitea.dev/modules/migration"
+	"gitea.dev/modules/structs"
+)
+
+var (
+	_ base.Downloader        = &BitbucketDownloader{}
+	_ base.DownloaderFactory = &BitbucketDownloaderFactory{}
+)
+
+func init() {
+	RegisterDownloaderFactory(&BitbucketDownloaderFactory{})
+}
+
+// BitbucketDownloaderFactory defines a bitbucket.org downloader factory.
+type BitbucketDownloaderFactory struct{}
+
+// New returns a Downloader related to this factory according MigrateOptions.
+func (f *BitbucketDownloaderFactory) New(ctx context.Context, opts base.MigrateOptions) (base.Downloader, error) {
+	u, err := url.Parse(opts.CloneAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	fields := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(fields) < 2 {
+		return nil, fmt.Errorf("invalid Bitbucket clone URL: %s", opts.CloneAddr)
+	}
+
+	workspace := fields[0]
+	repoSlug := strings.TrimSuffix(fields[1], ".git")
+	webBaseURL := u.Scheme + "://" + u.Host
+	apiBaseURL := "https://api.bitbucket.org/2.0"
+
+	return NewBitbucketDownloader(ctx, apiBaseURL, webBaseURL, workspace, repoSlug, opts.AuthUsername, opts.AuthPassword, opts.AuthToken)
+}
+
+// GitServiceType returns the type of git service.
+func (f *BitbucketDownloaderFactory) GitServiceType() structs.GitServiceType {
+	return structs.BitbucketService
+}
+
+type bitbucketAPIError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *bitbucketAPIError) Error() string {
+	if e.StatusCode == http.StatusTooManyRequests {
+		return fmt.Sprintf("bitbucket API rate limit exceeded (status 429): %s; authenticate with a username and app password (or an access token) to raise the limit — anonymous access is capped at 60 requests/hour", e.Body)
+	}
+	return fmt.Sprintf("bitbucket API returned status %d: %s", e.StatusCode, e.Body)
+}
+
+const (
+	// bitbucketMaxRetries bounds how many times a rate-limited or transiently failing
+	// request is retried before giving up.
+	bitbucketMaxRetries = 5
+	// bitbucketDefaultRetryBackoff is the base delay used for exponential backoff when the
+	// server does not tell us how long to wait.
+	bitbucketDefaultRetryBackoff = 2 * time.Second
+	// bitbucketMaxRetryBackoff caps a single wait so a migration never blocks unreasonably long.
+	bitbucketMaxRetryBackoff = 60 * time.Second
+	// bitbucketMaxRetryAfter caps an explicit Retry-After / rate-reset wait.
+	bitbucketMaxRetryAfter = 1 * time.Hour
+	// bitbucketResetEpochThreshold distinguishes an X-RateLimit-Reset expressed as seconds
+	// remaining (Bitbucket Cloud's format) from one expressed as an absolute Unix epoch.
+	bitbucketResetEpochThreshold = 1_000_000_000
+)
+
+type bitbucketPage[T any] struct {
+	Values  []T    `json:"values"`
+	Size    int    `json:"size"`
+	Page    int    `json:"page"`
+	Pagelen int    `json:"pagelen"`
+	Next    string `json:"next"`
+}
+
+type bitbucketContent struct {
+	Raw    string `json:"raw"`
+	Markup string `json:"markup"`
+}
+
+type bitbucketUser struct {
+	UUID        string `json:"uuid"`
+	AccountID   string `json:"account_id"`
+	Nickname    string `json:"nickname"`
+	DisplayName string `json:"display_name"`
+	Username    string `json:"username"`
+}
+
+type bitbucketNamedValue struct {
+	Name string `json:"name"`
+}
+
+type bitbucketRepoLink struct {
+	Href string `json:"href"`
+	Name string `json:"name"`
+}
+
+type bitbucketRepoLinks struct {
+	HTML  bitbucketRepoLink   `json:"html"`
+	Clone []bitbucketRepoLink `json:"clone"`
+}
+
+type bitbucketRepository struct {
+	Name        string              `json:"name"`
+	Slug        string              `json:"slug"`
+	FullName    string              `json:"full_name"`
+	Description string              `json:"description"`
+	IsPrivate   bool                `json:"is_private"`
+	Website     string              `json:"website"`
+	Links       bitbucketRepoLinks  `json:"links"`
+	MainBranch  bitbucketNamedValue `json:"mainbranch"`
+}
+
+type bitbucketIssue struct {
+	ID        int64                `json:"id"`
+	Title     string               `json:"title"`
+	Content   bitbucketContent     `json:"content"`
+	State     string               `json:"state"`
+	Kind      string               `json:"kind"`
+	Priority  string               `json:"priority"`
+	Reporter  bitbucketUser        `json:"reporter"`
+	Assignee  *bitbucketUser       `json:"assignee"`
+	Component *bitbucketNamedValue `json:"component"`
+	Version   *bitbucketNamedValue `json:"version"`
+	Milestone *bitbucketNamedValue `json:"milestone"`
+	Created   time.Time            `json:"created_on"`
+	Updated   time.Time            `json:"updated_on"`
+}
+
+type bitbucketBranch struct {
+	Name string `json:"name"`
+}
+
+type bitbucketCommit struct {
+	Hash string `json:"hash"`
+}
+
+type bitbucketPRSide struct {
+	Branch     bitbucketBranch      `json:"branch"`
+	Commit     bitbucketCommit      `json:"commit"`
+	Repository *bitbucketRepository `json:"repository"`
+}
+
+type bitbucketPullRequestLinks struct {
+	HTML  bitbucketRepoLink `json:"html"`
+	Patch bitbucketRepoLink `json:"patch"`
+}
+
+type bitbucketPullRequest struct {
+	ID          int64                     `json:"id"`
+	Title       string                    `json:"title"`
+	Description string                    `json:"description"`
+	State       string                    `json:"state"`
+	Author      bitbucketUser             `json:"author"`
+	Source      bitbucketPRSide           `json:"source"`
+	Destination bitbucketPRSide           `json:"destination"`
+	MergeCommit *bitbucketCommit          `json:"merge_commit"`
+	Links       bitbucketPullRequestLinks `json:"links"`
+	Created     time.Time                 `json:"created_on"`
+	Updated     time.Time                 `json:"updated_on"`
+}
+
+type bitbucketComment struct {
+	ID      int64            `json:"id"`
+	Content bitbucketContent `json:"content"`
+	User    bitbucketUser    `json:"user"`
+	Created time.Time        `json:"created_on"`
+	Updated time.Time        `json:"updated_on"`
+}
+
+// BitbucketDownloader implements a Downloader interface to get repository information from bitbucket.org.
+type BitbucketDownloader struct {
+	base.NullDownloader
+	client     *http.Client
+	apiBaseURL string
+	webBaseURL string
+	workspace  string
+	repoSlug   string
+	userName   string
+	password   string
+	token      string
+	maxPerPage int
+	maxRetries int
+	maxIssueID int64
+	allIssues  []bitbucketIssue
+	issuesRead bool
+	prIDFrozen bool
+}
+
+// NewBitbucketDownloader creates a bitbucket.org Downloader via API v2.
+func NewBitbucketDownloader(_ context.Context, apiBaseURL, webBaseURL, workspace, repoSlug, userName, password, token string) (*BitbucketDownloader, error) {
+	return &BitbucketDownloader{
+		client:     newMigrationHTTPClient(),
+		apiBaseURL: strings.TrimRight(apiBaseURL, "/"),
+		webBaseURL: strings.TrimRight(webBaseURL, "/"),
+		workspace:  workspace,
+		repoSlug:   repoSlug,
+		userName:   userName,
+		password:   password,
+		token:      token,
+		maxPerPage: 100,
+		maxRetries: bitbucketMaxRetries,
+	}, nil
+}
+
+// String implements Stringer.
+func (b *BitbucketDownloader) String() string {
+	return fmt.Sprintf("migration from bitbucket server %s %s/%s", b.webBaseURL, b.workspace, b.repoSlug)
+}
+
+func (b *BitbucketDownloader) LogString() string {
+	if b == nil {
+		return "<BitbucketDownloader nil>"
+	}
+	return fmt.Sprintf("<BitbucketDownloader %s %s/%s>", b.webBaseURL, b.workspace, b.repoSlug)
+}
+
+// FormatCloneURL adds authentication into the clone URL. Bitbucket Cloud requires the
+// username "x-token-auth" when cloning with an access token; app passwords use the normal
+// username/password basic-auth form.
+func (b *BitbucketDownloader) FormatCloneURL(opts base.MigrateOptions, remoteAddr string) (string, error) {
+	if opts.AuthToken != "" {
+		u, err := url.Parse(remoteAddr)
+		if err != nil {
+			return "", err
+		}
+		u.User = url.UserPassword("x-token-auth", opts.AuthToken)
+		return u.String(), nil
+	}
+	return b.NullDownloader.FormatCloneURL(opts, remoteAddr)
+}
+
+func (b *BitbucketDownloader) apiPath(format string, args ...any) string {
+	parts := []any{url.PathEscape(b.workspace), url.PathEscape(b.repoSlug)}
+	parts = append(parts, args...)
+	return fmt.Sprintf("/repositories/%s/%s"+format, parts...)
+}
+
+func (b *BitbucketDownloader) doAPI(ctx context.Context, path string, query url.Values, out any) error {
+	u, err := url.Parse(b.apiBaseURL + path)
+	if err != nil {
+		return err
+	}
+	u.RawQuery = query.Encode()
+
+	// Bitbucket Cloud enforces per-hour rate limits and answers with HTTP 429 once they are
+	// exceeded. Only idempotent GET requests are issued here, so it is safe to transparently
+	// wait-and-retry on rate limiting and a handful of transient server-side failures.
+	//
+	// totalWait bounds the cumulative time a single doAPI call may spend sleeping across all
+	// its retries. Each individual wait is already capped at bitbucketMaxRetryAfter, but a
+	// per-attempt cap still allows several long sleeps to stack up (and this downloader is
+	// additionally wrapped by base.NewRetryDownloader). Reusing bitbucketMaxRetryAfter as the
+	// total budget ensures a single call fails fast instead of blocking for hours.
+	var totalWait time.Duration
+	for attempt := 0; ; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Accept", "application/json")
+		if b.token != "" {
+			req.Header.Set("Authorization", "Bearer "+b.token)
+		} else if b.userName != "" || b.password != "" {
+			req.SetBasicAuth(b.userName, b.password)
+		}
+
+		resp, err := b.client.Do(req)
+		if err != nil {
+			return err
+		}
+
+		if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+			if strings.EqualFold(resp.Header.Get("X-RateLimit-NearLimit"), "true") {
+				log.Trace("Bitbucket rate limit near threshold on %s", path)
+			}
+			err = json.NewDecoder(resp.Body).Decode(out)
+			resp.Body.Close()
+			return err
+		}
+
+		switch resp.StatusCode {
+		case http.StatusTooManyRequests, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+			if attempt < b.maxRetries {
+				wait := bitbucketRetryWait(resp, attempt)
+				// Only retry while the cumulative sleep stays within the total budget; otherwise
+				// fall through to drain the body and return the bitbucketAPIError (fail fast).
+				if totalWait+wait <= bitbucketMaxRetryAfter {
+					totalWait += wait
+					// Drain and close the body so the underlying connection can be reused.
+					_, _ = io.Copy(io.Discard, resp.Body)
+					resp.Body.Close()
+
+					log.Warn("Bitbucket rate limited (status %d) on %s, waiting %s before retry %d/%d", resp.StatusCode, path, wait, attempt+1, b.maxRetries)
+
+					timer := time.NewTimer(wait)
+					select {
+					case <-ctx.Done():
+						timer.Stop()
+						return ctx.Err()
+					case <-timer.C:
+					}
+					continue
+				}
+			}
+		}
+
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return &bitbucketAPIError{StatusCode: resp.StatusCode, Body: string(body)}
+	}
+}
+
+// bitbucketRetryWait decides how long to wait before retrying a rate-limited or transient
+// response. It prefers the server-provided Retry-After header, then X-RateLimit-Reset, and
+// finally falls back to exponential backoff with jitter. All waits are capped.
+func bitbucketRetryWait(resp *http.Response, attempt int) time.Duration {
+	if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
+		if seconds, err := strconv.Atoi(strings.TrimSpace(retryAfter)); err == nil {
+			return clampDuration(time.Duration(seconds)*time.Second, 0, bitbucketMaxRetryAfter)
+		}
+		if date, err := http.ParseTime(retryAfter); err == nil {
+			return clampDuration(time.Until(date), 0, bitbucketMaxRetryAfter)
+		}
+	}
+
+	if reset := strings.TrimSpace(resp.Header.Get("X-RateLimit-Reset")); reset != "" {
+		var wait time.Duration
+		if t, err := time.Parse(time.RFC3339, reset); err == nil {
+			wait = time.Until(t)
+		} else if v, err := strconv.ParseInt(reset, 10, 64); err == nil {
+			// Bitbucket Cloud returns the number of seconds remaining until the rate-limit
+			// window resets (a delta), e.g. "2959". Values large enough to be a Unix epoch
+			// are treated as an absolute timestamp for robustness across Atlassian products.
+			if v >= bitbucketResetEpochThreshold {
+				wait = time.Until(time.Unix(v, 0))
+			} else {
+				wait = time.Duration(v) * time.Second
+			}
+		}
+		if wait > 0 {
+			return clampDuration(wait, 0, bitbucketMaxRetryAfter)
+		}
+	}
+
+	// Exponential backoff with jitter, capped so a migration never blocks for too long.
+	backoff := bitbucketDefaultRetryBackoff << attempt
+	if backoff <= 0 || backoff > bitbucketMaxRetryBackoff {
+		backoff = bitbucketMaxRetryBackoff
+	}
+	backoff += rand.N(time.Second)
+	return clampDuration(backoff, time.Millisecond, bitbucketMaxRetryBackoff+time.Second)
+}
+
+// clampDuration keeps d within the inclusive [minWait, maxWait] range.
+func clampDuration(d, minWait, maxWait time.Duration) time.Duration {
+	if d < minWait {
+		return minWait
+	}
+	if d > maxWait {
+		return maxWait
+	}
+	return d
+}
+
+func bitbucketUserID(user bitbucketUser) int64 {
+	identifier := user.AccountID
+	if identifier == "" {
+		identifier = user.UUID
+	}
+	if identifier == "" {
+		identifier = bitbucketUserName(user)
+	}
+	if identifier == "" {
+		return 0
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(identifier))
+	return int64(h.Sum64() & 0x7fffffffffffffff)
+}
+
+func bitbucketUserName(user bitbucketUser) string {
+	for _, value := range []string{user.Nickname, user.Username, user.DisplayName, user.AccountID, user.UUID} {
+		if value != "" {
+			return value
+		}
+	}
+	return "Ghost"
+}
+
+func bitbucketCloneURL(repo *bitbucketRepository) string {
+	if repo == nil {
+		return ""
+	}
+	for _, clone := range repo.Links.Clone {
+		if clone.Name == "https" && clone.Href != "" {
+			return clone.Href
+		}
+	}
+	if len(repo.Links.Clone) > 0 {
+		return repo.Links.Clone[0].Href
+	}
+	return ""
+}
+
+func bitbucketOwnerAndRepo(repo *bitbucketRepository) (string, string) {
+	if repo == nil {
+		return "", ""
+	}
+	owner, name, ok := strings.Cut(repo.FullName, "/")
+	if ok {
+		return owner, name
+	}
+	return "", repo.Slug
+}
+
+func bitbucketIssueState(state string) string {
+	switch strings.ToLower(state) {
+	case "resolved", "closed", "invalid", "duplicate", "wontfix":
+		return "closed"
+	default:
+		return "open"
+	}
+}
+
+func bitbucketPRState(state string) string {
+	if strings.EqualFold(state, "open") {
+		return "open"
+	}
+	return "closed"
+}
+
+func bitbucketClosedTime(state string, updated time.Time) *time.Time {
+	if state == "closed" && !updated.IsZero() {
+		return &updated
+	}
+	return nil
+}
+
+func bitbucketIssueLabels(issue bitbucketIssue) []*base.Label {
+	labels := make([]*base.Label, 0, 4)
+	for _, label := range []string{
+		bitbucketPrefixedLabel("kind", issue.Kind),
+		bitbucketPrefixedLabel("priority", issue.Priority),
+		bitbucketNamedLabel("component", issue.Component),
+		bitbucketNamedLabel("version", issue.Version),
+	} {
+		if label != "" {
+			labels = append(labels, &base.Label{Name: label, Color: bitbucketLabelColor(label)})
+		}
+	}
+	return labels
+}
+
+func bitbucketPrefixedLabel(prefix, value string) string {
+	if value == "" {
+		return ""
+	}
+	return prefix + "/" + value
+}
+
+func bitbucketNamedLabel(prefix string, value *bitbucketNamedValue) string {
+	if value == nil || value.Name == "" {
+		return ""
+	}
+	return bitbucketPrefixedLabel(prefix, value.Name)
+}
+
+func bitbucketLabelColor(name string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(name))
+	return fmt.Sprintf("%06x", h.Sum32()&0xffffff)
+}
+
+func (b *BitbucketDownloader) recordIssueID(issueID int64) {
+	if !b.prIDFrozen {
+		b.maxIssueID = max(b.maxIssueID, issueID)
+	}
+}
+
+// fetchAllIssues pages through the full /issues endpoint once and caches the result.
+// A 404 means issues are disabled for the repository, which is treated as an empty set.
+func (b *BitbucketDownloader) fetchAllIssues(ctx context.Context) ([]bitbucketIssue, error) {
+	if b.issuesRead {
+		return b.allIssues, nil
+	}
+	var all []bitbucketIssue
+	for page := 1; ; page++ {
+		var resp bitbucketPage[bitbucketIssue]
+		query := url.Values{
+			"pagelen": []string{strconv.Itoa(b.maxPerPage)},
+			"page":    []string{strconv.Itoa(page)},
+			"sort":    []string{"created_on"},
+		}
+		if err := b.doAPI(ctx, b.apiPath("/issues"), query, &resp); err != nil {
+			if apiErr, ok := err.(*bitbucketAPIError); ok && apiErr.StatusCode == http.StatusNotFound {
+				b.allIssues = []bitbucketIssue{}
+				b.issuesRead = true
+				return b.allIssues, nil
+			}
+			return nil, err
+		}
+		all = append(all, resp.Values...)
+		if resp.Next == "" {
+			break
+		}
+	}
+	b.allIssues = all
+	b.issuesRead = true
+	for _, issue := range all {
+		b.recordIssueID(issue.ID)
+	}
+	return all, nil
+}
+
+func (b *BitbucketDownloader) ensureIssueIDs(ctx context.Context) error {
+	_, err := b.fetchAllIssues(ctx)
+	return err
+}
+
+func (b *BitbucketDownloader) bitbucketPRNumber(ctx context.Context, prID int64) (int64, error) {
+	if err := b.ensureIssueIDs(ctx); err != nil {
+		return 0, err
+	}
+	b.prIDFrozen = true
+	return b.maxIssueID + prID, nil
+}
+
+// GetRepoInfo returns a repository information.
+func (b *BitbucketDownloader) GetRepoInfo(ctx context.Context) (*base.Repository, error) {
+	var repo bitbucketRepository
+	if err := b.doAPI(ctx, b.apiPath(""), nil, &repo); err != nil {
+		return nil, err
+	}
+
+	owner, _ := bitbucketOwnerAndRepo(&repo)
+	return &base.Repository{
+		Owner:         owner,
+		Name:          repo.Slug,
+		IsPrivate:     repo.IsPrivate,
+		Description:   repo.Description,
+		Website:       repo.Website,
+		OriginalURL:   repo.Links.HTML.Href,
+		CloneURL:      bitbucketCloneURL(&repo),
+		DefaultBranch: repo.MainBranch.Name,
+	}, nil
+}
+
+// GetLabels returns labels synthesized from Bitbucket issue metadata.
+func (b *BitbucketDownloader) GetLabels(ctx context.Context) ([]*base.Label, error) {
+	allIssues, err := b.fetchAllIssues(ctx)
+	if err != nil {
+		return nil, err
+	}
+	labels := make(map[string]*base.Label)
+	for _, issue := range allIssues {
+		for _, label := range bitbucketIssueLabels(issue) {
+			labels[label.Name] = label
+		}
+	}
+
+	result := make([]*base.Label, 0, len(labels))
+	for _, label := range labels {
+		result = append(result, label)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+	return result, nil
+}
+
+// GetMilestones returns milestones collected from Bitbucket issues.
+func (b *BitbucketDownloader) GetMilestones(ctx context.Context) ([]*base.Milestone, error) {
+	allIssues, err := b.fetchAllIssues(ctx)
+	if err != nil {
+		return nil, err
+	}
+	milestones := make(map[string]*base.Milestone)
+	for _, issue := range allIssues {
+		if issue.Milestone != nil && issue.Milestone.Name != "" {
+			milestones[issue.Milestone.Name] = &base.Milestone{
+				Title:   issue.Milestone.Name,
+				Created: time.Unix(0, 0),
+				State:   "open",
+			}
+		}
+	}
+
+	result := make([]*base.Milestone, 0, len(milestones))
+	for _, milestone := range milestones {
+		result = append(result, milestone)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Title < result[j].Title })
+	return result, nil
+}
+
+// GetIssues returns issues according start and limit.
+func (b *BitbucketDownloader) GetIssues(ctx context.Context, page, perPage int) ([]*base.Issue, bool, error) {
+	var resp bitbucketPage[bitbucketIssue]
+	query := url.Values{
+		"pagelen": []string{strconv.Itoa(perPage)},
+		"page":    []string{strconv.Itoa(page)},
+		"sort":    []string{"created_on"},
+	}
+	if err := b.doAPI(ctx, b.apiPath("/issues"), query, &resp); err != nil {
+		if apiErr, ok := err.(*bitbucketAPIError); ok && apiErr.StatusCode == http.StatusNotFound {
+			return nil, false, base.ErrNotSupported{Entity: "Issues"}
+		}
+		return nil, false, err
+	}
+
+	issues := make([]*base.Issue, 0, len(resp.Values))
+	for _, issue := range resp.Values {
+		b.recordIssueID(issue.ID)
+		state := bitbucketIssueState(issue.State)
+		assignees := []string{}
+		if issue.Assignee != nil {
+			assignees = append(assignees, bitbucketUserName(*issue.Assignee))
+		}
+		milestone := ""
+		if issue.Milestone != nil {
+			milestone = issue.Milestone.Name
+		}
+		issues = append(issues, &base.Issue{
+			Number:       issue.ID,
+			PosterID:     bitbucketUserID(issue.Reporter),
+			PosterName:   bitbucketUserName(issue.Reporter),
+			Title:        issue.Title,
+			Content:      issue.Content.Raw,
+			Milestone:    milestone,
+			State:        state,
+			Created:      issue.Created,
+			Updated:      issue.Updated,
+			Closed:       bitbucketClosedTime(state, issue.Updated),
+			Labels:       bitbucketIssueLabels(issue),
+			Assignees:    assignees,
+			ForeignIndex: issue.ID,
+		})
+	}
+	if resp.Next == "" {
+		b.issuesRead = true
+	}
+	return issues, resp.Next == "", nil
+}
+
+// GetComments returns comments of an issue or PR.
+func (b *BitbucketDownloader) GetComments(ctx context.Context, commentable base.Commentable) ([]*base.Comment, bool, error) {
+	var path string
+	switch commentable.(type) {
+	case *base.PullRequest:
+		path = b.apiPath("/pullrequests/%d/comments", commentable.GetForeignIndex())
+	default:
+		path = b.apiPath("/issues/%d/comments", commentable.GetForeignIndex())
+	}
+
+	comments := make([]*base.Comment, 0)
+	for page := 1; ; page++ {
+		var resp bitbucketPage[bitbucketComment]
+		query := url.Values{
+			"pagelen": []string{strconv.Itoa(b.maxPerPage)},
+			"page":    []string{strconv.Itoa(page)},
+		}
+		if err := b.doAPI(ctx, path, query, &resp); err != nil {
+			return nil, false, err
+		}
+		for _, comment := range resp.Values {
+			comments = append(comments, &base.Comment{
+				IssueIndex: commentable.GetLocalIndex(),
+				Index:      comment.ID,
+				PosterID:   bitbucketUserID(comment.User),
+				PosterName: bitbucketUserName(comment.User),
+				Created:    comment.Created,
+				Updated:    comment.Updated,
+				Content:    comment.Content.Raw,
+			})
+		}
+		if resp.Next == "" {
+			break
+		}
+	}
+	return comments, true, nil
+}
+
+// GetPullRequests returns pull requests according page and perPage.
+func (b *BitbucketDownloader) GetPullRequests(ctx context.Context, page, perPage int) ([]*base.PullRequest, bool, error) {
+	var resp bitbucketPage[bitbucketPullRequest]
+	query := url.Values{
+		"pagelen": []string{strconv.Itoa(perPage)},
+		"page":    []string{strconv.Itoa(page)},
+		"sort":    []string{"created_on"},
+		"state":   []string{"OPEN", "MERGED", "DECLINED", "SUPERSEDED"},
+	}
+	if err := b.doAPI(ctx, b.apiPath("/pullrequests"), query, &resp); err != nil {
+		return nil, false, err
+	}
+
+	pullRequests := make([]*base.PullRequest, 0, len(resp.Values))
+	for _, pr := range resp.Values {
+		number, err := b.bitbucketPRNumber(ctx, pr.ID)
+		if err != nil {
+			return nil, false, err
+		}
+		state := bitbucketPRState(pr.State)
+		merged := strings.EqualFold(pr.State, "merged")
+		var mergedTime *time.Time
+		if merged {
+			mergedTime = &pr.Updated
+		}
+		mergeCommitSHA := ""
+		if pr.MergeCommit != nil {
+			mergeCommitSHA = pr.MergeCommit.Hash
+		}
+		headOwner, headRepo := bitbucketOwnerAndRepo(pr.Source.Repository)
+		baseOwner, baseRepo := bitbucketOwnerAndRepo(pr.Destination.Repository)
+		pullRequests = append(pullRequests, &base.PullRequest{
+			Number:         number,
+			Title:          pr.Title,
+			PosterID:       bitbucketUserID(pr.Author),
+			PosterName:     bitbucketUserName(pr.Author),
+			Content:        pr.Description,
+			State:          state,
+			Created:        pr.Created,
+			Updated:        pr.Updated,
+			Closed:         bitbucketClosedTime(state, pr.Updated),
+			PatchURL:       pr.Links.Patch.Href,
+			Merged:         merged,
+			MergedTime:     mergedTime,
+			MergeCommitSHA: mergeCommitSHA,
+			Head: base.PullRequestBranch{
+				CloneURL:  bitbucketCloneURL(pr.Source.Repository),
+				Ref:       pr.Source.Branch.Name,
+				SHA:       pr.Source.Commit.Hash,
+				OwnerName: headOwner,
+				RepoName:  headRepo,
+			},
+			Base: base.PullRequestBranch{
+				Ref:       pr.Destination.Branch.Name,
+				SHA:       pr.Destination.Commit.Hash,
+				OwnerName: baseOwner,
+				RepoName:  baseRepo,
+			},
+			ForeignIndex: pr.ID,
+		})
+
+		_ = CheckAndEnsureSafePR(pullRequests[len(pullRequests)-1], b.webBaseURL, b)
+	}
+	return pullRequests, resp.Next == "", nil
+}

--- a/services/migrations/bitbucket_test.go
+++ b/services/migrations/bitbucket_test.go
@@ -1,0 +1,344 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package migrations
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	base "gitea.dev/modules/migration"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBitbucketDownloadRepo(t *testing.T) {
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/2.0/repositories/gitea/test-repo":
+			_, _ = fmt.Fprintf(w, `{
+				"name":"Test Repo",
+				"slug":"test-repo",
+				"full_name":"gitea/test-repo",
+				"description":"Test repository for testing migration from bitbucket to gitea",
+				"is_private":false,
+				"website":"https://gitea.com/test-repo",
+				"mainbranch":{"name":"main"},
+				"links":{
+					"html":{"href":"%[1]s/gitea/test-repo"},
+					"clone":[{"name":"ssh","href":"git@bitbucket.org:gitea/test-repo.git"},{"name":"https","href":"%[1]s/gitea/test-repo.git"}]
+				}
+			}`, serverURL)
+		case "/2.0/repositories/gitea/test-repo/issues":
+			writeBitbucketIssuesPage(w, r, serverURL)
+		case "/2.0/repositories/gitea/test-repo/issues/2/comments":
+			_, _ = fmt.Fprint(w, `{"values":[{
+				"id":11,
+				"content":{"raw":"This is a Bitbucket issue comment"},
+				"user":{"account_id":"user-1","nickname":"alice"},
+				"created_on":"2020-01-03T12:00:00Z",
+				"updated_on":"2020-01-03T12:10:00Z"
+			}]}`)
+		case "/2.0/repositories/gitea/test-repo/pullrequests":
+			_, _ = fmt.Fprintf(w, `{"values":[{
+				"id":1,
+				"title":"Add Bitbucket migration",
+				"description":"Implements migration support",
+				"state":"MERGED",
+				"author":{"account_id":"user-2","nickname":"bob"},
+				"source":{
+					"branch":{"name":"feature/bitbucket"},
+					"commit":{"hash":"1111111111111111111111111111111111111111"},
+					"repository":{"slug":"test-repo","full_name":"bob/test-repo","links":{"clone":[{"name":"https","href":"%[1]s/bob/test-repo.git"}]}}
+				},
+				"destination":{
+					"branch":{"name":"main"},
+					"commit":{"hash":"2222222222222222222222222222222222222222"},
+					"repository":{"slug":"test-repo","full_name":"gitea/test-repo","links":{"clone":[{"name":"https","href":"%[1]s/gitea/test-repo.git"}]}}
+				},
+				"merge_commit":{"hash":"3333333333333333333333333333333333333333"},
+				"links":{"patch":{"href":"%[1]s/gitea/test-repo/pull-requests/1.patch"}},
+				"created_on":"2020-01-04T12:00:00Z",
+				"updated_on":"2020-01-05T12:00:00Z"
+			}]}`, serverURL)
+		case "/2.0/repositories/gitea/test-repo/pullrequests/1/comments":
+			_, _ = fmt.Fprint(w, `{"values":[{
+				"id":21,
+				"content":{"raw":"This is a Bitbucket pull request comment"},
+				"user":{"account_id":"user-1","nickname":"alice"},
+				"created_on":"2020-01-04T13:00:00Z",
+				"updated_on":"2020-01-04T13:00:00Z"
+			}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	ctx := t.Context()
+	downloader, err := NewBitbucketDownloader(ctx, server.URL+"/2.0", server.URL, "gitea", "test-repo", "", "", "")
+	require.NoError(t, err)
+
+	repo, err := downloader.GetRepoInfo(ctx)
+	assert.NoError(t, err)
+	assertRepositoryEqual(t, &base.Repository{
+		Name:          "test-repo",
+		Owner:         "gitea",
+		Description:   "Test repository for testing migration from bitbucket to gitea",
+		Website:       "https://gitea.com/test-repo",
+		CloneURL:      server.URL + "/gitea/test-repo.git",
+		OriginalURL:   server.URL + "/gitea/test-repo",
+		DefaultBranch: "main",
+	}, repo)
+
+	labels, err := downloader.GetLabels(ctx)
+	assert.NoError(t, err)
+	sort.Slice(labels, func(i, j int) bool { return labels[i].Name < labels[j].Name })
+	assertLabelsEqual(t, []*base.Label{
+		{Name: "component/migrations", Color: bitbucketLabelColor("component/migrations")},
+		{Name: "kind/bug", Color: bitbucketLabelColor("kind/bug")},
+		{Name: "kind/enhancement", Color: bitbucketLabelColor("kind/enhancement")},
+		{Name: "priority/major", Color: bitbucketLabelColor("priority/major")},
+		{Name: "priority/minor", Color: bitbucketLabelColor("priority/minor")},
+		{Name: "version/1.0", Color: bitbucketLabelColor("version/1.0")},
+	}, labels)
+
+	milestones, err := downloader.GetMilestones(ctx)
+	assert.NoError(t, err)
+	sort.Slice(milestones, func(i, j int) bool { return milestones[i].Title < milestones[j].Title })
+	assertMilestonesEqual(t, []*base.Milestone{
+		{Title: "v1", Created: time.Unix(0, 0), State: "open"},
+	}, milestones)
+
+	issues, isEnd, err := downloader.GetIssues(ctx, 1, 1)
+	assert.NoError(t, err)
+	assert.False(t, isEnd)
+	assertIssuesEqual(t, []*base.Issue{{
+		Number:     1,
+		PosterID:   bitbucketUserID(bitbucketUser{AccountID: "user-1"}),
+		PosterName: "alice",
+		Title:      "Open issue",
+		Content:    "Issue body",
+		Milestone:  "v1",
+		State:      "open",
+		Created:    time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC),
+		Updated:    time.Date(2020, 1, 2, 12, 0, 0, 0, time.UTC),
+		Labels: []*base.Label{
+			{Name: "kind/bug", Color: bitbucketLabelColor("kind/bug")},
+			{Name: "priority/major", Color: bitbucketLabelColor("priority/major")},
+			{Name: "component/migrations", Color: bitbucketLabelColor("component/migrations")},
+			{Name: "version/1.0", Color: bitbucketLabelColor("version/1.0")},
+		},
+		Assignees: []string{"bob"},
+	}}, issues)
+
+	issues, isEnd, err = downloader.GetIssues(ctx, 2, 1)
+	assert.NoError(t, err)
+	assert.True(t, isEnd)
+	assertIssuesEqual(t, []*base.Issue{{
+		Number:     2,
+		PosterID:   bitbucketUserID(bitbucketUser{AccountID: "user-2"}),
+		PosterName: "bob",
+		Title:      "Closed issue",
+		Content:    "Closed body",
+		State:      "closed",
+		Created:    time.Date(2020, 1, 2, 12, 0, 0, 0, time.UTC),
+		Updated:    time.Date(2020, 1, 3, 12, 0, 0, 0, time.UTC),
+		Closed:     new(time.Date(2020, 1, 3, 12, 0, 0, 0, time.UTC)),
+		Labels: []*base.Label{
+			{Name: "kind/enhancement", Color: bitbucketLabelColor("kind/enhancement")},
+			{Name: "priority/minor", Color: bitbucketLabelColor("priority/minor")},
+		},
+	}}, issues)
+
+	comments, _, err := downloader.GetComments(ctx, &base.Issue{Number: 2, ForeignIndex: 2})
+	assert.NoError(t, err)
+	assertCommentsEqual(t, []*base.Comment{{
+		IssueIndex: 2,
+		PosterID:   bitbucketUserID(bitbucketUser{AccountID: "user-1"}),
+		PosterName: "alice",
+		Created:    time.Date(2020, 1, 3, 12, 0, 0, 0, time.UTC),
+		Updated:    time.Date(2020, 1, 3, 12, 10, 0, 0, time.UTC),
+		Content:    "This is a Bitbucket issue comment",
+	}}, comments)
+
+	prs, isEnd, err := downloader.GetPullRequests(ctx, 1, 10)
+	assert.NoError(t, err)
+	assert.True(t, isEnd)
+	assertPullRequestsEqual(t, []*base.PullRequest{{
+		Number:         3,
+		PosterID:       bitbucketUserID(bitbucketUser{AccountID: "user-2"}),
+		PosterName:     "bob",
+		Title:          "Add Bitbucket migration",
+		Content:        "Implements migration support",
+		State:          "closed",
+		Created:        time.Date(2020, 1, 4, 12, 0, 0, 0, time.UTC),
+		Updated:        time.Date(2020, 1, 5, 12, 0, 0, 0, time.UTC),
+		Closed:         new(time.Date(2020, 1, 5, 12, 0, 0, 0, time.UTC)),
+		PatchURL:       server.URL + "/gitea/test-repo/pull-requests/1.patch",
+		Merged:         true,
+		MergedTime:     new(time.Date(2020, 1, 5, 12, 0, 0, 0, time.UTC)),
+		MergeCommitSHA: "3333333333333333333333333333333333333333",
+		Head: base.PullRequestBranch{
+			CloneURL:  server.URL + "/bob/test-repo.git",
+			Ref:       "feature/bitbucket",
+			SHA:       "1111111111111111111111111111111111111111",
+			OwnerName: "bob",
+			RepoName:  "test-repo",
+		},
+		Base: base.PullRequestBranch{
+			Ref:       "main",
+			SHA:       "2222222222222222222222222222222222222222",
+			OwnerName: "gitea",
+			RepoName:  "test-repo",
+		},
+		ForeignIndex: 1,
+		EnsuredSafe:  true,
+	}}, prs)
+
+	comments, _, err = downloader.GetComments(ctx, prs[0])
+	assert.NoError(t, err)
+	assertCommentsEqual(t, []*base.Comment{{
+		IssueIndex: 3,
+		PosterID:   bitbucketUserID(bitbucketUser{AccountID: "user-1"}),
+		PosterName: "alice",
+		Created:    time.Date(2020, 1, 4, 13, 0, 0, 0, time.UTC),
+		Updated:    time.Date(2020, 1, 4, 13, 0, 0, 0, time.UTC),
+		Content:    "This is a Bitbucket pull request comment",
+	}}, comments)
+}
+
+// TestBitbucketRateLimitRetry verifies that doAPI transparently waits and retries when the
+// Bitbucket API answers with HTTP 429 Too Many Requests before eventually succeeding.
+func TestBitbucketRateLimitRetry(t *testing.T) {
+	const failuresBeforeSuccess = 2
+
+	var serverURL string
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/2.0/repositories/gitea/test-repo" {
+			http.NotFound(w, r)
+			return
+		}
+
+		// The first few attempts are rate limited; Retry-After: 0 keeps the test fast.
+		if attempts.Add(1) <= failuresBeforeSuccess {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = fmt.Fprint(w, `{"error":{"message":"Rate limit exceeded"}}`)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{
+			"name":"Test Repo",
+			"slug":"test-repo",
+			"full_name":"gitea/test-repo",
+			"description":"Test repository for testing migration from bitbucket to gitea",
+			"is_private":false,
+			"website":"https://gitea.com/test-repo",
+			"mainbranch":{"name":"main"},
+			"links":{
+				"html":{"href":"%[1]s/gitea/test-repo"},
+				"clone":[{"name":"https","href":"%[1]s/gitea/test-repo.git"}]
+			}
+		}`, serverURL)
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	ctx := t.Context()
+	downloader, err := NewBitbucketDownloader(ctx, server.URL+"/2.0", server.URL, "gitea", "test-repo", "", "", "")
+	require.NoError(t, err)
+
+	repo, err := downloader.GetRepoInfo(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "test-repo", repo.Name)
+	assert.Equal(t, int32(failuresBeforeSuccess+1), attempts.Load())
+}
+
+func writeBitbucketIssuesPage(w http.ResponseWriter, r *http.Request, serverURL string) {
+	if r.URL.Query().Get("pagelen") == "1" && r.URL.Query().Get("page") == "1" {
+		_, _ = fmt.Fprintf(w, `{"next":"%s/2.0/repositories/gitea/test-repo/issues?page=2","values":[%s]}`, serverURL, bitbucketIssueJSON(1))
+		return
+	}
+	if r.URL.Query().Get("pagelen") == "1" && r.URL.Query().Get("page") == "2" {
+		_, _ = fmt.Fprintf(w, `{"values":[%s]}`, bitbucketIssueJSON(2))
+		return
+	}
+	_, _ = fmt.Fprintf(w, `{"values":[%s,%s]}`, bitbucketIssueJSON(1), bitbucketIssueJSON(2))
+}
+
+func bitbucketIssueJSON(id int) string {
+	if id == 1 {
+		return `{
+			"id":1,
+			"title":"Open issue",
+			"content":{"raw":"Issue body"},
+			"state":"open",
+			"kind":"bug",
+			"priority":"major",
+			"reporter":{"account_id":"user-1","nickname":"alice"},
+			"assignee":{"account_id":"user-2","nickname":"bob"},
+			"component":{"name":"migrations"},
+			"version":{"name":"1.0"},
+			"milestone":{"name":"v1"},
+			"created_on":"2020-01-01T12:00:00Z",
+			"updated_on":"2020-01-02T12:00:00Z"
+		}`
+	}
+	return `{
+		"id":2,
+		"title":"Closed issue",
+		"content":{"raw":"Closed body"},
+		"state":"resolved",
+		"kind":"enhancement",
+		"priority":"minor",
+		"reporter":{"account_id":"user-2","nickname":"bob"},
+		"created_on":"2020-01-02T12:00:00Z",
+		"updated_on":"2020-01-03T12:00:00Z"
+	}`
+}
+
+func TestBitbucketRetryWait(t *testing.T) {
+	// retryWaitFor builds a bodyless response carrying the given headers and returns the
+	// wait that bitbucketRetryWait computes for it.
+	retryWaitFor := func(headers map[string]string) time.Duration {
+		resp := &http.Response{Header: http.Header{}}
+		for k, v := range headers {
+			resp.Header.Set(k, v)
+		}
+		return bitbucketRetryWait(resp, 0)
+	}
+
+	// Retry-After in seconds is honored exactly.
+	assert.Equal(t, 5*time.Second, retryWaitFor(map[string]string{"Retry-After": "5"}))
+
+	// Bitbucket's X-RateLimit-Reset is a seconds-remaining delta, not an epoch.
+	assert.Equal(t, 120*time.Second, retryWaitFor(map[string]string{"X-RateLimit-Reset": "120"}))
+
+	// A delta larger than the cap is clamped.
+	assert.Equal(t, bitbucketMaxRetryAfter, retryWaitFor(map[string]string{"X-RateLimit-Reset": "999999"}))
+
+	// A value large enough to be a Unix epoch is treated as an absolute timestamp.
+	epoch := strconv.FormatInt(time.Now().Add(5*time.Minute).Unix(), 10)
+	got := retryWaitFor(map[string]string{"X-RateLimit-Reset": epoch})
+	assert.InDelta(t, (5 * time.Minute).Seconds(), got.Seconds(), 5)
+
+	// An RFC3339 timestamp a few minutes in the future is honored as an absolute time.
+	rfc := time.Now().Add(3 * time.Minute).UTC().Format(time.RFC3339)
+	assert.InDelta(t, (3 * time.Minute).Seconds(), retryWaitFor(map[string]string{"X-RateLimit-Reset": rfc}).Seconds(), 5)
+
+	// With no rate-limit headers it falls back to a positive exponential backoff.
+	assert.Positive(t, retryWaitFor(nil))
+}

--- a/templates/repo/migrate/bitbucket.tmpl
+++ b/templates/repo/migrate/bitbucket.tmpl
@@ -1,0 +1,131 @@
+{{template "base/head" .}}
+<div role="main" aria-label="{{.Title}}" class="page-content repository new migrate">
+	<div class="ui container medium-width">
+		<h3 class="ui top attached header">
+			{{ctx.Locale.Tr "repo.migrate.migrate" .service.Title}}
+		</h3>
+		<div class="ui attached segment">
+			{{template "base/alert" .}}
+			<form class="ui form left-right-form" action="{{.Link}}" method="post">
+				{{template "base/disable_form_autofill"}}
+
+				<input id="service_type" type="hidden" name="service" value="{{.service}}">
+
+				<div class="inline required field {{if .Err_CloneAddr}}error{{end}}">
+					<label for="clone_addr">{{ctx.Locale.Tr "repo.migrate.clone_address"}}</label>
+					<input id="clone_addr" name="clone_addr" value="{{.clone_addr}}" autofocus required>
+					<span class="help">
+					{{ctx.Locale.Tr "repo.migrate.clone_address_desc"}}{{if .ContextUser.CanImportLocal}} {{ctx.Locale.Tr "repo.migrate.clone_local_path"}}{{end}}
+					</span>
+				</div>
+
+				<div class="inline field {{if .Err_Auth}}error{{end}}">
+					<label for="auth_username">{{ctx.Locale.Tr "username"}}</label>
+					<input id="auth_username" name="auth_username" value="{{.auth_username}}" {{if not .auth_username}}data-need-clear="true"{{end}}>
+				</div>
+				<div class="inline field {{if .Err_Auth}}error{{end}}">
+					<label for="auth_password">{{ctx.Locale.Tr "password"}}</label>
+					<input id="auth_password" name="auth_password" type="password" autocomplete="new-password" value="{{.auth_password}}">
+					<a target="_blank" href="https://support.atlassian.com/bitbucket-cloud/docs/create-an-app-password/">{{svg "octicon-question"}}</a>
+					<span class="help">
+					{{ctx.Locale.Tr "repo.migrate.bitbucket_token_desc"}}
+					</span>
+				</div>
+
+				{{template "repo/migrate/options" .}}
+
+				<div class="inline field">
+					<label>{{ctx.Locale.Tr "repo.migrate_items"}}</label>
+					<div class="ui checkbox">
+						<input name="wiki" type="checkbox" {{if .wiki}}checked{{end}}>
+						<label>{{ctx.Locale.Tr "repo.migrate_items_wiki"}}</label>
+					</div>
+				</div>
+
+				<div id="migrate_items" class="inline field">
+					<span class="help">{{ctx.Locale.Tr "repo.migrate.migrate_items_options"}}</span>
+					<div class="inline field">
+						<label></label>
+						<div class="ui checkbox">
+							<input name="labels" type="checkbox" {{if .labels}}checked{{end}}>
+							<label>{{ctx.Locale.Tr "repo.migrate_items_labels"}}</label>
+						</div>
+						<div class="ui checkbox">
+							<input name="issues" type="checkbox" {{if .issues}}checked{{end}}>
+							<label>{{ctx.Locale.Tr "repo.migrate_items_issues"}}</label>
+						</div>
+					</div>
+					<div class="inline field">
+						<label></label>
+						<div class="ui checkbox">
+							<input name="pull_requests" type="checkbox" {{if .pull_requests}}checked{{end}}>
+							<label>{{ctx.Locale.Tr "repo.migrate_items_pullrequests"}}</label>
+						</div>
+					</div>
+					<div class="inline field">
+						<label></label>
+						<div class="ui checkbox">
+							<input name="milestones" type="checkbox" {{if .milestones}}checked{{end}}>
+							<label>{{ctx.Locale.Tr "repo.migrate_items_milestones"}}</label>
+						</div>
+					</div>
+				</div>
+
+				<div class="divider"></div>
+
+				<div class="inline required field {{if .Err_Owner}}error{{end}}">
+					<label>{{ctx.Locale.Tr "repo.owner"}}</label>
+					<div class="ui selection owner dropdown ellipsis-text-items">
+						<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
+						<span class="text" title="{{.ContextUser.Name}}">
+							{{ctx.AvatarUtils.Avatar .ContextUser 28 "mini"}}
+							{{.ContextUser.ShortName 40}}
+						</span>
+						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
+						<div class="menu" title="{{.SignedUser.Name}}">
+							<div class="item" data-value="{{.SignedUser.ID}}">
+								{{ctx.AvatarUtils.Avatar .SignedUser 28 "mini"}}
+								{{.SignedUser.ShortName 40}}
+							</div>
+							{{range .Orgs}}
+								<div class="item" data-value="{{.ID}}" title="{{.Name}}">
+									{{ctx.AvatarUtils.Avatar . 28 "mini"}}
+									{{.ShortName 40}}
+								</div>
+							{{end}}
+						</div>
+					</div>
+				</div>
+
+				<div class="inline required field {{if .Err_RepoName}}error{{end}}">
+					<label for="repo_name">{{ctx.Locale.Tr "repo.repo_name"}}</label>
+					<input id="repo_name" name="repo_name" value="{{.repo_name}}" required maxlength="100">
+				</div>
+				<div class="inline field">
+					<label>{{ctx.Locale.Tr "repo.visibility"}}</label>
+					<div class="ui checkbox">
+						{{if .IsForcedPrivate}}
+							<input name="private" type="checkbox" checked disabled>
+							<label>{{ctx.Locale.Tr "repo.visibility_helper_forced"}}</label>
+						{{else}}
+							<input name="private" type="checkbox" {{if .private}}checked{{end}}>
+							<label>{{ctx.Locale.Tr "repo.visibility_helper"}}</label>
+						{{end}}
+					</div>
+				</div>
+				<div class="inline field {{if .Err_Description}}error{{end}}">
+					<label for="description">{{ctx.Locale.Tr "repo.repo_desc"}}</label>
+					<textarea id="description" name="description" maxlength="2048">{{.description}}</textarea>
+				</div>
+
+				<div class="inline field">
+					<label></label>
+					<button class="ui primary button">
+						{{ctx.Locale.Tr "repo.migrate_repo"}}
+					</button>
+				</div>
+			</form>
+		</div>
+	</div>
+</div>
+{{template "base/footer" .}}

--- a/templates/repo/migrate/bitbucket.tmpl
+++ b/templates/repo/migrate/bitbucket.tmpl
@@ -73,29 +73,7 @@
 
 				<div class="divider"></div>
 
-				<div class="inline required field {{if .Err_Owner}}error{{end}}">
-					<label>{{ctx.Locale.Tr "repo.owner"}}</label>
-					<div class="ui selection owner dropdown ellipsis-text-items">
-						<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
-						<span class="text" title="{{.ContextUser.Name}}">
-							{{ctx.AvatarUtils.Avatar .ContextUser 28 "mini"}}
-							{{.ContextUser.ShortName 40}}
-						</span>
-						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-						<div class="menu" title="{{.SignedUser.Name}}">
-							<div class="item" data-value="{{.SignedUser.ID}}">
-								{{ctx.AvatarUtils.Avatar .SignedUser 28 "mini"}}
-								{{.SignedUser.ShortName 40}}
-							</div>
-							{{range .Orgs}}
-								<div class="item" data-value="{{.ID}}" title="{{.Name}}">
-									{{ctx.AvatarUtils.Avatar . 28 "mini"}}
-									{{.ShortName 40}}
-								</div>
-							{{end}}
-						</div>
-					</div>
-				</div>
+				{{template "repo/migrate/owner" .}}
 
 				<div class="inline required field {{if .Err_RepoName}}error{{end}}">
 					<label for="repo_name">{{ctx.Locale.Tr "repo.repo_name"}}</label>

--- a/templates/repo/migrate/codebase.tmpl
+++ b/templates/repo/migrate/codebase.tmpl
@@ -57,29 +57,7 @@
 
 				<div class="divider"></div>
 
-				<div class="inline required field {{if .Err_Owner}}error{{end}}">
-					<label>{{ctx.Locale.Tr "repo.owner"}}</label>
-					<div class="ui selection owner dropdown ellipsis-text-items">
-						<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
-						<span class="text" title="{{.ContextUser.Name}}">
-							{{ctx.AvatarUtils.Avatar .ContextUser 28 "mini"}}
-							{{.ContextUser.ShortName 40}}
-						</span>
-						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-						<div class="menu" title="{{.SignedUser.Name}}">
-							<div class="item" data-value="{{.SignedUser.ID}}">
-								{{ctx.AvatarUtils.Avatar .SignedUser 28 "mini"}}
-								{{.SignedUser.ShortName 40}}
-							</div>
-							{{range .Orgs}}
-								<div class="item" data-value="{{.ID}}" title="{{.Name}}">
-									{{ctx.AvatarUtils.Avatar . 28 "mini"}}
-									{{.ShortName 40}}
-								</div>
-							{{end}}
-						</div>
-					</div>
-				</div>
+				{{template "repo/migrate/owner" .}}
 
 				<div class="inline required field {{if .Err_RepoName}}error{{end}}">
 					<label for="repo_name">{{ctx.Locale.Tr "repo.repo_name"}}</label>

--- a/templates/repo/migrate/codecommit.tmpl
+++ b/templates/repo/migrate/codecommit.tmpl
@@ -58,29 +58,7 @@
 
 				<div class="divider"></div>
 
-				<div class="inline required field {{if .Err_Owner}}error{{end}}">
-					<label>{{ctx.Locale.Tr "repo.owner"}}</label>
-					<div class="ui selection owner dropdown ellipsis-text-items">
-						<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
-						<span class="text" title="{{.ContextUser.Name}}">
-							{{ctx.AvatarUtils.Avatar .ContextUser 28 "mini"}}
-							{{.ContextUser.ShortName 40}}
-						</span>
-						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-						<div class="menu" title="{{.SignedUser.Name}}">
-							<div class="item" data-value="{{.SignedUser.ID}}">
-								{{ctx.AvatarUtils.Avatar .SignedUser 28 "mini"}}
-								{{.SignedUser.ShortName 40}}
-							</div>
-							{{range .Orgs}}
-								<div class="item" data-value="{{.ID}}" title="{{.Name}}">
-									{{ctx.AvatarUtils.Avatar . 28 "mini"}}
-									{{.ShortName 40}}
-								</div>
-							{{end}}
-						</div>
-					</div>
-				</div>
+				{{template "repo/migrate/owner" .}}
 
 				<div class="inline required field {{if .Err_RepoName}}error{{end}}">
 					<label for="repo_name">{{ctx.Locale.Tr "repo.repo_name"}}</label>

--- a/templates/repo/migrate/git.tmpl
+++ b/templates/repo/migrate/git.tmpl
@@ -31,29 +31,7 @@
 
 				<div class="divider"></div>
 
-				<div class="inline required field {{if .Err_Owner}}error{{end}}">
-					<label>{{ctx.Locale.Tr "repo.owner"}}</label>
-					<div class="ui selection owner dropdown ellipsis-text-items">
-						<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
-						<span class="text" title="{{.ContextUser.Name}}">
-							{{ctx.AvatarUtils.Avatar .ContextUser}}
-							{{.ContextUser.ShortName 40}}
-						</span>
-						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-						<div class="menu" title="{{.SignedUser.Name}}">
-							<div class="item" data-value="{{.SignedUser.ID}}">
-								{{ctx.AvatarUtils.Avatar .SignedUser}}
-								{{.SignedUser.ShortName 40}}
-							</div>
-							{{range .Orgs}}
-								<div class="item" data-value="{{.ID}}" title="{{.Name}}">
-									{{ctx.AvatarUtils.Avatar .}}
-									{{.ShortName 40}}
-								</div>
-							{{end}}
-						</div>
-					</div>
-				</div>
+				{{template "repo/migrate/owner" .}}
 
 				<div class="inline required field {{if .Err_RepoName}}error{{end}}">
 					<label for="repo_name">{{ctx.Locale.Tr "repo.repo_name"}}</label>

--- a/templates/repo/migrate/gitbucket.tmpl
+++ b/templates/repo/migrate/gitbucket.tmpl
@@ -73,29 +73,7 @@
 
 				<div class="divider"></div>
 
-				<div class="inline required field {{if .Err_Owner}}error{{end}}">
-					<label>{{ctx.Locale.Tr "repo.owner"}}</label>
-					<div class="ui selection owner dropdown ellipsis-text-items">
-						<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
-						<span class="text" title="{{.ContextUser.Name}}">
-							{{ctx.AvatarUtils.Avatar .ContextUser 28 "mini"}}
-							{{.ContextUser.ShortName 40}}
-						</span>
-						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-						<div class="menu" title="{{.SignedUser.Name}}">
-							<div class="item" data-value="{{.SignedUser.ID}}">
-								{{ctx.AvatarUtils.Avatar .SignedUser 28 "mini"}}
-								{{.SignedUser.ShortName 40}}
-							</div>
-							{{range .Orgs}}
-								<div class="item" data-value="{{.ID}}" title="{{.Name}}">
-									{{ctx.AvatarUtils.Avatar . 28 "mini"}}
-									{{.ShortName 40}}
-								</div>
-							{{end}}
-						</div>
-					</div>
-				</div>
+				{{template "repo/migrate/owner" .}}
 
 				<div class="inline required field {{if .Err_RepoName}}error{{end}}">
 					<label for="repo_name">{{ctx.Locale.Tr "repo.repo_name"}}</label>

--- a/templates/repo/migrate/gitea.tmpl
+++ b/templates/repo/migrate/gitea.tmpl
@@ -69,29 +69,7 @@
 
 				<div class="divider"></div>
 
-				<div class="inline required field {{if .Err_Owner}}error{{end}}">
-					<label>{{ctx.Locale.Tr "repo.owner"}}</label>
-					<div class="ui selection owner dropdown ellipsis-text-items">
-						<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
-						<span class="text" title="{{.ContextUser.Name}}">
-							{{ctx.AvatarUtils.Avatar .ContextUser}}
-							{{.ContextUser.ShortName 40}}
-						</span>
-						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-						<div class="menu" title="{{.SignedUser.Name}}">
-							<div class="item" data-value="{{.SignedUser.ID}}">
-								{{ctx.AvatarUtils.Avatar .SignedUser}}
-								{{.SignedUser.ShortName 40}}
-							</div>
-							{{range .Orgs}}
-							<div class="item" data-value="{{.ID}}" title="{{.Name}}">
-								{{ctx.AvatarUtils.Avatar .}}
-								{{.ShortName 40}}
-							</div>
-							{{end}}
-						</div>
-					</div>
-				</div>
+				{{template "repo/migrate/owner" .}}
 
 				<div class="inline required field {{if .Err_RepoName}}error{{end}}">
 					<label for="repo_name">{{ctx.Locale.Tr "repo.repo_name"}}</label>

--- a/templates/repo/migrate/github.tmpl
+++ b/templates/repo/migrate/github.tmpl
@@ -71,29 +71,7 @@
 
 				<div class="divider"></div>
 
-				<div class="inline required field {{if .Err_Owner}}error{{end}}">
-					<label>{{ctx.Locale.Tr "repo.owner"}}</label>
-					<div class="ui selection owner dropdown ellipsis-text-items">
-						<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
-						<span class="text" title="{{.ContextUser.Name}}">
-							{{ctx.AvatarUtils.Avatar .ContextUser 28 "mini"}}
-							{{.ContextUser.ShortName 40}}
-						</span>
-						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-						<div class="menu" title="{{.SignedUser.Name}}">
-							<div class="item" data-value="{{.SignedUser.ID}}">
-								{{ctx.AvatarUtils.Avatar .SignedUser 28 "mini"}}
-								{{.SignedUser.ShortName 40}}
-							</div>
-							{{range .Orgs}}
-								<div class="item" data-value="{{.ID}}" title="{{.Name}}">
-									{{ctx.AvatarUtils.Avatar . 28 "mini"}}
-									{{.ShortName 40}}
-								</div>
-							{{end}}
-						</div>
-					</div>
-				</div>
+				{{template "repo/migrate/owner" .}}
 
 				<div class="inline required field {{if .Err_RepoName}}error{{end}}">
 					<label for="repo_name">{{ctx.Locale.Tr "repo.repo_name"}}</label>

--- a/templates/repo/migrate/gitlab.tmpl
+++ b/templates/repo/migrate/gitlab.tmpl
@@ -68,29 +68,7 @@
 
 				<div class="divider"></div>
 
-				<div class="inline required field {{if .Err_Owner}}error{{end}}">
-					<label>{{ctx.Locale.Tr "repo.owner"}}</label>
-					<div class="ui selection owner dropdown ellipsis-text-items">
-						<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
-						<span class="text" title="{{.ContextUser.Name}}">
-							{{ctx.AvatarUtils.Avatar .ContextUser 28 "mini"}}
-							{{.ContextUser.ShortName 40}}
-						</span>
-						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-						<div class="menu" title="{{.SignedUser.Name}}">
-							<div class="item" data-value="{{.SignedUser.ID}}">
-								{{ctx.AvatarUtils.Avatar .SignedUser 28 "mini"}}
-								{{.SignedUser.ShortName 40}}
-							</div>
-							{{range .Orgs}}
-								<div class="item" data-value="{{.ID}}" title="{{.Name}}">
-									{{ctx.AvatarUtils.Avatar . 28 "mini"}}
-									{{.ShortName 40}}
-								</div>
-							{{end}}
-						</div>
-					</div>
-				</div>
+				{{template "repo/migrate/owner" .}}
 
 				<div class="inline required field {{if .Err_RepoName}}error{{end}}">
 					<label for="repo_name">{{ctx.Locale.Tr "repo.repo_name"}}</label>

--- a/templates/repo/migrate/gogs.tmpl
+++ b/templates/repo/migrate/gogs.tmpl
@@ -71,29 +71,7 @@
 
 				<div class="divider"></div>
 
-				<div class="inline required field {{if .Err_Owner}}error{{end}}">
-					<label>{{ctx.Locale.Tr "repo.owner"}}</label>
-					<div class="ui selection owner dropdown ellipsis-text-items">
-						<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
-						<span class="text" title="{{.ContextUser.Name}}">
-							{{ctx.AvatarUtils.Avatar .ContextUser}}
-							{{.ContextUser.ShortName 40}}
-						</span>
-						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-						<div class="menu" title="{{.SignedUser.Name}}">
-							<div class="item" data-value="{{.SignedUser.ID}}">
-								{{ctx.AvatarUtils.Avatar .SignedUser}}
-								{{.SignedUser.ShortName 40}}
-							</div>
-							{{range .Orgs}}
-							<div class="item" data-value="{{.ID}}" title="{{.Name}}">
-								{{ctx.AvatarUtils.Avatar .}}
-								{{.ShortName 40}}
-							</div>
-							{{end}}
-						</div>
-					</div>
-				</div>
+				{{template "repo/migrate/owner" .}}
 
 				<div class="inline required field {{if .Err_RepoName}}error{{end}}">
 					<label for="repo_name">{{ctx.Locale.Tr "repo.repo_name"}}</label>

--- a/templates/repo/migrate/migrate.tmpl
+++ b/templates/repo/migrate/migrate.tmpl
@@ -5,15 +5,17 @@
 			{{template "repo/migrate/helper" .}}
 			<div class="ui cards migrate-entries">
 				{{range .Services}}
-					<a class="ui card migrate-entry flex-text-block" href="{{AppSubUrl}}/repo/migrate?service_type={{.}}&org={{$.Org}}&mirror={{$.Mirror}}">
+					<a class="ui card migrate-entry" href="{{AppSubUrl}}/repo/migrate?service_type={{.}}&org={{$.Org}}&mirror={{$.Mirror}}">
 						{{if eq .Name "github"}}
-							{{svg "octicon-mark-github" 184 "tw-p-4"}}
+							{{svg "octicon-mark-github" 120 "tw-p-4"}}
 						{{else if eq .Name "gitlab"}}
-							{{svg "gitea-gitlab" 184 "tw-p-4"}}
+							{{svg "gitea-gitlab" 120 "tw-p-4"}}
 						{{else if eq .Name "gitbucket"}}
-							{{svg "gitea-gitbucket" 184 "tw-p-4"}}
+							{{svg "gitea-gitbucket" 120 "tw-p-4"}}
+						{{else if eq .Name "bitbucket"}}
+							{{svg "gitea-bitbucket" 120 "tw-p-4"}}
 						{{else}}
-							{{svg (printf "gitea-%s" .Name) 184}}
+							{{svg (printf "gitea-%s" .Name) 120}}
 						{{end}}
 						<div class="content">
 							<div class="header tw-text-center">

--- a/templates/repo/migrate/onedev.tmpl
+++ b/templates/repo/migrate/onedev.tmpl
@@ -58,29 +58,7 @@
 
 				<div class="divider"></div>
 
-				<div class="inline required field {{if .Err_Owner}}error{{end}}">
-					<label>{{ctx.Locale.Tr "repo.owner"}}</label>
-					<div class="ui selection owner dropdown ellipsis-text-items">
-						<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
-						<span class="text" title="{{.ContextUser.Name}}">
-							{{ctx.AvatarUtils.Avatar .ContextUser 28 "mini"}}
-							{{.ContextUser.ShortName 40}}
-						</span>
-						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-						<div class="menu" title="{{.SignedUser.Name}}">
-							<div class="item" data-value="{{.SignedUser.ID}}">
-								{{ctx.AvatarUtils.Avatar .SignedUser 28 "mini"}}
-								{{.SignedUser.ShortName 40}}
-							</div>
-							{{range .Orgs}}
-								<div class="item" data-value="{{.ID}}" title="{{.Name}}">
-									{{ctx.AvatarUtils.Avatar . 28 "mini"}}
-									{{.ShortName 40}}
-								</div>
-							{{end}}
-						</div>
-					</div>
-				</div>
+				{{template "repo/migrate/owner" .}}
 
 				<div class="inline required field {{if .Err_RepoName}}error{{end}}">
 					<label for="repo_name">{{ctx.Locale.Tr "repo.repo_name"}}</label>

--- a/templates/repo/migrate/owner.tmpl
+++ b/templates/repo/migrate/owner.tmpl
@@ -1,0 +1,23 @@
+<div class="inline required field {{if .Err_Owner}}error{{end}}">
+	<label>{{ctx.Locale.Tr "repo.owner"}}</label>
+	<div class="ui selection owner dropdown ellipsis-text-items">
+		<input type="hidden" id="uid" name="uid" value="{{.ContextUser.ID}}" required>
+		<span class="text" title="{{.ContextUser.Name}}">
+			{{ctx.AvatarUtils.Avatar .ContextUser 28 "mini"}}
+			{{.ContextUser.ShortName 40}}
+		</span>
+		{{svg "octicon-triangle-down" 14 "dropdown icon"}}
+		<div class="menu" title="{{.SignedUser.Name}}">
+			<div class="item" data-value="{{.SignedUser.ID}}">
+				{{ctx.AvatarUtils.Avatar .SignedUser 28 "mini"}}
+				{{.SignedUser.ShortName 40}}
+			</div>
+			{{range .Orgs}}
+				<div class="item" data-value="{{.ID}}" title="{{.Name}}">
+					{{ctx.AvatarUtils.Avatar . 28 "mini"}}
+					{{.ShortName 40}}
+				</div>
+			{{end}}
+		</div>
+	</div>
+</div>

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -27897,7 +27897,8 @@
             "onedev",
             "gitbucket",
             "codebase",
-            "codecommit"
+            "codecommit",
+            "bitbucket"
           ],
           "x-go-name": "Service"
         },

--- a/templates/swagger/v1_openapi3_json.tmpl
+++ b/templates/swagger/v1_openapi3_json.tmpl
@@ -7606,7 +7606,8 @@
               "onedev",
               "gitbucket",
               "codebase",
-              "codecommit"
+              "codecommit",
+              "bitbucket"
             ],
             "type": "string",
             "x-go-name": "Service"

--- a/tests/integration/repo_migrate_test.go
+++ b/tests/integration/repo_migrate_test.go
@@ -42,3 +42,25 @@ func TestRepoMigrate(t *testing.T) {
 	session := loginUser(t, "user2")
 	testRepoMigrate(t, session, "https://github.com/go-gitea/test_repo.git", "git")
 }
+
+// TestRepoMigrationUI verifies the per-service migration forms render, including the
+// newly added bitbucket.org service so its UI does not regress.
+func TestRepoMigrationUI(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+	session := loginUser(t, "user2")
+
+	for _, service := range []structs.GitServiceType{
+		structs.PlainGitService,
+		structs.GithubService,
+		structs.GitlabService,
+		structs.BitbucketService,
+	} {
+		req := NewRequest(t, "GET", fmt.Sprintf("/repo/migrate?service_type=%d", service))
+		resp := session.MakeRequest(t, req, http.StatusOK)
+		htmlDoc := NewHTMLParser(t, resp.Body)
+
+		serviceValue, exists := htmlDoc.doc.Find(`#service_type`).Attr("value")
+		assert.True(t, exists, "service_type input missing for %s", service.Title())
+		assert.Equal(t, fmt.Sprintf("%d", service), serviceValue)
+	}
+}

--- a/web_src/css/repo.css
+++ b/web_src/css/repo.css
@@ -1745,15 +1745,9 @@ tbody.commit-list {
 
 .migrate-entries {
   display: grid !important;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   gap: 25px;
   margin: 0 !important;
-}
-
-@media (max-width: 767.98px) {
-  .migrate-entries {
-    grid-template-columns: repeat(1, 1fr);
-  }
 }
 
 .migrate-entry {
@@ -1763,6 +1757,11 @@ tbody.commit-list {
   color: var(--color-text) !important;
   width: auto !important;
   margin: 0 !important;
+}
+
+.migrate-entry .svg {
+  align-self: center;
+  margin: 1rem 0;
 }
 
 .migrate-entry:hover {


### PR DESCRIPTION
## What this PR does

Adds support for migrating repositories and their metadata from **bitbucket.org** (Bitbucket Cloud), following Gitea's existing migration framework. Both the web UI and the REST API (`POST /repos/migrate` with `service=bitbucket`) are supported.

## Migrated content

Implemented via the Bitbucket Cloud REST API v2:

- Repository info (owner, name, description, website, default branch, clone URL, private flag)
- Issues (with reporter, assignee, state, timestamps)
- Issue & pull request comments
- Pull requests (source/target branch, SHAs, merge commit, patch URL, state)
- Labels — synthesized from Bitbucket issue metadata (`kind/*`, `priority/*`, `component/*`, `version/*`)
- Milestones — derived from the issue tracker

Bitbucket has **no "release" concept**, so releases are not supported and the option is hidden in the migration UI. Bitbucket also uses separate numbering for issues and pull requests, so PR numbers are offset past the highest issue ID to avoid index collisions.

## Rate limiting

Bitbucket Cloud enforces per-hour rate limits and returns HTTP 429 with an `X-RateLimit-Reset` header expressed as **seconds-remaining** (not a Unix epoch) and no `Retry-After`. The downloader transparently waits-and-retries on 429 (and transient 5xx) for idempotent GET requests:

- Honors `Retry-After`, then `X-RateLimit-Reset` (delta-seconds, with epoch/RFC3339 fallbacks), then exponential backoff with jitter
- All waits are capped, bounded by a per-call total budget, and interruptible via `context`
- On exhaustion, the error advises authenticating to raise the limit (anonymous access is capped at 60 requests/hour)

## Auth / clone

Supports username + app password (basic auth) and access tokens. `FormatCloneURL` uses Bitbucket's required `x-token-auth` username when cloning with a token.

## UI

- New per-service migration form (`bitbucket.tmpl`); Bitbucket appears after Gitea and before Gogs.
- Reworked the migration source picker into a responsive auto-fill grid (`minmax(200px, 1fr)`) with smaller icons, and fixed a long-standing bug where the card divider followed the text width instead of spanning the full card.

## Tests

- Unit tests for the downloader (repo/issues/comments/PRs/labels/milestones) against a mock server
- Unit tests for rate-limit wait computation (`Retry-After`, delta reset, epoch, RFC3339, backoff)
- A 429 retry test
- `TestToGitServiceType` extended for `bitbucket`
- `TestRepoMigrationUI` integration test verifying the migration forms render

## Notes

- Swagger/OpenAPI specs regenerated (`service` enum now includes `bitbucket`).
- Only the `en-US` locale was updated; other locales go through Crowdin.

## ScreenShot

<img width="1004" height="830" alt="image" src="https://github.com/user-attachments/assets/d579815a-732d-4504-b5d7-1747965144f0" />
