### PR TITLE
enhance(ui): color-code and shrink the activity feed action icons

### DIFF
--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -48,11 +48,12 @@ func newFuncMapWebPage() template.FuncMap {
 
 		// -----------------------------------------------------------------
 		// svg / avatar / icon / color
-		"svg":           svg.RenderHTML,
-		"MigrationIcon": migrationIcon,
-		"ActionIcon":    actionIcon,
-		"SortArrow":     sortArrow,
-		"ContrastColor": util.ContrastColor,
+		"svg":             svg.RenderHTML,
+		"MigrationIcon":   migrationIcon,
+		"ActionIcon":      actionIcon,
+		"ActionIconColor": actionIconColor,
+		"SortArrow":       sortArrow,
+		"ContrastColor":   util.ContrastColor,
 
 		// -----------------------------------------------------------------
 		// time / number / format

--- a/modules/templates/util_misc.go
+++ b/modules/templates/util_misc.go
@@ -104,6 +104,31 @@ func actionIcon(opType activities_model.ActionType) string {
 	}
 }
 
+// actionIconColor accepts an action operation type and returns a text color class
+// for its icon. It follows the same color conventions as the issue and pull
+// request icons, see templates/shared/issueicon.tmpl.
+func actionIconColor(opType activities_model.ActionType) string {
+	switch opType {
+	case activities_model.ActionCreateRepo, activities_model.ActionTransferRepo, activities_model.ActionRenameRepo, activities_model.ActionCommitRepo:
+		return "tw-text-blue"
+	case activities_model.ActionDeleteBranch:
+		return "tw-text-orange"
+	case activities_model.ActionMergePullRequest, activities_model.ActionAutoMergePullRequest:
+		return "tw-text-purple"
+	case activities_model.ActionCreatePullRequest, activities_model.ActionCreateIssue,
+		activities_model.ActionReopenIssue, activities_model.ActionReopenPullRequest,
+		activities_model.ActionApprovePullRequest:
+		return "tw-text-green"
+	case activities_model.ActionClosePullRequest, activities_model.ActionCloseIssue,
+		activities_model.ActionRejectPullRequest, activities_model.ActionPullReviewDismissed:
+		return "tw-text-red"
+	case activities_model.ActionPublishRelease, activities_model.ActionPushTag, activities_model.ActionDeleteTag:
+		return "tw-text-yellow"
+	default:
+		return "tw-text-text-light"
+	}
+}
+
 // ActionContent2Commits converts action content to push commits
 func ActionContent2Commits(act Actioner) *repository.PushCommits {
 	push := repository.NewPushCommits()

--- a/templates/user/dashboard/feeds.tmpl
+++ b/templates/user/dashboard/feeds.tmpl
@@ -122,7 +122,7 @@
 				{{end}}
 			</div>
 			<div class="item-trailing">
-				{{svg (printf "octicon-%s" (ActionIcon .GetOpType)) 32 "tw-text-text-light tw-mr-1"}}
+				{{svg (printf "octicon-%s" (ActionIcon .GetOpType)) 16 (printf "%s tw-mr-1" (ActionIconColor .GetOpType))}}
 			</div>
 		</div>
 	{{end}}


### PR DESCRIPTION
The dashboard activity feed renders every action icon at 32px in a single
muted color. The icon carries no information and visually dominates the row.

This renders it at 16px and colors it by action type, reusing the conventions
already used for issue and pull request icons in `templates/shared/issueicon.tmpl`:

| Color | Actions |
| --- | --- |
| green | opened, reopened, approved |
| red | closed, rejected, review dismissed |
| purple | merged, auto-merged |
| blue | repository and commit activity |
| yellow | tags and releases |
| orange | branch deletion |
| muted | everything else (unchanged) |

The colors come from the existing `tw-text-*` utilities, so they follow the
active theme rather than being hardcoded.

`star_repo`, `watch_repo` and `pull_request_ready_for_review` have no text
branch in `feeds.tmpl` and already fall back to `octicon-question`; they keep
the current muted color, so this changes nothing for them.

### Testing

Seeded a local instance with one action of every `ActionType` (all 27) and
checked the feed renders each one with the intended icon and color.

### AI assistance

The implementation was drafted with AI assistance. I reviewed and tested the
change myself and can explain and defend it.

**Before:**

<img width="2560" height="3000" alt="before" src="https://github.com/user-attachments/assets/9f90a928-4bd9-4f28-8558-188a71fa1d59" />

**After:**

<img width="2560" height="3000" alt="after" src="https://github.com/user-attachments/assets/350d8e0f-f533-42fa-9bc0-057d3a0681e7" />


