### PR TITLE
fix(api): allow label name on edit and delete label endpoints

### DIFF
--- a/routers/api/v1/org/label.go
+++ b/routers/api/v1/org/label.go
@@ -17,6 +17,26 @@ import (
 	"gitea.dev/services/convert"
 )
 
+// getOrgLabelByIDOrName resolves an org label from the path param, accepting either a numeric ID or a label name.
+// Name lookup matches GetLabel; EditLabel/DeleteLabel previously only accepted numeric IDs (#34937).
+func getOrgLabelByIDOrName(ctx *context.APIContext) (*issues_model.Label, error) {
+	strID := ctx.PathParam("id")
+	if intID, err := strconv.ParseInt(strID, 10, 64); err != nil {
+		return issues_model.GetLabelInOrgByName(ctx, ctx.Org.Organization.ID, strID)
+	} else {
+		return issues_model.GetLabelInOrgByID(ctx, ctx.Org.Organization.ID, intID)
+	}
+}
+
+// writeOrgLabelNotFound maps org label not-found errors to 404 (same as GetLabel).
+func writeOrgLabelErr(ctx *context.APIContext, err error) {
+	if issues_model.IsErrOrgLabelNotExist(err) {
+		ctx.APIErrorNotFound()
+	} else {
+		ctx.APIErrorInternal(err)
+	}
+}
+
 // ListLabels list all the labels of an organization
 func ListLabels(ctx *context.APIContext) {
 	// swagger:operation GET /orgs/{org}/labels organization orgListLabels
@@ -110,7 +130,7 @@ func CreateLabel(ctx *context.APIContext) {
 	ctx.JSON(http.StatusCreated, convert.ToLabel(label, nil, ctx.Org.Organization.AsUser()))
 }
 
-// GetLabel get label by organization and label id
+// GetLabel get label by organization and label id or name
 func GetLabel(ctx *context.APIContext) {
 	// swagger:operation GET /orgs/{org}/labels/{id} organization orgGetLabel
 	// ---
@@ -125,9 +145,8 @@ func GetLabel(ctx *context.APIContext) {
 	//   required: true
 	// - name: id
 	//   in: path
-	//   description: id of the label to get
-	//   type: integer
-	//   format: int64
+	//   description: id or name of the label to get
+	//   type: string
 	//   required: true
 	// responses:
 	//   "200":
@@ -135,22 +154,9 @@ func GetLabel(ctx *context.APIContext) {
 	//   "404":
 	//     "$ref": "#/responses/notFound"
 
-	var (
-		label *issues_model.Label
-		err   error
-	)
-	strID := ctx.PathParam("id")
-	if intID, err2 := strconv.ParseInt(strID, 10, 64); err2 != nil {
-		label, err = issues_model.GetLabelInOrgByName(ctx, ctx.Org.Organization.ID, strID)
-	} else {
-		label, err = issues_model.GetLabelInOrgByID(ctx, ctx.Org.Organization.ID, intID)
-	}
+	label, err := getOrgLabelByIDOrName(ctx)
 	if err != nil {
-		if issues_model.IsErrOrgLabelNotExist(err) {
-			ctx.APIErrorNotFound()
-		} else {
-			ctx.APIErrorInternal(err)
-		}
+		writeOrgLabelErr(ctx, err)
 		return
 	}
 
@@ -174,9 +180,8 @@ func EditLabel(ctx *context.APIContext) {
 	//   required: true
 	// - name: id
 	//   in: path
-	//   description: id of the label to edit
-	//   type: integer
-	//   format: int64
+	//   description: id or name of the label to edit
+	//   type: string
 	//   required: true
 	// - name: body
 	//   in: body
@@ -190,13 +195,9 @@ func EditLabel(ctx *context.APIContext) {
 	//   "422":
 	//     "$ref": "#/responses/validationError"
 	form := web.GetForm(ctx).(*api.EditLabelOption)
-	l, err := issues_model.GetLabelInOrgByID(ctx, ctx.Org.Organization.ID, ctx.PathParamInt64("id"))
+	l, err := getOrgLabelByIDOrName(ctx)
 	if err != nil {
-		if issues_model.IsErrOrgLabelNotExist(err) {
-			ctx.APIErrorNotFound()
-		} else {
-			ctx.APIErrorInternal(err)
-		}
+		writeOrgLabelErr(ctx, err)
 		return
 	}
 
@@ -239,9 +240,8 @@ func DeleteLabel(ctx *context.APIContext) {
 	//   required: true
 	// - name: id
 	//   in: path
-	//   description: id of the label to delete
-	//   type: integer
-	//   format: int64
+	//   description: id or name of the label to delete
+	//   type: string
 	//   required: true
 	// responses:
 	//   "204":
@@ -249,7 +249,13 @@ func DeleteLabel(ctx *context.APIContext) {
 	//   "404":
 	//     "$ref": "#/responses/notFound"
 
-	if err := issues_model.DeleteLabel(ctx, ctx.Org.Organization.ID, ctx.PathParamInt64("id")); err != nil {
+	l, err := getOrgLabelByIDOrName(ctx)
+	if err != nil {
+		writeOrgLabelErr(ctx, err)
+		return
+	}
+
+	if err := issues_model.DeleteLabel(ctx, ctx.Org.Organization.ID, l.ID); err != nil {
 		ctx.APIErrorInternal(err)
 		return
 	}

--- a/routers/api/v1/repo/label.go
+++ b/routers/api/v1/repo/label.go
@@ -17,6 +17,17 @@ import (
 	"gitea.dev/services/convert"
 )
 
+// getRepoLabelByIDOrName resolves a repo label from the path param, accepting either a numeric ID or a label name.
+// Name lookup matches GetLabel; EditLabel/DeleteLabel previously only accepted numeric IDs (#34937).
+func getRepoLabelByIDOrName(ctx *context.APIContext) (*issues_model.Label, error) {
+	strID := ctx.PathParam("id")
+	if intID, err := strconv.ParseInt(strID, 10, 64); err != nil {
+		return issues_model.GetLabelInRepoByName(ctx, ctx.Repo.Repository.ID, strID)
+	} else {
+		return issues_model.GetLabelInRepoByID(ctx, ctx.Repo.Repository.ID, intID)
+	}
+}
+
 // ListLabels list all the labels of a repository
 func ListLabels(ctx *context.APIContext) {
 	// swagger:operation GET /repos/{owner}/{repo}/labels issue issueListLabels
@@ -65,7 +76,7 @@ func ListLabels(ctx *context.APIContext) {
 	ctx.JSON(http.StatusOK, convert.ToLabelList(labels, ctx.Repo.Repository, nil))
 }
 
-// GetLabel get label by repository and label id
+// GetLabel get label by repository and label id or name
 func GetLabel(ctx *context.APIContext) {
 	// swagger:operation GET /repos/{owner}/{repo}/labels/{id} issue issueGetLabel
 	// ---
@@ -85,9 +96,8 @@ func GetLabel(ctx *context.APIContext) {
 	//   required: true
 	// - name: id
 	//   in: path
-	//   description: id of the label to get
-	//   type: integer
-	//   format: int64
+	//   description: id or name of the label to get
+	//   type: string
 	//   required: true
 	// responses:
 	//   "200":
@@ -95,16 +105,7 @@ func GetLabel(ctx *context.APIContext) {
 	//   "404":
 	//     "$ref": "#/responses/notFound"
 
-	var (
-		l   *issues_model.Label
-		err error
-	)
-	strID := ctx.PathParam("id")
-	if intID, err2 := strconv.ParseInt(strID, 10, 64); err2 != nil {
-		l, err = issues_model.GetLabelInRepoByName(ctx, ctx.Repo.Repository.ID, strID)
-	} else {
-		l, err = issues_model.GetLabelInRepoByID(ctx, ctx.Repo.Repository.ID, intID)
-	}
+	l, err := getRepoLabelByIDOrName(ctx)
 	if err != nil {
 		ctx.APIErrorAuto(err)
 		return
@@ -191,9 +192,8 @@ func EditLabel(ctx *context.APIContext) {
 	//   required: true
 	// - name: id
 	//   in: path
-	//   description: id of the label to edit
-	//   type: integer
-	//   format: int64
+	//   description: id or name of the label to edit
+	//   type: string
 	//   required: true
 	// - name: body
 	//   in: body
@@ -208,7 +208,7 @@ func EditLabel(ctx *context.APIContext) {
 	//     "$ref": "#/responses/validationError"
 
 	form := web.GetForm(ctx).(*api.EditLabelOption)
-	l, err := issues_model.GetLabelInRepoByID(ctx, ctx.Repo.Repository.ID, ctx.PathParamInt64("id"))
+	l, err := getRepoLabelByIDOrName(ctx)
 	if err != nil {
 		ctx.APIErrorAuto(err)
 		return
@@ -258,9 +258,8 @@ func DeleteLabel(ctx *context.APIContext) {
 	//   required: true
 	// - name: id
 	//   in: path
-	//   description: id of the label to delete
-	//   type: integer
-	//   format: int64
+	//   description: id or name of the label to delete
+	//   type: string
 	//   required: true
 	// responses:
 	//   "204":
@@ -268,7 +267,13 @@ func DeleteLabel(ctx *context.APIContext) {
 	//   "404":
 	//     "$ref": "#/responses/notFound"
 
-	if err := issues_model.DeleteLabel(ctx, ctx.Repo.Repository.ID, ctx.PathParamInt64("id")); err != nil {
+	l, err := getRepoLabelByIDOrName(ctx)
+	if err != nil {
+		ctx.APIErrorAuto(err)
+		return
+	}
+
+	if err := issues_model.DeleteLabel(ctx, ctx.Repo.Repository.ID, l.ID); err != nil {
 		ctx.APIErrorInternal(err)
 		return
 	}

--- a/templates/swagger/v1_json.tmpl
+++ b/templates/swagger/v1_json.tmpl
@@ -3169,9 +3169,8 @@
             "required": true
           },
           {
-            "type": "integer",
-            "format": "int64",
-            "description": "id of the label to get",
+            "type": "string",
+            "description": "id or name of the label to get",
             "name": "id",
             "in": "path",
             "required": true
@@ -3201,9 +3200,8 @@
             "required": true
           },
           {
-            "type": "integer",
-            "format": "int64",
-            "description": "id of the label to delete",
+            "type": "string",
+            "description": "id or name of the label to delete",
             "name": "id",
             "in": "path",
             "required": true
@@ -3239,9 +3237,8 @@
             "required": true
           },
           {
-            "type": "integer",
-            "format": "int64",
-            "description": "id of the label to edit",
+            "type": "string",
+            "description": "id or name of the label to edit",
             "name": "id",
             "in": "path",
             "required": true
@@ -13604,9 +13601,8 @@
             "required": true
           },
           {
-            "type": "integer",
-            "format": "int64",
-            "description": "id of the label to get",
+            "type": "string",
+            "description": "id or name of the label to get",
             "name": "id",
             "in": "path",
             "required": true
@@ -13643,9 +13639,8 @@
             "required": true
           },
           {
-            "type": "integer",
-            "format": "int64",
-            "description": "id of the label to delete",
+            "type": "string",
+            "description": "id or name of the label to delete",
             "name": "id",
             "in": "path",
             "required": true
@@ -13688,9 +13683,8 @@
             "required": true
           },
           {
-            "type": "integer",
-            "format": "int64",
-            "description": "id of the label to edit",
+            "type": "string",
+            "description": "id or name of the label to edit",
             "name": "id",
             "in": "path",
             "required": true

--- a/templates/swagger/v1_openapi3_json.tmpl
+++ b/templates/swagger/v1_openapi3_json.tmpl
@@ -13928,13 +13928,12 @@
             }
           },
           {
-            "description": "id of the label to delete",
+            "description": "id or name of the label to delete",
             "in": "path",
             "name": "id",
             "required": true,
             "schema": {
-              "format": "int64",
-              "type": "integer"
+              "type": "string"
             }
           }
         ],
@@ -13964,13 +13963,12 @@
             }
           },
           {
-            "description": "id of the label to get",
+            "description": "id or name of the label to get",
             "in": "path",
             "name": "id",
             "required": true,
             "schema": {
-              "format": "int64",
-              "type": "integer"
+              "type": "string"
             }
           }
         ],
@@ -14000,13 +13998,12 @@
             }
           },
           {
-            "description": "id of the label to edit",
+            "description": "id or name of the label to edit",
             "in": "path",
             "name": "id",
             "required": true,
             "schema": {
-              "format": "int64",
-              "type": "integer"
+              "type": "string"
             }
           }
         ],
@@ -25276,13 +25273,12 @@
             }
           },
           {
-            "description": "id of the label to delete",
+            "description": "id or name of the label to delete",
             "in": "path",
             "name": "id",
             "required": true,
             "schema": {
-              "format": "int64",
-              "type": "integer"
+              "type": "string"
             }
           }
         ],
@@ -25321,13 +25317,12 @@
             }
           },
           {
-            "description": "id of the label to get",
+            "description": "id or name of the label to get",
             "in": "path",
             "name": "id",
             "required": true,
             "schema": {
-              "format": "int64",
-              "type": "integer"
+              "type": "string"
             }
           }
         ],
@@ -25366,13 +25361,12 @@
             }
           },
           {
-            "description": "id of the label to edit",
+            "description": "id or name of the label to edit",
             "in": "path",
             "name": "id",
             "required": true,
             "schema": {
-              "format": "int64",
-              "type": "integer"
+              "type": "string"
             }
           }
         ],

--- a/tests/integration/api_issue_label_test.go
+++ b/tests/integration/api_issue_label_test.go
@@ -87,6 +87,48 @@ func TestAPIModifyLabels(t *testing.T) {
 	req = NewRequest(t, "DELETE", singleURLStr).
 		AddTokenAuth(token)
 	MakeRequest(t, req, http.StatusNoContent)
+
+	// EditLabel / DeleteLabel by name (parity with GetLabel; #34937)
+	req = NewRequestWithJSON(t, "POST", urlStr, &api.CreateLabelOption{
+		Name:  "by-name-label",
+		Color: "#fedcba",
+	}).AddTokenAuth(token)
+	resp = MakeRequest(t, req, http.StatusCreated)
+	apiLabel = DecodeJSON(t, resp, &api.Label{})
+	assert.Equal(t, "by-name-label", apiLabel.Name)
+
+	nameURLStr := fmt.Sprintf("/api/v1/repos/%s/%s/labels/%s", owner.Name, repo.Name, "by-name-label")
+	req = NewRequest(t, "GET", nameURLStr).
+		AddTokenAuth(token)
+	resp = MakeRequest(t, req, http.StatusOK)
+	apiLabel = DecodeJSON(t, resp, &api.Label{})
+	assert.Equal(t, "by-name-label", apiLabel.Name)
+
+	nameEdited := "by-name-edited"
+	nameColor := "112233"
+	req = NewRequestWithJSON(t, "PATCH", nameURLStr, &api.EditLabelOption{
+		Name:  &nameEdited,
+		Color: &nameColor,
+	}).AddTokenAuth(token)
+	resp = MakeRequest(t, req, http.StatusOK)
+	apiLabel = DecodeJSON(t, resp, &api.Label{})
+	assert.Equal(t, nameEdited, apiLabel.Name)
+	assert.Equal(t, nameColor, apiLabel.Color)
+
+	// name path must track rename; old name is gone
+	req = NewRequest(t, "DELETE", nameURLStr).
+		AddTokenAuth(token)
+	MakeRequest(t, req, http.StatusNotFound)
+	editedURLStr := fmt.Sprintf("/api/v1/repos/%s/%s/labels/%s", owner.Name, repo.Name, nameEdited)
+	req = NewRequest(t, "DELETE", editedURLStr).
+		AddTokenAuth(token)
+	MakeRequest(t, req, http.StatusNoContent)
+	unittest.AssertNotExistsBean(t, &issues_model.Label{ID: apiLabel.ID})
+
+	// missing name -> 404 (not silent 204)
+	req = NewRequest(t, "DELETE", fmt.Sprintf("/api/v1/repos/%s/%s/labels/%s", owner.Name, repo.Name, "does-not-exist")).
+		AddTokenAuth(token)
+	MakeRequest(t, req, http.StatusNotFound)
 }
 
 func TestAPIAddIssueLabels(t *testing.T) {
@@ -291,4 +333,44 @@ func TestAPIModifyOrgLabels(t *testing.T) {
 	req = NewRequest(t, "DELETE", singleURLStr).
 		AddTokenAuth(token)
 	MakeRequest(t, req, http.StatusNoContent)
+
+	// EditLabel / DeleteLabel by name (parity with GetLabel; #34937)
+	req = NewRequestWithJSON(t, "POST", urlStr, &api.CreateLabelOption{
+		Name:  "org-by-name-label",
+		Color: "#fedcba",
+	}).AddTokenAuth(token)
+	resp = MakeRequest(t, req, http.StatusCreated)
+	apiLabel = DecodeJSON(t, resp, &api.Label{})
+	assert.Equal(t, "org-by-name-label", apiLabel.Name)
+
+	nameURLStr := fmt.Sprintf("/api/v1/orgs/%s/labels/%s", owner.Name, "org-by-name-label")
+	req = NewRequest(t, "GET", nameURLStr).
+		AddTokenAuth(token)
+	resp = MakeRequest(t, req, http.StatusOK)
+	apiLabel = DecodeJSON(t, resp, &api.Label{})
+	assert.Equal(t, "org-by-name-label", apiLabel.Name)
+
+	nameEdited := "org-by-name-edited"
+	nameColor := "112233"
+	req = NewRequestWithJSON(t, "PATCH", nameURLStr, &api.EditLabelOption{
+		Name:  &nameEdited,
+		Color: &nameColor,
+	}).AddTokenAuth(token)
+	resp = MakeRequest(t, req, http.StatusOK)
+	apiLabel = DecodeJSON(t, resp, &api.Label{})
+	assert.Equal(t, nameEdited, apiLabel.Name)
+	assert.Equal(t, nameColor, apiLabel.Color)
+
+	req = NewRequest(t, "DELETE", nameURLStr).
+		AddTokenAuth(token)
+	MakeRequest(t, req, http.StatusNotFound)
+	editedURLStr := fmt.Sprintf("/api/v1/orgs/%s/labels/%s", owner.Name, nameEdited)
+	req = NewRequest(t, "DELETE", editedURLStr).
+		AddTokenAuth(token)
+	MakeRequest(t, req, http.StatusNoContent)
+	unittest.AssertNotExistsBean(t, &issues_model.Label{ID: apiLabel.ID})
+
+	req = NewRequest(t, "DELETE", fmt.Sprintf("/api/v1/orgs/%s/labels/%s", owner.Name, "does-not-exist")).
+		AddTokenAuth(token)
+	MakeRequest(t, req, http.StatusNotFound)
 }


### PR DESCRIPTION
## Summary

`GET /repos/{owner}/{repo}/labels/{id}` already accepts a numeric ID **or** a label name. `PATCH` and `DELETE` only accepted numeric IDs via `PathParamInt64`, so clients that address labels by name (e.g. [label-sync](https://github.com/marketplace/actions/label-sync)) received 404 on personal repos (and the same gap existed for org labels).

This change:

- Resolves ID-or-name for **Edit** and **Delete** on both repo and org label APIs (same logic as `GetLabel`)
- Returns **404** when a name does not exist on DELETE (previously a non-numeric path became id `0` and deleted nothing with **204**)
- Documents the path param as id or name in swagger comments

Fixes #34937

## Test plan

- [x] `gofmt` / `make fmt` on touched Go files
- [x] `go vet ./routers/api/v1/repo/ ./routers/api/v1/org/`
- [x] `go test ./tests/integration/ -run 'TestAPIModifyLabels|TestAPIModifyOrgLabels' -count=1`
  - Repo: GET/PATCH/DELETE by name; rename then DELETE old name → 404; missing name DELETE → 404
  - Org: same coverage

## AI assistance

Implemented with assistance from Hermes (grok-4.5). I reviewed the change for correctness against existing `GetLabel` behavior and added integration coverage for the new paths.