### PR TITLE
fix(repo): allow repository admins to delete repos

### DIFF
--- a/modules/repository/delete.go
+++ b/modules/repository/delete.go
@@ -7,11 +7,15 @@ import (
 	"context"
 
 	"gitea.dev/models/organization"
+	access_model "gitea.dev/models/perm/access"
 	repo_model "gitea.dev/models/repo"
 	user_model "gitea.dev/models/user"
 )
 
-// CanUserDelete returns true if user could delete the repository
+// CanUserDelete returns true if user could delete the repository.
+// Allowed: site admins, personal-repo owners, org admins (owner/admin teams),
+// and users with repository admin access (including creators of org repos who
+// receive AccessModeAdmin when the org grants creator admin rights).
 func CanUserDelete(ctx context.Context, repo *repo_model.Repository, user *user_model.User) (bool, error) {
 	if user.IsAdmin || user.ID == repo.OwnerID {
 		return true, nil
@@ -26,8 +30,10 @@ func CanUserDelete(ctx context.Context, repo *repo_model.Repository, user *user_
 		if err != nil {
 			return false, err
 		}
-		return isAdmin, nil
+		if isAdmin {
+			return true, nil
+		}
 	}
 
-	return false, nil
+	return access_model.IsUserRepoAdmin(ctx, repo, user)
 }

--- a/modules/repository/delete.go
+++ b/modules/repository/delete.go
@@ -6,34 +6,13 @@ package repository
 import (
 	"context"
 
-	"gitea.dev/models/organization"
 	access_model "gitea.dev/models/perm/access"
 	repo_model "gitea.dev/models/repo"
 	user_model "gitea.dev/models/user"
 )
 
 // CanUserDelete returns true if user could delete the repository.
-// Allowed: site admins, personal-repo owners, org admins (owner/admin teams),
-// and users with repository admin access (including creators of org repos who
-// receive AccessModeAdmin when the org grants creator admin rights).
+// Same criteria as IsUserRepoAdmin (site admin, owner, repo admin access).
 func CanUserDelete(ctx context.Context, repo *repo_model.Repository, user *user_model.User) (bool, error) {
-	if user.IsAdmin || user.ID == repo.OwnerID {
-		return true, nil
-	}
-
-	if err := repo.LoadOwner(ctx); err != nil {
-		return false, err
-	}
-
-	if repo.Owner.IsOrganization() {
-		isAdmin, err := organization.OrgFromUser(repo.Owner).IsOrgAdmin(ctx, user.ID)
-		if err != nil {
-			return false, err
-		}
-		if isAdmin {
-			return true, nil
-		}
-	}
-
 	return access_model.IsUserRepoAdmin(ctx, repo, user)
 }

--- a/modules/repository/delete_test.go
+++ b/modules/repository/delete_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package repository
+
+import (
+	"testing"
+
+	"gitea.dev/models/db"
+	"gitea.dev/models/perm"
+	access_model "gitea.dev/models/perm/access"
+	repo_model "gitea.dev/models/repo"
+	"gitea.dev/models/unittest"
+	user_model "gitea.dev/models/user"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanUserDelete(t *testing.T) {
+	require.NoError(t, unittest.PrepareTestDatabase())
+
+	// Personal repo: owner can delete, unrelated user cannot
+	personalRepo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+	owner := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: personalRepo.OwnerID})
+	stranger := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 4})
+
+	can, err := CanUserDelete(t.Context(), personalRepo, owner)
+	require.NoError(t, err)
+	assert.True(t, can, "personal repo owner should be able to delete")
+
+	can, err = CanUserDelete(t.Context(), personalRepo, stranger)
+	require.NoError(t, err)
+	assert.False(t, can, "unrelated user should not delete personal repo")
+
+	// Site admin can always delete
+	siteAdmin := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 1})
+	can, err = CanUserDelete(t.Context(), personalRepo, siteAdmin)
+	require.NoError(t, err)
+	assert.True(t, can, "site admin should be able to delete")
+
+	// Org repo: write collaborator cannot delete; admin collaborator can
+	// (admin access is what org-repo creators receive — see create.go)
+	orgRepo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 3}) // org3/repo3
+	// user5 is not an org3 owner/admin; use a clean collaborator on repo3
+	collab := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 5})
+
+	can, err = CanUserDelete(t.Context(), orgRepo, collab)
+	require.NoError(t, err)
+	assert.False(t, can, "non-admin user should not delete org repo")
+
+	// Grant write only — still cannot delete
+	require.NoError(t, db.Insert(t.Context(), &repo_model.Collaboration{
+		RepoID: orgRepo.ID,
+		UserID: collab.ID,
+		Mode:   perm.AccessModeWrite,
+	}))
+	require.NoError(t, access_model.RecalculateUserAccess(t.Context(), orgRepo, collab.ID))
+
+	can, err = CanUserDelete(t.Context(), orgRepo, collab)
+	require.NoError(t, err)
+	assert.False(t, can, "write-only collaborator should not delete org repo")
+
+	// Promote to repo admin — can delete (matches creator-gets-admin behavior)
+	_, err = db.GetEngine(t.Context()).
+		Where("repo_id=? AND user_id=?", orgRepo.ID, collab.ID).
+		Cols("mode").
+		Update(&repo_model.Collaboration{Mode: perm.AccessModeAdmin})
+	require.NoError(t, err)
+	require.NoError(t, access_model.RecalculateUserAccess(t.Context(), orgRepo, collab.ID))
+
+	can, err = CanUserDelete(t.Context(), orgRepo, collab)
+	require.NoError(t, err)
+	assert.True(t, can, "repo admin (org-repo creator style) should be able to delete")
+}

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -1159,7 +1159,7 @@ func Delete(ctx *context.APIContext) {
 		ctx.APIErrorInternal(err)
 		return
 	} else if !canDelete {
-		ctx.APIError(http.StatusForbidden, "Given user is not owner of organization.")
+		ctx.APIError(http.StatusForbidden, "User does not have permission to delete this repository.")
 		return
 	}
 

