### PR TITLE
fix(webhook): remove slack channel name check

### DIFF
--- a/services/webhook/slack.go
+++ b/services/webhook/slack.go
@@ -317,12 +317,10 @@ func init() {
 	RegisterWebhookRequester(webhook_module.SLACK, newSlackRequest)
 }
 
-var slackChannel = regexp.MustCompile(`^#?[a-z0-9_-]{1,80}$`)
+var slackChannel = regexp.MustCompile(`^#?[\p{Ll}\p{Lo}\p{Lm}\p{M}\p{Nd}_-]{1,80}$`)
 
-// IsValidSlackChannel validates a channel name conforms to what slack expects:
-// https://api.slack.com/methods/conversations.rename#naming
-// Conversation names can only contain lowercase letters, numbers, hyphens, and underscores, and must be 80 characters or less.
-// Gitea accepts if it starts with a #.
+// IsValidSlackChannel validates a channel name against Slack's documented naming rules.
+// Gitea additionally accepts uncased Unicode letters and marks supported by Slack clients, and an optional leading #.
 func IsValidSlackChannel(name string) bool {
 	return slackChannel.MatchString(name)
 }

--- a/services/webhook/slack.go
+++ b/services/webhook/slack.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"regexp"
 	"strings"
 
 	webhook_model "gitea.dev/models/webhook"
@@ -317,10 +316,10 @@ func init() {
 	RegisterWebhookRequester(webhook_module.SLACK, newSlackRequest)
 }
 
-var slackChannel = regexp.MustCompile(`^#?[\p{Ll}\p{Lo}\p{Lm}\p{M}\p{Nd}_-]{1,80}$`)
-
-// IsValidSlackChannel validates a channel name against Slack's documented naming rules.
-// Gitea additionally accepts uncased Unicode letters and marks supported by Slack clients, and an optional leading #.
 func IsValidSlackChannel(name string) bool {
-	return slackChannel.MatchString(name)
+	// Some documents: https://api.slack.com/methods/conversations.rename#naming
+	// 1. Internal channel name should "only contain lowercase letters, numbers, hyphens, and underscores, and must be 80 characters or less"
+	// 2. Slack would also "modify it to meet the above criteria"
+	// Since we know nothing about the details, don't do any validation here.
+	return name != ""
 }

--- a/services/webhook/slack_test.go
+++ b/services/webhook/slack_test.go
@@ -4,6 +4,7 @@
 package webhook
 
 import (
+	"strings"
 	"testing"
 
 	webhook_model "gitea.dev/models/webhook"
@@ -199,6 +200,13 @@ func TestIsValidSlackChannel(t *testing.T) {
 	}{
 		{"gitea", true},
 		{"#gitea", true},
+		{"개발알림", true},
+		{"#개발알림", true},
+		{"Gitea", false},
+		{"개발 알림", false},
+		{"개발!알림", false},
+		{strings.Repeat("가", 80), true},
+		{strings.Repeat("가", 81), false},
 		{"  ", false},
 		{"#", false},
 		{" #", false},

--- a/services/webhook/slack_test.go
+++ b/services/webhook/slack_test.go
@@ -4,7 +4,6 @@
 package webhook
 
 import (
-	"strings"
 	"testing"
 
 	webhook_model "gitea.dev/models/webhook"
@@ -191,30 +190,4 @@ func TestSlackJSONPayload(t *testing.T) {
 	err = json.NewDecoder(req.Body).Decode(&body)
 	assert.NoError(t, err)
 	assert.Equal(t, "[<http://localhost:3000/test/repo|test/repo>:<http://localhost:3000/test/repo/src/branch/test|test>] 2 new commits pushed by user1", body.Text)
-}
-
-func TestIsValidSlackChannel(t *testing.T) {
-	tt := []struct {
-		channelName string
-		expected    bool
-	}{
-		{"gitea", true},
-		{"#gitea", true},
-		{"개발알림", true},
-		{"#개발알림", true},
-		{"Gitea", false},
-		{"개발 알림", false},
-		{"개발!알림", false},
-		{strings.Repeat("가", 80), true},
-		{strings.Repeat("가", 81), false},
-		{"  ", false},
-		{"#", false},
-		{" #", false},
-		{"gitea   ", false},
-		{"  gitea", false},
-	}
-
-	for _, v := range tt {
-		assert.Equal(t, v.expected, IsValidSlackChannel(v.channelName))
-	}
 }


### PR DESCRIPTION
Users should know what they are doing, don't check everything, especially for that we don't understand.

Fixes #23840