### PR TITLE
fix: Alpine registry APKINDEX.tar.gz returns 405 for HEAD requests

### DIFF
--- a/routers/api/packages/api.go
+++ b/routers/api/packages/api.go
@@ -135,7 +135,7 @@ func CommonRoutes() *web.Router {
 			r.Group("/{branch}/{repository}", func() {
 				r.Put("", reqPackageAccess(perm.AccessModeWrite), alpine.UploadPackageFile)
 				r.Group("/{architecture}", func() {
-					r.Get("/APKINDEX.tar.gz", alpine.GetRepositoryFile)
+					r.Methods("HEAD,GET", "/APKINDEX.tar.gz", alpine.GetRepositoryFile)
 					r.Group("/{filename}", func() {
 						r.Get("", alpine.DownloadPackageFile)
 						r.Delete("", reqPackageAccess(perm.AccessModeWrite), alpine.DeletePackageFile)


### PR DESCRIPTION
### Description

Fixes #38676

The Alpine package registry registers  for  only, so a  request returns . Clients that probe the index with  before fetching it (like  and other -based tools) fail outright.

**Fix:** Change  to  for the APKINDEX.tar.gz route, matching the pattern already used by the i386 registry a few lines below.

### Related issue

Closes #38676