--- a/routers/web/repo/setting/setting.go
+++ b/routers/web/repo/setting/setting.go
@@ -22,6 +22,7 @@ import (
 	"gitea.dev/modules/indexer/stats"
 	"gitea.dev/modules/lfs"
 	"gitea.dev/modules/log"
+	repo_module "gitea.dev/modules/repository"
 	"gitea.dev/modules/setting"
 	"gitea.dev/modules/structs"
 	"gitea.dev/modules/templates"
@@ -67,6 +68,14 @@ func SettingsCtxData(ctx *context.Context) {
 	ctx.Data["DefaultMirrorInterval"] = setting.Mirror.DefaultInterval
 	ctx.Data["MinimumMirrorInterval"] = setting.Mirror.MinInterval
 	ctx.Data["CanConvertFork"] = ctx.Repo.Repository.IsFork && ctx.Doer.CanCreateRepoIn(ctx.Repo.Repository.Owner)
+
+	// Repo admins (including org-repo creators) may delete even without AccessModeOwner.
+	canDeleteRepo, err := repo_module.CanUserDelete(ctx, ctx.Repo.Repository, ctx.Doer)
+	if err != nil {
+		ctx.ServerError("CanUserDelete", err)
+		return
+	}
+	ctx.Data["CanDeleteRepo"] = canDeleteRepo
 
 	signing, _ := git.GetSigningKey(ctx)
 	ctx.Data["SigningKeyAvailable"] = signing != nil
@@ -936,7 +945,12 @@ func handleSettingsPostCancelTransfer(ctx *context.Context) {
 func handleSettingsPostDelete(ctx *context.Context) {
 	form := web.GetForm(ctx).(*forms.RepoSettingForm)
 	repo := ctx.Repo.Repository
-	if !ctx.Repo.Permission.IsOwner() {
+	canDelete, err := repo_module.CanUserDelete(ctx, repo, ctx.Doer)
+	if err != nil {
+		ctx.ServerError("CanUserDelete", err)
+		return
+	}
+	if !canDelete {
 		ctx.JSONErrorNotFound()
 		return
 	}

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -780,12 +780,13 @@
 		</div>
 		{{end}}
 
-		{{if .Permission.IsOwner}}
+		{{if or .Permission.IsOwner .CanDeleteRepo}}
 		<h4 class="ui top attached error header">
 			{{ctx.Locale.Tr "repo.settings.danger_zone"}}
 		</h4>
 		<div class="ui attached error danger segment">
 			<div class="flex-divided-list items-with-main">
+				{{if .Permission.IsOwner}}
 				{{if not .Repository.IsFork}}
 					<div class="item tw-items-center">
 						<div class="item-main">
@@ -862,6 +863,8 @@
 						</div>
 					</div>
 				{{end}}
+				{{end}}{{/* end Permission.IsOwner-only danger items */}}
+				{{if .CanDeleteRepo}}
 				<div class="item">
 					<div class="item-main">
 						<div class="item-title">{{ctx.Locale.Tr "repo.settings.delete"}}</div>
@@ -871,7 +874,8 @@
 						<button class="ui basic red show-modal button" data-modal="#delete-repo-modal">{{ctx.Locale.Tr "repo.settings.delete"}}</button>
 					</div>
 				</div>
-				{{if not .Repository.IsMirror}}
+				{{end}}
+				{{if and .Permission.IsOwner (not .Repository.IsMirror)}}
 					<div class="item tw-items-center">
 						<div class="item-main">
 							{{if .Repository.IsArchived}}
@@ -899,7 +903,8 @@
 	</div>
 {{template "repo/settings/layout_footer" .}}
 
-{{if .Permission.IsOwner}}
+{{if or .Permission.IsOwner .CanDeleteRepo}}
+	{{if .Permission.IsOwner}}
 	{{if .Repository.IsMirror}}
 		<div class="ui small modal" id="convert-mirror-repo-modal">
 			<div class="header">
@@ -954,26 +959,6 @@
 				</div>
 
 				{{template "base/modal_actions_confirm" (dict "ModalButtonDangerText" (ctx.Locale.Tr "repo.settings.transfer_perform"))}}
-			</form>
-		</div>
-	</div>
-
-	<div class="ui small modal" id="delete-repo-modal">
-		<div class="header">
-			{{ctx.Locale.Tr "repo.settings.delete"}}
-		</div>
-		<div class="content">
-			<div class="ui warning message">
-				{{ctx.Locale.Tr "repo.settings.delete_notices_1"}}<br>
-				{{ctx.Locale.Tr "repo.settings.delete_notices_2" .Repository.FullName}}
-				{{if .Repository.NumForks}}<br>
-				{{ctx.Locale.Tr "repo.settings.delete_notices_fork_1"}}
-				{{end}}
-			</div>
-			<form class="ui form form-fetch-action" action="{{.Link}}" method="post">
-				<input type="hidden" name="action" value="delete">
-				{{template "repo/settings/repo_name_confirm_fields" (dict "RepoName" .Repository.Name)}}
-				{{template "base/modal_actions_confirm" (dict "ModalButtonDangerText" (ctx.Locale.Tr "repo.settings.confirm_delete"))}}
 			</form>
 		</div>
 	</div>
@@ -1069,6 +1054,29 @@
 				{{template "base/modal_actions_confirm" .}}
 			</form>
 		</div>
+	{{end}}
+	{{end}}{{/* end Permission.IsOwner modals */}}
+
+	{{if .CanDeleteRepo}}
+	<div class="ui small modal" id="delete-repo-modal">
+		<div class="header">
+			{{ctx.Locale.Tr "repo.settings.delete"}}
+		</div>
+		<div class="content">
+			<div class="ui warning message">
+				{{ctx.Locale.Tr "repo.settings.delete_notices_1"}}<br>
+				{{ctx.Locale.Tr "repo.settings.delete_notices_2" .Repository.FullName}}
+				{{if .Repository.NumForks}}<br>
+				{{ctx.Locale.Tr "repo.settings.delete_notices_fork_1"}}
+				{{end}}
+			</div>
+			<form class="ui form form-fetch-action" action="{{.Link}}" method="post">
+				<input type="hidden" name="action" value="delete">
+				{{template "repo/settings/repo_name_confirm_fields" (dict "RepoName" .Repository.Name)}}
+				{{template "base/modal_actions_confirm" (dict "ModalButtonDangerText" (ctx.Locale.Tr "repo.settings.confirm_delete"))}}
+			</form>
+		</div>
+	</div>
 	{{end}}
 {{end}}
 


### PR DESCRIPTION
## Summary

When organization members create a repository, Gitea grants them repository **admin** access and the settings UI states that the creator will get administrator access. Deleting the repository, however, required `AccessModeOwner` on the web settings danger zone / POST handler, and `CanUserDelete` only allowed site admins, personal-repo owners, and org-level admins—not repository admins.

This left creators unable to delete repositories they just created unless an org owner did it for them.

### Changes
- `CanUserDelete` delegates to `access_model.IsUserRepoAdmin` (covers site admin, owner, repo admin / org-repo creator admin access).
- Web settings delete action uses `CanUserDelete` instead of `Permission.IsOwner`.
- Settings UI shows the delete control and modal when `CanDeleteRepo` is true; other danger-zone actions (transfer, visibility, archive, etc.) remain owner-only.
- Clarify the API delete 403 message.

Fixes #38058

## Test plan
- [x] `go test ./modules/repository/ -run '^TestCanUserDelete$' -count=1` (PASS)
- [x] `go test ./modules/repository/ ./routers/web/repo/setting/ -count=0` (compile)
- [x] `gofmt` / `make fmt` on touched Go files
- [x] `go vet` on touched packages

## AI disclosure
AI assistance (Hermes / grok-4.5) was used to locate the permission gap, implement the fix, write unit tests, and draft this PR. Changes were reviewed for correctness against the existing owner vs admin access model.