### PR TITLE
fix(api): round-trip webhook issue/PR event names on GET

### DIFF
--- a/models/webhook/webhook.go
+++ b/models/webhook/webhook.go
@@ -183,7 +183,33 @@ func (w *Webhook) HasEvent(evt webhook_module.HookEventType) bool {
 	return w.HookEvents[checkEvt]
 }
 
-// EventsArray returns an array of hook events
+// issueHookEventTypes are issue-related events stored in HookEvents.
+// Used for API create/edit: "issues" enables all; "issues_only" enables only HookEventIssues.
+var issueHookEventTypes = []webhook_module.HookEventType{
+	webhook_module.HookEventIssues,
+	webhook_module.HookEventIssueAssign,
+	webhook_module.HookEventIssueLabel,
+	webhook_module.HookEventIssueMilestone,
+	webhook_module.HookEventIssueComment,
+}
+
+// pullRequestHookEventTypes are pull-request-related events stored in HookEvents.
+// Used for API create/edit: "pull_request" enables all; "pull_request_only" enables only HookEventPullRequest.
+var pullRequestHookEventTypes = []webhook_module.HookEventType{
+	webhook_module.HookEventPullRequest,
+	webhook_module.HookEventPullRequestAssign,
+	webhook_module.HookEventPullRequestLabel,
+	webhook_module.HookEventPullRequestMilestone,
+	webhook_module.HookEventPullRequestComment,
+	webhook_module.HookEventPullRequestReview,
+	webhook_module.HookEventPullRequestReviewRequest,
+	webhook_module.HookEventPullRequestSync,
+}
+
+// EventsArray returns an array of hook events suitable for the API.
+// Issue and pull-request related events are collapsed so the list round-trips
+// through create/edit: "issues" / "pull_request" mean all related events, while
+// "issues_only" / "pull_request_only" mean only the main event (see updateHookEvents).
 func (w *Webhook) EventsArray() []string {
 	if w.SendEverything {
 		events := make([]string, 0, len(webhook_module.AllEvents()))
@@ -198,12 +224,65 @@ func (w *Webhook) EventsArray() []string {
 	}
 
 	events := make([]string, 0, len(w.HookEvents))
+	issueHandled := appendGroupedHookEvents(&events, w.HookEvents, issueHookEventTypes,
+		string(webhook_module.HookEventIssues), "issues_only", webhook_module.HookEventIssues)
+	prHandled := appendGroupedHookEvents(&events, w.HookEvents, pullRequestHookEventTypes,
+		string(webhook_module.HookEventPullRequest), "pull_request_only", webhook_module.HookEventPullRequest)
+
 	for event, enabled := range w.HookEvents {
-		if enabled {
-			events = append(events, string(event))
+		if !enabled {
+			continue
 		}
+		if issueHandled[event] || prHandled[event] {
+			continue
+		}
+		events = append(events, string(event))
 	}
 	return events
+}
+
+// appendGroupedHookEvents collapses a family of related hook events into API names
+// that round-trip with updateHookEvents. Returns the set of event keys already handled.
+func appendGroupedHookEvents(events *[]string, enabled webhook_module.HookEvents, group []webhook_module.HookEventType, allName, onlyName string, mainEvt webhook_module.HookEventType) map[webhook_module.HookEventType]bool {
+	handled := make(map[webhook_module.HookEventType]bool, len(group))
+	enabledCount := 0
+	for _, evt := range group {
+		if enabled[evt] {
+			enabledCount++
+		}
+	}
+	if enabledCount == 0 {
+		return handled
+	}
+
+	for _, evt := range group {
+		handled[evt] = true
+	}
+
+	// All related events on → single group name ("issues" / "pull_request")
+	if enabledCount == len(group) {
+		*events = append(*events, allName)
+		return handled
+	}
+
+	// Only the main event → "issues_only" / "pull_request_only" so create/edit does not expand to all
+	if enabledCount == 1 && enabled[mainEvt] {
+		*events = append(*events, onlyName)
+		return handled
+	}
+
+	// Partial selection → list each enabled event; use onlyName for the main event
+	for _, evt := range group {
+		if !enabled[evt] {
+			continue
+		}
+		if evt == mainEvt {
+			*events = append(*events, onlyName)
+		} else {
+			*events = append(*events, string(evt))
+		}
+	}
+	return handled
 }
 
 // HeaderAuthorization returns the decrypted Authorization header.

--- a/models/webhook/webhook_test.go
+++ b/models/webhook/webhook_test.go
@@ -151,6 +151,71 @@ func TestWebhook_EventsArray(t *testing.T) {
 			HookEvent: &webhook_module.HookEvent{PushOnly: true},
 		}).EventsArray(),
 	)
