### PR TITLE
fix(pull): allow head repo collaborators to edit PR title/body

### DIFF
--- a/routers/api/v1/repo/issue.go
+++ b/routers/api/v1/repo/issue.go
@@ -778,7 +778,12 @@ func EditIssue(ctx *context.APIContext) {
 		return
 	}
 
-	if !issue.IsPoster(ctx.Doer.ID) && !canWrite {
+	canEditMeta, err := issue_service.CanEditIssueOrPullMeta(ctx, ctx.Doer, issue, ctx.Repo.Permission)
+	if err != nil {
+		ctx.APIErrorInternal(err)
+		return
+	}
+	if !canEditMeta {
 		ctx.Status(http.StatusForbidden)
 		return
 	}

--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -652,7 +652,13 @@ func EditPullRequest(ctx *context.APIContext) {
 		return
 	}
 
-	if !issue.IsPoster(ctx.Doer.ID) && !ctx.Repo.Permission.CanWrite(unit.TypePullRequests) {
+	canWrite := ctx.Repo.Permission.CanWrite(unit.TypePullRequests)
+	canEditMeta, err := issue_service.CanEditIssueOrPullMeta(ctx, ctx.Doer, issue, ctx.Repo.Permission)
+	if err != nil {
+		ctx.APIErrorInternal(err)
+		return
+	}
+	if !canEditMeta {
 		ctx.Status(http.StatusForbidden)
 		return
 	}
@@ -691,7 +697,7 @@ func EditPullRequest(ctx *context.APIContext) {
 	}
 
 	// Update or remove deadline if set
-	if form.Deadline != nil || form.RemoveDeadline != nil {
+	if canWrite && (form.Deadline != nil || form.RemoveDeadline != nil) {
 		var deadlineUnix timeutil.TimeStamp
 		if (form.RemoveDeadline == nil || !*form.RemoveDeadline) && !form.Deadline.IsZero() {
 			deadline := time.Date(form.Deadline.Year(), form.Deadline.Month(), form.Deadline.Day(),
@@ -714,7 +720,7 @@ func EditPullRequest(ctx *context.APIContext) {
 	// Pass one or more user logins to replace the set of assignees on this Issue.
 	// Send an empty array ([]) to clear all assignees from the Issue.
 
-	if ctx.Repo.Permission.CanWrite(unit.TypePullRequests) && (form.Assignees != nil || len(form.Assignee) > 0) {
+	if canWrite && (form.Assignees != nil || len(form.Assignee) > 0) {
 		err = issue_service.UpdateAssignees(ctx, issue, form.Assignee, form.Assignees, ctx.Doer)
 		if err != nil {
 			if user_model.IsErrUserNotExist(err) {
@@ -728,7 +734,7 @@ func EditPullRequest(ctx *context.APIContext) {
 		}
 	}
 
-	if ctx.Repo.Permission.CanWrite(unit.TypePullRequests) && form.Milestone != 0 &&
+	if canWrite && form.Milestone != 0 &&
 		issue.MilestoneID != form.Milestone {
 		oldMilestoneID := issue.MilestoneID
 		issue.MilestoneID = form.Milestone
@@ -743,7 +749,7 @@ func EditPullRequest(ctx *context.APIContext) {
 		}
 	}
 
-	if ctx.Repo.Permission.CanWrite(unit.TypePullRequests) && form.Labels != nil {
+	if canWrite && form.Labels != nil {
 		labels, err := issues_model.GetLabelsInRepoByIDs(ctx, ctx.Repo.Repository.ID, form.Labels)
 		if err != nil {
 			ctx.APIErrorInternal(err)

--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -279,7 +279,12 @@ func UpdateIssueTitle(ctx *context.Context) {
 		return
 	}
 
-	if !ctx.IsSigned || (!issue.IsPoster(ctx.Doer.ID) && !ctx.Repo.Permission.CanWriteIssuesOrPulls(issue.IsPull)) {
+	canEdit, err := issue_service.CanEditIssueOrPullMeta(ctx, ctx.Doer, issue, ctx.Repo.Permission)
+	if err != nil {
+		ctx.ServerError("CanEditIssueOrPullMeta", err)
+		return
+	}
+	if !ctx.IsSigned || !canEdit {
 		ctx.HTTPError(http.StatusForbidden)
 		return
 	}
@@ -331,7 +336,12 @@ func UpdateIssueContent(ctx *context.Context) {
 		return
 	}
 
-	if !ctx.IsSigned || (ctx.Doer.ID != issue.PosterID && !ctx.Repo.Permission.CanWriteIssuesOrPulls(issue.IsPull)) {
+	canEdit, err := issue_service.CanEditIssueOrPullMeta(ctx, ctx.Doer, issue, ctx.Repo.Permission)
+	if err != nil {
+		ctx.ServerError("CanEditIssueOrPullMeta", err)
+		return
+	}
+	if !ctx.IsSigned || !canEdit {
 		ctx.HTTPError(http.StatusForbidden)
 		return
 	}

--- a/routers/web/repo/issue_view.go
+++ b/routers/web/repo/issue_view.go
@@ -402,6 +402,12 @@ func ViewIssue(ctx *context.Context) {
 	ctx.Data["SignInLink"] = middleware.RedirectLinkUserLogin(ctx.Req)
 	ctx.Data["IsIssuePoster"] = ctx.IsSigned && issue.IsPoster(ctx.Doer.ID)
 	ctx.Data["HasIssuesOrPullsWritePermission"] = ctx.Repo.Permission.CanWriteIssuesOrPulls(issue.IsPull)
+	canEditIssueMeta, err := issue_service.CanEditIssueOrPullMeta(ctx, ctx.Doer, issue, ctx.Repo.Permission)
+	if err != nil {
+		ctx.ServerError("CanEditIssueOrPullMeta", err)
+		return
+	}
+	ctx.Data["CanEditIssueMeta"] = ctx.IsSigned && canEditIssueMeta
 	ctx.Data["HasProjectsWritePermission"] = ctx.Repo.Permission.CanWrite(unit.TypeProjects)
 	ctx.Data["IsRepoAdmin"] = ctx.IsSigned && (ctx.Repo.Permission.IsAdmin() || ctx.Doer.IsAdmin)
 	ctx.Data["LockReasons"] = setting.Repository.Issue.LockReasons

--- a/services/issue/permission.go
+++ b/services/issue/permission.go
@@ -1,0 +1,59 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package issue
+
+import (
+	"context"
+
+	issues_model "gitea.dev/models/issues"
+	access_model "gitea.dev/models/perm/access"
+	"gitea.dev/models/unit"
+	user_model "gitea.dev/models/user"
+)
+
+// CanEditIssueOrPullMeta reports whether doer may edit the title or body of an
+// issue or pull request.
+//
+// Allowed when the user is the poster, has write access to issues/pulls on the
+// base repository, or (for pull requests) has write access to the head
+// repository — so collaborators on a fork can refine the PR they share with
+// the author (see #36860).
+func CanEditIssueOrPullMeta(ctx context.Context, doer *user_model.User, issue *issues_model.Issue, basePerm access_model.Permission) (bool, error) {
+	if doer == nil {
+		return false, nil
+	}
+	if issue.IsPoster(doer.ID) {
+		return true, nil
+	}
+	if basePerm.CanWriteIssuesOrPulls(issue.IsPull) {
+		return true, nil
+	}
+	if !issue.IsPull {
+		return false, nil
+	}
+	return canWriteToPullHeadRepo(ctx, doer, issue)
+}
+
+func canWriteToPullHeadRepo(ctx context.Context, doer *user_model.User, issue *issues_model.Issue) (bool, error) {
+	if err := issue.LoadPullRequest(ctx); err != nil {
+		return false, err
+	}
+	pr := issue.PullRequest
+	if pr == nil {
+		return false, nil
+	}
+	if err := pr.LoadHeadRepo(ctx); err != nil {
+		return false, err
+	}
+	if pr.HeadRepo == nil {
+		return false, nil
+	}
+	// Same-repo PRs: head write is already covered by base write above when the
+	// user has PR write on the only repo; still check head for completeness.
+	headPerm, err := access_model.GetDoerRepoPermission(ctx, pr.HeadRepo, doer)
+	if err != nil {
+		return false, err
+	}
+	return headPerm.CanWrite(unit.TypeCode), nil
+}

--- a/services/issue/permission_test.go
+++ b/services/issue/permission_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package issue
+
+import (
+	"testing"
+
+	"gitea.dev/models/db"
+	issues_model "gitea.dev/models/issues"
+	"gitea.dev/models/perm"
+	access_model "gitea.dev/models/perm/access"
+	repo_model "gitea.dev/models/repo"
+	"gitea.dev/models/unittest"
+	user_model "gitea.dev/models/user"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanEditIssueOrPullMeta(t *testing.T) {
+	require.NoError(t, unittest.PrepareTestDatabase())
+
+	// Cross-repo PR: issue 8 / pull 3, poster user11, base repo10 (user12), head repo11 (user13)
+	issue := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{ID: 8})
+	require.NoError(t, issue.LoadPullRequest(t.Context()))
+	require.NoError(t, issue.LoadRepo(t.Context()))
+
+	poster := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 11})
+	baseOwner := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 12})
+	headOwner := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 13})
+	// user4 has no relation to base or head by default
+	stranger := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 4})
+
+	basePermFor := func(u *user_model.User) access_model.Permission {
+		p, err := access_model.GetDoerRepoPermission(t.Context(), issue.Repo, u)
+		require.NoError(t, err)
+		return p
+	}
+
+	t.Run("Poster", func(t *testing.T) {
+		ok, err := CanEditIssueOrPullMeta(t.Context(), poster, issue, basePermFor(poster))
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("BaseOwner", func(t *testing.T) {
+		ok, err := CanEditIssueOrPullMeta(t.Context(), baseOwner, issue, basePermFor(baseOwner))
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("HeadOwner", func(t *testing.T) {
+		// Head owner is not the poster and has no write on base PR unit, but
+		// owns the head repo — should be allowed to edit title/body.
+		ok, err := CanEditIssueOrPullMeta(t.Context(), headOwner, issue, basePermFor(headOwner))
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("Stranger", func(t *testing.T) {
+		ok, err := CanEditIssueOrPullMeta(t.Context(), stranger, issue, basePermFor(stranger))
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("HeadCollaboratorWrite", func(t *testing.T) {
+		// Grant write collaboration on head only
+		collaboration := &repo_model.Collaboration{
+			RepoID: issue.PullRequest.HeadRepoID,
+			UserID: stranger.ID,
+			Mode:   perm.AccessModeWrite,
+		}
+		require.NoError(t, db.Insert(t.Context(), collaboration))
+		defer db.DeleteByBean(t.Context(), collaboration)
+
+		require.NoError(t, issue.PullRequest.LoadHeadRepo(t.Context()))
+		require.NoError(t, access_model.RecalculateUserAccess(t.Context(), issue.PullRequest.HeadRepo, stranger.ID))
+
+		ok, err := CanEditIssueOrPullMeta(t.Context(), stranger, issue, basePermFor(stranger))
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("HeadCollaboratorReadOnly", func(t *testing.T) {
+		collaboration := &repo_model.Collaboration{
+			RepoID: issue.PullRequest.HeadRepoID,
+			UserID: stranger.ID,
+			Mode:   perm.AccessModeRead,
+		}
+		require.NoError(t, db.Insert(t.Context(), collaboration))
+		defer db.DeleteByBean(t.Context(), collaboration)
+
+		require.NoError(t, issue.PullRequest.LoadHeadRepo(t.Context()))
+		require.NoError(t, access_model.RecalculateUserAccess(t.Context(), issue.PullRequest.HeadRepo, stranger.ID))
+
+		ok, err := CanEditIssueOrPullMeta(t.Context(), stranger, issue, basePermFor(stranger))
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("RegularIssueNoHeadBypass", func(t *testing.T) {
+		// Non-PR issue: head-repo write must not apply
+		plainIssue := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{ID: 1})
+		require.False(t, plainIssue.IsPull)
+		require.NoError(t, plainIssue.LoadRepo(t.Context()))
+		plainPerm, err := access_model.GetDoerRepoPermission(t.Context(), plainIssue.Repo, stranger)
+		require.NoError(t, err)
+
+		ok, err := CanEditIssueOrPullMeta(t.Context(), stranger, plainIssue, plainPerm)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("NilDoer", func(t *testing.T) {
+		ok, err := CanEditIssueOrPullMeta(t.Context(), nil, issue, basePermFor(poster))
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+}

--- a/templates/repo/issue/view_content.tmpl
+++ b/templates/repo/issue/view_content.tmpl
@@ -41,11 +41,11 @@
 							{{if not $.Repository.IsArchived}}
 								{{template "repo/issue/view_content/add_reaction" dict "ActionURL" (printf "%s/issues/%d/reactions" $.RepoLink .Issue.Index)}}
 							{{end}}
-							{{template "repo/issue/view_content/context_menu" dict "item" .Issue "delete" false "issue" true "diff" false "IsCommentPoster" $.IsIssuePoster}}
+							{{template "repo/issue/view_content/context_menu" dict "item" .Issue "delete" false "issue" true "diff" false "IsCommentPoster" $.CanEditIssueMeta}}
 						</div>
 					</div>
 					<div class="ui attached segment comment-body" role="article">
-						<div class="render-content markup" {{if or $.Permission.IsAdmin $.HasIssuesOrPullsWritePermission $.IsIssuePoster}}data-can-edit="true"{{end}}>
+						<div class="render-content markup" {{if or $.Permission.IsAdmin $.CanEditIssueMeta}}data-can-edit="true"{{end}}>
 							{{if .Issue.RenderedContent}}
 								{{.Issue.RenderedContent}}
 							{{else}}

--- a/templates/repo/issue/view_title.tmpl
+++ b/templates/repo/issue/view_title.tmpl
@@ -10,7 +10,7 @@
 	data-issue-repo-id="{{$.Repository.ID}}"
 ></div>
 <div class="issue-title-header">
-	{{$canEditIssueTitle := and (or .HasIssuesOrPullsWritePermission .IsIssuePoster) (not .Repository.IsArchived)}}
+	{{$canEditIssueTitle := and .CanEditIssueMeta (not .Repository.IsArchived)}}
 	<div class="issue-title" id="issue-title-display">
 		<h1>
 			{{ctx.RenderUtils.RenderIssueTitle .Issue.Title $.Repository}}

--- a/tests/integration/api_pull_test.go
+++ b/tests/integration/api_pull_test.go
@@ -485,6 +485,70 @@ func TestAPIEditPull(t *testing.T) {
 	})
 }
 
+// TestAPIEditPullByHeadCollaborator ensures head-repo collaborators can edit
+// PR title/body on the base repo (cross-fork), matching GitHub behaviour (#36860).
+func TestAPIEditPullByHeadCollaborator(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	// Fixture PR #3: head user13/repo11 -> base user12/repo10, poster user11
+	baseRepo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 10})
+	baseOwner := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: baseRepo.OwnerID})
+	headRepo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 11})
+	pr := unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{ID: 3})
+	require.Equal(t, headRepo.ID, pr.HeadRepoID)
+	require.Equal(t, baseRepo.ID, pr.BaseRepoID)
+
+	// user4 has no base-repo write access
+	headCollab := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 4})
+	require.NoError(t, repo_service.AddOrUpdateCollaborator(t.Context(), headRepo, headCollab, perm.AccessModeWrite))
+
+	// Stranger without head write cannot edit
+	session := loginUser(t, headCollab.Name)
+	// temporarily remove write and verify deny — actually user4 now has write. Use a different user.
+	stranger := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 5})
+	strangerSession := loginUser(t, stranger.Name)
+	strangerToken := getTokenForLoggedInUser(t, strangerSession, auth_model.AccessTokenScopeWriteRepository)
+	urlStr := fmt.Sprintf("/api/v1/repos/%s/%s/pulls/%d", baseOwner.Name, baseRepo.Name, pr.Index)
+	req := NewRequestWithJSON(t, http.MethodPatch, urlStr, &api.EditPullRequestOption{
+		Title: "should be forbidden",
+	}).AddTokenAuth(strangerToken)
+	MakeRequest(t, req, http.StatusForbidden)
+
+	// Head collaborator can edit title and body
+	token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteRepository)
+	newTitle := "edited by head collaborator"
+	newBody := "body edited by head collaborator"
+	req = NewRequestWithJSON(t, http.MethodPatch, urlStr, &api.EditPullRequestOption{
+		Title: newTitle,
+		Body:  &newBody,
+	}).AddTokenAuth(token)
+	resp := MakeRequest(t, req, http.StatusCreated)
+	apiPull := DecodeJSON(t, resp, &api.PullRequest{})
+	assert.Equal(t, newTitle, apiPull.Title)
+	assert.Equal(t, newBody, apiPull.Body)
+
+	// Head collaborator still cannot manage labels (needs base write)
+	req = NewRequestWithJSON(t, http.MethodPatch, urlStr, &api.EditPullRequestOption{
+		Labels: []int64{1},
+	}).AddTokenAuth(token)
+	// Labels are ignored without canWrite — request succeeds but labels unchanged
+	resp = MakeRequest(t, req, http.StatusCreated)
+	apiPull = DecodeJSON(t, resp, &api.PullRequest{})
+	assert.Empty(t, apiPull.Labels)
+
+	// Head owner (user13) can also edit
+	headOwner := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: headRepo.OwnerID})
+	headOwnerSession := loginUser(t, headOwner.Name)
+	headOwnerToken := getTokenForLoggedInUser(t, headOwnerSession, auth_model.AccessTokenScopeWriteRepository)
+	ownerTitle := "edited by head owner"
+	req = NewRequestWithJSON(t, http.MethodPatch, urlStr, &api.EditPullRequestOption{
+		Title: ownerTitle,
+	}).AddTokenAuth(headOwnerToken)
+	resp = MakeRequest(t, req, http.StatusCreated)
+	apiPull = DecodeJSON(t, resp, &api.PullRequest{})
+	assert.Equal(t, ownerTitle, apiPull.Title)
+}
+
 func testAPIPullContentVersion(t *testing.T, pullID int64) {
 	pull := unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{ID: pullID})
 	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: pull.BaseRepoID})


### PR DESCRIPTION
## Summary

When a pull request is opened from a fork (or another head repository), only the PR poster or users with write access on the **base** repository could edit the title and description. Collaborators on the **head** repository (e.g. other owners of the org that owns the fork) could not refine the PR text even though they can push to the head branch.

This change allows users with write access to the head repository to edit PR title and body on the base repository, which matches the practical expectation for fork teams and is consistent with how maintainers already treat head collaborators for push/update flows.

**Still restricted to base write (unchanged):** assignees, labels, milestones, deadlines, and other management fields.

## Changes

- Add `issue.CanEditIssueOrPullMeta` (poster **or** base issues/PR write **or** head-repo code write for PRs)
- Web: `UpdateIssueTitle` / `UpdateIssueContent` use the helper
- API: `EditIssue` / `EditPullRequest` use the helper for title/body; base-only fields still require base write
- UI: title editor and issue-body edit menu use `CanEditIssueMeta`

## Fixes

Fixes #36860

## Test plan

- [x] `go test -count=1 ./services/issue/ -run 'TestCanEditIssueOrPullMeta'`
- [x] `make 'test-integration#TestAPIEditPullByHeadCollaborator'`
- [x] `gofmt` on touched Go files
- [x] `go vet ./services/issue/`

### Coverage

- Unit: poster, base owner, head owner, head write collaborator, head read-only collaborator, stranger, plain issue (no head bypass)
- Integration: stranger forbidden; head write collaborator can change title/body; labels not applied without base write; head owner can edit title

## AI assistance

Assisted by Hermes (grok-4.5). I reviewed the permission model, kept base-only management fields gated, and verified with unit + integration tests.