### PR TITLE
chore: still keep ctx in git.Repository struct for cat-file batch command

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -128,7 +128,7 @@ func runRepoSyncReleases(ctx context.Context, _ *cli.Command) error {
 		log.Trace("Processing next %d repos of %d", len(repos), count)
 		for _, repo := range repos {
 			log.Trace("Synchronizing repo %s", repo.FullName())
-			gitRepo, err := git.OpenRepository(repo)
+			gitRepo, err := git.OpenRepository(ctx, repo)
 			if err != nil {
 				log.Warn("OpenRepository: %v", err)
 				continue

--- a/modelmigration/v1_14/v156.go
+++ b/modelmigration/v1_14/v156.go
@@ -97,7 +97,7 @@ func FixPublisherIDforTagReleases(ctx context.Context, x base.EngineMigration) e
 						return err
 					}
 				}
-				gitRepo, err = git.OpenRepository(base.LocalCodeGitRepo(repo.OwnerName, repo.Name))
+				gitRepo, err = git.OpenRepository(ctx, base.LocalCodeGitRepo(repo.OwnerName, repo.Name))
 				if err != nil {
 					log.Error("Error whilst opening git repo for [%d]%s/%s. Error: %v", repo.ID, repo.OwnerName, repo.Name, err)
 					return err

--- a/modelmigration/v1_9/v82.go
+++ b/modelmigration/v1_9/v82.go
@@ -85,7 +85,7 @@ func FixReleaseSha1OnReleaseTable(ctx context.Context, x base.EngineMigration) e
 					userCache[repo.OwnerID] = user
 				}
 
-				gitRepo, err = git.OpenRepository(base.LocalCodeGitRepo(user.Name, repo.Name))
+				gitRepo, err = git.OpenRepository(ctx, base.LocalCodeGitRepo(user.Name, repo.Name))
 				if err != nil {
 					return err
 				}

--- a/models/git/commit_status_test.go
+++ b/models/git/commit_status_test.go
@@ -186,7 +186,7 @@ func TestFindRepoRecentCommitStatusContexts(t *testing.T) {
 
 	repo2 := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 2})
 	user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
-	gitRepo, err := git.OpenRepository(repo2)
+	gitRepo, err := git.OpenRepository(t.Context(), repo2)
 	assert.NoError(t, err)
 	defer gitRepo.Close()
 

