### PR TITLE
perf(actions): skip re-sending unchanged job summaries on the run vie…

### DIFF
--- a/models/actions/run_job_summary.go
+++ b/models/actions/run_job_summary.go
@@ -5,6 +5,7 @@ package actions
 
 import (
 	"context"
+	"fmt"
 
 	"gitea.dev/models/db"
 	"gitea.dev/modules/setting"
@@ -189,6 +190,31 @@ WHEN NOT MATCHED THEN
 	}
 
 	return util.ErrInvalidArgument
+}
+
+// GetActionRunJobSummariesVersion returns a cheap DB-side fingerprint of a run attempt's summaries (same
+// optional jobID scoping as ListActionRunJobSummaries) so the poll can tell whether any changed without
+// loading content. Empty means no summaries. COUNT is needed alongside MAX(updated) because "updated" has
+// 1s granularity: MAX alone misses a deleted row and a step inserted in the same second as the previous one.
+func GetActionRunJobSummariesVersion(ctx context.Context, repoID, runID, runAttemptID, jobID int64) (string, error) {
+	sess := db.GetEngine(ctx).Table(new(ActionRunJobSummary)).
+		Where("repo_id=? AND run_id=? AND run_attempt_id=?", repoID, runID, runAttemptID)
+	if jobID > 0 {
+		sess = sess.And("job_id=?", jobID)
+	}
+	var agg struct {
+		Count      int64 `xorm:"count"`
+		MaxUpdated int64 `xorm:"max_updated"`
+	}
+	if _, err := sess.
+		Select("COUNT(*) AS count, COALESCE(MAX(updated), 0) AS max_updated").
+		Get(&agg); err != nil {
+		return "", err
+	}
+	if agg.Count == 0 {
+		return "", nil
+	}
+	return fmt.Sprintf("%d-%d", agg.Count, agg.MaxUpdated), nil
 }
 
 // ListActionRunJobSummaries lists the stored summaries for a run attempt, ordered by job

--- a/models/actions/run_job_summary_test.go
+++ b/models/actions/run_job_summary_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package actions
+
+import (
+	"testing"
+
+	"gitea.dev/models/unittest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetActionRunJobSummariesVersion(t *testing.T) {
+	require.NoError(t, unittest.PrepareTestDatabase())
+	ctx := t.Context()
+
+	const repoID, runID, attemptID int64 = 4, 9601, 0
+	const jobA, jobB int64 = 71, 72
+
+	version := func(jobID int64) string {
+		v, err := GetActionRunJobSummariesVersion(ctx, repoID, runID, attemptID, jobID)
+		require.NoError(t, err)
+		return v
+	}
+
+	// No summaries yet: empty fingerprint.
+	assert.Empty(t, version(0))
+
+	// First summary for job A: fingerprint becomes non-empty and stable across repeated calls.
+	require.NoError(t, UpsertActionRunJobSummary(ctx, repoID, runID, attemptID, jobA, 0, JobSummaryContentTypeMarkdown, []byte("# hello")))
+	v1 := version(0)
+	assert.NotEmpty(t, v1)
+	assert.Equal(t, v1, version(0))
+
+	// A new step (higher row count) changes the fingerprint.
+	require.NoError(t, UpsertActionRunJobSummary(ctx, repoID, runID, attemptID, jobA, 1, JobSummaryContentTypeMarkdown, []byte("more")))
+	v2 := version(0)
+	assert.NotEqual(t, v1, v2)
+
+	// Job scoping: adding job B changes the all-jobs fingerprint but leaves job A's untouched.
+	vA := version(jobA)
+	require.NoError(t, UpsertActionRunJobSummary(ctx, repoID, runID, attemptID, jobB, 0, JobSummaryContentTypeMarkdown, []byte("b summary")))
+	assert.NotEqual(t, v2, version(0))
+	assert.Equal(t, vA, version(jobA))
+
+	// Deleting a step changes the fingerprint.
+	beforeDelete := version(jobA)
+	require.NoError(t, DeleteActionRunJobSummary(ctx, repoID, runID, attemptID, jobA, 1))
+	assert.NotEqual(t, beforeDelete, version(jobA))
+}

