### PR TITLE
perf(gitdiff): optimize inline diff highlighting using cache

### DIFF
--- a/modules/charset/escape_status.go
+++ b/modules/charset/escape_status.go
@@ -10,14 +10,8 @@ type EscapeStatus struct {
 	HasAmbiguous bool
 }
 
-// Or combines two EscapeStatus structs into one representing the conjunction of the two
-func (status *EscapeStatus) Or(other *EscapeStatus) *EscapeStatus {
-	st := status
-	if status == nil {
-		st = &EscapeStatus{}
-	}
+func (st *EscapeStatus) Combine(other *EscapeStatus) {
 	st.Escaped = st.Escaped || other.Escaped
 	st.HasAmbiguous = st.HasAmbiguous || other.HasAmbiguous
 	st.HasInvisible = st.HasInvisible || other.HasInvisible
-	return st
 }

--- a/modules/highlight/benchmark_test.go
+++ b/modules/highlight/benchmark_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package highlight
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/chroma/v2/lexers"
+)
+
+func BenchmarkDetectChromaLexerByFileName(b *testing.B) {
+	for b.Loop() {
+		// BenchmarkDetectChromaLexerByFileName-12    	18214717	        61.35 ns/op
+		DetectChromaLexerByFileName("a.sql", "")
+	}
+}
+
+func BenchmarkDetectChromaLexerWithAnalyze(b *testing.B) {
+	code := []byte(strings.Repeat("SELECT * FROM table;\n", 1000))
+	b.ResetTimer()
+	for b.Loop() {
+		// BenchmarkRenderCodeSlowGuess-12    	   87946	     13310 ns/op
+		detectChromaLexerWithAnalyze("a", "", code)
+	}
+}
+
+func BenchmarkChromaAnalyze(b *testing.B) {
+	code := strings.Repeat("SELECT * FROM table;\n", 1000)
+	b.ResetTimer()
+	for b.Loop() {
+		// comparing to detectChromaLexerWithAnalyze (go-enry), "chroma/lexers.Analyse" is very slow
+		// BenchmarkChromaAnalyze-12    	     519	   2247104 ns/op
+		lexers.Analyse(code)
+	}
+}
+
+func BenchmarkRenderCodeByLexer(b *testing.B) {
+	code := strings.Repeat("SELECT * FROM table;\n", 1000)
+	lexer := DetectChromaLexerByFileName("a.sql", "")
+	b.ResetTimer()
+	for b.Loop() {
+		// HINT: CODE-HIGHLIGHT-PERFORMANCE: Really slow ....... the regexp2 used by Chroma takes most of the time
+		// BenchmarkRenderCodeByLexer-12    	      22	  47159038 ns/op
+		RenderCodeByLexer(lexer, code)
+	}
+}

--- a/modules/highlight/lexerdetect_test.go
+++ b/modules/highlight/lexerdetect_test.go
@@ -4,52 +4,10 @@
 package highlight
 
 import (
-	"strings"
 	"testing"
 
-	"github.com/alecthomas/chroma/v2/lexers"
 	"github.com/stretchr/testify/assert"
 )