+
+	// Only main pull_request event → pull_request_only (round-trips with API create/edit)
+	assert.Equal(t, []string{"pull_request_only"},
+		(&Webhook{
+			HookEvent: &webhook_module.HookEvent{
+				ChooseEvents: true,
+				HookEvents: webhook_module.HookEvents{
+					webhook_module.HookEventPullRequest: true,
+				},
+			},
+		}).EventsArray(),
+	)
+
+	// Only main issues event → issues_only
+	assert.Equal(t, []string{"issues_only"},
+		(&Webhook{
+			HookEvent: &webhook_module.HookEvent{
+				ChooseEvents: true,
+				HookEvents: webhook_module.HookEvents{
+					webhook_module.HookEventIssues: true,
+				},
+			},
+		}).EventsArray(),
+	)
+
+	// All PR-related events → collapsed to pull_request
+	allPR := webhook_module.HookEvents{}
+	for _, evt := range pullRequestHookEventTypes {
+		allPR[evt] = true
+	}
+	assert.Equal(t, []string{"pull_request"},
+		(&Webhook{
+			HookEvent: &webhook_module.HookEvent{
+				ChooseEvents: true,
+				HookEvents:   allPR,
+			},
+		}).EventsArray(),
+	)
+
+	// All issue-related events → collapsed to issues
+	allIssues := webhook_module.HookEvents{}
+	for _, evt := range issueHookEventTypes {
+		allIssues[evt] = true
+	}
+	assert.Equal(t, []string{"issues"},
+		(&Webhook{
+			HookEvent: &webhook_module.HookEvent{
+				ChooseEvents: true,
+				HookEvents:   allIssues,
+			},
+		}).EventsArray(),
+	)
+
+	// Partial PR selection uses pull_request_only for the main event
+	partial := (&Webhook{
+		HookEvent: &webhook_module.HookEvent{
+			ChooseEvents: true,
+			HookEvents: webhook_module.HookEvents{
+				webhook_module.HookEventPullRequest:       true,
+				webhook_module.HookEventPullRequestAssign: true,
+				webhook_module.HookEventPush:              true,
+			},
+		},
+	}).EventsArray()
+	assert.ElementsMatch(t, []string{"pull_request_only", "pull_request_assign", "push"}, partial)
 }
 
 func TestCreateWebhook(t *testing.T) {

--- a/modules/structs/hook.go
+++ b/modules/structs/hook.go
@@ -59,7 +59,10 @@ type CreateHookOption struct {
 	// required: true
 	// Configuration settings for the webhook
 	Config CreateHookOptionConfig `json:"config" binding:"Required"`
-	// List of events that will trigger this webhook
+	// List of events that will trigger this webhook.
+	// Special values: "issues" / "pull_request" enable all related issue or PR events;
+	// "issues_only" / "pull_request_only" enable only the main issues or pull_request event.
+	// GET responses use the same names so create/edit round-trips cleanly.
 	Events []string `json:"events"`
 	// Branch filter pattern to determine which branches trigger the webhook
 	BranchFilter string `json:"branch_filter" binding:"GlobPattern"`
@@ -76,7 +79,9 @@ type CreateHookOption struct {
 type EditHookOption struct {
 	// Configuration settings for the webhook
 	Config map[string]string `json:"config"`
-	// List of events that trigger this webhook
+	// List of events that trigger this webhook.
+	// Special values: "issues" / "pull_request" enable all related issue or PR events;
+	// "issues_only" / "pull_request_only" enable only the main issues or pull_request event.
 	Events []string `json:"events"`
 	// Branch filter pattern to determine which branches trigger the webhook
 	BranchFilter string `json:"branch_filter" binding:"GlobPattern"`

--- a/routers/api/v1/utils/hook_test.go
+++ b/routers/api/v1/utils/hook_test.go
@@ -5,10 +5,13 @@ package utils
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"gitea.dev/models/unittest"
+	"gitea.dev/models/webhook"
 	"gitea.dev/modules/structs"
+	webhook_module "gitea.dev/modules/webhook"
 	"gitea.dev/services/contexttest"
 
 	"github.com/stretchr/testify/assert"
@@ -79,4 +82,79 @@ func TestTestHookValidation(t *testing.T) {
 		})
 		assert.Equal(t, http.StatusUnprocessableEntity, ctx.Resp.WrittenStatus())
 	})
+}
+
+func TestUpdateHookEvents(t *testing.T) {
+	t.Run("pull_request enables all PR-related events", func(t *testing.T) {
+		events := updateHookEvents([]string{"pull_request"})
+		assert.True(t, events[webhook_module.HookEventPullRequest])
+		assert.True(t, events[webhook_module.HookEventPullRequestAssign])
+		assert.True(t, events[webhook_module.HookEventPullRequestLabel])
+		assert.True(t, events[webhook_module.HookEventPullRequestMilestone])
+		assert.True(t, events[webhook_module.HookEventPullRequestComment])
+		assert.True(t, events[webhook_module.HookEventPullRequestReview])
+		assert.True(t, events[webhook_module.HookEventPullRequestReviewRequest])
+		assert.True(t, events[webhook_module.HookEventPullRequestSync])
+		assert.False(t, events[webhook_module.HookEventPush])
+		assert.False(t, events[webhook_module.HookEventIssues])
+	})
+
+	t.Run("pull_request_only enables only main pull_request event", func(t *testing.T) {
+		events := updateHookEvents([]string{"pull_request_only"})
+		assert.True(t, events[webhook_module.HookEventPullRequest])
+		assert.False(t, events[webhook_module.HookEventPullRequestAssign])
+		assert.False(t, events[webhook_module.HookEventPullRequestLabel])
+		assert.False(t, events[webhook_module.HookEventPullRequestReview])
+		assert.False(t, events[webhook_module.HookEventPullRequestSync])
+	})
+
+	t.Run("issues enables all issue-related events", func(t *testing.T) {
+		events := updateHookEvents([]string{"issues"})
+		assert.True(t, events[webhook_module.HookEventIssues])
+		assert.True(t, events[webhook_module.HookEventIssueAssign])
+		assert.True(t, events[webhook_module.HookEventIssueLabel])
+		assert.True(t, events[webhook_module.HookEventIssueMilestone])
+		assert.True(t, events[webhook_module.HookEventIssueComment])
+		assert.False(t, events[webhook_module.HookEventPullRequest])
+	})
+
+	t.Run("issues_only enables only main issues event", func(t *testing.T) {
+		events := updateHookEvents([]string{"issues_only"})
+		assert.True(t, events[webhook_module.HookEventIssues])
+		assert.False(t, events[webhook_module.HookEventIssueAssign])
+		assert.False(t, events[webhook_module.HookEventIssueComment])
+	})
+
+	t.Run("empty defaults to push", func(t *testing.T) {
+		events := updateHookEvents(nil)
+		assert.True(t, events[webhook_module.HookEventPush])
+		assert.False(t, events[webhook_module.HookEventPullRequest])
+	})
+}
+
+func TestHookEventsRoundTrip(t *testing.T) {
+	// EventsArray output must be accepted by updateHookEvents and restore the same flags.
+	cases := [][]string{
+		{"pull_request"},
+		{"pull_request_only"},
+		{"issues"},
+		{"issues_only"},
+		{"pull_request_only", "pull_request_assign", "push"},
+		{"issues_only", "issue_comment"},
+		{"push", "create", "release"},
+	}
+	for _, input := range cases {
+		t.Run(strings.Join(input, "+"), func(t *testing.T) {
+			stored := updateHookEvents(input)
+			w := &webhook.Webhook{
+				HookEvent: &webhook_module.HookEvent{
+					ChooseEvents: true,
+					HookEvents:   stored,
+				},
+			}
+			// Only compare events that updateHookEvents can express
+			got := updateHookEvents(w.EventsArray())
+			assert.Equal(t, stored, got, "EventsArray %v did not round-trip", w.EventsArray())
+		})
+	}
 }

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -24248,7 +24248,7 @@
           "$ref": "#/definitions/CreateHookOptionConfig"
         },
         "events": {
-          "description": "List of events that will trigger this webhook",
+          "description": "List of events that will trigger this webhook.\nSpecial values: \"issues\" / \"pull_request\" enable all related issue or PR events;\n\"issues_only\" / \"pull_request_only\" enable only the main issues or pull_request event.\nGET responses use the same names so create/edit round-trips cleanly.",
           "type": "array",
           "items": {
             "type": "string"
@@ -25638,7 +25638,7 @@
           "x-go-name": "Config"
         },
         "events": {
-          "description": "List of events that trigger this webhook",
+          "description": "List of events that trigger this webhook.\nSpecial values: \"issues\" / \"pull_request\" enable all related issue or PR events;\n\"issues_only\" / \"pull_request_only\" enable only the main issues or pull_request event.",
           "type": "array",
           "items": {
             "type": "string"

--- a/templates/swagger/v1_openapi3_json.tmpl
+++ b/templates/swagger/v1_openapi3_json.tmpl
@@ -3989,7 +3989,7 @@
             "$ref": "#/components/schemas/CreateHookOptionConfig"
           },
           "events": {
-            "description": "List of events that will trigger this webhook",
+            "description": "List of events that will trigger this webhook.\nSpecial values: \"issues\" / \"pull_request\" enable all related issue or PR events;\n\"issues_only\" / \"pull_request_only\" enable only the main issues or pull_request event.\nGET responses use the same names so create/edit round-trips cleanly.",
             "items": {
               "type": "string"
             },
@@ -5353,7 +5353,7 @@
             "x-go-name": "Config"
           },
           "events": {
-            "description": "List of events that trigger this webhook",
+            "description": "List of events that trigger this webhook.\nSpecial values: \"issues\" / \"pull_request\" enable all related issue or PR events;\n\"issues_only\" / \"pull_request_only\" enable only the main issues or pull_request event.",
             "items": {
               "type": "string"
             },


### PR DESCRIPTION
## Summary

Fixes a webhook API round-trip bug for issue/PR event lists (#35462).

Creating a hook with `"events": ["pull_request"]` intentionally enables **all** PR-related events (use `pull_request_only` for the main event only; same pattern for `issues` / `issues_only`). That behavior is unchanged.

The bug was on **GET**: `EventsArray()` returned storage key names literally. A hook created with `pull_request_only` was returned as `["pull_request"]`. Feeding that list back into create/edit expanded the hook to every PR-related event.

`EventsArray()` now emits the same names `updateHookEvents` already accepts:

| Stored selection | API `events` |
| --- | --- |
| All issue-related events | `issues` |
| Only main `issues` | `issues_only` |
| All PR-related events | `pull_request` |
| Only main `pull_request` | `pull_request_only` |
| Partial families | individual names, with `*_only` for the main event |

Swagger comments on `CreateHookOption` / `EditHookOption` document the special values.

Fixes #35462

## Test plan

- [x] `gofmt` on touched files
- [x] `go vet gitea.dev/models/webhook gitea.dev/routers/api/v1/utils gitea.dev/modules/structs`
- [x] `go test gitea.dev/models/webhook -count=1`
- [x] `go test gitea.dev/routers/api/v1/utils -count=1`
- [x] New/extended unit coverage: `TestWebhook_EventsArray`, `TestUpdateHookEvents`, `TestHookEventsRoundTrip`

## AI assistance

Implemented with assistance from Hermes (grok-4.5). I reviewed the create/edit event mapping (`updateHookEvents` / `pullHook` / `issuesHook`), matched GET output to those names, and added round-trip tests.