--- a/routers/web/repo/actions/view.go
+++ b/routers/web/repo/actions/view.go
@@ -279,6 +279,9 @@ type LogCursor struct {
 
 type ViewRequest struct {
 	LogCursors []LogCursor `json:"logCursors"`
+	// JobSummariesVersion is the summaries fingerprint the client holds; when it matches, the response
+	// omits jobSummaries. Empty on first load.
+	JobSummariesVersion string `json:"jobSummariesVersion"`
 }
 
 type ArtifactsViewItem struct {
@@ -326,6 +329,9 @@ type ViewResponse struct {
 			TriggerEvent string `json:"triggerEvent"` // e.g. pull_request, push, schedule
 
 			JobSummaries []*ViewJobSummary `json:"jobSummaries,omitempty"`
+			// JobSummariesVersion is the current summaries fingerprint; jobSummaries is only sent when it
+			// differs from the client's.
+			JobSummariesVersion string `json:"jobSummariesVersion"`
 		} `json:"run"`
 		CurrentJob struct {
 			Title  string         `json:"title"`
@@ -553,19 +559,20 @@ func ViewPost(ctx *context_module.Context) {
 		return
 	}
 
+	form := web.GetForm(ctx).(*ViewRequest)
 	resp := &ViewResponse{}
-	fillViewRunResponseSummary(ctx, resp, run, attempt, jobs)
+	fillViewRunResponseSummary(ctx, form, resp, run, attempt, jobs)
 	if ctx.Written() {
 		return
 	}
-	fillViewRunResponseCurrentJob(ctx, resp, run, jobs)
+	fillViewRunResponseCurrentJob(ctx, form, resp, run, jobs)
 	if ctx.Written() {
 		return
 	}
 	ctx.JSON(http.StatusOK, resp)
 }
 
-func fillViewRunResponseSummary(ctx *context_module.Context, resp *ViewResponse, run *actions_model.ActionRun, attempt *actions_model.ActionRunAttempt, jobs []*actions_model.ActionRunJob) {
+func fillViewRunResponseSummary(ctx *context_module.Context, form *ViewRequest, resp *ViewResponse, run *actions_model.ActionRun, attempt *actions_model.ActionRunAttempt, jobs []*actions_model.ActionRunJob) {
 	// Latest when the run has no attempts yet (legacy) or the viewed attempt is the run's latest.
 	isLatestAttempt := run.LatestAttemptID == 0 || (attempt != nil && attempt.ID == run.LatestAttemptID)
 
@@ -679,16 +686,26 @@ func fillViewRunResponseSummary(ctx *context_module.Context, resp *ViewResponse,
 		runAttemptID = attempt.ID
 	}
 
-	// Each step's markdown is rendered independently so an unclosed construct
-	// in one step can't bleed into the next.
-	// On a single-job view only that job's summaries are needed; the run view shows all.
-	// Scoping server-side avoids rendering every job's markdown on each 1s poll.
-	summaries, err := actions_model.ListActionRunJobSummaries(ctx, ctx.Repo.Repository.ID, run.ID, runAttemptID, ctx.PathParamInt64("job"))
+	// jobID>0 scopes to a single job (job view); 0 returns all jobs (run view).
+	jobID := ctx.PathParamInt64("job")
+
+	// Send a cheap fingerprint and skip the content load, render and payload when the client already
+	// holds this version — so the ~1s poll only re-renders summaries that actually changed.
+	summariesVersion, err := actions_model.GetActionRunJobSummariesVersion(ctx, ctx.Repo.Repository.ID, run.ID, runAttemptID, jobID)
 	if err != nil {
-		ctx.ServerError("ListActionRunJobSummaries", err)
+		ctx.ServerError("GetActionRunJobSummariesVersion", err)
 		return
 	}
-	if len(summaries) > 0 {
+	resp.State.Run.JobSummariesVersion = summariesVersion
+
+	if form.JobSummariesVersion != summariesVersion {
+		summaries, err := actions_model.ListActionRunJobSummaries(ctx, ctx.Repo.Repository.ID, run.ID, runAttemptID, jobID)
+		if err != nil {
+			ctx.ServerError("ListActionRunJobSummaries", err)
+			return
+		}
+		// Version changed: send the current set (empty clears the client's; jobSummaries is then omitted).
+		resp.State.Run.JobSummaries = make([]*ViewJobSummary, 0, len(summaries))
 		jobNameByID := make(map[int64]string, len(jobs))
 		for _, j := range jobs {
 			jobNameByID[j.ID] = j.Name
@@ -704,6 +721,7 @@ func fillViewRunResponseSummary(ctx *context_module.Context, resp *ViewResponse,
 				current = &ViewJobSummary{JobID: s.JobID, JobName: jobNameByID[s.JobID]}
 				resp.State.Run.JobSummaries = append(resp.State.Run.JobSummaries, current)
 			}
+			// Render each step independently so an unclosed construct can't bleed into the next.
 			current.SummaryHTML += renderUtils.MarkdownToHtml(s.Content)
 		}
 	}
@@ -724,8 +742,7 @@ func fillViewRunResponseSummary(ctx *context_module.Context, resp *ViewResponse,
 	}
 }
 
-func fillViewRunResponseCurrentJob(ctx *context_module.Context, resp *ViewResponse, run *actions_model.ActionRun, jobs []*actions_model.ActionRunJob) {
-	req := web.GetForm(ctx).(*ViewRequest)
+func fillViewRunResponseCurrentJob(ctx *context_module.Context, form *ViewRequest, resp *ViewResponse, run *actions_model.ActionRun, jobs []*actions_model.ActionRunJob) {
 	current, hasPathParam := findCurrentJobByPathParam(ctx, jobs)
 	if current == nil {
 		if hasPathParam {
@@ -759,7 +776,7 @@ func fillViewRunResponseCurrentJob(ctx *context_module.Context, resp *ViewRespon
 	resp.State.CurrentJob.Steps = make([]*ViewJobStep, 0) // marshal to '[]' instead fo 'null' in json
 	resp.Logs.StepsLog = make([]*ViewStepLog, 0)          // marshal to '[]' instead fo 'null' in json
 	if task != nil {
-		steps, logs, err := convertToViewModel(ctx, ctx.Locale, req.LogCursors, task)
+		steps, logs, err := convertToViewModel(ctx, ctx.Locale, form.LogCursors, task)
 		if err != nil {
 			ctx.ServerError("convertToViewModel", err)
 			return

--- a/web_src/js/components/ActionRunView.ts
+++ b/web_src/js/components/ActionRunView.ts
@@ -131,6 +131,7 @@ export function createEmptyActionsRun(): ActionsRun {
     pullRequest: null,
     jobs: [] as Array<ActionsJob>,
     jobSummaries: [],
+    jobSummariesVersion: '',
     commit: {
       localeCommit: '',
       localePushedBy: '',
@@ -162,12 +163,22 @@ export function createActionRunViewStore(viewUrl: string) {
     const abortController = new AbortController();
     loadingAbortController = abortController;
     try {
-      const resp = await POST(viewUrl, {signal: abortController.signal, data: {}});
+      const resp = await POST(viewUrl, {
+        signal: abortController.signal,
+        // Let the server skip re-sending summaries we already hold.
+        data: {jobSummariesVersion: viewData.currentRun.jobSummariesVersion},
+      });
       const runResp = await resp.json();
       if (loadingAbortController !== abortController) return;
 
       viewData.runArtifacts = runResp.artifacts || [];
-      viewData.currentRun = runResp.state.run;
+      const newRun = runResp.state.run;
+      // Unchanged version: keep the summaries we already rendered (server omitted them).
+      // An empty version never matches: it is both "no summaries" and the initial client state.
+      if (newRun.jobSummariesVersion && newRun.jobSummariesVersion === viewData.currentRun.jobSummariesVersion) {
+        newRun.jobSummaries = viewData.currentRun.jobSummaries;
+      }
+      viewData.currentRun = newRun;
       // clear the interval timer if the job is done
       if (viewData.currentRun.done && intervalID) {
         clearInterval(intervalID);

--- a/web_src/js/modules/gitea-actions.ts
+++ b/web_src/js/modules/gitea-actions.ts
@@ -31,6 +31,8 @@ export type ActionsRun = {
   } | null,
   jobs: Array<ActionsJob>,
   jobSummaries?: Array<ActionsJobSummary>,
+  // Fingerprint of jobSummaries; the poll only re-sends them when this changes.
+  jobSummariesVersion: string,
   commit: {
     localeCommit: string,
     localePushedBy: string,


### PR DESCRIPTION
Split out of #38518, where the review asked to keep that branch to the correctness
fixes being backported to 1.27. The change is dropped there and continues here.

The run view polls roughly every second while a run is in progress. Every poll
loaded and re-rendered each job's `GITHUB_STEP_SUMMARY` markdown — up to
`MaxJobNumPerRun` jobs of up to 1 MiB each — even when nothing had changed, so
the cost scaled with both job count and the number of people watching the run.

- **DB-side fingerprint** — `GetActionRunJobSummariesVersion` returns `COUNT(*)`
  plus `MAX(updated)` for the summaries in scope, with the same optional `jobID`
  scoping as `ListActionRunJobSummaries`. `COUNT` is needed alongside
  `MAX(updated)` because `updated` has 1s granularity: `MAX` alone misses a
  deleted row, and a step inserted in the same second as the previous one.
- **Conditional payload** — the fingerprint travels both ways (`jobSummariesVersion`
  on the view request and response). When the client's matches, the response omits
  `jobSummaries` and the content load and markdown render are skipped entirely;
  when it differs, the full set is sent as before.
- **Empty never matches** — an empty fingerprint means both "this run has no
  summaries" and "the client holds none yet", so it is always treated as a miss.

There is no in-process cache: the fingerprint is computed and compared per
request, so no state is shared between requests. The rendered HTML is unchanged —
only how often it is recomputed and re-sent.
