### PR TITLE
docs: Clean up build section in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,10 +59,6 @@ been added to each release, please refer to the [blog](https://blog.gitea.com).
   * fix(org): align follow button and wrap description (#38448) (#38454)
   * fix(actions): populate `github.event` for scheduled runs (#38446) (#38452)
 
-* BUILD
-  * ci: set AWS_REGION for Cloudflare R2 upload steps (#38658) (#38665)
-  * chore(build): upload release to Cloudflare R2 (#38635) (#38651)
-
 * MISC
   * refactor: git patch apply (#38637) (#38638)
 


### PR DESCRIPTION
Removed build-related entries from CHANGELOG.

<!--
Before submitting:
- Target the `main` branch; release branches are for backports only.
- Use a Conventional Commits title, e.g. `fix(repo): handle empty branch names`.
- Read the contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
- Documentation changes go to https://gitea.com/gitea/docs

Describe your change below and link any issue it fixes.
-->