-
-func BenchmarkDetectChromaLexerByFileName(b *testing.B) {
-	for b.Loop() {
-		// BenchmarkDetectChromaLexerByFileName-12    	18214717	        61.35 ns/op
-		DetectChromaLexerByFileName("a.sql", "")
-	}
-}
-
-func BenchmarkDetectChromaLexerWithAnalyze(b *testing.B) {
-	b.StopTimer()
-	code := []byte(strings.Repeat("SELECT * FROM table;\n", 1000))
-	b.StartTimer()
-	for b.Loop() {
-		// BenchmarkRenderCodeSlowGuess-12    	   87946	     13310 ns/op
-		detectChromaLexerWithAnalyze("a", "", code)
-	}
-}
-
-func BenchmarkChromaAnalyze(b *testing.B) {
-	b.StopTimer()
-	code := strings.Repeat("SELECT * FROM table;\n", 1000)
-	b.StartTimer()
-	for b.Loop() {
-		// comparing to detectChromaLexerWithAnalyze (go-enry), "chroma/lexers.Analyse" is very slow
-		// BenchmarkChromaAnalyze-12    	     519	   2247104 ns/op
-		lexers.Analyse(code)
-	}
-}
-
-func BenchmarkRenderCodeByLexer(b *testing.B) {
-	b.StopTimer()
-	code := strings.Repeat("SELECT * FROM table;\n", 1000)
-	lexer := DetectChromaLexerByFileName("a.sql", "")
-	b.StartTimer()
-	for b.Loop() {
-		// Really slow ....... the regexp2 used by Chroma takes most of the time
-		// BenchmarkRenderCodeByLexer-12    	      22	  47159038 ns/op
-		RenderCodeByLexer(lexer, code)
-	}
-}
 
 func TestDetectChromaLexer(t *testing.T) {
 	globalVars().highlightMapping[".my-html"] = "HTML"

--- a/routers/web/devtest/devtest.go
+++ b/routers/web/devtest/devtest.go
@@ -288,7 +288,7 @@ func prepareMockDataUnicodeEscape(ctx *context.Context) {
 	lineEscapeStatus := make([]*charset.EscapeStatus, len(highlightLines))
 	for i, hl := range highlightLines {
 		lineEscapeStatus[i], hl.FormattedContent = charset.EscapeControlHTML(hl.FormattedContent, ctx.Locale)
-		escapeStatus = escapeStatus.Or(lineEscapeStatus[i])
+		escapeStatus.Combine(lineEscapeStatus[i])
 	}
 	ctx.Data["HighlightLines"] = highlightLines
 	ctx.Data["EscapeStatus"] = escapeStatus

--- a/routers/web/repo/blame.go
+++ b/routers/web/repo/blame.go
@@ -272,7 +272,7 @@ func renderBlame(ctx *context.Context, blameParts []*git.BlamePart, commitNames 
 			line = template.HTML(util.UnsafeBytesToString(unsafeLines[i]))
 		}
 		br.EscapeStatus, br.Code = charset.EscapeControlHTML(line, ctx.Locale)
-		escapeStatus = escapeStatus.Or(br.EscapeStatus)
+		escapeStatus.Combine(br.EscapeStatus)
 	}
 
 	ctx.Data["EscapeStatus"] = escapeStatus

--- a/routers/web/repo/view_file.go
+++ b/routers/web/repo/view_file.go
@@ -127,7 +127,7 @@ func handleFileViewRenderSource(ctx *context.Context, attrs *attribute.Attribute
 	statuses := make([]*charset.EscapeStatus, len(fileContent))
 	for i, line := range fileContent {
 		statuses[i], fileContent[i] = charset.EscapeControlHTML(line, ctx.Locale)
-		status = status.Or(statuses[i])
+		status.Combine(statuses[i])
 	}
 	ctx.Data["EscapeStatus"] = status
 	ctx.Data["FileContent"] = fileContent

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -411,8 +411,8 @@ func (diffSection *DiffSection) GetComputedInlineDiffFor(diffLine *DiffLine, loc
 	// try to find equivalent diff line. ignore, otherwise
 	switch diffLine.Type {
 	case DiffLineSection:
-		// section content is something like diff hunk info, not code diff, no need to escape or do any other process
-		return DiffInline{Content: htmlutil.EscapeString(diffLine.Content), EscapeStatus: &charset.EscapeStatus{}}
+		// section content is a diff hunk header, it isn't code diff, but its trailing context comes from the file content
+		return diffInlineWithUnicodeEscape(htmlutil.EscapeString(diffLine.Content), locale)
 	case DiffLineAdd:
 		compareDiffLine := diffSection.GetLine(diffLine.Match)
 		return diffSection.getDiffLineForRender(DiffLineAdd, compareDiffLine, diffLine, locale)

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -79,6 +79,8 @@ type DiffLine struct {
 	Content     string
 	Comments    issues_model.CommentList // related PR code comments
 	SectionInfo *DiffLineSectionInfo
+
+	cachedDiffInline *DiffInline
 }
 
 // DiffLineSectionInfo represents diff line section meta data
@@ -356,6 +358,13 @@ func (diffSection *DiffSection) getLineContentForRender(lineIdx int, diffLine *D
 }
 
 func (diffSection *DiffSection) getDiffLineForRender(diffLineType DiffLineType, leftLine, rightLine *DiffLine, locale translation.Locale) DiffInline {
+	if diffLineType == DiffLineDel && leftLine != nil && leftLine.cachedDiffInline != nil {
+		return *leftLine.cachedDiffInline
+	}
+	if diffLineType == DiffLineAdd && rightLine != nil && rightLine.cachedDiffInline != nil {
+		return *rightLine.cachedDiffInline
+	}
+
 	var fileLanguage string
 	var highlightedLeftLines, highlightedRightLines map[int]template.HTML
 	// when a "diff section" is manually prepared by ExcerptBlob, it doesn't have "file" information
@@ -365,7 +374,6 @@ func (diffSection *DiffSection) getDiffLineForRender(diffLineType DiffLineType, 
 	}
 
 	var lineHTML template.HTML
-	hcd := newHighlightCodeDiff()
 	if diffLineType == DiffLinePlain {
 		// left and right are the same, no need to do line-level diff
 		if leftLine != nil {
@@ -373,23 +381,40 @@ func (diffSection *DiffSection) getDiffLineForRender(diffLineType DiffLineType, 
 		} else if rightLine != nil {
 			lineHTML = diffSection.getLineContentForRender(rightLine.RightIdx, rightLine, fileLanguage, highlightedRightLines)
 		}
-	} else {
-		var diff1, diff2 template.HTML
+		return DiffInlineWithUnicodeEscape(lineHTML, locale)
+	}
+
+	var diff1, diff2 template.HTML
+	if leftLine != nil {
+		diff1 = diffSection.getLineContentForRender(leftLine.LeftIdx, leftLine, fileLanguage, highlightedLeftLines)
+	}
+	if rightLine != nil {
+		diff2 = diffSection.getLineContentForRender(rightLine.RightIdx, rightLine, fileLanguage, highlightedRightLines)
+	}
+
+	if diff1 != "" && diff2 != "" {
+		// if only some parts of a line are changed, highlight these changed parts as "deleted/added".
+		hcd := newHighlightCodeDiff()
+		lineHTMLDel, lineHTMLAdd := hcd.diffLineWithHighlightBoth(diff1, diff2)
+		inlineDel := DiffInlineWithUnicodeEscape(lineHTMLDel, locale)
+		inlineAdd := DiffInlineWithUnicodeEscape(lineHTMLAdd, locale)
+
 		if leftLine != nil {
-			diff1 = diffSection.getLineContentForRender(leftLine.LeftIdx, leftLine, fileLanguage, highlightedLeftLines)
+			leftLine.cachedDiffInline = &inlineDel
 		}
 		if rightLine != nil {
-			diff2 = diffSection.getLineContentForRender(rightLine.RightIdx, rightLine, fileLanguage, highlightedRightLines)
+			rightLine.cachedDiffInline = &inlineAdd
 		}
-		if diff1 != "" && diff2 != "" {
-			// if only some parts of a line are changed, highlight these changed parts as "deleted/added".
-			lineHTML = hcd.diffLineWithHighlight(diffLineType, diff1, diff2)
-		} else {
-			// if left is empty or right is empty (a line is fully deleted or added), then we do not need to diff anymore.
-			// the tmpl code already adds background colors for these cases.
-			lineHTML = util.Iif(diffLineType == DiffLineDel, diff1, diff2)
+
+		if diffLineType == DiffLineDel {
+			return inlineDel
 		}
+		return inlineAdd
 	}
+
+	// if left is empty or right is empty (a line is fully deleted or added), then we do not need to diff anymore.
+	// the tmpl code already adds background colors for these cases.
+	lineHTML = util.Iif(diffLineType == DiffLineDel, diff1, diff2)
 	return DiffInlineWithUnicodeEscape(lineHTML, locale)
 }
 

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -367,7 +367,7 @@ func (diffSection *DiffSection) getDiffLineForRender(diffLineType DiffLineType, 
 
 	if diffLineType == DiffLinePlain {
 		// left and right are the same, no need to do line-level diff, can just pick any side
-		// caller always use the "right side" for this type
+		// caller always uses the "right side" for this type
 		lineHTML := diffSection.getLineContentForRender(rightLine.RightIdx, rightLine, fileLanguage, highlightedRightLines)
 		return diffInlineWithUnicodeEscape(lineHTML, locale)
 	}
@@ -383,8 +383,8 @@ func (diffSection *DiffSection) getDiffLineForRender(diffLineType DiffLineType, 
 	if leftLine != nil && rightLine != nil {
 		// if only some parts of a line are changed, highlight these changed parts as "deleted/added".
 		// "diff" the left&right sides together, then cache the diff result for another side,
-		// because when viewing the diff page, bother "deleted" and "added" lines will to be rendered eventually,
-		// so here only diff them once, then next render can just use the cached result, no  need to "diff" again.
+		// because when viewing the diff page, both "deleted" and "added" lines will to be rendered eventually,
+		// so here only diff them once, then next render can just use the cached result, no need to "diff" again.
 		hcd := newHighlightCodeDiff()
 		lineHTMLDel, lineHTMLAdd := hcd.diffLineWithHighlight(diffs[0], diffs[1])
 		leftLine.cachedDiffInline = new(diffInlineWithUnicodeEscape(lineHTMLDel, locale))
@@ -417,7 +417,7 @@ func (diffSection *DiffSection) GetComputedInlineDiffFor(diffLine *DiffLine, loc
 		compareDiffLine := diffSection.GetLine(diffLine.Match)
 		return diffSection.getDiffLineForRender(DiffLineDel, diffLine, compareDiffLine, locale)
 	default: // Plain
-		// Here it always uses "right side" to render the plain content (not changed lines)
+		// Here it always uses "right side" to render the plain content (unchanged lines)
 		// tmpl also uses "RightIdx" to check whether to add "lines-code-old" CSS class to a line
 		return diffSection.getDiffLineForRender(DiffLinePlain, nil, diffLine, locale)
 	}

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -412,7 +412,7 @@ func (diffSection *DiffSection) GetComputedInlineDiffFor(diffLine *DiffLine, loc
 	switch diffLine.Type {
 	case DiffLineSection:
 		// section content is something like diff hunk info, not code diff, no need to escape or do any other process
-		return DiffInline{Content: htmlutil.EscapeString(diffLine.Content)}
+		return DiffInline{Content: htmlutil.EscapeString(diffLine.Content), EscapeStatus: &charset.EscapeStatus{}}
 	case DiffLineAdd:
 		compareDiffLine := diffSection.GetLine(diffLine.Match)
 		return diffSection.getDiffLineForRender(DiffLineAdd, compareDiffLine, diffLine, locale)

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -408,7 +408,7 @@ func (diffSection *DiffSection) GetComputedInlineDiffFor(diffLine *DiffLine, loc
 	// try to find equivalent diff line. ignore, otherwise
 	switch diffLine.Type {
 	case DiffLineSection:
-		// section content is a diff hunk header, it isn't code diff, but its trailing context comes from the file content
+		// section content is a diff hunk header, it isn't code diff, its trailing context might come from the file content, might not
 		return diffInlineWithUnicodeEscape(htmlutil.EscapeString(diffLine.Content), locale)
 	case DiffLineAdd:
 		compareDiffLine := diffSection.GetLine(diffLine.Match)

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -296,14 +296,6 @@ func newDiffLineSectionInfo(curFile *DiffFile, line string, lastLeftIdx, lastRig
 	}
 }
 
-// escape a line's content or return <br> needed for copy/paste purposes
-func getLineContent(content string, locale translation.Locale) DiffInline {
-	if len(content) > 0 {
-		return DiffInlineWithUnicodeEscape(template.HTML(html.EscapeString(content)), locale)
-	}
-	return DiffInline{EscapeStatus: &charset.EscapeStatus{}, Content: "<br>"}
-}
-
 // DiffSection represents a section of a DiffFile.
 type DiffSection struct {
 	language              *diffVarMutable[string]
@@ -334,8 +326,8 @@ type DiffInline struct {
 	Content      template.HTML
 }
 
-// DiffInlineWithUnicodeEscape makes a DiffInline with hidden Unicode characters escaped
-func DiffInlineWithUnicodeEscape(s template.HTML, locale translation.Locale) DiffInline {
+// diffInlineWithUnicodeEscape makes a DiffInline with hidden Unicode characters escaped
+func diffInlineWithUnicodeEscape(s template.HTML, locale translation.Locale) DiffInline {
 	status, content := charset.EscapeControlHTML(s, locale)
 	return DiffInline{EscapeStatus: status, Content: content}
 }
@@ -381,7 +373,7 @@ func (diffSection *DiffSection) getDiffLineForRender(diffLineType DiffLineType, 
 		} else if rightLine != nil {
 			lineHTML = diffSection.getLineContentForRender(rightLine.RightIdx, rightLine, fileLanguage, highlightedRightLines)
 		}
-		return DiffInlineWithUnicodeEscape(lineHTML, locale)
+		return diffInlineWithUnicodeEscape(lineHTML, locale)
 	}
 
 	var diff1, diff2 template.HTML
@@ -394,10 +386,12 @@ func (diffSection *DiffSection) getDiffLineForRender(diffLineType DiffLineType, 
 
 	if diff1 != "" && diff2 != "" {
 		// if only some parts of a line are changed, highlight these changed parts as "deleted/added".
+		// "diff" them together, then cache the diff result, because when viewing the diff page,
+		// bother "deleted" and "added" lines will to be rendered eventually, so here only diff them once.
 		hcd := newHighlightCodeDiff()
-		lineHTMLDel, lineHTMLAdd := hcd.diffLineWithHighlightBoth(diff1, diff2)
-		inlineDel := DiffInlineWithUnicodeEscape(lineHTMLDel, locale)
-		inlineAdd := DiffInlineWithUnicodeEscape(lineHTMLAdd, locale)
+		lineHTMLDel, lineHTMLAdd := hcd.diffLineWithHighlight(diff1, diff2)
+		inlineDel := diffInlineWithUnicodeEscape(lineHTMLDel, locale)
+		inlineAdd := diffInlineWithUnicodeEscape(lineHTMLAdd, locale)
 
 		if leftLine != nil {
 			leftLine.cachedDiffInline = &inlineDel
@@ -415,7 +409,7 @@ func (diffSection *DiffSection) getDiffLineForRender(diffLineType DiffLineType, 
 	// if left is empty or right is empty (a line is fully deleted or added), then we do not need to diff anymore.
 	// the tmpl code already adds background colors for these cases.
 	lineHTML = util.Iif(diffLineType == DiffLineDel, diff1, diff2)
-	return DiffInlineWithUnicodeEscape(lineHTML, locale)
+	return diffInlineWithUnicodeEscape(lineHTML, locale)
 }
 
 // GetComputedInlineDiffFor computes inline diff for the given line.
@@ -429,7 +423,8 @@ func (diffSection *DiffSection) GetComputedInlineDiffFor(diffLine *DiffLine, loc
 	// try to find equivalent diff line. ignore, otherwise
 	switch diffLine.Type {
 	case DiffLineSection:
-		return getLineContent(diffLine.Content, locale)
+		// section content is something like diff hunk info, not code diff, no need to escape or do any other process
+		return DiffInline{Content: htmlutil.EscapeString(diffLine.Content)}
 	case DiffLineAdd:
 		compareDiffLine := diffSection.GetLine(diffLine.Match)
 		return diffSection.getDiffLineForRender(DiffLineAdd, compareDiffLine, diffLine, locale)

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -350,11 +350,11 @@ func (diffSection *DiffSection) getLineContentForRender(lineIdx int, diffLine *D
 }
 
 func (diffSection *DiffSection) getDiffLineForRender(diffLineType DiffLineType, leftLine, rightLine *DiffLine, locale translation.Locale) DiffInline {
-	if diffLineType == DiffLineDel && leftLine != nil && leftLine.cachedDiffInline != nil {
-		return *leftLine.cachedDiffInline
-	}
-	if diffLineType == DiffLineAdd && rightLine != nil && rightLine.cachedDiffInline != nil {
-		return *rightLine.cachedDiffInline
+	sideIdx := util.Iif(diffLineType == DiffLineDel, 0, 1) // del=left, add=right
+	lines := [2]*DiffLine{leftLine, rightLine}
+
+	if lines[sideIdx] != nil && lines[sideIdx].cachedDiffInline != nil {
+		return *lines[sideIdx].cachedDiffInline
 	}
 
 	var fileLanguage string
@@ -365,9 +365,8 @@ func (diffSection *DiffSection) getDiffLineForRender(diffLineType DiffLineType, 
 		highlightedLeftLines, highlightedRightLines = diffSection.highlightedLeftLines.value, diffSection.highlightedRightLines.value
 	}
 
-	var lineHTML template.HTML
 	if diffLineType == DiffLinePlain {
-		// left and right are the same, no need to do line-level diff
+		var lineHTML template.HTML // left and right are the same, no need to do line-level diff, can just pick any side
 		if leftLine != nil {
 			lineHTML = diffSection.getLineContentForRender(leftLine.LeftIdx, leftLine, fileLanguage, highlightedLeftLines)
 		} else if rightLine != nil {
@@ -376,40 +375,29 @@ func (diffSection *DiffSection) getDiffLineForRender(diffLineType DiffLineType, 
 		return diffInlineWithUnicodeEscape(lineHTML, locale)
 	}
 
-	var diff1, diff2 template.HTML
+	var diffs [2]template.HTML
 	if leftLine != nil {
-		diff1 = diffSection.getLineContentForRender(leftLine.LeftIdx, leftLine, fileLanguage, highlightedLeftLines)
+		diffs[0] = diffSection.getLineContentForRender(leftLine.LeftIdx, leftLine, fileLanguage, highlightedLeftLines)
 	}
 	if rightLine != nil {
-		diff2 = diffSection.getLineContentForRender(rightLine.RightIdx, rightLine, fileLanguage, highlightedRightLines)
+		diffs[1] = diffSection.getLineContentForRender(rightLine.RightIdx, rightLine, fileLanguage, highlightedRightLines)
 	}
 
-	if diff1 != "" && diff2 != "" {
+	if leftLine != nil && rightLine != nil {
 		// if only some parts of a line are changed, highlight these changed parts as "deleted/added".
-		// "diff" them together, then cache the diff result, because when viewing the diff page,
-		// bother "deleted" and "added" lines will to be rendered eventually, so here only diff them once.
+		// "diff" the left&right sides together, then cache the diff result for another side,
+		// because when viewing the diff page, bother "deleted" and "added" lines will to be rendered eventually,
+		// so here only diff them once, then next render can just use the cached result, no  need to "diff" again.
 		hcd := newHighlightCodeDiff()
-		lineHTMLDel, lineHTMLAdd := hcd.diffLineWithHighlight(diff1, diff2)
-		inlineDel := diffInlineWithUnicodeEscape(lineHTMLDel, locale)
-		inlineAdd := diffInlineWithUnicodeEscape(lineHTMLAdd, locale)
-
-		if leftLine != nil {
-			leftLine.cachedDiffInline = &inlineDel
-		}
-		if rightLine != nil {
-			rightLine.cachedDiffInline = &inlineAdd
-		}
-
-		if diffLineType == DiffLineDel {
-			return inlineDel
-		}
-		return inlineAdd
+		lineHTMLDel, lineHTMLAdd := hcd.diffLineWithHighlight(diffs[0], diffs[1])
+		leftLine.cachedDiffInline = new(diffInlineWithUnicodeEscape(lineHTMLDel, locale))
+		rightLine.cachedDiffInline = new(diffInlineWithUnicodeEscape(lineHTMLAdd, locale))
+		return *lines[sideIdx].cachedDiffInline
 	}
 
 	// if left is empty or right is empty (a line is fully deleted or added), then we do not need to diff anymore.
 	// the tmpl code already adds background colors for these cases.
-	lineHTML = util.Iif(diffLineType == DiffLineDel, diff1, diff2)
-	return diffInlineWithUnicodeEscape(lineHTML, locale)
+	return diffInlineWithUnicodeEscape(diffs[sideIdx], locale)
 }
 
 // GetComputedInlineDiffFor computes inline diff for the given line.
@@ -559,8 +547,7 @@ func (diffFile *DiffFile) addTailSection(detail DiffRenderDetail) {
 	lastSection := diffFile.Sections[len(diffFile.Sections)-1]
 	lastLine := lastSection.Lines[len(lastSection.Lines)-1]
 	tailDiffLine := &DiffLine{
-		Type:    DiffLineSection,
-		Content: " ",
+		Type: DiffLineSection,
 		SectionInfo: &DiffLineSectionInfo{
 			language:     &diffFile.language,
 			Path:         diffFile.Name,

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -366,12 +366,9 @@ func (diffSection *DiffSection) getDiffLineForRender(diffLineType DiffLineType, 
 	}
 
 	if diffLineType == DiffLinePlain {
-		var lineHTML template.HTML // left and right are the same, no need to do line-level diff, can just pick any side
-		if leftLine != nil {
-			lineHTML = diffSection.getLineContentForRender(leftLine.LeftIdx, leftLine, fileLanguage, highlightedLeftLines)
-		} else if rightLine != nil {
-			lineHTML = diffSection.getLineContentForRender(rightLine.RightIdx, rightLine, fileLanguage, highlightedRightLines)
-		}
+		// left and right are the same, no need to do line-level diff, can just pick any side
+		// caller always use the "right side" for this type
+		lineHTML := diffSection.getLineContentForRender(rightLine.RightIdx, rightLine, fileLanguage, highlightedRightLines)
 		return diffInlineWithUnicodeEscape(lineHTML, locale)
 	}
 
@@ -420,8 +417,8 @@ func (diffSection *DiffSection) GetComputedInlineDiffFor(diffLine *DiffLine, loc
 		compareDiffLine := diffSection.GetLine(diffLine.Match)
 		return diffSection.getDiffLineForRender(DiffLineDel, diffLine, compareDiffLine, locale)
 	default: // Plain
-		// TODO: there was an "if" check: `if diffLine.Content >strings.IndexByte(" +-", diffLine.Content[0]) > -1 { ... } else { ... }`
-		// no idea why it needs that check, it seems that the "if" should be always true, so try to simplify the code
+		// Here it always uses "right side" to render the plain content (not changed lines)
+		// tmpl also uses "RightIdx" to check whether to add "lines-code-old" CSS class to a line
 		return diffSection.getDiffLineForRender(DiffLinePlain, nil, diffLine, locale)
 	}
 }

--- a/services/gitdiff/gitdiff_test.go
+++ b/services/gitdiff/gitdiff_test.go
@@ -1110,6 +1110,15 @@ func TestDiffLine_GetExpandDirection(t *testing.T) {
 	}
 }
 
+func TestDiffSection_GetComputedInlineDiffFor(t *testing.T) {
+	t.Run("Section", func(t *testing.T) {
+		diffLine := &DiffLine{Type: DiffLineSection, Content: "@@ -1,3 +1,3 @@ func \u202ename() <b>"}
+		diffInline := (&DiffSection{}).GetComputedInlineDiffFor(diffLine, translation.MockLocale{})
+		assert.True(t, diffInline.EscapeStatus.Escaped)
+		assert.Equal(t, `@@ -1,3 +1,3 @@ func <span class="escaped-code-point" data-escaped="[U+202E]"><span class="char">`+"\u202e"+`</span></span>name() &lt;b&gt;`, string(diffInline.Content))
+	})
+}
+
 func TestHighlightCodeLines(t *testing.T) {
 	t.Run("CharsetDetecting", func(t *testing.T) {
 		diffFile := &DiffFile{
@@ -1157,14 +1166,6 @@ func TestHighlightCodeLines(t *testing.T) {
 		assert.Equal(t, "a␍b\n", string(ret[0]))
 		assert.Equal(t, `c`, string(ret[1]))
 	})
-}
-
-func TestGetComputedInlineDiffForSection(t *testing.T) {
-	// a hunk header's trailing context is copied from the file content, so it may contain hidden Unicode characters
-	diffLine := &DiffLine{Type: DiffLineSection, Content: "@@ -1,3 +1,3 @@ func \u202ename() <b>"}
-	diffInline := (&DiffSection{}).GetComputedInlineDiffFor(diffLine, translation.MockLocale{})
-	assert.True(t, diffInline.EscapeStatus.Escaped)
-	assert.Equal(t, `@@ -1,3 +1,3 @@ func <span class="escaped-code-point" data-escaped="[U+202E]"><span class="char">`+"\u202e"+`</span></span>name() &lt;b&gt;`, string(diffInline.Content))
 }
 
 func TestSyncUserSpecificDiff_UpdatedFiles(t *testing.T) {

--- a/services/gitdiff/gitdiff_test.go
+++ b/services/gitdiff/gitdiff_test.go
@@ -18,6 +18,7 @@ import (
 	"gitea.dev/modules/git/gitcmd"
 	"gitea.dev/modules/json"
 	"gitea.dev/modules/setting"
+	"gitea.dev/modules/translation"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1156,6 +1157,14 @@ func TestHighlightCodeLines(t *testing.T) {
 		assert.Equal(t, "a␍b\n", string(ret[0]))
 		assert.Equal(t, `c`, string(ret[1]))
 	})
+}
+
+func TestGetComputedInlineDiffForSection(t *testing.T) {
+	// a hunk header's trailing context is copied from the file content, so it may contain hidden Unicode characters
+	diffLine := &DiffLine{Type: DiffLineSection, Content: "@@ -1,3 +1,3 @@ func \u202ename() <b>"}
+	diffInline := (&DiffSection{}).GetComputedInlineDiffFor(diffLine, translation.MockLocale{})
+	assert.True(t, diffInline.EscapeStatus.Escaped)
+	assert.Equal(t, `@@ -1,3 +1,3 @@ func <span class="escaped-code-point" data-escaped="[U+202E]"><span class="char">`+"\u202e"+`</span></span>name() &lt;b&gt;`, string(diffInline.Content))
 }
 
 func TestSyncUserSpecificDiff_UpdatedFiles(t *testing.T) {

--- a/services/gitdiff/highlightdiff.go
+++ b/services/gitdiff/highlightdiff.go
@@ -161,9 +161,6 @@ func (hcd *highlightCodeDiff) diffLineWithHighlight(codeA, codeB template.HTML) 
 	diffs := dmp.DiffMain(convertedCodeA, convertedCodeB, true)
 	diffs = dmp.DiffCleanupSemantic(diffs)
 
-	bufDel := bytes.NewBuffer(nil)
-	bufAdd := bytes.NewBuffer(nil)
-
 	if hcd.diffCodeClose == 0 {
 		// tests can pre-set the placeholders
 		hcd.diffCodeAddedOpen = hcd.registerTokenAsPlaceholder(`<span class="added-code">`)
@@ -184,6 +181,8 @@ func (hcd *highlightCodeDiff) diffLineWithHighlight(codeA, codeB template.HTML) 
 	// only add "added"/"removed" tags when needed:
 	// * non-space contents appear in the DiffEqual parts (not a full-line add/del)
 	// * placeholder map still works (not exhausted, can get the closing tag placeholder)
+	bufDel := bytes.NewBuffer(nil)
+	bufAdd := bytes.NewBuffer(nil)
 	addDiffTags := !equalPartSpaceOnly && hcd.diffCodeClose != 0
 	if addDiffTags {
 		for _, diff := range diffs {
@@ -212,7 +211,7 @@ func (hcd *highlightCodeDiff) diffLineWithHighlight(codeA, codeB template.HTML) 
 			}
 		}
 	}
-	return hcd.recoverOneDiff(bufDel.String()), hcd.recoverOneDiff(bufAdd.String())
+	return hcd.recoverOneDiff(util.UnsafeBytesToString(bufDel.Bytes())), hcd.recoverOneDiff(util.UnsafeBytesToString(bufAdd.Bytes()))
 }
 
 func (hcd *highlightCodeDiff) registerTokenAsPlaceholder(token string) rune {

--- a/services/gitdiff/highlightdiff.go
+++ b/services/gitdiff/highlightdiff.go
@@ -151,6 +151,14 @@ func (hcd *highlightCodeDiff) diffEqualPartIsSpaceOnly(s string) bool {
 }
 
 func (hcd *highlightCodeDiff) diffLineWithHighlight(lineType DiffLineType, codeA, codeB template.HTML) template.HTML {
+	del, add := hcd.diffLineWithHighlightBoth(codeA, codeB)
+	if lineType == DiffLineDel {
+		return del
+	}
+	return add
+}
+
+func (hcd *highlightCodeDiff) diffLineWithHighlightBoth(codeA, codeB template.HTML) (template.HTML, template.HTML) {
 	hcd.collectUsedRunes(codeA)
 	hcd.collectUsedRunes(codeB)
 
@@ -161,7 +169,8 @@ func (hcd *highlightCodeDiff) diffLineWithHighlight(lineType DiffLineType, codeA
 	diffs := dmp.DiffMain(convertedCodeA, convertedCodeB, true)
 	diffs = dmp.DiffCleanupSemantic(diffs)
 
-	buf := bytes.NewBuffer(nil)
+	bufDel := bytes.NewBuffer(nil)
+	bufAdd := bytes.NewBuffer(nil)
 
 	if hcd.diffCodeClose == 0 {
 		// tests can pre-set the placeholders
@@ -186,29 +195,32 @@ func (hcd *highlightCodeDiff) diffLineWithHighlight(lineType DiffLineType, codeA
 	addDiffTags := !equalPartSpaceOnly && hcd.diffCodeClose != 0
 	if addDiffTags {
 		for _, diff := range diffs {
-			switch {
-			case diff.Type == diffmatchpatch.DiffEqual:
-				buf.WriteString(diff.Text)
-			case diff.Type == diffmatchpatch.DiffInsert && lineType == DiffLineAdd:
-				buf.WriteRune(hcd.diffCodeAddedOpen)
-				buf.WriteString(diff.Text)
-				buf.WriteRune(hcd.diffCodeClose)
-			case diff.Type == diffmatchpatch.DiffDelete && lineType == DiffLineDel:
-				buf.WriteRune(hcd.diffCodeRemovedOpen)
-				buf.WriteString(diff.Text)
-				buf.WriteRune(hcd.diffCodeClose)
+			switch diff.Type {
+			case diffmatchpatch.DiffEqual:
+				bufDel.WriteString(diff.Text)
+				bufAdd.WriteString(diff.Text)
+			case diffmatchpatch.DiffInsert:
+				bufAdd.WriteRune(hcd.diffCodeAddedOpen)
+				bufAdd.WriteString(diff.Text)
+				bufAdd.WriteRune(hcd.diffCodeClose)
+			case diffmatchpatch.DiffDelete:
+				bufDel.WriteRune(hcd.diffCodeRemovedOpen)
+				bufDel.WriteString(diff.Text)
+				bufDel.WriteRune(hcd.diffCodeClose)
 			}
 		}
 	} else {
 		// the caller will still add added/removed backgrounds for the whole line
 		for _, diff := range diffs {
-			take := diff.Type == diffmatchpatch.DiffEqual || (diff.Type == diffmatchpatch.DiffInsert && lineType == DiffLineAdd) || (diff.Type == diffmatchpatch.DiffDelete && lineType == DiffLineDel)
-			if take {
-				buf.WriteString(diff.Text)
+			if diff.Type == diffmatchpatch.DiffEqual || diff.Type == diffmatchpatch.DiffDelete {
+				bufDel.WriteString(diff.Text)
+			}
+			if diff.Type == diffmatchpatch.DiffEqual || diff.Type == diffmatchpatch.DiffInsert {
+				bufAdd.WriteString(diff.Text)
 			}
 		}
 	}
-	return hcd.recoverOneDiff(buf.String())
+	return hcd.recoverOneDiff(bufDel.String()), hcd.recoverOneDiff(bufAdd.String())
 }
 
 func (hcd *highlightCodeDiff) registerTokenAsPlaceholder(token string) rune {

--- a/services/gitdiff/highlightdiff.go
+++ b/services/gitdiff/highlightdiff.go
@@ -150,15 +150,7 @@ func (hcd *highlightCodeDiff) diffEqualPartIsSpaceOnly(s string) bool {
 	return true
 }
 
-func (hcd *highlightCodeDiff) diffLineWithHighlight(lineType DiffLineType, codeA, codeB template.HTML) template.HTML {
-	del, add := hcd.diffLineWithHighlightBoth(codeA, codeB)
-	if lineType == DiffLineDel {
-		return del
-	}
-	return add
-}
-
-func (hcd *highlightCodeDiff) diffLineWithHighlightBoth(codeA, codeB template.HTML) (template.HTML, template.HTML) {
+func (hcd *highlightCodeDiff) diffLineWithHighlight(codeA, codeB template.HTML) (del, add template.HTML) {
 	hcd.collectUsedRunes(codeA)
 	hcd.collectUsedRunes(codeB)
 

--- a/services/gitdiff/highlightdiff_test.go
+++ b/services/gitdiff/highlightdiff_test.go
@@ -19,8 +19,6 @@ import (
 func BenchmarkHighlightDiff(b *testing.B) {
 	for b.Loop() {
 		// still fast enough: BenchmarkHighlightDiff-12    	 1000000	      1027 ns/op
-		// TODO: the real bottleneck is that "diffLineWithHighlight" is called twice when rendering "added" and "removed" lines by the caller
-		// Ideally the caller should cache the diff result, and then use the diff result to render "added" and "removed" lines separately
 		hcd := newHighlightCodeDiff()
 		codeA := template.HTML(`x <span class="k">foo</span> y`)
 		codeB := template.HTML(`x <span class="k">bar</span> y`)

--- a/services/gitdiff/highlightdiff_test.go
+++ b/services/gitdiff/highlightdiff_test.go
@@ -24,7 +24,7 @@ func BenchmarkHighlightDiff(b *testing.B) {
 		hcd := newHighlightCodeDiff()
 		codeA := template.HTML(`x <span class="k">foo</span> y`)
 		codeB := template.HTML(`x <span class="k">bar</span> y`)
-		hcd.diffLineWithHighlight(DiffLineDel, codeA, codeB)
+		hcd.diffLineWithHighlight(codeA, codeB)
 	}
 }
 
@@ -34,9 +34,8 @@ func TestDiffWithHighlight(t *testing.T) {
 			hcd := newHighlightCodeDiff()
 			codeA := template.HTML(`x <span class="k">foo</span> y`)
 			codeB := template.HTML(`x <span class="k">bar</span> y`)
-			outDel := hcd.diffLineWithHighlight(DiffLineDel, codeA, codeB)
+			outDel, outAdd := hcd.diffLineWithHighlight(codeA, codeB)
 			assert.Equal(t, `x <span class="removed-code"><span class="k">foo</span></span> y`, string(outDel))
-			outAdd := hcd.diffLineWithHighlight(DiffLineAdd, codeA, codeB)
 			assert.Equal(t, `x <span class="added-code"><span class="k">bar</span></span> y`, string(outAdd))
 		})
 		t.Run("NoRedundantTags", func(t *testing.T) {
@@ -45,9 +44,9 @@ func TestDiffWithHighlight(t *testing.T) {
 			hcd := newHighlightCodeDiff()
 			codeA := template.HTML("<span> </span> \t<span>foo</span> ")
 			codeB := template.HTML(" <span>bar</span> \n")
-			outDel := hcd.diffLineWithHighlight(DiffLineDel, codeA, codeB)
+			outDel, outAdd := hcd.diffLineWithHighlight(codeA, codeB)
 			assert.Equal(t, string(codeA), string(outDel))
-			outAdd := hcd.diffLineWithHighlight(DiffLineAdd, codeA, codeB)
+			assert.Equal(t, string(codeB), string(outAdd))
 			assert.Equal(t, string(codeB), string(outAdd))
 		})
 	})
@@ -56,16 +55,14 @@ func TestDiffWithHighlight(t *testing.T) {
 		hcd := newHighlightCodeDiff()
 		codeA := template.HTML(` <span class="cm">this is a comment</span>`)
 		codeB := template.HTML(` <span class="cm">this is updated comment</span>`)
-		outDel := hcd.diffLineWithHighlight(DiffLineDel, codeA, codeB)
+		outDel, outAdd := hcd.diffLineWithHighlight(codeA, codeB)
 		assert.Equal(t, ` <span class="cm">this is <span class="removed-code">a</span> comment</span>`, string(outDel))
-		outAdd := hcd.diffLineWithHighlight(DiffLineAdd, codeA, codeB)
 		assert.Equal(t, ` <span class="cm">this is <span class="added-code">updated</span> comment</span>`, string(outAdd))
 
 		codeA = `<span class="line"><span>line1</span></span>` + "\n" + `<span class="cl"><span>line2</span></span>`
 		codeB = `<span class="cl"><span>line1</span></span>` + "\n" + `<span class="line"><span>line!</span></span>`
-		outDel = hcd.diffLineWithHighlight(DiffLineDel, codeA, codeB)
+		outDel, outAdd = hcd.diffLineWithHighlight(codeA, codeB)
 		assert.Equal(t, `<span>line1</span>`+"\n"+`<span class="removed-code"><span>line2</span></span>`, string(outDel))
-		outAdd = hcd.diffLineWithHighlight(DiffLineAdd, codeA, codeB)
 		assert.Equal(t, `<span>line1</span>`+"\n"+`<span><span class="added-code">line!</span></span>`, string(outAdd))
 	})
 
@@ -81,12 +78,12 @@ func TestDiffWithHighlight(t *testing.T) {
 		oldCode, _, _ := highlight.RenderCodeSlowGuess("a.go", "Go", `xxx || yyy`)
 		newCode, _, _ := highlight.RenderCodeSlowGuess("a.go", "Go", `bot&xxx || bot&yyy`)
 		hcd := newHighlightCodeDiff()
-		out := hcd.diffLineWithHighlight(DiffLineAdd, oldCode, newCode)
+		_, add := hcd.diffLineWithHighlight(oldCode, newCode)
 		assert.Equal(t, strings.ReplaceAll(`
 <span class="added-code"><span class="nx">bot</span></span><span class="o"><span class="added-code">&amp;</span></span>
 <span class="nx">xxx</span><span class="w"> </span><span class="o">||</span><span class="w"> </span>
 <span class="added-code"><span class="nx">bot</span></span><span class="o"><span class="added-code">&amp;</span></span>
-<span class="nx">yyy</span>`, "\n", ""), string(out))
+<span class="nx">yyy</span>`, "\n", ""), string(add))
 	})
 
 	forceTokenAsPlaceholder := func(hcd *highlightCodeDiff, r rune, token string) rune {
@@ -129,14 +126,14 @@ func TestDiffWithHighlight(t *testing.T) {
 
 func TestDiffWithHighlightPlaceholder(t *testing.T) {
 	hcd := newHighlightCodeDiff()
-	output := hcd.diffLineWithHighlight(DiffLineDel, "a='\U00100000'", "a='\U0010FFFD''")
+	output, _ := hcd.diffLineWithHighlight("a='\U00100000'", "a='\U0010FFFD''")
 	assert.Empty(t, hcd.placeholderTokenMap[0x00100000])
 	assert.Empty(t, hcd.placeholderTokenMap[0x0010FFFD])
 	expected := fmt.Sprintf(`a='<span class="removed-code">%s</span>'`, "\U00100000")
 	assert.Equal(t, expected, string(output))
 
 	hcd = newHighlightCodeDiff()
-	output = hcd.diffLineWithHighlight(DiffLineAdd, "a='\U00100000'", "a='\U0010FFFD'")
+	_, output = hcd.diffLineWithHighlight("a='\U00100000'", "a='\U0010FFFD'")
 	expected = fmt.Sprintf(`a='<span class="added-code">%s</span>'`, "\U0010FFFD")
 	assert.Equal(t, expected, string(output))
 }
@@ -145,34 +142,29 @@ func TestDiffWithHighlightPlaceholderExhausted(t *testing.T) {
 	hcd := newHighlightCodeDiff()
 	hcd.placeholderMaxCount = 0
 	placeHolderAmp := string(rune(0xFFFD))
-	output := hcd.diffLineWithHighlight(DiffLineDel, `<span class="k">&lt;</span>`, `<span class="k">&gt;</span>`)
-	assert.Equal(t, placeHolderAmp+"lt;", string(output))
-	output = hcd.diffLineWithHighlight(DiffLineAdd, `<span class="k">&lt;</span>`, `<span class="k">&gt;</span>`)
-	assert.Equal(t, placeHolderAmp+"gt;", string(output))
+	del, add := hcd.diffLineWithHighlight(`<span class="k">&lt;</span>`, `<span class="k">&gt;</span>`)
+	assert.Equal(t, placeHolderAmp+"lt;", string(del))
+	assert.Equal(t, placeHolderAmp+"gt;", string(add))
 
-	output = hcd.diffLineWithHighlight(DiffLineDel, `<span class="k">foo</span>`, `<span class="k">bar</span>`)
-	assert.Equal(t, "foo", string(output))
-	output = hcd.diffLineWithHighlight(DiffLineAdd, `<span class="k">foo</span>`, `<span class="k">bar</span>`)
-	assert.Equal(t, "bar", string(output))
+	del, add = hcd.diffLineWithHighlight(`<span class="k">foo</span>`, `<span class="k">bar</span>`)
+	assert.Equal(t, "foo", string(del))
+	assert.Equal(t, "bar", string(add))
 }
 
 func TestDiffWithHighlightTagMatch(t *testing.T) {
-	f := func(t *testing.T, lineType DiffLineType) {
-		totalOverflow := 0
-		for i := 0; ; i++ {
-			hcd := newHighlightCodeDiff()
-			hcd.placeholderMaxCount = i
-			output := string(hcd.diffLineWithHighlight(lineType, `<span class="k">&lt;</span>`, `<span class="k">&gt;</span>`))
-			totalOverflow += hcd.placeholderOverflowCount
-			assert.Equal(t, strings.Count(output, "<span"), strings.Count(output, "</span"))
-			if hcd.placeholderOverflowCount == 0 {
-				break
-			}
+	totalOverflow := 0
+	for i := 0; ; i++ {
+		hcd := newHighlightCodeDiff()
+		hcd.placeholderMaxCount = i
+		del, add := hcd.diffLineWithHighlight(`<span class="k">&lt;</span>`, `<span class="k">&gt;</span>`)
+		totalOverflow += hcd.placeholderOverflowCount
+		assert.Equal(t, strings.Count(string(del), "<span"), strings.Count(string(del), "</span"))
+		assert.Equal(t, strings.Count(string(add), "<span"), strings.Count(string(add), "</span"))
+		if hcd.placeholderOverflowCount == 0 {
+			break
 		}
-		assert.NotZero(t, totalOverflow)
 	}
-	t.Run("DiffLineAdd", func(t *testing.T) { f(t, DiffLineAdd) })
-	t.Run("DiffLineDel", func(t *testing.T) { f(t, DiffLineDel) })
+	assert.NotZero(t, totalOverflow)
 }
 
 func BenchmarkGetDiffLineForRender(b *testing.B) {

--- a/services/gitdiff/highlightdiff_test.go
+++ b/services/gitdiff/highlightdiff_test.go
@@ -35,7 +35,6 @@ func TestDiffWithHighlight(t *testing.T) {
 			outDel, outAdd := hcd.diffLineWithHighlight(codeA, codeB)
 			assert.Equal(t, string(codeA), string(outDel))
 			assert.Equal(t, string(codeB), string(outAdd))
-			assert.Equal(t, string(codeB), string(outAdd))
 		})
 	})
 

--- a/services/gitdiff/highlightdiff_test.go
+++ b/services/gitdiff/highlightdiff_test.go
@@ -10,7 +10,9 @@ import (
 	"testing"
 
 	"gitea.dev/modules/highlight"
+	"gitea.dev/modules/translation"
 
+	"github.com/alecthomas/chroma/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -171,4 +173,30 @@ func TestDiffWithHighlightTagMatch(t *testing.T) {
 	}
 	t.Run("DiffLineAdd", func(t *testing.T) { f(t, DiffLineAdd) })
 	t.Run("DiffLineDel", func(t *testing.T) { f(t, DiffLineDel) })
+}
+
+func BenchmarkGetDiffLineForRender(b *testing.B) {
+	diffSection := &DiffSection{
+		FileName:       "test.go",
+		highlightLexer: &diffVarMutable[chroma.Lexer]{},
+	}
+	leftLine := &DiffLine{
+		LeftIdx: 1,
+		Content: `-x <span class="k">foo</span> y`,
+	}
+	rightLine := &DiffLine{
+		RightIdx: 1,
+		Content:  `+x <span class="k">bar</span> y`,
+	}
+	locale := translation.MockLocale{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Clear cache only at the start of rendering the pair
+		leftLine.cachedDiffInline = nil
+		rightLine.cachedDiffInline = nil
+
+		_ = diffSection.getDiffLineForRender(DiffLineDel, leftLine, rightLine, locale)
+		_ = diffSection.getDiffLineForRender(DiffLineAdd, leftLine, rightLine, locale)
+	}
 }

--- a/services/gitdiff/highlightdiff_test.go
+++ b/services/gitdiff/highlightdiff_test.go
@@ -16,16 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func BenchmarkHighlightDiff(b *testing.B) {
-	for b.Loop() {
-		// still fast enough: BenchmarkHighlightDiff-12    	 1000000	      1027 ns/op
-		hcd := newHighlightCodeDiff()
-		codeA := template.HTML(`x <span class="k">foo</span> y`)
-		codeB := template.HTML(`x <span class="k">bar</span> y`)
-		hcd.diffLineWithHighlight(codeA, codeB)
-	}
-}
-
 func TestDiffWithHighlight(t *testing.T) {
 	t.Run("DiffLineAddDel", func(t *testing.T) {
 		t.Run("WithDiffTags", func(t *testing.T) {
@@ -165,27 +155,32 @@ func TestDiffWithHighlightTagMatch(t *testing.T) {
 	assert.NotZero(t, totalOverflow)
 }
 
+func BenchmarkHighlightDiff(b *testing.B) {
+	// still fast enough: BenchmarkHighlightDiff-12    	 1000000	      1027 ns/op
+	// HINT: CODE-HIGHLIGHT-PERFORMANCE: the real bottleneck is in the Chroma highlighter.
+	for b.Loop() {
+		hcd := newHighlightCodeDiff()
+		codeA := template.HTML(`x <span class="k">foo</span> y`)
+		codeB := template.HTML(`x <span class="k">bar</span> y`)
+		hcd.diffLineWithHighlight(codeA, codeB)
+	}
+}
+
 func BenchmarkGetDiffLineForRender(b *testing.B) {
 	diffSection := &DiffSection{
 		FileName:       "test.go",
 		highlightLexer: &diffVarMutable[chroma.Lexer]{},
 	}
-	leftLine := &DiffLine{
-		LeftIdx: 1,
-		Content: `-x <span class="k">foo</span> y`,
-	}
-	rightLine := &DiffLine{
-		RightIdx: 1,
-		Content:  `+x <span class="k">bar</span> y`,
-	}
+	leftLine := &DiffLine{LeftIdx: 1, Content: `-x <span class="k">foo</span> y`}
+	rightLine := &DiffLine{RightIdx: 1, Content: `+x <span class="k">bar</span> y`}
 	locale := translation.MockLocale{}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	// HINT: CODE-HIGHLIGHT-PERFORMANCE: the real bottleneck is in the Chroma highlighter.
+	for b.Loop() {
 		// Clear cache only at the start of rendering the pair
 		leftLine.cachedDiffInline = nil
 		rightLine.cachedDiffInline = nil
-
 		_ = diffSection.getDiffLineForRender(DiffLineDel, leftLine, rightLine, locale)
 		_ = diffSection.getDiffLineForRender(DiffLineAdd, leftLine, rightLine, locale)
 	}

--- a/services/markup/renderhelper_codepreview.go
+++ b/services/markup/renderhelper_codepreview.go
@@ -102,7 +102,7 @@ func renderRepoFileCodePreview(ctx context.Context, opts markup.RenderCodePrevie
 	lineEscapeStatus := make([]*charset.EscapeStatus, len(highlightLines))
 	for i, hl := range highlightLines {
 		lineEscapeStatus[i], hl.FormattedContent = charset.EscapeControlHTML(hl.FormattedContent, webCtx.Base.Locale, charset.EscapeOptionsForView())
-		escapeStatus = escapeStatus.Or(lineEscapeStatus[i])
+		escapeStatus.Combine(lineEscapeStatus[i])
 	}
 
 	return webCtx.RenderToHTML("base/markup_codepreview", map[string]any{


### PR DESCRIPTION
This pull request optimizes code diff highlighting in the PR Files Changed view, which is a major CPU bottleneck and hot path in production.

Previously, Gitea executed the expensive `DiffMatchPatch` algorithm twice for every matching deleted/added line pair (once for the deleted line, and once for the added line). We now run the diff algorithm once and cache the resulting `DiffInline` on the `DiffLine` struct itself, allowing the second line to render via a 0-cost cache lookup.

### Production Impact (Per 1,000 Modified Lines)
* **Server Latency (CPU Time):**
  * **Before:** ~958.5 ms
  * **After:** ~466.4 ms (Reduces latency by **~492 ms / 2.05x faster**)
* **Heap Memory Allocated:**
  * **Before:** ~445.2 MB
  * **After:** ~222.3 MB (Saves **~222.9 MB**)
* **Heap Allocations:**
  * **Before:** ~5.87 million
  * **After:** ~2.93 million (Reduces allocations by **~2.94 million**)

### Results (BenchmarkGetDiffLineForRender)
* **Execution Time:** ~958,500 ns/op -> ~466,433 ns/op (51.3% speedup)
* **Allocations:** 5,873 allocs/op -> 2,935 allocs/op (50% reduction)
* **Memory Allocated:** ~445,200 B/op -> ~222,314 B/op (50% reduction)