### PR TITLE
enhance(ui): hide the dashboard context switcher when there is nothing to switch to

### DIFF
--- a/templates/user/dashboard/navbar.tmpl
+++ b/templates/user/dashboard/navbar.tmpl
@@ -1,3 +1,4 @@
+{{if or .Orgs .ContextUser.IsOrganization}}
 <div class="secondary-nav tw-border-b tw-border-b-secondary">
 	<div class="ui secondary stackable menu">
 		<div class="item">
@@ -105,3 +106,4 @@
 	{{end}}
 	</div>
 </div>
+{{end}}


### PR DESCRIPTION
For a user who belongs to no organization, the secondary navigation bar on the dashboard, issues, pulls and milestones pages holds a single dropdown whose only entry is the user themselves - a full-width strip of chrome that cannot change anything.

It is now rendered only when the user belongs to at least one organization, or when the dashboard is viewed in an organization context, where the bar also carries the team filter and the organization navigation.

"New Organization" stays reachable: the navbar create menu already links to `/org/create` behind the same `CanCreateOrganization` check. No CSS change is needed, `base.css` already gives the page its top spacing when the bar is absent.

## Screenshots

Dashboard of a user who belongs to no organization.

Before:

<img width="1440" height="520" alt="dashboard-before" src="https://github.com/user-attachments/assets/cbbfdf3c-5a97-41eb-9eee-e416411012cb" />

After:

<img width="1440" height="520" alt="dashboard-after" src="https://github.com/user-attachments/assets/91689a3f-011b-4eda-88ab-fda2fa1e2320" />

Unchanged for users who belong to an organization, and on organization dashboards.

## AI disclosure

Made with AI assistance (Claude Opus 5 via Claude Code), which drafted the change and this summary; the commit carries a matching `Co-authored-by` trailer. I reviewed the diff, verified it against a local build, and can explain and revise it during review.