### PR TITLE
fix(issues): change multi-project filter to use AND instead of OR

### DIFF
--- a/models/issues/issue_project_multi_test.go
+++ b/models/issues/issue_project_multi_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	"gitea.dev/models/db"
 	issues_model "gitea.dev/models/issues"
 	project_model "gitea.dev/models/project"
 	"gitea.dev/models/unittest"
@@ -139,24 +140,28 @@ func TestIssueMultipleProjects(t *testing.T) {
 		}
 		assert.True(t, foundIssue2, "Issue 2 should be found when querying project 3")
 
-		// Query for issues in projects 1 and 2 (should find issue1)
-		issues12, err := issues_model.Issues(t.Context(), &issues_model.IssuesOptions{
-			RepoIDs:    []int64{issue1.RepoID},
-			ProjectIDs: []int64{projects[0].ID, projects[1].ID},
-		})
-		require.NoError(t, err)
-		assert.Len(t, issues12, 1)
-		if len(issues12) > 0 {
-			assert.Equal(t, issue1.ID, issues12[0].ID)
+		queryIssueIDs := func(projectIDs ...int64) []int64 {
+			found, err := issues_model.Issues(t.Context(), &issues_model.IssuesOptions{
+				RepoIDs:    []int64{issue1.RepoID},
+				ProjectIDs: projectIDs,
+			})
+			require.NoError(t, err)
+			ids := make([]int64, 0, len(found))
+			for _, issue := range found {
+				ids = append(ids, issue.ID)
+			}
+			return ids
 		}
 
-		// Query for issues in projects 2 and 3 (should find none, as no issue is in both)
-		issues23, err := issues_model.Issues(t.Context(), &issues_model.IssuesOptions{
-			RepoIDs:    []int64{issue1.RepoID},
-			ProjectIDs: []int64{projects[1].ID, projects[2].ID},
-		})
-		require.NoError(t, err)
-		assert.Empty(t, issues23)
+		// issue1 is in projects 1 and 2, so it matches only when every queried project is one of them
+		assert.Equal(t, []int64{issue1.ID}, queryIssueIDs(projects[0].ID, projects[1].ID))
+		assert.Empty(t, queryIssueIDs(projects[1].ID, projects[2].ID), "no issue is in both project 2 and 3")
+
+		// a repeated ID must not narrow the result down to nothing
+		assert.Equal(t, queryIssueIDs(projects[0].ID), queryIssueIDs(projects[0].ID, projects[0].ID))
+
+		// "no project" combined with a real project can never match
+		assert.Empty(t, queryIssueIDs(db.NoConditionID, projects[0].ID))
 
 		// Clean up
 		err = issues_model.IssueAssignOrRemoveProject(t.Context(), issue1, user2, []int64{})

--- a/models/issues/issue_project_multi_test.go
+++ b/models/issues/issue_project_multi_test.go
@@ -139,7 +139,25 @@ func TestIssueMultipleProjects(t *testing.T) {
 		}
 		assert.True(t, foundIssue2, "Issue 2 should be found when querying project 3")
 
-		// FIXME: ISSUE-MULTIPLE-PROJECTS-FILTER: no multiple project filter support yet. Search logic is wrong. It should use "AND" but not "OR".
+		// Query for issues in projects 1 and 2 (should find issue1)
+		issues12, err := issues_model.Issues(t.Context(), &issues_model.IssuesOptions{
+			RepoIDs:    []int64{issue1.RepoID},
+			ProjectIDs: []int64{projects[0].ID, projects[1].ID},
+		})
+		require.NoError(t, err)
+		assert.Len(t, issues12, 1)
+		if len(issues12) > 0 {
+			assert.Equal(t, issue1.ID, issues12[0].ID)
+		}
+
+		// Query for issues in projects 2 and 3 (should find none, as no issue is in both)
+		issues23, err := issues_model.Issues(t.Context(), &issues_model.IssuesOptions{
+			RepoIDs:    []int64{issue1.RepoID},
+			ProjectIDs: []int64{projects[1].ID, projects[2].ID},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, issues23)
+
 		// Clean up
 		err = issues_model.IssueAssignOrRemoveProject(t.Context(), issue1, user2, []int64{})
 		require.NoError(t, err)

--- a/models/issues/issue_search.go
+++ b/models/issues/issue_search.go
@@ -203,11 +203,13 @@ func applyProjectCondition(sess db.Session, opts *IssuesOptions) {
 	} else if len(projectIDs) == 1 && projectIDs[0] > 0 { // single specific project
 		sess.Join("INNER", "project_issue", "issue.id = project_issue.issue_id AND project_issue.project_id = ?", projectIDs[0])
 	} else if len(projectIDs) > 1 { // multiple projects
+		// a repeated ID would inflate the count below and make it unsatisfiable
+		projectIDs = container.SetOf(projectIDs...).Values()
 		sess.And(builder.In("issue.id",
 			builder.Select("issue_id").From("project_issue").
 				Where(builder.In("project_id", projectIDs)).
 				GroupBy("issue_id").
-				Having(fmt.Sprintf("COUNT(DISTINCT project_id) = %d", len(projectIDs))),
+				Having(builder.Expr("COUNT(DISTINCT project_id) = ?", len(projectIDs))),
 		))
 	}
 	// empty projectIDs means all projects,

--- a/models/issues/issue_search.go
+++ b/models/issues/issue_search.go
@@ -203,8 +203,12 @@ func applyProjectCondition(sess db.Session, opts *IssuesOptions) {
 	} else if len(projectIDs) == 1 && projectIDs[0] > 0 { // single specific project
 		sess.Join("INNER", "project_issue", "issue.id = project_issue.issue_id AND project_issue.project_id = ?", projectIDs[0])
 	} else if len(projectIDs) > 1 { // multiple projects
-		// FIXME: ISSUE-MULTIPLE-PROJECTS-FILTER: this logic is not right, it should use "AND" but not "OR"
-		sess.And(builder.In("issue.id", builder.Select("issue_id").From("project_issue").Where(builder.In("project_id", projectIDs))))
+		sess.And(builder.In("issue.id",
+			builder.Select("issue_id").From("project_issue").
+				Where(builder.In("project_id", projectIDs)).
+				GroupBy("issue_id").
+				Having(fmt.Sprintf("COUNT(DISTINCT project_id) = %d", len(projectIDs))),
+		))
 	}
 	// empty projectIDs means all projects,
 	// do not need to apply any condition


### PR DESCRIPTION
Previously, filtering issues by multiple projects returned any issue that belonged to *at least one* of the selected projects (OR behavior).

This PR changes that behavior so an issue is returned only if it belongs to *all* of the selected projects (AND behavior), which is more consistent with how users typically expect multi-project filters to work.

## Changes

### `models/issues/issue_search.go`

* Updated `applyProjectCondition` to perform an intersection instead of a union by grouping `project_issue` records by `issue_id` and requiring `COUNT(DISTINCT project_id) = len(projectIDs)`.

### `models/issues/issue_project_multi_test.go`

* Added assertions to `TestIssueMultipleProjects/QueryByMultipleProjectIDs` to verify the new filtering behavior.

## Testing

```bash
go test -v -run '^TestIssueMultipleProjects$' ./models/issues/
```
