### PR TITLE
ci: match `# renovate:` markers that trail the value

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,7 +3,6 @@
   "extends": [
     "config:recommended",
     "helpers:pinGitHubActionDigests",
-    "customManagers:githubActionsVersions",
     "schedule:weekly", // dependency update PR on monday, vulnerabilityAlerts bypasses this
   ],
   "configMigration": true,
@@ -19,6 +18,13 @@
     "semanticCommitType": "fix", // overrides packageRules
   },
   "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)\\.(gitea|github)/(workflows|actions)/.+\\.ya?ml$/"],
+      "matchStrings": [
+        "[A-Za-z0-9_]+_VERSION[ \\t]*:[ \\t]*[\"']?(?<currentValue>[^\\s\"']+)[\"']?[ \\t]*# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?(?=\\s|$)",
+      ],
+    },
     {
       "customType": "regex",
       "managerFilePatterns": ["/(^|/)Makefile$/"],


### PR DESCRIPTION
The preset we extended only matches a `# renovate:` comment on the line above the `_VERSION` assignment. Ours trails the value, like the ones in the `Makefile`, so it never matched and the pin has sat at `43.141.5` since https://github.com/go-gitea/gitea/pull/37050.