--- a/modules/git/attribute/batch_test.go
+++ b/modules/git/attribute/batch_test.go
@@ -119,7 +119,7 @@ func Test_BatchChecker(t *testing.T) {
 	setting.AppDataPath = t.TempDir()
 	repoPath := "../tests/repos/language_stats_repo"
 	ctx := t.Context()
-	gitRepo, err := git.OpenRepositoryLocal(repoPath)
+	gitRepo, err := git.OpenRepositoryLocal(ctx, repoPath)
 	require.NoError(t, err)
 	defer gitRepo.Close()
 
@@ -144,7 +144,7 @@ func Test_BatchChecker(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		tempRepo, err := git.OpenRepositoryLocal(dir)
+		tempRepo, err := git.OpenRepositoryLocal(ctx, dir)
 		assert.NoError(t, err)
 		defer tempRepo.Close()
 

--- a/modules/git/attribute/checker_test.go
+++ b/modules/git/attribute/checker_test.go
@@ -18,7 +18,7 @@ import (
 func Test_Checker(t *testing.T) {
 	setting.AppDataPath = t.TempDir()
 	repoPath := "../tests/repos/language_stats_repo"
-	gitRepo, err := git.OpenRepositoryLocal(repoPath)
+	gitRepo, err := git.OpenRepositoryLocal(t.Context(), repoPath)
 	require.NoError(t, err)
 	defer gitRepo.Close()
 
@@ -44,7 +44,7 @@ func Test_Checker(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		tempRepo, err := git.OpenRepositoryLocal(dir)
+		tempRepo, err := git.OpenRepositoryLocal(t.Context(), dir)
 		assert.NoError(t, err)
 		defer tempRepo.Close()
 

--- a/modules/git/blame_sha256_test.go
+++ b/modules/git/blame_sha256_test.go
@@ -24,7 +24,7 @@ func TestReadingBlameOutputSha256(t *testing.T) {
 
 	t.Run("Without .git-blame-ignore-revs", func(t *testing.T) {
 		storage := mockRepository("repo5_pulls_sha256")
-		repo, err := OpenRepository(storage)
+		repo, err := OpenRepository(ctx, storage)
 		assert.NoError(t, err)
 		defer repo.Close()
 
@@ -70,7 +70,7 @@ func TestReadingBlameOutputSha256(t *testing.T) {
 
 	t.Run("With .git-blame-ignore-revs", func(t *testing.T) {
 		storage := mockRepository("repo6_blame_sha256")
-		repo, err := OpenRepository(storage)
+		repo, err := OpenRepository(ctx, storage)
 		assert.NoError(t, err)
 		defer repo.Close()
 

--- a/modules/git/blame_test.go
+++ b/modules/git/blame_test.go
@@ -19,7 +19,7 @@ func TestReadingBlameOutput(t *testing.T) {
 
 	t.Run("Without .git-blame-ignore-revs", func(t *testing.T) {
 		storage := mockRepository("repo5_pulls")
-		repo, err := OpenRepository(storage)
+		repo, err := OpenRepository(ctx, storage)
 		assert.NoError(t, err)
 		defer repo.Close()
 		commit, err := repo.GetCommit(t.Context(), "f32b0a9dfd09a60f616f29158f772cedd89942d2")
@@ -64,7 +64,7 @@ func TestReadingBlameOutput(t *testing.T) {
 
 	t.Run("With .git-blame-ignore-revs", func(t *testing.T) {
 		storage := mockRepository("repo6_blame")
-		repo, err := OpenRepository(storage)
+		repo, err := OpenRepository(ctx, storage)
 		assert.NoError(t, err)
 		defer repo.Close()
 

--- a/modules/git/blob_nogogit.go
+++ b/modules/git/blob_nogogit.go
@@ -25,7 +25,7 @@ type Blob struct {
 // DataAsync gets a ReadCloser for the contents of a blob without reading it all.
 // Calling the Close function on the result will discard all unread output.
 func (b *Blob) DataAsync(ctx context.Context) (_ io.ReadCloser, retErr error) {
-	batch, cancel, err := b.repo.CatFileBatch(ctx)
+	batch, cancel, err := b.repo.CatFileBatch()
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func (b *Blob) Size(ctx context.Context) int64 {
 		return b.size
 	}
 
-	batch, cancel, err := b.repo.CatFileBatch(ctx)
+	batch, cancel, err := b.repo.CatFileBatch()
 	if err != nil {
 		log.Debug("error whilst reading size for %s in %s. Error: %v", b.ID.String(), b.repo.LogString(), err)
 		return 0

--- a/modules/git/blob_test.go
+++ b/modules/git/blob_test.go
@@ -16,7 +16,7 @@ import (
 func TestBlob_Data(t *testing.T) {
 	output := "file2\n"
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
-	repo, err := OpenRepositoryLocal(bareRepo1Path)
+	repo, err := OpenRepositoryLocal(t.Context(), bareRepo1Path)
 	require.NoError(t, err)
 	defer repo.Close()
 
@@ -36,7 +36,7 @@ func TestBlob_Data(t *testing.T) {
 
 func Benchmark_Blob_Data(b *testing.B) {
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
-	repo, err := OpenRepositoryLocal(bareRepo1Path)
+	repo, err := OpenRepositoryLocal(b.Context(), bareRepo1Path)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/modules/git/branch.go
+++ b/modules/git/branch.go
@@ -14,7 +14,7 @@ import (
 // GetBranchesByPath returns a branch by its path
 // if limit = 0 it will not limit
 func GetBranchesByPath(ctx context.Context, repo RepositoryFacade, skip, limit int) ([]string, int, error) {
-	gitRepo, err := OpenRepository(repo)
+	gitRepo, err := OpenRepository(ctx, repo)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -24,7 +24,7 @@ func GetBranchesByPath(ctx context.Context, repo RepositoryFacade, skip, limit i
 }
 
 func GetBranchCommitID(ctx context.Context, repo RepositoryFacade, branch string) (string, error) {
-	gitRepo, err := OpenRepository(repo)
+	gitRepo, err := OpenRepository(ctx, repo)
 	if err != nil {
 		return "", err
 	}

--- a/modules/git/catfile_batch_command.go
+++ b/modules/git/catfile_batch_command.go
@@ -9,6 +9,7 @@ import (
 
 	"gitea.dev/modules/git/gitcmd"
 	"gitea.dev/modules/setting"
+	"gitea.dev/modules/util"
 )
 
 // catFileBatchCommand implements the CatFileBatch interface using the "cat-file --batch-command" command
@@ -26,11 +27,11 @@ func newCatFileBatchCommand(ctx context.Context, repo RepositoryFacade) *catFile
 	return &catFileBatchCommand{ctx: ctx, repo: repo}
 }
 
-func (b *catFileBatchCommand) getBatch() *catFileBatchCommunicator {
+func (b *catFileBatchCommand) getBatch(callerInfo string) *catFileBatchCommunicator {
 	if b.batch != nil {
 		return b.batch
 	}
-	b.batch = newCatFileBatch(b.ctx, b.repo, gitcmd.NewCommand("cat-file", "--batch-command"))
+	b.batch = newCatFileBatch(b.ctx, b.repo, gitcmd.NewCommand("cat-file", "--batch-command").WithParentCallerInfo(callerInfo))
 	return b.batch
 }
 
@@ -42,26 +43,28 @@ func (b *catFileBatchCommand) QueryContent(obj string) (*CatFileObject, Buffered
 	if strings.Contains(obj, "\n") {
 		setting.PanicInDevOrTesting("invalid object name with newline: %q", obj)
 	}
-	_, err := b.getBatch().reqWriter.Write([]byte("contents " + obj + "\n"))
+	batch := b.getBatch(util.CallerFuncName(1))
+	_, err := batch.reqWriter.Write([]byte("contents " + obj + "\n"))
 	if err != nil {
 		return nil, nil, err
 	}
-	info, err := catFileBatchParseInfoLine(b.getBatch().respReader)
+	info, err := catFileBatchParseInfoLine(batch.respReader)
 	if err != nil {
 		return nil, nil, err
 	}
-	return info, b.getBatch().respReader, nil
+	return info, batch.respReader, nil
 }
 
 func (b *catFileBatchCommand) QueryInfo(obj string) (*CatFileObject, error) {
 	if strings.Contains(obj, "\n") {
 		setting.PanicInDevOrTesting("invalid object name with newline: %q", obj)
 	}
-	_, err := b.getBatch().reqWriter.Write([]byte("info " + obj + "\n"))
+	batch := b.getBatch(util.CallerFuncName(1))
+	_, err := batch.reqWriter.Write([]byte("info " + obj + "\n"))
 	if err != nil {
 		return nil, err
 	}
-	return catFileBatchParseInfoLine(b.getBatch().respReader)
+	return catFileBatchParseInfoLine(batch.respReader)
 }
 
 func (b *catFileBatchCommand) Close() {

--- a/modules/git/catfile_batch_reader.go
+++ b/modules/git/catfile_batch_reader.go
@@ -52,7 +52,7 @@ func newCatFileBatch(ctx context.Context, repo RepositoryFacade, cmdCatFile *git
 		stdPipeClose()
 	}))
 
-	err := cmdCatFile.WithRepo(repo).StartWithStderr(ctx)
+	err := cmdCatFile.WithParentCallerInfo().WithRepo(repo).StartWithStderr(ctx)
 	if err != nil {
 		log.Error("Unable to start git command %v: %v", cmdCatFile.LogString(), err)
 		// ideally here it should return the error, but it would require refactoring all callers

--- a/modules/git/commit_info_nogogit_test.go
+++ b/modules/git/commit_info_nogogit_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestEntries_GetCommitsInfo_ContextErr(t *testing.T) {
-	repo, err := OpenRepositoryLocal(filepath.Join(testReposDir, "repo1_bare"))
+	repo, err := OpenRepositoryLocal(t.Context(), filepath.Join(testReposDir, "repo1_bare"))
 	require.NoError(t, err)
 	defer repo.Close()
 

--- a/modules/git/commit_info_test.go
+++ b/modules/git/commit_info_test.go
@@ -127,7 +127,7 @@ func testGetCommitsInfo(t *testing.T, repo1 *Repository) {
 
 func TestEntries_GetCommitsInfo(t *testing.T) {
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
-	bareRepo1, err := OpenRepositoryLocal(bareRepo1Path)
+	bareRepo1, err := OpenRepositoryLocal(t.Context(), bareRepo1Path)
 	assert.NoError(t, err)
 	defer bareRepo1.Close()
 
@@ -137,7 +137,7 @@ func TestEntries_GetCommitsInfo(t *testing.T) {
 	if err != nil {
 		assert.NoError(t, err)
 	}
-	clonedRepo1, err := OpenRepositoryLocal(clonedPath)
+	clonedRepo1, err := OpenRepositoryLocal(t.Context(), clonedPath)
 	if err != nil {
 		assert.NoError(t, err)
 	}

--- a/modules/git/commit_sha256_test.go
+++ b/modules/git/commit_sha256_test.go
@@ -56,7 +56,7 @@ signed commit`
 		0x94, 0x33, 0xb2, 0xa6, 0x2b, 0x96, 0x4c, 0x17, 0xa4, 0x48, 0x5a, 0xe1, 0x80, 0xf4, 0x5f, 0x59,
 		0x5d, 0x3e, 0x69, 0xd3, 0x1b, 0x78, 0x60, 0x87, 0x77, 0x5e, 0x28, 0xc6, 0xb6, 0x39, 0x9d, 0xf0,
 	}
-	gitRepo, err := OpenRepositoryLocal(filepath.Join(testReposDir, "repo1_bare_sha256"))
+	gitRepo, err := OpenRepositoryLocal(t.Context(), filepath.Join(testReposDir, "repo1_bare_sha256"))
 	assert.NoError(t, err)
 	assert.NotNil(t, gitRepo)
 	defer gitRepo.Close()
@@ -99,7 +99,7 @@ signed commit`, commitFromReader.Signature.Payload)
 func TestHasPreviousCommitSha256(t *testing.T) {
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare_sha256")
 
-	repo, err := OpenRepositoryLocal(bareRepo1Path)
+	repo, err := OpenRepositoryLocal(t.Context(), bareRepo1Path)
 	assert.NoError(t, err)
 	defer repo.Close()
 

--- a/modules/git/commit_test.go
+++ b/modules/git/commit_test.go
@@ -52,7 +52,7 @@ gpgsig -----BEGIN PGP SIGNATURE-----
 empty commit`
 
 	sha := &Sha1Hash{0xfe, 0xaf, 0x4b, 0xa6, 0xbc, 0x63, 0x5f, 0xec, 0x44, 0x2f, 0x46, 0xdd, 0xd4, 0x51, 0x24, 0x16, 0xec, 0x43, 0xc2, 0xc2}
-	gitRepo, err := OpenRepositoryLocal(filepath.Join(testReposDir, "repo1_bare"))
+	gitRepo, err := OpenRepositoryLocal(t.Context(), filepath.Join(testReposDir, "repo1_bare"))
 	assert.NoError(t, err)
 	assert.NotNil(t, gitRepo)
 	defer gitRepo.Close()
@@ -116,7 +116,7 @@ gpgsig -----BEGIN PGP SIGNATURE-----
 ISO-8859-1`
 	commitString = strings.ReplaceAll(commitString, "<SPACE>", " ")
 	sha := &Sha1Hash{0xfe, 0xaf, 0x4b, 0xa6, 0xbc, 0x63, 0x5f, 0xec, 0x44, 0x2f, 0x46, 0xdd, 0xd4, 0x51, 0x24, 0x16, 0xec, 0x43, 0xc2, 0xc2}
-	gitRepo, err := OpenRepositoryLocal(filepath.Join(testReposDir, "repo1_bare"))
+	gitRepo, err := OpenRepositoryLocal(t.Context(), filepath.Join(testReposDir, "repo1_bare"))
 	assert.NoError(t, err)
 	assert.NotNil(t, gitRepo)
 	defer gitRepo.Close()
@@ -158,7 +158,7 @@ ISO-8859-1`, commitFromReader.Signature.Payload)
 func TestHasPreviousCommit(t *testing.T) {
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
 
-	repo, err := OpenRepositoryLocal(bareRepo1Path)
+	repo, err := OpenRepositoryLocal(t.Context(), bareRepo1Path)
 	assert.NoError(t, err)
 	defer repo.Close()
 
@@ -183,7 +183,7 @@ func TestHasPreviousCommit(t *testing.T) {
 
 func Test_GetCommitBranchStart(t *testing.T) {
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
-	repo, err := OpenRepositoryLocal(bareRepo1Path)
+	repo, err := OpenRepositoryLocal(t.Context(), bareRepo1Path)
 	assert.NoError(t, err)
 	defer repo.Close()
 	commit, err := repo.GetBranchCommit(t.Context(), "branch1")

--- a/modules/git/gitcmd/command.go
+++ b/modules/git/gitcmd/command.go
@@ -382,12 +382,7 @@ func (c *Command) WithParentCallerInfo(optInfo ...string) *Command {
 		return c
 	}
 	skip := 1 /*parent "wrap/run" functions*/ + 1 /*this function*/
-	callerFuncName := util.CallerFuncName(skip)
-	callerInfo := callerFuncName
-	if pos := strings.LastIndex(callerInfo, "/"); pos >= 0 {
-		callerInfo = callerInfo[pos+1:]
-	}
-	c.callerInfo = callerInfo
+	c.callerInfo = util.CallerFuncName(skip)
 	return c
 }
 
@@ -535,7 +530,7 @@ func (c *Command) StartWithStderr(ctx context.Context) RunStdError {
 	}
 	c.cmdManagedStderr = &bytes.Buffer{}
 	c.cmdStderr = c.cmdManagedStderr
-	err := c.Start(ctx)
+	err := c.WithParentCallerInfo().Start(ctx)
 	if err != nil {
 		return &runStdError{err: err}
 	}
@@ -555,14 +550,14 @@ func (c *Command) WaitWithStderr() RunStdError {
 }
 
 func (c *Command) RunWithStderr(ctx context.Context) RunStdError {
-	if err := c.StartWithStderr(ctx); err != nil {
+	if err := c.WithParentCallerInfo().StartWithStderr(ctx); err != nil {
 		return &runStdError{err: err}
 	}
 	return c.WaitWithStderr()
 }
 
 func (c *Command) Run(ctx context.Context) (err error) {
-	if err = c.Start(ctx); err != nil {
+	if err = c.WithParentCallerInfo().Start(ctx); err != nil {
 		return err
 	}
 	return c.Wait()
@@ -585,7 +580,7 @@ func (c *Command) runStdBytes(ctx context.Context) ([]byte, []byte, RunStdError)
 		panic("stdout and stderr field must be nil when using RunStdBytes")
 	}
 	stdoutBuf := &bytes.Buffer{}
-	err := c.WithParentCallerInfo().WithStdoutBuffer(stdoutBuf).RunWithStderr(ctx)
+	err := c.WithStdoutBuffer(stdoutBuf).RunWithStderr(ctx)
 	return stdoutBuf.Bytes(), c.cmdManagedStderr.Bytes(), err
 }
 

--- a/modules/git/gitrepo.go
+++ b/modules/git/gitrepo.go
@@ -25,7 +25,7 @@ func RepositoryFromContextOrOpen(ctx context.Context, repo RepositoryFacade) (*R
 		gitRepo, err := RepositoryFromRequestContextOrOpen(reqCtx, repo)
 		return gitRepo, util.NopCloser{}, err
 	}
-	gitRepo, err := OpenRepository(repo)
+	gitRepo, err := OpenRepository(ctx, repo)
 	return gitRepo, gitRepo, err
 }
 
@@ -36,7 +36,7 @@ func RepositoryFromRequestContextOrOpen(ctx reqctx.RequestContext, repo Reposito
 	if gitRepo, ok := ctx.Value(ck).(*Repository); ok {
 		return gitRepo, nil
 	}
-	gitRepo, err := OpenRepository(repo)
+	gitRepo, err := OpenRepository(ctx, repo)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/git/grep_test.go
+++ b/modules/git/grep_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestGrepSearch(t *testing.T) {
 	defer test.MockVariableValue(&setting.RepoRootPath, t.TempDir())()
-	repo, err := OpenRepositoryLocal(filepath.Join(testReposDir, "language_stats_repo"))
+	repo, err := OpenRepositoryLocal(t.Context(), filepath.Join(testReposDir, "language_stats_repo"))
 	assert.NoError(t, err)
 	defer repo.Close()
 

--- a/modules/git/languagestats/language_stats_get.go
+++ b/modules/git/languagestats/language_stats_get.go
@@ -21,7 +21,7 @@ import (
 func GetLanguageStats(ctx context.Context, repo *git.Repository, commitID string) (map[string]int64, error) {
 	// We will feed the commit IDs in order into cat-file --batch, followed by blobs as necessary.
 	// so let's create a batch stdin and stdout
-	batch, cancel, err := repo.CatFileBatch(ctx)
+	batch, cancel, err := repo.CatFileBatch()
 	if err != nil {
 		return nil, err
 	}

--- a/modules/git/languagestats/language_stats_test.go
+++ b/modules/git/languagestats/language_stats_test.go
@@ -16,7 +16,7 @@ import (
 func TestRepository_GetLanguageStats(t *testing.T) {
 	setting.AppDataPath = t.TempDir()
 	repoPath := "../tests/repos/language_stats_repo"
-	gitRepo, err := git.OpenRepositoryLocal(repoPath)
+	gitRepo, err := git.OpenRepositoryLocal(t.Context(), repoPath)
 	require.NoError(t, err)
 	defer gitRepo.Close()
 

--- a/modules/git/notes_test.go
+++ b/modules/git/notes_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestGetNotes(t *testing.T) {
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
-	bareRepo1, err := OpenRepositoryLocal(bareRepo1Path)
+	bareRepo1, err := OpenRepositoryLocal(t.Context(), bareRepo1Path)
 	assert.NoError(t, err)
 	defer bareRepo1.Close()
 
@@ -25,7 +25,7 @@ func TestGetNotes(t *testing.T) {
 
 func TestGetNestedNotes(t *testing.T) {
 	repoPath := filepath.Join(testReposDir, "repo3_notes")
-	repo, err := OpenRepositoryLocal(repoPath)
+	repo, err := OpenRepositoryLocal(t.Context(), repoPath)
 	assert.NoError(t, err)
 	defer repo.Close()
 
@@ -40,7 +40,7 @@ func TestGetNestedNotes(t *testing.T) {
 
 func TestGetNonExistentNotes(t *testing.T) {
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
-	bareRepo1, err := OpenRepositoryLocal(bareRepo1Path)
+	bareRepo1, err := OpenRepositoryLocal(t.Context(), bareRepo1Path)
 	assert.NoError(t, err)
 	defer bareRepo1.Close()
 

--- a/modules/git/pipeline/lfs_find.go
+++ b/modules/git/pipeline/lfs_find.go
@@ -32,7 +32,7 @@ func findLFSFileFunc(ctx context.Context, repo *git.Repository, objectID git.Obj
 	results := make([]*LFSResult, 0)
 	// Next feed the commits in order into cat-file --batch, followed by their trees and sub trees as necessary.
 	// so let's create a batch stdin and stdout
-	batch, cancel, err := repo.CatFileBatch(ctx)
+	batch, cancel, err := repo.CatFileBatch()
 	if err != nil {
 		return nil, err
 	}

--- a/modules/git/pipeline/lfs_test.go
+++ b/modules/git/pipeline/lfs_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestFindLFSFile(t *testing.T) {
 	repoPath := "../../../tests/gitea-repositories-meta/user2/lfs.git"
-	gitRepo, err := git.OpenRepositoryLocal(repoPath)
+	gitRepo, err := git.OpenRepositoryLocal(t.Context(), repoPath)
 	require.NoError(t, err)
 	defer gitRepo.Close()
 

--- a/modules/git/repo.go
+++ b/modules/git/repo.go
@@ -33,6 +33,7 @@ type RepositoryBase struct {
 	objectFormatCache ObjectFormat
 
 	mu                 sync.Mutex
+	catFileBatchCtx    context.Context
 	catFileBatchCloser CatFileBatchCloser
 	catFileBatchInUse  bool
 }
@@ -51,7 +52,7 @@ func (repo *Repository) LogString() string {
 	return repo.repoFacade.LogString()
 }
 
-func OpenRepository(repo RepositoryFacade) (*Repository, error) {
+func OpenRepository(catFileBatchCtx context.Context, repo RepositoryFacade) (*Repository, error) {
 	repoPath := gitrepo.RepoLocalPath(repo)
 	exist, err := util.IsDir(repoPath)
 	if err != nil {
@@ -61,7 +62,7 @@ func OpenRepository(repo RepositoryFacade) (*Repository, error) {
 		return nil, util.NewNotExistErrorf("no such file or directory")
 	}
 	gitRepo := &Repository{
-		RepositoryBase: RepositoryBase{tagCache: newObjectCache[*Tag](), repoFacade: repo},
+		RepositoryBase: RepositoryBase{tagCache: newObjectCache[*Tag](), repoFacade: repo, catFileBatchCtx: catFileBatchCtx},
 	}
 	if err = openRepositoryInternal(gitRepo); err != nil {
 		return nil, err
@@ -71,14 +72,14 @@ func OpenRepository(repo RepositoryFacade) (*Repository, error) {
 
 // OpenRepositoryLocal opens a local repository that is not managed by Gitea
 // If the path is relative, it will be converted to an absolute path using filepath.Abs (base on current working path)
-func OpenRepositoryLocal(localPath string) (_ *Repository, err error) {
+func OpenRepositoryLocal(catFileBatchCtx context.Context, localPath string) (_ *Repository, err error) {
 	if !filepath.IsAbs(localPath) {
 		localPath, err = filepath.Abs(localPath)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return OpenRepository(gitrepo.RepositoryUnmanaged(localPath))
+	return OpenRepository(catFileBatchCtx, gitrepo.RepositoryUnmanaged(localPath))
 }
 
 func (repo *Repository) Close() error {
@@ -276,30 +277,21 @@ func Push(ctx context.Context, localRepoPath string, opts PushOptions) error {
 
 // CatFileBatch obtains a "batch object provider" for this repository.
 // It reuses an existing one if available, otherwise creates a new one.
-func (repo *Repository) CatFileBatch(ctx context.Context) (_ CatFileBatch, closeFunc func(), err error) {
+func (repo *Repository) CatFileBatch() (_ CatFileBatch, closeFunc func(), err error) {
 	repo.mu.Lock()
 	defer repo.mu.Unlock()
 
-	// clean up the cached but canceled batcher
-	if repo.catFileBatchCloser != nil && repo.catFileBatchCloser.Context().Err() != nil && !repo.catFileBatchInUse {
-		repo.catFileBatchCloser.Close()
-		repo.catFileBatchCloser = nil
-		repo.catFileBatchInUse = false
-	}
-
 	// if no cached batcher, make a new managed one, and cache it
 	if repo.catFileBatchCloser == nil {
-		repo.catFileBatchCloser, err = NewBatch(ctx, repo)
+		repo.catFileBatchCloser, err = NewBatch(repo.catFileBatchCtx, repo)
 		if err != nil {
 			repo.catFileBatchCloser = nil // otherwise it is "interface(nil)" and will cause wrong logic
 			return nil, nil, err
 		}
 	}
 
-	// if the cached batcher is in use, or the cached ctx is not the current ctx, then we need a new temp one
-	// for example: the cached one is from request context, the current ctx is a cancelable ctx with timeout
-	needTemp := repo.catFileBatchInUse || repo.catFileBatchCloser.Context() != ctx
-	if !needTemp {
+	// if the cached batcher is not in use, return it
+	if !repo.catFileBatchInUse {
 		repo.catFileBatchInUse = true
 		return CatFileBatch(repo.catFileBatchCloser), func() {
 			repo.mu.Lock()
@@ -308,7 +300,8 @@ func (repo *Repository) CatFileBatch(ctx context.Context) (_ CatFileBatch, close
 		}, nil
 	}
 
-	tempBatch, err := NewBatch(ctx, repo)
+	// return a temp one (won't be cached or shared)
+	tempBatch, err := NewBatch(repo.catFileBatchCtx, repo)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/modules/git/repo.go
+++ b/modules/git/repo.go
@@ -32,7 +32,10 @@ type RepositoryBase struct {
 	tagCache          *ObjectCache[*Tag]
 	objectFormatCache ObjectFormat
 
-	mu                 sync.Mutex
+	mu sync.Mutex
+	// Unfortunately, we can't completely remove the ctx, because CatBatch still heavily depends on a parent context.
+	// If we remove the ctx, then CatBatch's process management will become a mess and create a lot of unnecessary git processes.
+	// ATTENTION: this ctx is for cached cat-file process only, don't use it for other purposes.
 	catFileBatchCtx    context.Context
 	catFileBatchCloser CatFileBatchCloser
 	catFileBatchInUse  bool

--- a/modules/git/repo.go
+++ b/modules/git/repo.go
@@ -33,8 +33,12 @@ type RepositoryBase struct {
 	objectFormatCache ObjectFormat
 
 	mu sync.Mutex
-	// Unfortunately, we can't completely remove the ctx, because CatBatch still heavily depends on a parent context.
-	// If we remove the ctx, then CatBatch's process management will become a mess and create a lot of unnecessary git processes.
+	// Unfortunately, we can't completely remove the ctx, because CatFileBatch still heavily depends on a parent context.
+	// If we remove the ctx, then CatFileBatch's process management will become a mess and create a lot of unnecessary git processes.
+	// ref: http://localhost:3000/-/admin/monitor/perftrace
+	// The root problem is that some functions like "GetCommit" need to use CatFileBatch,
+	// if CatFileBatch accepts its own ctx, then every sub-context needs a git process.
+	// e.g.: open a repo home, dozens of git processes (duplicate cat-file)
 	// ATTENTION: this ctx is for cached cat-file process only, don't use it for other purposes.
 	catFileBatchCtx    context.Context
 	catFileBatchCloser CatFileBatchCloser

--- a/modules/git/repo_base_nogogit_test.go
+++ b/modules/git/repo_base_nogogit_test.go
@@ -17,7 +17,7 @@ func TestRepoCatFileBatch(t *testing.T) {
 	t.Run("MissingRepoAndClose", func(t *testing.T) {
 		testDir := filepath.Join(t.TempDir(), "testdir")
 		_ = os.Mkdir(testDir, 0o755)
-		repo, err := OpenRepositoryLocal(testDir)
+		repo, err := OpenRepositoryLocal(t.Context(), testDir)
 		require.NoError(t, err)
 		// when the repo is missing (it usually occurs during testing because the fixtures are synced frequently)
 		err = os.Remove(testDir)

--- a/modules/git/repo_base_nogogit_test.go
+++ b/modules/git/repo_base_nogogit_test.go
@@ -22,7 +22,7 @@ func TestRepoCatFileBatch(t *testing.T) {
 		// when the repo is missing (it usually occurs during testing because the fixtures are synced frequently)
 		err = os.Remove(testDir)
 		require.NoError(t, err)
-		_, _, err = repo.CatFileBatch(t.Context())
+		_, _, err = repo.CatFileBatch()
 		require.Error(t, err)
 		require.NoError(t, repo.Close()) // shouldn't panic
 	})

--- a/modules/git/repo_blob_test.go
+++ b/modules/git/repo_blob_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestRepository_GetBlob_Found(t *testing.T) {
 	repoPath := filepath.Join(testReposDir, "repo1_bare")
-	r, err := OpenRepositoryLocal(repoPath)
+	r, err := OpenRepositoryLocal(t.Context(), repoPath)
 	assert.NoError(t, err)
 	defer r.Close()
 
@@ -42,7 +42,7 @@ func TestRepository_GetBlob_Found(t *testing.T) {
 
 func TestRepository_GetBlob_NotExist(t *testing.T) {
 	repoPath := filepath.Join(testReposDir, "repo1_bare")
-	r, err := OpenRepositoryLocal(repoPath)
+	r, err := OpenRepositoryLocal(t.Context(), repoPath)
 	assert.NoError(t, err)
 	defer r.Close()
 
@@ -56,7 +56,7 @@ func TestRepository_GetBlob_NotExist(t *testing.T) {
 
 func TestRepository_GetBlob_NoId(t *testing.T) {
 	repoPath := filepath.Join(testReposDir, "repo1_bare")
-	r, err := OpenRepositoryLocal(repoPath)
+	r, err := OpenRepositoryLocal(t.Context(), repoPath)
 	assert.NoError(t, err)
 	defer r.Close()
 

--- a/modules/git/repo_branch_nogogit.go
+++ b/modules/git/repo_branch_nogogit.go
@@ -23,7 +23,7 @@ func (repo *Repository) IsObjectExist(ctx context.Context, name string) bool {
 		return false
 	}
 
-	batch, cancel, err := repo.CatFileBatch(ctx)
+	batch, cancel, err := repo.CatFileBatch()
 	if err != nil {
 		log.Debug("Error opening CatFileBatch %v", err)
 		return false
@@ -43,7 +43,7 @@ func (repo *Repository) IsReferenceExist(ctx context.Context, name string) bool 
 		return false
 	}
 
-	batch, cancel, err := repo.CatFileBatch(ctx)
+	batch, cancel, err := repo.CatFileBatch()
 	if err != nil {
 		log.Error("Error opening CatFileBatch %v", err)
 		return false

--- a/modules/git/repo_branch_test.go
+++ b/modules/git/repo_branch_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestRepository_GetBranches(t *testing.T) {
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
-	bareRepo1, err := OpenRepositoryLocal(bareRepo1Path)
+	bareRepo1, err := OpenRepositoryLocal(t.Context(), bareRepo1Path)
 	assert.NoError(t, err)
 	defer bareRepo1.Close()
 
@@ -41,7 +41,7 @@ func TestRepository_GetBranches(t *testing.T) {
 
 func BenchmarkRepository_GetBranches(b *testing.B) {
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
-	bareRepo1, err := OpenRepositoryLocal(bareRepo1Path)
+	bareRepo1, err := OpenRepositoryLocal(b.Context(), bareRepo1Path)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -57,7 +57,7 @@ func BenchmarkRepository_GetBranches(b *testing.B) {
 
 func TestGetRefsBySha(t *testing.T) {
 	bareRepo5Path := filepath.Join(testReposDir, "repo5_pulls")
-	bareRepo5, err := OpenRepositoryLocal(bareRepo5Path)
+	bareRepo5, err := OpenRepositoryLocal(t.Context(), bareRepo5Path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestGetRefsBySha(t *testing.T) {
 
 func BenchmarkGetRefsBySha(b *testing.B) {
 	bareRepo5Path := filepath.Join(testReposDir, "repo5_pulls")
-	bareRepo5, err := OpenRepositoryLocal(bareRepo5Path)
+	bareRepo5, err := OpenRepositoryLocal(b.Context(), bareRepo5Path)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -98,7 +98,7 @@ func BenchmarkGetRefsBySha(b *testing.B) {
 
 func TestRepository_IsObjectExist(t *testing.T) {
 	ctx := t.Context()
-	repo, err := OpenRepositoryLocal(filepath.Join(testReposDir, "repo1_bare"))
+	repo, err := OpenRepositoryLocal(ctx, filepath.Join(testReposDir, "repo1_bare"))
 	require.NoError(t, err)
 	defer repo.Close()
 
@@ -151,7 +151,7 @@ func TestRepository_IsObjectExist(t *testing.T) {
 
 func TestRepository_IsReferenceExist(t *testing.T) {
 	ctx := t.Context()
-	repo, err := OpenRepositoryLocal(filepath.Join(testReposDir, "repo1_bare"))
+	repo, err := OpenRepositoryLocal(ctx, filepath.Join(testReposDir, "repo1_bare"))
 	require.NoError(t, err)
 	defer repo.Close()
 

--- a/modules/git/repo_commit_nogogit.go
+++ b/modules/git/repo_commit_nogogit.go
@@ -37,7 +37,7 @@ func (repo *Repository) ResolveReference(ctx context.Context, name string) (stri
 
 // GetRefCommitID returns the last commit ID string of given reference (branch or tag).
 func (repo *Repository) GetRefCommitID(ctx context.Context, name string) (string, error) {
-	batch, cancel, err := repo.CatFileBatch(ctx)
+	batch, cancel, err := repo.CatFileBatch()
 	if err != nil {
 		return "", err
 	}
@@ -52,7 +52,7 @@ func (repo *Repository) GetRefCommitID(ctx context.Context, name string) (string
 }
 
 func (repo *Repository) getCommit(ctx context.Context, id ObjectID) (*Commit, error) {
-	batch, cancel, err := repo.CatFileBatch(ctx)
+	batch, cancel, err := repo.CatFileBatch()
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func (repo *Repository) ConvertToGitID(ctx context.Context, ref string) (ObjectI
 		}
 	}
 
-	batch, cancel, err := repo.CatFileBatch(ctx)
+	batch, cancel, err := repo.CatFileBatch()
 	if err != nil {
 		return nil, err
 	}

--- a/modules/git/repo_commit_test.go
+++ b/modules/git/repo_commit_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestRepository_GetCommitBranches(t *testing.T) {
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
-	bareRepo1, err := OpenRepositoryLocal(bareRepo1Path)
+	bareRepo1, err := OpenRepositoryLocal(t.Context(), bareRepo1Path)
 	assert.NoError(t, err)
 	defer bareRepo1.Close()
 
@@ -45,7 +45,7 @@ func TestRepository_GetCommitBranches(t *testing.T) {
 
 func TestGetTagCommitWithSignature(t *testing.T) {
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
-	bareRepo1, err := OpenRepositoryLocal(bareRepo1Path)
+	bareRepo1, err := OpenRepositoryLocal(t.Context(), bareRepo1Path)
 	assert.NoError(t, err)
 	defer bareRepo1.Close()
 
@@ -60,7 +60,7 @@ func TestGetTagCommitWithSignature(t *testing.T) {
 
 func TestGetCommitWithBadCommitID(t *testing.T) {
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
-	bareRepo1, err := OpenRepositoryLocal(bareRepo1Path)
+	bareRepo1, err := OpenRepositoryLocal(t.Context(), bareRepo1Path)
 	assert.NoError(t, err)
 	defer bareRepo1.Close()
 
@@ -72,7 +72,7 @@ func TestGetCommitWithBadCommitID(t *testing.T) {
 
 func TestIsCommitInBranch(t *testing.T) {
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
-	bareRepo1, err := OpenRepositoryLocal(bareRepo1Path)
+	bareRepo1, err := OpenRepositoryLocal(t.Context(), bareRepo1Path)
 	assert.NoError(t, err)
 	defer bareRepo1.Close()
 
@@ -87,7 +87,7 @@ func TestIsCommitInBranch(t *testing.T) {
 
 func TestRepository_CommitsBetween(t *testing.T) {
 	bareRepo1Path := filepath.Join(testReposDir, "repo4_commitsbetween")
-	bareRepo1, err := OpenRepositoryLocal(bareRepo1Path)
+	bareRepo1, err := OpenRepositoryLocal(t.Context(), bareRepo1Path)
 	assert.NoError(t, err)
 	defer bareRepo1.Close()
 
@@ -109,7 +109,7 @@ func TestRepository_CommitsBetween(t *testing.T) {
 
 func TestGetRefCommitID(t *testing.T) {
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
-	bareRepo1, err := OpenRepositoryLocal(bareRepo1Path)
+	bareRepo1, err := OpenRepositoryLocal(t.Context(), bareRepo1Path)
 	assert.NoError(t, err)
 	defer bareRepo1.Close()
 
@@ -136,7 +136,7 @@ func TestCommitsByFileAndRange(t *testing.T) {
 	defer test.MockVariableValue(&setting.Git.CommitsRangeSize, 2)()
 
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
-	bareRepo1, err := OpenRepositoryLocal(bareRepo1Path)
+	bareRepo1, err := OpenRepositoryLocal(t.Context(), bareRepo1Path)
 	require.NoError(t, err)
 	defer bareRepo1.Close()
 
@@ -179,7 +179,7 @@ M 100644 :1 b.txt
 	`))).RunStdString(t.Context())
 	require.NoError(t, runErr)
 
-	repoFollowRename, err := OpenRepositoryLocal(repoFollowRenameDir)
+	repoFollowRename, err := OpenRepositoryLocal(t.Context(), repoFollowRenameDir)
 	require.NoError(t, err)
 	defer repoFollowRename.Close()
 

--- a/modules/git/repo_compare_test.go
+++ b/modules/git/repo_compare_test.go
@@ -22,7 +22,7 @@ func TestGetFormatPatch(t *testing.T) {
 		return
 	}
 
-	repo, err := OpenRepositoryLocal(clonedPath)
+	repo, err := OpenRepositoryLocal(t.Context(), clonedPath)
 	if err != nil {
 		assert.NoError(t, err)
 		return
@@ -50,7 +50,7 @@ func TestGetFormatPatch(t *testing.T) {
 func TestReadPatch(t *testing.T) {
 	// Ensure we can read the patch files
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
-	repo, err := OpenRepositoryLocal(bareRepo1Path)
+	repo, err := OpenRepositoryLocal(t.Context(), bareRepo1Path)
 	if err != nil {
 		assert.NoError(t, err)
 		return
@@ -88,7 +88,7 @@ func TestReadWritePullHead(t *testing.T) {
 		return
 	}
 
-	repo, err := OpenRepositoryLocal(clonedPath)
+	repo, err := OpenRepositoryLocal(t.Context(), clonedPath)
 	if err != nil {
 		assert.NoError(t, err)
 		return
@@ -130,7 +130,7 @@ func TestReadWritePullHead(t *testing.T) {
 
 func TestGetCommitFilesChanged(t *testing.T) {
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
-	repo, err := OpenRepositoryLocal(bareRepo1Path)
+	repo, err := OpenRepositoryLocal(t.Context(), bareRepo1Path)
 	assert.NoError(t, err)
 	defer repo.Close()
 

--- a/modules/git/repo_ref_test.go
+++ b/modules/git/repo_ref_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestRepository_GetRefs(t *testing.T) {
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
-	bareRepo1, err := OpenRepositoryLocal(bareRepo1Path)
+	bareRepo1, err := OpenRepositoryLocal(t.Context(), bareRepo1Path)
 	assert.NoError(t, err)
 	defer bareRepo1.Close()
 
@@ -37,7 +37,7 @@ func TestRepository_GetRefs(t *testing.T) {
 
 func TestRepository_GetRefsFiltered(t *testing.T) {
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
-	bareRepo1, err := OpenRepositoryLocal(bareRepo1Path)
+	bareRepo1, err := OpenRepositoryLocal(t.Context(), bareRepo1Path)
 	assert.NoError(t, err)
 	defer bareRepo1.Close()
 

--- a/modules/git/repo_stats_test.go
+++ b/modules/git/repo_stats_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestRepository_GetCodeActivityStats(t *testing.T) {
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
-	bareRepo1, err := OpenRepositoryLocal(bareRepo1Path)
+	bareRepo1, err := OpenRepositoryLocal(t.Context(), bareRepo1Path)
 	assert.NoError(t, err)
 	defer bareRepo1.Close()
 

--- a/modules/git/repo_tag_nogogit.go
+++ b/modules/git/repo_tag_nogogit.go
@@ -25,7 +25,7 @@ func (repo *Repository) IsTagExist(ctx context.Context, name string) bool {
 
 // GetTagType gets the type of the tag, either commit (simple) or tag (annotated)
 func (repo *Repository) GetTagType(ctx context.Context, id ObjectID) (string, error) {
-	batch, cancel, err := repo.CatFileBatch(ctx)
+	batch, cancel, err := repo.CatFileBatch()
 	if err != nil {
 		return "", err
 	}
@@ -85,7 +85,7 @@ func (repo *Repository) getTag(ctx context.Context, tagID ObjectID, name string)
 	}
 
 	// The tag is an annotated tag with a message.
-	batch, cancel, err := repo.CatFileBatch(ctx)
+	batch, cancel, err := repo.CatFileBatch()
 	if err != nil {
 		return nil, err
 	}

--- a/modules/git/repo_tag_test.go
+++ b/modules/git/repo_tag_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestRepository_GetTagInfos(t *testing.T) {
 	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
-	bareRepo1, err := OpenRepositoryLocal(bareRepo1Path)
+	bareRepo1, err := OpenRepositoryLocal(t.Context(), bareRepo1Path)
 	if err != nil {
 		assert.NoError(t, err)
 		return
@@ -44,7 +44,7 @@ func TestRepository_GetTag(t *testing.T) {
 		return
 	}
 
-	bareRepo1, err := OpenRepositoryLocal(clonedPath)
+	bareRepo1, err := OpenRepositoryLocal(t.Context(), clonedPath)
 	if err != nil {
 		assert.NoError(t, err)
 		return
@@ -136,7 +136,7 @@ func TestRepository_GetAnnotatedTag(t *testing.T) {
 		return
 	}
 
-	bareRepo1, err := OpenRepositoryLocal(clonedPath)
+	bareRepo1, err := OpenRepositoryLocal(t.Context(), clonedPath)
 	if err != nil {
 		assert.NoError(t, err)
 		return

--- a/modules/git/repo_test.go
+++ b/modules/git/repo_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestRepoIsEmpty(t *testing.T) {
 	emptyRepo2Path := filepath.Join(testReposDir, "repo2_empty")
-	repo, err := OpenRepositoryLocal(emptyRepo2Path)
+	repo, err := OpenRepositoryLocal(t.Context(), emptyRepo2Path)
 	assert.NoError(t, err)
 	defer repo.Close()
 	isEmpty, err := repo.IsEmpty(t.Context())

--- a/modules/git/repo_tree_nogogit.go
+++ b/modules/git/repo_tree_nogogit.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (repo *Repository) getTree(ctx context.Context, id ObjectID) (*Tree, error) {
-	batch, cancel, err := repo.CatFileBatch(ctx)
+	batch, cancel, err := repo.CatFileBatch()
 	if err != nil {
 		return nil, err
 	}

--- a/modules/git/tree_entry_common_test.go
+++ b/modules/git/tree_entry_common_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestFollowLink(t *testing.T) {
-	r, err := OpenRepositoryLocal(filepath.Join(testReposDir, "repo1_bare"))
+	r, err := OpenRepositoryLocal(t.Context(), filepath.Join(testReposDir, "repo1_bare"))
 	require.NoError(t, err)
 	defer r.Close()
 

--- a/modules/git/tree_entry_nogogit.go
+++ b/modules/git/tree_entry_nogogit.go
@@ -18,7 +18,7 @@ func (te *TreeEntry) GetSize(ctx context.Context, gitRepo *Repository) int64 {
 		return te.size
 	}
 
-	batch, cancel, err := gitRepo.CatFileBatch(ctx)
+	batch, cancel, err := gitRepo.CatFileBatch()
 	if err != nil {
 		log.Debug("error whilst reading size for %s in %s. Error: %v", te.ID.String(), gitRepo.LogString(), err)
 		return 0

--- a/modules/git/tree_nogogit.go
+++ b/modules/git/tree_nogogit.go
@@ -26,7 +26,7 @@ func (t *Tree) ListEntries(ctx context.Context, gitRepo *Repository) (Entries, e
 		return t.entries, nil
 	}
 
-	batch, cancel, err := gitRepo.CatFileBatch(ctx)
+	batch, cancel, err := gitRepo.CatFileBatch()
 	if err != nil {
 		return nil, err
 	}

--- a/modules/git/tree_test.go
+++ b/modules/git/tree_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSubTree_Issue29101(t *testing.T) {
-	repo, err := OpenRepositoryLocal(filepath.Join(testReposDir, "repo1_bare"))
+	repo, err := OpenRepositoryLocal(t.Context(), filepath.Join(testReposDir, "repo1_bare"))
 	assert.NoError(t, err)
 	defer repo.Close()
 
@@ -27,7 +27,7 @@ func TestSubTree_Issue29101(t *testing.T) {
 }
 
 func Test_GetTreePathLatestCommit(t *testing.T) {
-	repo, err := OpenRepositoryLocal(filepath.Join(testReposDir, "repo6_blame"))
+	repo, err := OpenRepositoryLocal(t.Context(), filepath.Join(testReposDir, "repo6_blame"))
 	assert.NoError(t, err)
 	defer repo.Close()
 

--- a/modules/indexer/stats/db.go
+++ b/modules/indexer/stats/db.go
@@ -36,7 +36,7 @@ func (db *DBIndexer) Index(id int64) error {
 		return err
 	}
 
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(ctx, repo)
 	if err != nil {
 		if err.Error() == "no such file or directory" {
 			return nil

--- a/modules/repository/branch.go
+++ b/modules/repository/branch.go
@@ -32,7 +32,7 @@ func SyncRepoBranches(ctx context.Context, repoID, doerID int64) (int64, error) 
 
 	log.Debug("SyncRepoBranches: in Repo[%d:%s]", repo.ID, repo.FullName())
 
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(ctx, repo)
 	if err != nil {
 		log.Error("OpenRepository[%s]: %w", repo.FullName(), err)
 		return 0, err

--- a/modules/repository/repo.go
+++ b/modules/repository/repo.go
@@ -46,7 +46,7 @@ func SyncRepoTags(ctx context.Context, repoID int64) error {
 		return err
 	}
 
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(ctx, repo)
 	if err != nil {
 		return err
 	}

--- a/modules/util/runtime.go
+++ b/modules/util/runtime.go
@@ -3,7 +3,10 @@
 
 package util
 
-import "runtime"
+import (
+	"runtime"
+	"strings"
+)
 
 const isOSWindows = runtime.GOOS == "windows"
 
@@ -15,5 +18,9 @@ func CallerFuncName(optSkipParent ...int) string {
 	}
 	runtime.Callers(skipParent+1 /*this*/ +1 /*runtime*/, pc)
 	funcName := runtime.FuncForPC(pc[0]).Name()
+	if pos := strings.LastIndex(funcName, "/"); pos >= 0 {
+		// only keep the last package name and func name
+		funcName = funcName[pos+1:]
+	}
 	return funcName
 }

--- a/modules/util/runtime_test.go
+++ b/modules/util/runtime_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestCallerFuncName(t *testing.T) {
 	s := CallerFuncName()
-	assert.Equal(t, "gitea.dev/modules/util.TestCallerFuncName", s)
+	assert.Equal(t, "util.TestCallerFuncName", s)
 }
 
 func BenchmarkCallerFuncName(b *testing.B) {

--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -1106,7 +1106,7 @@ func parseCompareInfo(ctx *context.APIContext, compareParam string) (result *git
 		headGitRepo = ctx.Repo.GitRepo
 		closer = func() {} // no need to close the head repo because it shares the base repo
 	} else {
-		headGitRepo, err = git.OpenRepository(headRepo)
+		headGitRepo, err = git.OpenRepository(ctx, headRepo)
 		if err != nil {
 			ctx.APIErrorInternal(err)
 			return nil, nil

--- a/routers/api/v1/repo/wiki.go
+++ b/routers/api/v1/repo/wiki.go
@@ -467,7 +467,7 @@ func findEntryForFile(ctx *context.APIContext, wikiRepo *git.Repository, commit 
 // findWikiRepoCommit opens the wiki repo and returns the latest commit, writing to context on error.
 // The caller is responsible for closing the returned repo again
 func findWikiRepoCommit(ctx *context.APIContext) (*git.Repository, *git.Commit) {
-	wikiRepo, err := git.OpenRepository(ctx.Repo.Repository.WikiStorageRepo())
+	wikiRepo, err := git.OpenRepository(ctx, ctx.Repo.Repository.WikiStorageRepo())
 	if err != nil {
 		ctx.APIErrorAuto(err)
 		return nil, nil

--- a/routers/private/hook_verification_test.go
+++ b/routers/private/hook_verification_test.go
@@ -16,7 +16,7 @@ import (
 func TestVerifyCommits(t *testing.T) {
 	unittest.PrepareTestEnv(t)
 
-	gitRepo, err := git.OpenRepositoryLocal("tests/repos/repo1_hook_verification")
+	gitRepo, err := git.OpenRepositoryLocal(t.Context(), "tests/repos/repo1_hook_verification")
 	require.NoError(t, err)
 	defer gitRepo.Close()
 

--- a/routers/web/repo/actions/view.go
+++ b/routers/web/repo/actions/view.go
@@ -1476,7 +1476,7 @@ func viewScopedWorkflowFile(ctx *context_module.Context, run *actions_model.Acti
 		return
 	}
 
-	sourceGitRepo, err := git.OpenRepository(sourceRepo)
+	sourceGitRepo, err := git.OpenRepository(ctx, sourceRepo)
 	if err != nil {
 		ctx.ServerError("OpenRepository", err)
 		return

--- a/routers/web/repo/commit.go
+++ b/routers/web/repo/commit.go
@@ -430,7 +430,7 @@ func Diff(ctx *context.Context) {
 func RawDiff(ctx *context.Context) {
 	var gitRepo *git.Repository
 	if ctx.Data["PageIsWiki"] != nil {
-		wikiRepo, err := git.OpenRepository(ctx.Repo.Repository.WikiStorageRepo())
+		wikiRepo, err := git.OpenRepository(ctx, ctx.Repo.Repository.WikiStorageRepo())
 		if err != nil {
 			ctx.ServerError("OpenRepository", err)
 			return

--- a/routers/web/repo/editor_test.go
+++ b/routers/web/repo/editor_test.go
@@ -21,7 +21,7 @@ func TestEditorUtils(t *testing.T) {
 		assert.Equal(t, "user2-patch-1", branchName)
 	})
 	t.Run("getClosestParentWithFiles", func(t *testing.T) {
-		gitRepo, _ := git.OpenRepository(repo)
+		gitRepo, _ := git.OpenRepository(t.Context(), repo)
 		defer gitRepo.Close()
 		treePath := getClosestParentWithFiles(t.Context(), gitRepo, "sub-home-md-img-check", "docs/foo/bar")
 		assert.Equal(t, "docs", treePath)

--- a/routers/web/repo/setting/lfs.go
+++ b/routers/web/repo/setting/lfs.go
@@ -121,7 +121,7 @@ func LFSLocks(ctx *context.Context) {
 		return
 	}
 
-	gitRepo, err := git.OpenRepositoryLocal(tmpBasePath)
+	gitRepo, err := git.OpenRepositoryLocal(ctx, tmpBasePath)
 	if err != nil {
 		log.Error("Unable to open temporary repository: %s (%v)", tmpBasePath, err)
 		ctx.ServerError("LFSLocks", fmt.Errorf("failed to open new temporary repository in: %s %w", tmpBasePath, err))

--- a/routers/web/repo/wiki_test.go
+++ b/routers/web/repo/wiki_test.go
@@ -28,7 +28,7 @@ const (
 )
 
 func wikiEntry(t *testing.T, repo *repo_model.Repository, wikiName wiki_service.WebPath) (*git.Repository, *git.TreeEntry) {
-	wikiRepo, err := git.OpenRepository(repo.WikiStorageRepo())
+	wikiRepo, err := git.OpenRepository(t.Context(), repo.WikiStorageRepo())
 	assert.NoError(t, err)
 	t.Cleanup(func() {
 		defer wikiRepo.Close()

--- a/services/actions/commit_status_test.go
+++ b/services/actions/commit_status_test.go
@@ -47,7 +47,7 @@ func TestCreateCommitStatus_Dedupe(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
 
 	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 4})
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(t.Context(), repo)
 	require.NoError(t, err)
 	defer gitRepo.Close()
 

--- a/services/actions/notifier_helper.go
+++ b/services/actions/notifier_helper.go
@@ -147,7 +147,7 @@ func notify(ctx context.Context, input *notifyInput) error {
 		return nil
 	}
 
-	gitRepo, err := git.OpenRepository(input.Repo)
+	gitRepo, err := git.OpenRepository(ctx, input.Repo)
 	if err != nil {
 		return fmt.Errorf("git.OpenRepository: %w", err)
 	}
@@ -590,7 +590,7 @@ func DetectAndHandleSchedules(ctx context.Context, repo *repo_model.Repository) 
 		return nil
 	}
 
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(ctx, repo)
 	if err != nil {
 		return fmt.Errorf("git.OpenRepository: %w", err)
 	}

--- a/services/actions/reusable_workflow.go
+++ b/services/actions/reusable_workflow.go
@@ -94,7 +94,7 @@ func loadReusableWorkflowSource(ctx context.Context, run *actions_model.ActionRu
 
 // readWorkflowFromRepo loads a workflow file from `repo` at `refOrSHA` and returns its content plus the resolved commit SHA.
 func readWorkflowFromRepo(ctx context.Context, repo *repo_model.Repository, refOrSHA, path string) ([]byte, string, error) {
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(ctx, repo)
 	if err != nil {
 		return nil, "", fmt.Errorf("open repo %s: %w", repo.FullName(), err)
 	}

--- a/services/actions/scoped_workflow_cache.go
+++ b/services/actions/scoped_workflow_cache.go
@@ -50,7 +50,7 @@ func LoadParsedScopedWorkflows(ctx context.Context, sourceRepo *repo_model.Repos
 	}
 
 	// cache miss: open the source repo at the exact SHA we keyed on
-	sourceGitRepo, err := git.OpenRepository(sourceRepo)
+	sourceGitRepo, err := git.OpenRepository(ctx, sourceRepo)
 	if err != nil {
 		return "", nil, fmt.Errorf("open source repo: %w", err)
 	}

--- a/services/automerge/automerge.go
+++ b/services/automerge/automerge.go
@@ -103,7 +103,7 @@ func StartPRCheckAndAutoMergeBySHA(ctx context.Context, sha string, repo *repo_m
 }
 
 func getPullRequestsByHeadSHA(ctx context.Context, sha string, repo *repo_model.Repository, filter func(*issues_model.PullRequest) bool) (map[int64]*issues_model.PullRequest, error) {
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(ctx, repo)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func handlePullRequestAutoMerge(pullID int64, sha string) {
 	}
 
 	// check the sha is the same as pull request head commit id
-	baseGitRepo, err := git.OpenRepository(pr.BaseRepo)
+	baseGitRepo, err := git.OpenRepository(ctx, pr.BaseRepo)
 	if err != nil {
 		log.Error("OpenRepository: %v", err)
 		return

--- a/services/automergequeue/automergequeue.go
+++ b/services/automergequeue/automergequeue.go
@@ -34,7 +34,7 @@ func StartPRCheckAndAutoMerge(ctx context.Context, pull *issues_model.PullReques
 		return
 	}
 
-	gitRepo, err := git.OpenRepository(pull.BaseRepo)
+	gitRepo, err := git.OpenRepository(ctx, pull.BaseRepo)
 	if err != nil {
 		log.Error("OpenRepository: %v", err)
 		return

--- a/services/contexttest/context_tests.go
+++ b/services/contexttest/context_tests.go
@@ -140,7 +140,7 @@ func LoadRepoCommit(t *testing.T, ctx gocontext.Context) {
 		assert.FailNow(t, "context is not *context.Context or *context.APIContext")
 	}
 
-	gitRepo, err := git_module.OpenRepository(repo.Repository)
+	gitRepo, err := git_module.OpenRepository(ctx, repo.Repository)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		gitRepo.Close()
@@ -184,7 +184,7 @@ func LoadGitRepo(t *testing.T, ctx gocontext.Context) {
 	}
 	assert.NoError(t, repo.Repository.LoadOwner(ctx))
 	var err error
-	repo.GitRepo, err = git_module.OpenRepository(repo.Repository)
+	repo.GitRepo, err = git_module.OpenRepository(ctx, repo.Repository)
 	assert.NoError(t, err)
 }
 

--- a/services/convert/action_test.go
+++ b/services/convert/action_test.go
@@ -62,7 +62,7 @@ func TestGetActionWorkflow_FallbackRef(t *testing.T) {
 
 	repoDir := buildWorkflowTestRepo(t)
 
-	gitRepo, err := git.OpenRepositoryLocal(repoDir)
+	gitRepo, err := git.OpenRepositoryLocal(ctx, repoDir)
 	require.NoError(t, err)
 	defer gitRepo.Close()
 

--- a/services/convert/convert.go
+++ b/services/convert/convert.go
@@ -679,7 +679,7 @@ func ResolveActionWorkflowForRun(ctx context.Context, repo *repo_model.Repositor
 		if err != nil {
 			return nil, err
 		}
-		sourceGitRepo, err := git.OpenRepository(sourceRepo)
+		sourceGitRepo, err := git.OpenRepository(ctx, sourceRepo)
 		if err != nil {
 			return nil, err
 		}
@@ -687,7 +687,7 @@ func ResolveActionWorkflowForRun(ctx context.Context, repo *repo_model.Repositor
 		return GetScopedActionWorkflow(ctx, sourceGitRepo, sourceRepo, run.WorkflowID, run.WorkflowCommitSHA)
 	}
 
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(ctx, repo)
 	if err != nil {
 		return nil, err
 	}

--- a/services/convert/pull.go
+++ b/services/convert/pull.go
@@ -144,7 +144,7 @@ func ToAPIPullRequest(ctx context.Context, pr *issues_model.PullRequest, doer *u
 		apiPullRequest.Closed = pr.Issue.ClosedUnix.AsTimePtr()
 	}
 
-	gitRepo, err := git.OpenRepository(pr.BaseRepo)
+	gitRepo, err := git.OpenRepository(ctx, pr.BaseRepo)
 	if err != nil {
 		log.Error("OpenRepository[%s]: %v", pr.BaseRepo.FullName(), err)
 		return nil
@@ -190,7 +190,7 @@ func ToAPIPullRequest(ctx context.Context, pr *issues_model.PullRequest, doer *u
 		apiPullRequest.Head.RepoID = pr.HeadRepo.ID
 		apiPullRequest.Head.Repository = ToRepo(ctx, pr.HeadRepo, p)
 
-		headGitRepo, err := git.OpenRepository(pr.HeadRepo)
+		headGitRepo, err := git.OpenRepository(ctx, pr.HeadRepo)
 		if err != nil {
 			log.Error("OpenRepository[%s]: %v", pr.HeadRepo.FullName(), err)
 			return nil
@@ -246,7 +246,7 @@ func ToAPIPullRequest(ctx context.Context, pr *issues_model.PullRequest, doer *u
 	}
 
 	if len(apiPullRequest.Head.Sha) == 0 && len(apiPullRequest.Head.Ref) != 0 {
-		baseGitRepo, err := git.OpenRepository(pr.BaseRepo)
+		baseGitRepo, err := git.OpenRepository(ctx, pr.BaseRepo)
 		if err != nil {
 			log.Error("OpenRepository[%s]: %v", pr.BaseRepo.FullName(), err)
 			return nil
@@ -328,7 +328,7 @@ func ToAPIPullRequests(ctx context.Context, baseRepo *repo_model.Repository, prs
 		return nil, err
 	}
 
-	gitRepo, err := git.OpenRepository(baseRepo)
+	gitRepo, err := git.OpenRepository(ctx, baseRepo)
 	if err != nil {
 		return nil, err
 	}

--- a/services/gitdiff/git_diff_tree_test.go
+++ b/services/gitdiff/git_diff_tree_test.go
@@ -208,7 +208,7 @@ func TestGitDiffTree(t *testing.T) {
 
 	for _, tt := range test {
 		t.Run(tt.Name, func(t *testing.T) {
-			gitRepo, err := git.OpenRepositoryLocal(tt.RepoPath)
+			gitRepo, err := git.OpenRepositoryLocal(t.Context(), tt.RepoPath)
 			assert.NoError(t, err)
 			defer gitRepo.Close()
 
@@ -221,7 +221,7 @@ func TestGitDiffTree(t *testing.T) {
 }
 
 func TestGitDiffTreeRespectsDiffOrderFile(t *testing.T) {
-	gitRepo, err := git.OpenRepositoryLocal("../../modules/git/tests/repos/repo5_pulls")
+	gitRepo, err := git.OpenRepositoryLocal(t.Context(), "../../modules/git/tests/repos/repo5_pulls")
 	require.NoError(t, err)
 	defer gitRepo.Close()
 
@@ -454,7 +454,7 @@ func TestGitDiffTreeErrors(t *testing.T) {
 
 	for _, tt := range test {
 		t.Run(tt.Name, func(t *testing.T) {
-			gitRepo, err := git.OpenRepositoryLocal(tt.RepoPath)
+			gitRepo, err := git.OpenRepositoryLocal(t.Context(), tt.RepoPath)
 			assert.NoError(t, err)
 			defer gitRepo.Close()
 

--- a/services/gitdiff/gitdiff_test.go
+++ b/services/gitdiff/gitdiff_test.go
@@ -601,7 +601,7 @@ func TestDiffLine_GetCommentSide(t *testing.T) {
 }
 
 func TestGetDiffRangeWithWhitespaceBehavior(t *testing.T) {
-	gitRepo, err := git.OpenRepositoryLocal("../../modules/git/tests/repos/repo5_pulls")
+	gitRepo, err := git.OpenRepositoryLocal(t.Context(), "../../modules/git/tests/repos/repo5_pulls")
 	require.NoError(t, err)
 
 	defer gitRepo.Close()
@@ -1188,7 +1188,7 @@ D test2.txt
 D test10.txt`
 	require.NoError(t, gitcmd.NewCommand("fast-import").WithRepo(pull.BaseRepo).WithStdinBytes([]byte(stdin)).Run(t.Context()))
 
-	gitRepo, err := git.OpenRepository(pull.BaseRepo)
+	gitRepo, err := git.OpenRepository(t.Context(), pull.BaseRepo)
 	assert.NoError(t, err)
 	defer gitRepo.Close()
 

--- a/services/issue/pull.go
+++ b/services/issue/pull.go
@@ -54,7 +54,7 @@ func PullRequestCodeOwnersReview(ctx context.Context, pr *issues_model.PullReque
 		return nil, nil
 	}
 
-	repo, err := git.OpenRepository(pr.BaseRepo)
+	repo, err := git.OpenRepository(ctx, pr.BaseRepo)
 	if err != nil {
 		return nil, err
 	}

--- a/services/markup/renderhelper_codepreview.go
+++ b/services/markup/renderhelper_codepreview.go
@@ -50,7 +50,7 @@ func renderRepoFileCodePreview(ctx context.Context, opts markup.RenderCodePrevie
 		return "", util.ErrPermissionDenied
 	}
 
-	gitRepo, err := git.OpenRepository(dbRepo)
+	gitRepo, err := git.OpenRepository(ctx, dbRepo)
 	if err != nil {
 		return "", err
 	}

--- a/services/migrations/dump.go
+++ b/services/migrations/dump.go
@@ -195,7 +195,7 @@ func (g *RepositoryDumper) CreateRepo(ctx context.Context, repo *base.Repository
 		}
 	}
 
-	g.gitRepo, err = git.OpenRepositoryLocal(repoAbsPath)
+	g.gitRepo, err = git.OpenRepositoryLocal(ctx, repoAbsPath)
 	return err
 }
 

--- a/services/migrations/gitea_uploader.go
+++ b/services/migrations/gitea_uploader.go
@@ -138,7 +138,7 @@ func (g *GiteaLocalUploader) CreateRepo(ctx context.Context, repo *base.Reposito
 	if err != nil {
 		return err
 	}
-	g.gitRepo, err = git.OpenRepository(g.repo)
+	g.gitRepo, err = git.OpenRepository(ctx, g.repo)
 	if err != nil {
 		return err
 	}

--- a/services/mirror/mirror_pull.go
+++ b/services/mirror/mirror_pull.go
@@ -174,7 +174,7 @@ func runSync(ctx context.Context, m *repo_model.Mirror) ([]*repo_module.SyncResu
 		log.Error("SyncMirrors [repo: %-v]: %v", m.Repo, err)
 	}
 
-	gitRepo, err := git.OpenRepository(m.Repo)
+	gitRepo, err := git.OpenRepository(ctx, m.Repo)
 	if err != nil {
 		log.Error("SyncMirrors [repo: %-v]: failed to OpenRepository: %v", m.Repo, err)
 		return nil, false
@@ -323,7 +323,7 @@ func SyncPullMirror(ctx context.Context, repoID int64) bool {
 		return false
 	}
 
-	gitRepo, err := git.OpenRepository(m.Repo)
+	gitRepo, err := git.OpenRepository(ctx, m.Repo)
 	if err != nil {
 		log.Error("SyncMirrors [repo: %-v]: unable to OpenRepository: %v", m.Repo, err)
 		return false

--- a/services/mirror/mirror_push.go
+++ b/services/mirror/mirror_push.go
@@ -137,7 +137,7 @@ func runPushSync(ctx context.Context, m *repo_model.PushMirror) error {
 		if setting.LFS.StartServer {
 			log.Trace("SyncMirrors [repo: %-v]: syncing LFS objects...", m.Repo)
 
-			gitRepo, err := git.OpenRepository(storageRepo)
+			gitRepo, err := git.OpenRepository(ctx, storageRepo)
 			if err != nil {
 				log.Error("OpenRepository %s failed: %v", mirrorLogName, err)
 				return errors.New("OpenRepository failed")

--- a/services/pull/check.go
+++ b/services/pull/check.go
@@ -332,7 +332,7 @@ func getMergeCommit(ctx context.Context, pr *issues_model.PullRequest) (*git.Com
 		return nil, fmt.Errorf("GetFullCommitID(%s) in %s: %w", prHeadRef, pr.BaseRepo.FullName(), err)
 	}
 
-	gitRepo, err := git.OpenRepository(pr.BaseRepo)
+	gitRepo, err := git.OpenRepository(ctx, pr.BaseRepo)
 	if err != nil {
 		return nil, fmt.Errorf("%-v OpenRepository: %w", pr.BaseRepo, err)
 	}

--- a/services/pull/comment_test.go
+++ b/services/pull/comment_test.go
@@ -25,7 +25,7 @@ func TestCreatePushPullCommentForcePushDeletesOldComments(t *testing.T) {
 	require.NoError(t, pr.LoadIssue(ctx))
 	require.NoError(t, pr.LoadBaseRepo(ctx))
 
-	gitRepo, err := git.OpenRepository(pr.BaseRepo)
+	gitRepo, err := git.OpenRepository(ctx, pr.BaseRepo)
 	require.NoError(t, err)
 	defer gitRepo.Close()
 

--- a/services/pull/merge_prepare.go
+++ b/services/pull/merge_prepare.go
@@ -102,7 +102,7 @@ func createTemporaryRepoForMerge(ctx context.Context, pr *issues_model.PullReque
 	mergeCtx.sig = doer.NewGitSig()
 	mergeCtx.committer = mergeCtx.sig
 
-	gitRepo, err := git.OpenRepositoryLocal(mergeCtx.tmpBasePath)
+	gitRepo, err := git.OpenRepositoryLocal(ctx, mergeCtx.tmpBasePath)
 	if err != nil {
 		defer cancel()
 		return nil, nil, fmt.Errorf("failed to open temp git repo for pr[%d]: %w", mergeCtx.pr.ID, err)

--- a/services/pull/merge_rebase.go
+++ b/services/pull/merge_rebase.go
@@ -58,7 +58,7 @@ func doMergeRebaseFastForward(ctx *mergeContext) error {
 	}
 
 	// Original repo to read template from.
-	baseGitRepo, err := git.OpenRepository(ctx.pr.BaseRepo)
+	baseGitRepo, err := git.OpenRepository(ctx, ctx.pr.BaseRepo)
 	if err != nil {
 		log.Error("Unable to get Git repo for rebase: %v", err)
 		return err

--- a/services/pull/merge_squash.go
+++ b/services/pull/merge_squash.go
@@ -25,7 +25,7 @@ func getAuthorSignatureSquash(ctx *mergeContext) (*git.Signature, error) {
 	// Try to get a signature from the same user in one of the commits, as the
 	// poster email might be private or commits might have a different signature
 	// than the primary email address of the poster.
-	gitRepo, err := git.OpenRepositoryLocal(ctx.tmpBasePath)
+	gitRepo, err := git.OpenRepositoryLocal(ctx, ctx.tmpBasePath)
 	if err != nil {
 		log.Error("%-v Unable to open base repository: %v", ctx.pr, err)
 		return nil, err

--- a/services/pull/merge_tree.go
+++ b/services/pull/merge_tree.go
@@ -54,7 +54,7 @@ func checkPullRequestMergeableByMergeTree(ctx context.Context, pr *issues_model.
 	if err := pr.LoadHeadRepo(ctx); err != nil {
 		return err
 	}
-	headGitRepo, err := git.OpenRepository(pr.HeadRepo)
+	headGitRepo, err := git.OpenRepository(ctx, pr.HeadRepo)
 	if err != nil {
 		return fmt.Errorf("OpenRepository: %w", err)
 	}
@@ -65,7 +65,7 @@ func checkPullRequestMergeableByMergeTree(ctx context.Context, pr *issues_model.
 	if pr.IsSameRepo() {
 		baseGitRepo = headGitRepo
 	} else {
-		baseGitRepo, err = git.OpenRepository(pr.BaseRepo)
+		baseGitRepo, err = git.OpenRepository(ctx, pr.BaseRepo)
 		if err != nil {
 			return fmt.Errorf("OpenRepository: %w", err)
 		}

--- a/services/pull/patch.go
+++ b/services/pull/patch.go
@@ -73,7 +73,7 @@ func checkPullRequestMergeableByTmpRepo(ctx context.Context, pr *issues_model.Pu
 	}
 	defer cancel()
 
-	tmpGitRepo, err := git.OpenRepositoryLocal(prCtx.tmpBasePath)
+	tmpGitRepo, err := git.OpenRepositoryLocal(ctx, prCtx.tmpBasePath)
 	if err != nil {
 		return fmt.Errorf("OpenRepository: %w", err)
 	}

--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -364,7 +364,7 @@ func checkForInvalidation(ctx context.Context, requests issues_model.PullRequest
 	if err != nil {
 		return fmt.Errorf("GetRepositoryByIDCtx: %w", err)
 	}
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(ctx, repo)
 	if err != nil {
 		return fmt.Errorf("gitrepo.OpenRepository: %w", err)
 	}
@@ -959,7 +959,7 @@ func GetIssuesAllCommitStatus(ctx context.Context, issues issues_model.IssueList
 		}
 		gitRepo, ok := gitRepos[issue.RepoID]
 		if !ok {
-			gitRepo, err = git.OpenRepository(issue.Repo)
+			gitRepo, err = git.OpenRepository(ctx, issue.Repo)
 			if err != nil {
 				log.Error("Cannot open git repository %-v for issue #%d[%d]. Error: %v", issue.Repo, issue.Index, issue.ID, err)
 				continue

--- a/services/pull/pull_test.go
+++ b/services/pull/pull_test.go
@@ -44,7 +44,7 @@ func TestPullRequest_GetDefaultMergeMessage_InternalTracker(t *testing.T) {
 	pr := unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{ID: 2})
 
 	assert.NoError(t, pr.LoadBaseRepo(t.Context()))
-	gitRepo, err := git.OpenRepository(pr.BaseRepo)
+	gitRepo, err := git.OpenRepository(t.Context(), pr.BaseRepo)
 	assert.NoError(t, err)
 	defer gitRepo.Close()
 
@@ -74,7 +74,7 @@ func TestPullRequest_GetDefaultMergeMessage_ExternalTracker(t *testing.T) {
 	pr := unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{ID: 2, BaseRepo: baseRepo})
 
 	assert.NoError(t, pr.LoadBaseRepo(t.Context()))
-	gitRepo, err := git.OpenRepository(pr.BaseRepo)
+	gitRepo, err := git.OpenRepository(t.Context(), pr.BaseRepo)
 	assert.NoError(t, err)
 	defer gitRepo.Close()
 

--- a/services/release/notes_test.go
+++ b/services/release/notes_test.go
@@ -23,7 +23,7 @@ func TestGenerateReleaseNotes(t *testing.T) {
 
 	t.Run("ChangeLogsWithPRs", func(t *testing.T) {
 		repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
-		gitRepo, err := git.OpenRepository(repo)
+		gitRepo, err := git.OpenRepository(t.Context(), repo)
 		require.NoError(t, err)
 		t.Cleanup(func() { gitRepo.Close() })
 
@@ -52,7 +52,7 @@ func TestGenerateReleaseNotes(t *testing.T) {
 
 	t.Run("NoPreviousTag", func(t *testing.T) {
 		repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 16})
-		gitRepo, err := git.OpenRepository(repo)
+		gitRepo, err := git.OpenRepository(t.Context(), repo)
 		require.NoError(t, err)
 		t.Cleanup(func() { gitRepo.Close() })
 
@@ -83,7 +83,7 @@ func TestGenerateReleaseNotes(t *testing.T) {
 
 	t.Run("EmptyPreviousTagWithExistingTags", func(t *testing.T) {
 		repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
-		gitRepo, err := git.OpenRepository(repo)
+		gitRepo, err := git.OpenRepository(t.Context(), repo)
 		require.NoError(t, err)
 		t.Cleanup(func() { gitRepo.Close() })
 

--- a/services/release/release_test.go
+++ b/services/release/release_test.go
@@ -33,7 +33,7 @@ func TestRelease_Create(t *testing.T) {
 	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
 	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
 
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(t.Context(), repo)
 	assert.NoError(t, err)
 	defer gitRepo.Close()
 
@@ -138,7 +138,7 @@ func TestRelease_Update(t *testing.T) {
 	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
 	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
 
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(t.Context(), repo)
 	assert.NoError(t, err)
 	defer gitRepo.Close()
 
@@ -297,7 +297,7 @@ func TestRelease_createTag(t *testing.T) {
 	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
 	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
 
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(t.Context(), repo)
 	assert.NoError(t, err)
 	defer gitRepo.Close()
 

--- a/services/repository/adopt.go
+++ b/services/repository/adopt.go
@@ -142,7 +142,7 @@ func adoptRepository(ctx context.Context, repo *repo_model.Repository, defaultBr
 	}
 
 	// Don't bother looking this repo in the context it won't be there
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(ctx, repo)
 	if err != nil {
 		return fmt.Errorf("openRepository: %w", err)
 	}

--- a/services/repository/branch.go
+++ b/services/repository/branch.go
@@ -225,7 +225,7 @@ func loadOneBranch(ctx context.Context, repo *repo_model.Repository, dbBranch *g
 		if pr.HasMerged {
 			baseGitRepo, ok := repoIDToGitRepo[pr.BaseRepoID]
 			if !ok {
-				baseGitRepo, err = git.OpenRepository(pr.BaseRepo)
+				baseGitRepo, err = git.OpenRepository(ctx, pr.BaseRepo)
 				if err != nil {
 					return nil, fmt.Errorf("OpenRepository: %v", err)
 				}

--- a/services/repository/files/patch_test.go
+++ b/services/repository/files/patch_test.go
@@ -21,7 +21,7 @@ func TestGitPatchPrepare(t *testing.T) {
 	user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
 	repo1 := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
 
-	gitRepo, err := git.OpenRepository(repo1.CodeStorageRepo())
+	gitRepo, err := git.OpenRepository(t.Context(), repo1.CodeStorageRepo())
 	require.NoError(t, err)
 	defer gitRepo.Close()
 

--- a/services/repository/files/temp_repo.go
+++ b/services/repository/files/temp_repo.go
@@ -76,7 +76,7 @@ func (t *TemporaryUploadRepository) Clone(ctx context.Context, branch string, ba
 		}
 		return fmt.Errorf("temp repo clone error: %w, %s", err, stderr)
 	}
-	gitRepo, err := git.OpenRepositoryLocal(t.basePath)
+	gitRepo, err := git.OpenRepositoryLocal(ctx, t.basePath)
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func (t *TemporaryUploadRepository) Init(ctx context.Context, objectFormatName s
 	if err := git.InitRepositoryLocal(ctx, t.basePath, false, objectFormatName); err != nil {
 		return err
 	}
-	gitRepo, err := git.OpenRepositoryLocal(t.basePath)
+	gitRepo, err := git.OpenRepositoryLocal(ctx, t.basePath)
 	if err != nil {
 		return err
 	}

--- a/services/repository/fork.go
+++ b/services/repository/fork.go
@@ -170,7 +170,7 @@ func ForkRepository(ctx context.Context, doer, owner *user_model.User, opts Fork
 
 	// 6 - Sync the repository branches and tags
 	var gitRepo *git.Repository
-	gitRepo, err = git.OpenRepository(repo)
+	gitRepo, err = git.OpenRepository(ctx, repo)
 	if err != nil {
 		return nil, fmt.Errorf("OpenRepository: %w", err)
 	}

--- a/services/repository/gitgraph/graph_test.go
+++ b/services/repository/gitgraph/graph_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func BenchmarkGetCommitGraph(b *testing.B) {
-	currentRepo, err := git.OpenRepositoryLocal(".")
+	currentRepo, err := git.OpenRepositoryLocal(b.Context(), ".")
 	if err != nil || currentRepo == nil {
 		b.Error("Could not open repository")
 	}

--- a/services/repository/hooks.go
+++ b/services/repository/hooks.go
@@ -52,13 +52,13 @@ func SyncRepositoryHooks(ctx context.Context) error {
 
 // GenerateGitHooks generates git hooks from a template repository
 func GenerateGitHooks(ctx context.Context, templateRepo, generateRepo *repo_model.Repository) error {
-	generateGitRepo, err := git.OpenRepository(generateRepo)
+	generateGitRepo, err := git.OpenRepository(ctx, generateRepo)
 	if err != nil {
 		return err
 	}
 	defer generateGitRepo.Close()
 
-	templateGitRepo, err := git.OpenRepository(templateRepo)
+	templateGitRepo, err := git.OpenRepository(ctx, templateRepo)
 	if err != nil {
 		return err
 	}

--- a/services/repository/lfs.go
+++ b/services/repository/lfs.go
@@ -69,7 +69,7 @@ func GarbageCollectLFSMetaObjectsForRepo(ctx context.Context, repo *repo_model.R
 		}
 	}()
 
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(ctx, repo)
 	if err != nil {
 		log.Error("Unable to open git repository %-v: %v", repo, err)
 		return err

--- a/services/repository/license.go
+++ b/services/repository/license.go
@@ -71,7 +71,7 @@ func repoLicenseUpdater(items ...*LicenseUpdaterOptions) []*LicenseUpdaterOption
 			continue
 		}
 
-		gitRepo, err := git.OpenRepository(repo)
+		gitRepo, err := git.OpenRepository(ctx, repo)
 		if err != nil {
 			log.Error("repoLicenseUpdater [%d] failed: OpenRepository: %v", opts.RepoID, err)
 			continue

--- a/services/repository/migrate.go
+++ b/services/repository/migrate.go
@@ -121,7 +121,7 @@ func MigrateRepositoryGitData(ctx context.Context, u *user_model.User,
 		return nil, fmt.Errorf("updateGitRepoAfterCreate: %w", err)
 	}
 
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(ctx, repo)
 	if err != nil {
 		return repo, fmt.Errorf("OpenRepository: %w", err)
 	}

--- a/services/repository/push.go
+++ b/services/repository/push.go
@@ -73,7 +73,7 @@ func pushQueueHandleUpdates(optsList []*repo_module.PushUpdateOptions) error {
 		return fmt.Errorf("GetRepositoryByOwnerAndName failed: %w", err)
 	}
 
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(ctx, repo)
 	if err != nil {
 		return fmt.Errorf("OpenRepository[%s]: %w", repo.FullName(), err)
 	}

--- a/services/wiki/wiki.go
+++ b/services/wiki/wiki.go
@@ -122,7 +122,7 @@ func updateWikiPage(ctx context.Context, doer *user_model.User, repo *repo_model
 		return fmt.Errorf("failed to clone repository: %s (%w)", repo.FullName(), err)
 	}
 
-	gitRepo, err := git.OpenRepositoryLocal(basePath)
+	gitRepo, err := git.OpenRepositoryLocal(ctx, basePath)
 	if err != nil {
 		log.Error("Unable to open temporary repository: %s (%v)", basePath, err)
 		return fmt.Errorf("failed to open new temporary repository in: %s %w", basePath, err)
@@ -281,7 +281,7 @@ func DeleteWikiPage(ctx context.Context, doer *user_model.User, repo *repo_model
 		return fmt.Errorf("failed to clone repository: %s (%w)", repo.FullName(), err)
 	}
 
-	gitRepo, err := git.OpenRepositoryLocal(basePath)
+	gitRepo, err := git.OpenRepositoryLocal(ctx, basePath)
 	if err != nil {
 		log.Error("Unable to open temporary repository: %s (%v)", basePath, err)
 		return fmt.Errorf("failed to open new temporary repository in: %s %w", basePath, err)

--- a/services/wiki/wiki_test.go
+++ b/services/wiki/wiki_test.go
@@ -166,7 +166,7 @@ func TestRepository_AddWikiPage(t *testing.T) {
 			webPath := UserTitleToWebPath("", userTitle)
 			assert.NoError(t, AddWikiPage(t.Context(), doer, repo, webPath, wikiContent, commitMsg))
 			// Now need to show that the page has been added:
-			gitRepo, err := git.OpenRepository(repo.WikiStorageRepo())
+			gitRepo, err := git.OpenRepository(t.Context(), repo.WikiStorageRepo())
 			require.NoError(t, err)
 
 			defer gitRepo.Close()
@@ -213,7 +213,7 @@ func TestRepository_EditWikiPage(t *testing.T) {
 		assert.NoError(t, EditWikiPage(t.Context(), doer, repo, "Home", webPath, newWikiContent, commitMsg))
 
 		// Now need to show that the page has been added:
-		gitRepo, err := git.OpenRepository(repo.WikiStorageRepo())
+		gitRepo, err := git.OpenRepository(t.Context(), repo.WikiStorageRepo())
 		assert.NoError(t, err)
 		masterTree, err := gitRepo.GetTree(t.Context(), repo.DefaultWikiBranch)
 		assert.NoError(t, err)
@@ -237,7 +237,7 @@ func TestRepository_DeleteWikiPage(t *testing.T) {
 	assert.NoError(t, DeleteWikiPage(t.Context(), doer, repo, "Home"))
 
 	// Now need to show that the page has been added:
-	gitRepo, err := git.OpenRepository(repo.WikiStorageRepo())
+	gitRepo, err := git.OpenRepository(t.Context(), repo.WikiStorageRepo())
 	require.NoError(t, err)
 
 	defer gitRepo.Close()
@@ -251,7 +251,7 @@ func TestRepository_DeleteWikiPage(t *testing.T) {
 func TestPrepareWikiFileName(t *testing.T) {
 	unittest.PrepareTestEnv(t)
 	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
-	gitRepo, err := git.OpenRepository(repo.WikiStorageRepo())
+	gitRepo, err := git.OpenRepository(t.Context(), repo.WikiStorageRepo())
 	require.NoError(t, err)
 
 	defer gitRepo.Close()
@@ -304,7 +304,7 @@ func TestPrepareWikiFileName_FirstPage(t *testing.T) {
 	err := git.InitRepositoryLocal(t.Context(), tmpDir, true, git.Sha1ObjectFormat.Name())
 	assert.NoError(t, err)
 
-	gitRepo, err := git.OpenRepositoryLocal(tmpDir)
+	gitRepo, err := git.OpenRepositoryLocal(t.Context(), tmpDir)
 	require.NoError(t, err)
 
 	defer gitRepo.Close()

--- a/tests/integration/actions_trigger_test.go
+++ b/tests/integration/actions_trigger_test.go
@@ -787,8 +787,8 @@ func TestPullRequestReviewCommitStatusEvent(t *testing.T) {
 		assert.NotEmpty(t, repo)
 
 		// add user4 as collaborator so they can review
-		ctx := NewAPITestContext(t, repo.OwnerName, repo.Name, auth_model.AccessTokenScopeWriteRepository)
-		t.Run("AddUser4AsCollaboratorWithWriteAccess", doAPIAddCollaborator(ctx, "user4", perm.AccessModeWrite))
+		apiTestCtx := NewAPITestContext(t, repo.OwnerName, repo.Name, auth_model.AccessTokenScopeWriteRepository)
+		t.Run("AddUser4AsCollaboratorWithWriteAccess", doAPIAddCollaborator(apiTestCtx, "user4", perm.AccessModeWrite))
 
 		// add workflow file that triggers on pull_request_review
 		addWorkflow, err := files_service.ChangeRepoFiles(t.Context(), repo, user2, &files_service.ChangeRepoFilesOptions{
@@ -829,7 +829,7 @@ jobs:
 
 		// create a branch and a PR
 		testBranch := "test-review-branch"
-		testCreateBranch(t, ctx.Session, repo.OwnerName, repo.Name, "branch/main", testBranch, http.StatusSeeOther)
+		testCreateBranch(t, apiTestCtx.Session, repo.OwnerName, repo.Name, "branch/main", testBranch, http.StatusSeeOther)
 
 		// add a file on the test branch so the PR has changes
 		addFileResp, err := files_service.ChangeRepoFiles(t.Context(), repo, user2, &files_service.ChangeRepoFilesOptions{
@@ -881,7 +881,7 @@ jobs:
 		assert.NoError(t, err)
 
 		// submit an approval review as user4
-		gitRepo, err := git.OpenRepository(ctx, repo)
+		gitRepo, err := git.OpenRepository(t.Context(), repo)
 		assert.NoError(t, err)
 		defer gitRepo.Close()
 

--- a/tests/integration/actions_trigger_test.go
+++ b/tests/integration/actions_trigger_test.go
@@ -477,7 +477,7 @@ jobs:
 		assert.NotEmpty(t, addWorkflowToBaseResp)
 
 		// Get the commit ID of the default branch
-		gitRepo, err := git.OpenRepository(repo)
+		gitRepo, err := git.OpenRepository(t.Context(), repo)
 		assert.NoError(t, err)
 		defer gitRepo.Close()
 		branch, err := git_model.GetBranchExisting(t.Context(), repo.ID, repo.DefaultBranch)
@@ -881,7 +881,7 @@ jobs:
 		assert.NoError(t, err)
 
 		// submit an approval review as user4
-		gitRepo, err := git.OpenRepository(repo)
+		gitRepo, err := git.OpenRepository(ctx, repo)
 		assert.NoError(t, err)
 		defer gitRepo.Close()
 
@@ -961,7 +961,7 @@ jobs:
 		assert.NotEmpty(t, addWorkflowToBaseResp)
 
 		// Get the commit ID of the default branch
-		gitRepo, err := git.OpenRepository(repo)
+		gitRepo, err := git.OpenRepository(t.Context(), repo)
 		assert.NoError(t, err)
 		defer gitRepo.Close()
 		branch, err := git_model.GetBranchExisting(t.Context(), repo.ID, repo.DefaultBranch)
@@ -1132,7 +1132,7 @@ jobs:
 		assert.NotEmpty(t, addWorkflowToBaseResp)
 
 		// Get the commit ID of the default branch
-		gitRepo, err := git.OpenRepository(repo)
+		gitRepo, err := git.OpenRepository(t.Context(), repo)
 		assert.NoError(t, err)
 		defer gitRepo.Close()
 		branch, err := git_model.GetBranchExisting(t.Context(), repo.ID, repo.DefaultBranch)
@@ -1223,7 +1223,7 @@ jobs:
 		assert.NotEmpty(t, addWorkflowToBaseResp)
 
 		// Get the commit ID of the default branch
-		gitRepo, err := git.OpenRepository(repo)
+		gitRepo, err := git.OpenRepository(t.Context(), repo)
 		assert.NoError(t, err)
 		defer gitRepo.Close()
 		branch, err := git_model.GetBranchExisting(t.Context(), repo.ID, repo.DefaultBranch)
@@ -1309,7 +1309,7 @@ jobs:
 		assert.NotEmpty(t, addWorkflowToBaseResp)
 
 		// Get the commit ID of the default branch
-		gitRepo, err := git.OpenRepository(repo)
+		gitRepo, err := git.OpenRepository(t.Context(), repo)
 		assert.NoError(t, err)
 		defer gitRepo.Close()
 		branch, err := git_model.GetBranchExisting(t.Context(), repo.ID, repo.DefaultBranch)
@@ -1439,7 +1439,7 @@ jobs:
 		assert.NotEmpty(t, addWorkflowToBaseResp)
 
 		// Get the commit ID of the dispatch branch
-		gitRepo, err := git.OpenRepository(repo)
+		gitRepo, err := git.OpenRepository(t.Context(), repo)
 		assert.NoError(t, err)
 		defer gitRepo.Close()
 		commit, err := gitRepo.GetBranchCommit(t.Context(), "dispatch")
@@ -1637,7 +1637,7 @@ jobs:
 		assert.Equal(t, workflows.Workflows[0].State, workflow.State)
 
 		// Get the commit ID of the default branch
-		gitRepo, err := git.OpenRepository(repo)
+		gitRepo, err := git.OpenRepository(t.Context(), repo)
 		assert.NoError(t, err)
 		defer gitRepo.Close()
 		branch, err := git_model.GetBranchExisting(t.Context(), repo.ID, repo.DefaultBranch)
@@ -1806,7 +1806,7 @@ jobs:
 		assert.NoError(t, err)
 		assert.NotEmpty(t, addWorkflowToBaseResp)
 
-		gitRepo, err := git.OpenRepository(repo)
+		gitRepo, err := git.OpenRepository(t.Context(), repo)
 		assert.NoError(t, err)
 		defer gitRepo.Close()
 
@@ -1884,7 +1884,7 @@ jobs:
 		assert.NoError(t, err)
 		assert.NotEmpty(t, addWorkflowToBaseResp)
 
-		gitRepo, err := git.OpenRepository(repo)
+		gitRepo, err := git.OpenRepository(t.Context(), repo)
 		assert.NoError(t, err)
 		defer gitRepo.Close()
 

--- a/tests/integration/api_packages_cargo_test.go
+++ b/tests/integration/api_packages_cargo_test.go
@@ -76,7 +76,7 @@ func testPackageCargo(t *testing.T, _ *neturl.URL) {
 	assert.NoError(t, err)
 
 	readGitContent := func(t *testing.T, path string) string {
-		gitRepo, err := git.OpenRepository(repo)
+		gitRepo, err := git.OpenRepository(t.Context(), repo)
 		assert.NoError(t, err)
 		defer gitRepo.Close()
 

--- a/tests/integration/api_pull_review_test.go
+++ b/tests/integration/api_pull_review_test.go
@@ -375,7 +375,7 @@ func TestAPIPullReviewCommentResolveEndpoints(t *testing.T) {
 
 	doer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: pullIssue.PosterID})
 	require.NoError(t, pullIssue.LoadPullRequest(ctx))
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(ctx, repo)
 	require.NoError(t, err)
 	defer gitRepo.Close()
 
@@ -536,7 +536,7 @@ func testAPIPullReviewCommentReply(t *testing.T) {
 	require.NoError(t, pullIssue.LoadRepo(t.Context()))
 	require.NoError(t, pullIssue.LoadPullRequest(t.Context()))
 	doer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
-	gitRepo, err := git.OpenRepository(pullIssue.Repo)
+	gitRepo, err := git.OpenRepository(t.Context(), pullIssue.Repo)
 	require.NoError(t, err)
 	defer gitRepo.Close()
 

--- a/tests/integration/api_releases_test.go
+++ b/tests/integration/api_releases_test.go
@@ -186,7 +186,7 @@ func TestAPICreateAndUpdateRelease(t *testing.T) {
 	session := loginUser(t, owner.LowerName)
 	token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteRepository)
 
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(t.Context(), repo)
 	assert.NoError(t, err)
 	defer gitRepo.Close()
 
@@ -237,7 +237,7 @@ func TestAPICreateProtectedTagRelease(t *testing.T) {
 	session := loginUser(t, writer.LowerName)
 	token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteRepository)
 
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(t.Context(), repo)
 	assert.NoError(t, err)
 	defer gitRepo.Close()
 
@@ -273,7 +273,7 @@ func TestAPICreateReleaseToDefaultBranchOnExistingTag(t *testing.T) {
 	session := loginUser(t, owner.LowerName)
 	token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteRepository)
 
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(t.Context(), repo)
 	assert.NoError(t, err)
 	defer gitRepo.Close()
 

--- a/tests/integration/api_repo_file_create_test.go
+++ b/tests/integration/api_repo_file_create_test.go
@@ -153,7 +153,7 @@ func TestAPICreateFile(t *testing.T) {
 			req := NewRequestWithJSON(t, "POST", fmt.Sprintf("/api/v1/repos/%s/%s/contents/%s", user2.Name, repo1.Name, treePath), &createFileOptions).
 				AddTokenAuth(token2)
 			resp := MakeRequest(t, req, http.StatusCreated)
-			gitRepo, _ := git.OpenRepository(repo1)
+			gitRepo, _ := git.OpenRepository(t.Context(), repo1)
 			defer gitRepo.Close()
 			commitID, _ := gitRepo.GetBranchCommitID(t.Context(), createFileOptions.NewBranchName)
 			lastCommit, _ := gitRepo.GetCommitByPath(t.Context(), treePath)
@@ -276,7 +276,7 @@ func TestAPICreateFile(t *testing.T) {
 			AddTokenAuth(token2)
 		resp = MakeRequest(t, req, http.StatusCreated)
 		emptyRepo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{OwnerName: "user2", Name: "empty-repo"}) // public repo
-		gitRepo, _ := git.OpenRepository(emptyRepo)
+		gitRepo, _ := git.OpenRepository(t.Context(), emptyRepo)
 		defer gitRepo.Close()
 		commitID, _ := gitRepo.GetBranchCommitID(t.Context(), createFileOptions.NewBranchName)
 		latestCommit, _ := gitRepo.GetCommitByPath(t.Context(), treePath)

--- a/tests/integration/api_repo_file_update_test.go
+++ b/tests/integration/api_repo_file_update_test.go
@@ -136,7 +136,7 @@ func TestAPIUpdateFile(t *testing.T) {
 			req := NewRequestWithJSON(t, "PUT", fmt.Sprintf("/api/v1/repos/%s/%s/contents/%s", user2.Name, repo1.Name, treePath), &updateFileOptions).
 				AddTokenAuth(token2)
 			resp := MakeRequest(t, req, http.StatusOK)
-			gitRepo, _ := git.OpenRepository(repo1)
+			gitRepo, _ := git.OpenRepository(t.Context(), repo1)
 			defer gitRepo.Close()
 			commitID, _ := gitRepo.GetBranchCommitID(t.Context(), updateFileOptions.NewBranchName)
 			lasCommit, _ := gitRepo.GetCommitByPath(t.Context(), treePath)

--- a/tests/integration/api_repo_files_change_test.go
+++ b/tests/integration/api_repo_files_change_test.go
@@ -93,7 +93,7 @@ func TestAPIChangeFiles(t *testing.T) {
 				req := NewRequestWithJSON(t, "POST", fmt.Sprintf("/api/v1/repos/%s/%s/contents", user2.Name, repo1.Name), &changeFilesOptions).
 					AddTokenAuth(token2)
 				resp := MakeRequest(t, req, http.StatusCreated)
-				gitRepo, _ := git.OpenRepository(repo1)
+				gitRepo, _ := git.OpenRepository(t.Context(), repo1)
 				defer gitRepo.Close()
 				commitID, _ := gitRepo.GetBranchCommitID(t.Context(), changeFilesOptions.NewBranchName)
 				createLasCommit, _ := gitRepo.GetCommitByPath(t.Context(), createTreePath)

--- a/tests/integration/api_repo_files_get_test.go
+++ b/tests/integration/api_repo_files_get_test.go
@@ -42,7 +42,7 @@ func TestAPIGetRequestedFiles(t *testing.T) {
 	session = loginUser(t, user4.Name)
 	token4 := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteRepository)
 
-	gitRepo, err := git.OpenRepository(repo1)
+	gitRepo, err := git.OpenRepository(t.Context(), repo1)
 	assert.NoError(t, err)
 	defer gitRepo.Close()
 	lastCommit, _ := gitRepo.GetCommitByPath(t.Context(), "README.md")

--- a/tests/integration/api_repo_get_contents_list_test.go
+++ b/tests/integration/api_repo_get_contents_list_test.go
@@ -73,7 +73,7 @@ func testAPIGetContentsList(t *testing.T, u *url.URL) {
 	token4 := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeReadRepository)
 
 	// Get the commit ID of the default branch
-	gitRepo, err := git.OpenRepository(repo1)
+	gitRepo, err := git.OpenRepository(t.Context(), repo1)
 	assert.NoError(t, err)
 	defer gitRepo.Close()
 

--- a/tests/integration/api_repo_get_contents_test.go
+++ b/tests/integration/api_repo_get_contents_test.go
@@ -78,7 +78,7 @@ func testAPIGetContents(t *testing.T, _ *url.URL) {
 	token4 := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeReadRepository)
 
 	// Get the commit ID of the default branch
-	gitRepo, err := git.OpenRepository(repo1)
+	gitRepo, err := git.OpenRepository(t.Context(), repo1)
 	require.NoError(t, err)
 	defer gitRepo.Close()
 

--- a/tests/integration/api_repo_git_tags_test.go
+++ b/tests/integration/api_repo_git_tags_test.go
@@ -31,7 +31,7 @@ func TestAPIGitTags(t *testing.T) {
 	_ = git.ManagedConfigSet(t.Context(), repo, "user.name", user.Name)
 	_ = git.ManagedConfigSet(t.Context(), repo, "user.email", user.Email)
 
-	gitRepo, _ := git.OpenRepository(repo)
+	gitRepo, _ := git.OpenRepository(t.Context(), repo)
 	defer gitRepo.Close()
 
 	commit, _ := gitRepo.GetBranchCommit(t.Context(), "master")

--- a/tests/integration/compare_test.go
+++ b/tests/integration/compare_test.go
@@ -182,7 +182,7 @@ func TestResolveRefWithSuffixContract(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
 
 	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 31})
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(t.Context(), repo)
 	require.NoError(t, err)
 	defer gitRepo.Close()
 

--- a/tests/integration/editor_test.go
+++ b/tests/integration/editor_test.go
@@ -220,7 +220,7 @@ func testEditorWebGitCommitEmail(t *testing.T) {
 	require.True(t, user.KeepEmailPrivate)
 
 	repo1 := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
-	gitRepo, _ := git.OpenRepository(repo1)
+	gitRepo, _ := git.OpenRepository(t.Context(), repo1)
 	defer gitRepo.Close()
 	getLastCommit := func(t *testing.T) *git.Commit {
 		c, err := gitRepo.GetBranchCommit(t.Context(), "master")

--- a/tests/integration/git_general_test.go
+++ b/tests/integration/git_general_test.go
@@ -811,7 +811,7 @@ func doCreateAgitFlowPull(dstPath string, ctx *APITestContext, headBranch string
 			return
 		}
 
-		gitRepo, err := git.OpenRepositoryLocal(dstPath)
+		gitRepo, err := git.OpenRepositoryLocal(t.Context(), dstPath)
 		require.NoError(t, err)
 
 		defer gitRepo.Close()

--- a/tests/integration/git_misc_test.go
+++ b/tests/integration/git_misc_test.go
@@ -43,7 +43,7 @@ func TestDataAsyncDoubleRead_Issue29101(t *testing.T) {
 
 		sha := resp.Commit.SHA
 
-		gitRepo, err := git.OpenRepository(repo)
+		gitRepo, err := git.OpenRepository(t.Context(), repo)
 		assert.NoError(t, err)
 
 		commit, err := gitRepo.GetCommit(t.Context(), sha)
@@ -86,7 +86,7 @@ func TestAgitPullPush(t *testing.T) {
 		dstPath := t.TempDir()
 		doGitClone(dstPath, u)(t)
 
-		gitRepo, err := git.OpenRepositoryLocal(dstPath)
+		gitRepo, err := git.OpenRepositoryLocal(t.Context(), dstPath)
 		assert.NoError(t, err)
 		defer gitRepo.Close()
 
@@ -149,7 +149,7 @@ func TestAgitReviewStaleness(t *testing.T) {
 		dstPath := t.TempDir()
 		doGitClone(dstPath, u)(t)
 
-		gitRepo, err := git.OpenRepositoryLocal(dstPath)
+		gitRepo, err := git.OpenRepositoryLocal(t.Context(), dstPath)
 		assert.NoError(t, err)
 		defer gitRepo.Close()
 
@@ -218,7 +218,7 @@ func TestAgitReviewStaleness(t *testing.T) {
 
 		// For AGit PRs, HeadCommitID must be loaded from git references
 		baseRepo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
-		baseGitRepo, err := git.OpenRepository(baseRepo)
+		baseGitRepo, err := git.OpenRepository(t.Context(), baseRepo)
 		assert.NoError(t, err)
 		defer baseGitRepo.Close()
 

--- a/tests/integration/git_push_test.go
+++ b/tests/integration/git_push_test.go
@@ -205,7 +205,7 @@ func runTestGitPush(t *testing.T, u *url.URL, gitOperation func(t *testing.T, gi
 
 	doGitAddRemote(gitPath, "origin", u)(t)
 
-	gitRepo, err := git.OpenRepositoryLocal(gitPath)
+	gitRepo, err := git.OpenRepositoryLocal(t.Context(), gitPath)
 	require.NoError(t, err)
 	defer gitRepo.Close()
 

--- a/tests/integration/migrate_test.go
+++ b/tests/integration/migrate_test.go
@@ -336,7 +336,7 @@ func Test_MigrateFromGiteaToGitea(t *testing.T) {
 	assert.False(t, pr13.HasMerged)
 	assert.True(t, pr13.Issue.IsLocked)
 
-	gitRepo, err := git.OpenRepository(migratedRepo)
+	gitRepo, err := git.OpenRepository(t.Context(), migratedRepo)
 	require.NoError(t, err)
 	defer gitRepo.Close()
 

--- a/tests/integration/mirror_pull_test.go
+++ b/tests/integration/mirror_pull_test.go
@@ -67,7 +67,7 @@ func TestMirrorPull(t *testing.T) {
 	assert.True(t, slices.ContainsFunc(mirrorRepo.Units, func(u *repo_model.RepoUnit) bool { return u.Type == unit.TypeReleases }))
 	assert.True(t, slices.ContainsFunc(mirrorRepo.Units, func(u *repo_model.RepoUnit) bool { return u.Type == unit.TypeWiki }))
 
-	gitRepo, err := git.OpenRepository(repo)
+	gitRepo, err := git.OpenRepository(ctx, repo)
 	assert.NoError(t, err)
 	defer gitRepo.Close()
 

--- a/tests/integration/mirror_push_test.go
+++ b/tests/integration/mirror_push_test.go
@@ -60,14 +60,14 @@ func testMirrorPush(t *testing.T, u *url.URL) {
 	ok := mirror_service.SyncPushMirror(t.Context(), mirrors[0].ID)
 	assert.True(t, ok)
 
-	srcGitRepo, err := git.OpenRepository(srcRepo)
+	srcGitRepo, err := git.OpenRepository(t.Context(), srcRepo)
 	assert.NoError(t, err)
 	defer srcGitRepo.Close()
 
 	srcCommit, err := srcGitRepo.GetBranchCommit(t.Context(), "master")
 	assert.NoError(t, err)
 
-	mirrorGitRepo, err := git.OpenRepository(mirrorRepo)
+	mirrorGitRepo, err := git.OpenRepository(t.Context(), mirrorRepo)
 	assert.NoError(t, err)
 	defer mirrorGitRepo.Close()
 

--- a/tests/integration/pull_merge_test.go
+++ b/tests/integration/pull_merge_test.go
@@ -836,7 +836,7 @@ func TestPullAutoMergeAfterCommitStatusSucceed(t *testing.T) {
 		assert.Empty(t, pr.MergedCommitID)
 
 		// update commit status to success, then it should be merged automatically
-		baseGitRepo, err := git.OpenRepository(baseRepo)
+		baseGitRepo, err := git.OpenRepository(t.Context(), baseRepo)
 		assert.NoError(t, err)
 		sha, err := baseGitRepo.GetRefCommitID(t.Context(), pr.GetGitHeadRefName())
 		assert.NoError(t, err)
@@ -908,7 +908,7 @@ func TestPullAutoMergeAfterCommitStatusSucceedAndApproval(t *testing.T) {
 		assert.Empty(t, pr.MergedCommitID)
 
 		// update commit status to success, then it should be merged automatically
-		baseGitRepo, err := git.OpenRepository(baseRepo)
+		baseGitRepo, err := git.OpenRepository(t.Context(), baseRepo)
 		assert.NoError(t, err)
 		sha, err := baseGitRepo.GetRefCommitID(t.Context(), pr.GetGitHeadRefName())
 		assert.NoError(t, err)
@@ -1021,7 +1021,7 @@ func TestPullAutoMergeAfterCommitStatusSucceedAndApprovalForAgitFlow(t *testing.
 		assert.Empty(t, pr.MergedCommitID)
 
 		// update commit status to success, then it should be merged automatically
-		baseGitRepo, err := git.OpenRepository(baseRepo)
+		baseGitRepo, err := git.OpenRepository(t.Context(), baseRepo)
 		assert.NoError(t, err)
 		sha, err := baseGitRepo.GetRefCommitID(t.Context(), pr.GetGitHeadRefName())
 		assert.NoError(t, err)

--- a/tests/integration/pull_review_test.go
+++ b/tests/integration/pull_review_test.go
@@ -99,7 +99,7 @@ func TestPullView_CodeOwner(t *testing.T) {
 
 			// capture the current PR head ref so we can wait for the async
 			// refs/pull/N/head sync triggered by the next push to complete
-			baseGitRepo, err := git.OpenRepository(repo)
+			baseGitRepo, err := git.OpenRepository(t.Context(), repo)
 			require.NoError(t, err)
 			defer baseGitRepo.Close()
 			headRefBefore, err := baseGitRepo.GetRefCommitID(t.Context(), pr.GetGitHeadRefName())

--- a/tests/integration/repo_webhook_test.go
+++ b/tests/integration/repo_webhook_test.go
@@ -409,7 +409,7 @@ func Test_WebhookPushDevBranch(t *testing.T) {
 		assert.Empty(t, payloads)
 
 		repo1 := unittest.AssertExistsAndLoadBean(t, &repo.Repository{ID: 1})
-		gitRepo, err := git.OpenRepository(repo1)
+		gitRepo, err := git.OpenRepository(t.Context(), repo1)
 		assert.NoError(t, err)
 		defer gitRepo.Close()
 
@@ -460,7 +460,7 @@ func Test_WebhookPushToNewBranch(t *testing.T) {
 		testAPICreateWebhookForRepo(t, session, "user2", "repo1", provider.URL(), "push", "new_branch")
 
 		repo1 := unittest.AssertExistsAndLoadBean(t, &repo.Repository{ID: 1})
-		gitRepo, err := git.OpenRepository(repo1)
+		gitRepo, err := git.OpenRepository(t.Context(), repo1)
 		assert.NoError(t, err)
 		defer gitRepo.Close()
 
@@ -925,7 +925,7 @@ func Test_WebhookStatus(t *testing.T) {
 
 		repo1 := unittest.AssertExistsAndLoadBean(t, &repo.Repository{ID: 1})
 
-		gitRepo1, err := git.OpenRepository(repo1)
+		gitRepo1, err := git.OpenRepository(t.Context(), repo1)
 		assert.NoError(t, err)
 		commitID, err := gitRepo1.GetBranchCommitID(t.Context(), repo1.DefaultBranch)
 		assert.NoError(t, err)
@@ -998,7 +998,7 @@ func Test_WebhookWorkflowJob(t *testing.T) {
 
 		repo1 := unittest.AssertExistsAndLoadBean(t, &repo.Repository{ID: 1})
 
-		gitRepo1, err := git.OpenRepository(repo1)
+		gitRepo1, err := git.OpenRepository(t.Context(), repo1)
 		assert.NoError(t, err)
 
 		runner := newMockRunner()
@@ -1190,7 +1190,7 @@ func testWorkflowRunEvents(t *testing.T, webhookData *workflowRunWebhook) {
 
 	repo1 := unittest.AssertExistsAndLoadBean(t, &repo.Repository{ID: 1})
 
-	gitRepo1, err := git.OpenRepository(repo1)
+	gitRepo1, err := git.OpenRepository(t.Context(), repo1)
 	assert.NoError(t, err)
 
 	// 2.2 trigger the webhooks
@@ -1315,7 +1315,7 @@ func testWorkflowRunEventsOnRerun(t *testing.T, webhookData *workflowRunWebhook)
 
 	repo1 := unittest.AssertExistsAndLoadBean(t, &repo.Repository{ID: 1})
 
-	gitRepo1, err := git.OpenRepository(repo1)
+	gitRepo1, err := git.OpenRepository(t.Context(), repo1)
 	assert.NoError(t, err)
 
 	// 2.2 trigger the webhooks
@@ -1485,7 +1485,7 @@ func testWorkflowRunEventsOnCancellingAbandonedRun(t *testing.T, webhookData *wo
 	testAPICreateWebhookForRepo(t, session, "user2", repoName, webhookData.URL, "workflow_run")
 
 	ctx := t.Context()
-	gitRepo, err := git.OpenRepository(testRepo)
+	gitRepo, err := git.OpenRepository(ctx, testRepo)
 	assert.NoError(t, err)
 
 	// 2.2 trigger the webhooks
@@ -1703,7 +1703,7 @@ func testWebhookWorkflowRun(t *testing.T, webhookData *workflowRunWebhook) {
 
 	repo1 := unittest.AssertExistsAndLoadBean(t, &repo.Repository{ID: 1})
 
-	gitRepo1, err := git.OpenRepository(repo1)
+	gitRepo1, err := git.OpenRepository(t.Context(), repo1)
 	assert.NoError(t, err)
 
 	runner := newMockRunner()
@@ -1804,7 +1804,7 @@ func testWebhookWorkflowRunDepthLimit(t *testing.T, webhookData *workflowRunWebh
 
 	repo1 := unittest.AssertExistsAndLoadBean(t, &repo.Repository{ID: 1})
 
-	gitRepo1, err := git.OpenRepository(repo1)
+	gitRepo1, err := git.OpenRepository(t.Context(), repo1)
 	assert.NoError(t, err)
 
 	// 2. trigger the webhooks

--- a/tests/integration/repofiles_change_test.go
+++ b/tests/integration/repofiles_change_test.go
@@ -361,7 +361,7 @@ func TestChangeRepoFilesForCreate(t *testing.T) {
 
 		// asserts
 		assert.NoError(t, err)
-		gitRepo, _ := git.OpenRepository(repo)
+		gitRepo, _ := git.OpenRepository(ctx, repo)
 		defer gitRepo.Close()
 
 		commitID, _ := gitRepo.GetBranchCommitID(t.Context(), opts.NewBranch)
@@ -398,7 +398,7 @@ func TestChangeRepoFilesForUpdate(t *testing.T) {
 
 		// asserts
 		assert.NoError(t, err)
-		gitRepo, _ := git.OpenRepository(repo)
+		gitRepo, _ := git.OpenRepository(ctx, repo)
 		defer gitRepo.Close()
 
 		commit, _ := gitRepo.GetBranchCommit(t.Context(), opts.NewBranch)
@@ -434,7 +434,7 @@ func TestChangeRepoFilesForUpdateWithFileMove(t *testing.T) {
 
 		// asserts
 		assert.NoError(t, err)
-		gitRepo, _ := git.OpenRepository(repo)
+		gitRepo, _ := git.OpenRepository(ctx, repo)
 		defer gitRepo.Close()
 
 		commit, _ := gitRepo.GetBranchCommit(t.Context(), opts.NewBranch)
@@ -480,7 +480,7 @@ func TestChangeRepoFilesForUpdateWithFileRename(t *testing.T) {
 
 		// asserts
 		assert.NoError(t, err)
-		gitRepo, _ := git.OpenRepository(repo)
+		gitRepo, _ := git.OpenRepository(ctx, repo)
 		defer gitRepo.Close()
 
 		commit, _ := gitRepo.GetBranchCommit(t.Context(), repo.DefaultBranch)
@@ -517,7 +517,7 @@ func TestChangeRepoFilesWithoutBranchNames(t *testing.T) {
 
 		// asserts
 		assert.NoError(t, err)
-		gitRepo, _ := git.OpenRepository(repo)
+		gitRepo, _ := git.OpenRepository(ctx, repo)
 		defer gitRepo.Close()
 
 		commit, _ := gitRepo.GetBranchCommit(t.Context(), repo.DefaultBranch)


### PR DESCRIPTION
Unfortunately, we can't completely remove the ctx from git.Repository, because the CatFileBatch still heavily depends on a parent context.

If we remove the Repository ctx, the CatFileBatch will become a mess and create a lot of unnecessary git processes.

http://localhost:3000/-/admin/monitor/perftrace

* Before: open a repo home, dozens of git processes (duplicate cat-file)
* After: only a few (no duplicate cat-file)