### PR TITLE
fix(markdown): fix double strikethough on code

### DIFF
--- a/web_src/css/markup/content.css
+++ b/web_src/css/markup/content.css
@@ -366,10 +366,6 @@ html[data-gitea-theme-dark="false"] .markup img[src*="#gh-dark-mode-only"] {
   display: none;
 }
 
-.markup del code {
-  text-decoration: inherit;
-}
-
 .markup pre > code {
   font-size: 100%;
 }


### PR DESCRIPTION
`.markup del code { text-decoration: inherit }` makes inline code inside `<del>` paint its own line-through in addition to the one already propagating from the parent. Since `code` is `font-size: 85%`, the two land at different heights and render as a doubled strikethrough.

The rule was inherited from primer-markdown, where it was added in https://github.com/primer/css/commit/762b8b8264aa4c4beed0a7f842f90c142eb2b310 ("so that `<del>` or `<a>` has the same effects on `<code>` tags") at a time when inline `code` was `display: inline-block`, a box that text decorations do not propagate into. That `display: inline-block` was removed 11 days later in https://github.com/primer/css/commit/f1131d5ab618ac41d4097823b511ca0b373b2ee2, which made the rule redundant, but it survived the squashed import into primer/css and every copy downstream of it.

No other popular markdown stylesheet carries an equivalent rule, GitHub still ships it and shows the same doubled line.

Fixes: https://github.com/go-gitea/gitea/issues/34786