### PR TITLE
fix(ui): align activity commit hashes

### DIFF
--- a/templates/user/dashboard/feeds.tmpl
+++ b/templates/user/dashboard/feeds.tmpl
@@ -92,10 +92,10 @@
 							{{$commitLink := printf "%s/commit/%s" $repoLink $pushCommit.Sha1}}
 							<div class="flex-text-block">
 								{{ctx.RenderUtils.AvatarStackPushCommit $pushCommit}}
-								<a class="ui sha label" href="{{$commitLink}}">{{ShortSha $pushCommit.Sha1}}</a>
-								<span class="tw-inline-block tw-truncate">
+								<span class="tw-inline-block tw-truncate tw-flex-1">
 									{{ctx.RenderUtils.RenderCommitMessage $pushCommit.Message $repo}}
 								</span>
+								<a class="ui sha label tw-shrink-0" href="{{$commitLink}}">{{ShortSha $pushCommit.Sha1}}</a>
 							</div>
 						{{end}}
 					</div>


### PR DESCRIPTION
Commit activity rows previously placed the hash immediately after the avatar stack, so commits with different co-author counts produced an uneven hash column.

This moves the truncated commit message into the flexible middle position and keeps the hash as a non-shrinking trailing item. Hashes now align at the right edge regardless of avatar-stack width, following the layout suggested in the issue.

Before:

![Uneven commit hashes](https://github.com/user-attachments/assets/106569f0-0df1-46bf-b791-34e4601b7bcc)

After screenshot will be added before marking this draft ready for review.

Validation:

- `make lint-templates` (569 templates, 0 errors)
- `make fmt`
- `git diff --check`

AI assistance: Codex assisted with code analysis and drafting. I reviewed the template change and validation results.

Fixes #38646.