### PR TITLE
fix(pull): allow re-request after stale review request

### DIFF
--- a/models/issues/review.go
+++ b/models/issues/review.go
@@ -584,12 +584,14 @@ func SubmitReview(ctx context.Context, doer *user_model.User, issue *Issue, revi
 	return review, comm, committer.Commit()
 }
 
-// GetReviewByIssueIDAndUserID get the latest review of reviewer for a pull request
-func GetReviewByIssueIDAndUserID(ctx context.Context, issueID, userID int64) (*Review, error) {
+// getLatestReviewByIssueIDAndUserIDOfTypes returns the reviewer's latest review (highest ID)
+// among the given types, for the same issue/reviewer, ignoring reviews left by another
+// original author.
+func getLatestReviewByIssueIDAndUserIDOfTypes(ctx context.Context, issueID, userID int64, types ...ReviewType) (*Review, error) {
 	review := new(Review)
 
 	has, err := db.GetEngine(ctx).Where(
-		builder.In("type", ReviewTypeApprove, ReviewTypeReject, ReviewTypeRequest).
+		builder.In("type", types).
 			And(builder.Eq{"issue_id": issueID, "reviewer_id": userID, "original_author_id": 0})).
 		Desc("id").
 		Get(review)
@@ -602,6 +604,11 @@ func GetReviewByIssueIDAndUserID(ctx context.Context, issueID, userID int64) (*R
 	}
 
 	return review, nil
+}
+
+// GetReviewByIssueIDAndUserID get the latest review of reviewer for a pull request
+func GetReviewByIssueIDAndUserID(ctx context.Context, issueID, userID int64) (*Review, error) {
+	return getLatestReviewByIssueIDAndUserIDOfTypes(ctx, issueID, userID, ReviewTypeApprove, ReviewTypeReject, ReviewTypeRequest)
 }
 
 // GetTeamReviewerByIssueIDAndTeamID get the latest review request of reviewer team for a pull request
@@ -700,17 +707,43 @@ func AddReviewRequest(ctx context.Context, issue *Issue, reviewer, doer *user_mo
 	return db.WithTx2(ctx, func(ctx context.Context) (*Comment, error) {
 		sess := db.GetEngine(ctx)
 
-		review, err := GetReviewByIssueIDAndUserID(ctx, issue.ID, reviewer.ID)
+		// A stale ReviewTypeRequest row can survive alongside a newer ReviewTypeComment
+		// row (e.g. legacy data imported via InsertReviews, which skips the usual
+		// CreateReview cleanup of stale request rows). Widen the lookup to ReviewTypeComment
+		// only to decide idempotency, so such a stale request row doesn't shadow the newer
+		// comment and silently no-op a genuine re-request.
+		latestMeaningfulReview, err := getLatestReviewByIssueIDAndUserIDOfTypes(ctx, issue.ID, reviewer.ID,
+			ReviewTypeApprove, ReviewTypeReject, ReviewTypeRequest, ReviewTypeComment)
 		if err != nil && !IsErrReviewNotExist(err) {
 			return nil, err
 		}
 
-		if review != nil {
+		if latestMeaningfulReview != nil && latestMeaningfulReview.Type == ReviewTypeRequest {
 			// skip it when reviewer has been request to review
-			if review.Type == ReviewTypeRequest {
-				return nil, nil // still commit the transaction, or committer.Close() will rollback it, even if it's a reused transaction.
-			}
+			return nil, nil // still commit the transaction, or committer.Close() will rollback it, even if it's a reused transaction.
+		}
 
+		// The closed/merged PR guard must keep its original scope: it only ever applied
+		// when the reviewer already had an approve/reject/request review, never for a
+		// reviewer whose only history is a comment. latestMeaningfulReview already answers
+		// that question except when it's a comment, which may be shadowing an older
+		// approve/reject/request review; only then fall back to the narrower, unwidened
+		// lookup, so that scope is preserved exactly.
+		var existingReview *Review
+		switch {
+		case latestMeaningfulReview == nil:
+			// no approve/reject/request/comment review on record at all
+		case latestMeaningfulReview.Type == ReviewTypeComment:
+			existingReview, err = GetReviewByIssueIDAndUserID(ctx, issue.ID, reviewer.ID)
+			if err != nil && !IsErrReviewNotExist(err) {
+				return nil, err
+			}
+		default:
+			// ReviewTypeApprove or ReviewTypeReject: also the latest approve/reject/request review
+			existingReview = latestMeaningfulReview
+		}
+
+		if existingReview != nil {
 			if issue.IsClosed {
 				return nil, ErrReviewRequestOnClosedPR{}
 			}
@@ -736,7 +769,7 @@ func AddReviewRequest(ctx context.Context, issue *Issue, reviewer, doer *user_mo
 			}
 		}
 
-		review, err = CreateReview(ctx, CreateReviewOptions{
+		review, err := CreateReview(ctx, CreateReviewOptions{
 			Type:     ReviewTypeRequest,
 			Issue:    issue,
 			Reviewer: reviewer,

--- a/models/issues/review_test.go
+++ b/models/issues/review_test.go
@@ -14,6 +14,7 @@ import (
 	user_model "gitea.dev/models/user"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetReviewByID(t *testing.T) {
@@ -387,6 +388,163 @@ func TestAddReviewRequest(t *testing.T) {
 	assert.NotNil(t, comment)
 	assert.NotNil(t, comment.CommentMetaData)
 	assert.Equal(t, issues_model.SpecialDoerNameCodeOwners, comment.CommentMetaData.SpecialDoerName)
+}
+
+func TestAddReviewRequestIsIdempotentWhenAlreadyRequested(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	pull := unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{ID: 2})
+	assert.NoError(t, pull.LoadIssue(t.Context()))
+	issue := pull.Issue
+	assert.NoError(t, issue.LoadRepo(t.Context()))
+	reviewer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 8})
+	doer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+
+	requestReview, err := issues_model.CreateReview(t.Context(), issues_model.CreateReviewOptions{
+		Type:     issues_model.ReviewTypeRequest,
+		Issue:    issue,
+		Reviewer: reviewer,
+	})
+	assert.NoError(t, err)
+
+	comment, err := issues_model.AddReviewRequest(t.Context(), issue, reviewer, doer, false)
+	assert.NoError(t, err)
+	assert.Nil(t, comment)
+
+	unittest.AssertCount(t, &issues_model.Review{IssueID: issue.ID, ReviewerID: reviewer.ID}, 1)
+	unittest.AssertExistsAndLoadBean(t, &issues_model.Review{ID: requestReview.ID})
+}
+
+func TestAddReviewRequestRecoversFromStaleRequestAlongsideNewerComment(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	pull := unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{ID: 2})
+	assert.NoError(t, pull.LoadIssue(t.Context()))
+	issue := pull.Issue
+	assert.NoError(t, issue.LoadRepo(t.Context()))
+	reviewer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 9})
+	doer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+
+	// reproduce legacy data (e.g. imported via InsertReviews) where an old review
+	// request row survives alongside a newer comment row for the same reviewer,
+	// bypassing the usual CreateReview cleanup of stale request rows
+	staleRequest := &issues_model.Review{Type: issues_model.ReviewTypeRequest, IssueID: issue.ID, ReviewerID: reviewer.ID}
+	_, err := db.GetEngine(t.Context()).Insert(staleRequest)
+	assert.NoError(t, err)
+
+	newerComment := &issues_model.Review{Type: issues_model.ReviewTypeComment, IssueID: issue.ID, ReviewerID: reviewer.ID, Content: "looks good"}
+	_, err = db.GetEngine(t.Context()).Insert(newerComment)
+	assert.NoError(t, err)
+
+	comment, err := issues_model.AddReviewRequest(t.Context(), issue, reviewer, doer, false)
+	assert.NoError(t, err)
+	require.NotNil(t, comment)
+	assert.Equal(t, issues_model.CommentTypeReviewRequest, comment.Type)
+
+	unittest.AssertNotExistsBean(t, &issues_model.Review{ID: staleRequest.ID})
+	unittest.AssertCount(t, &issues_model.Review{IssueID: issue.ID, ReviewerID: reviewer.ID, Type: issues_model.ReviewTypeRequest}, 1)
+	newRequest := unittest.AssertExistsAndLoadBean(t, &issues_model.Review{IssueID: issue.ID, ReviewerID: reviewer.ID, Type: issues_model.ReviewTypeRequest})
+	assert.Equal(t, newRequest.ID, comment.ReviewID)
+}
+
+func TestAddReviewRequestAfterCommentOnly(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	pull := unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{ID: 2})
+	assert.NoError(t, pull.LoadIssue(t.Context()))
+	issue := pull.Issue
+	assert.NoError(t, issue.LoadRepo(t.Context()))
+	reviewer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 10})
+	doer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+
+	_, err := issues_model.CreateReview(t.Context(), issues_model.CreateReviewOptions{
+		Type:     issues_model.ReviewTypeComment,
+		Issue:    issue,
+		Reviewer: reviewer,
+		Content:  "just a comment",
+	})
+	assert.NoError(t, err)
+
+	comment, err := issues_model.AddReviewRequest(t.Context(), issue, reviewer, doer, false)
+	assert.NoError(t, err)
+	assert.NotNil(t, comment)
+
+	unittest.AssertCount(t, &issues_model.Review{IssueID: issue.ID, ReviewerID: reviewer.ID, Type: issues_model.ReviewTypeRequest}, 1)
+}
+
+func TestAddReviewRequestIsIdempotentAfterApproveThenRequest(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	pull := unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{ID: 2})
+	assert.NoError(t, pull.LoadIssue(t.Context()))
+	issue := pull.Issue
+	assert.NoError(t, issue.LoadRepo(t.Context()))
+	reviewer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 11})
+	doer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+
+	_, err := issues_model.CreateReview(t.Context(), issues_model.CreateReviewOptions{
+		Type:     issues_model.ReviewTypeApprove,
+		Issue:    issue,
+		Reviewer: reviewer,
+	})
+	assert.NoError(t, err)
+
+	requestReview, err := issues_model.CreateReview(t.Context(), issues_model.CreateReviewOptions{
+		Type:     issues_model.ReviewTypeRequest,
+		Issue:    issue,
+		Reviewer: reviewer,
+	})
+	assert.NoError(t, err)
+
+	comment, err := issues_model.AddReviewRequest(t.Context(), issue, reviewer, doer, false)
+	assert.NoError(t, err)
+	assert.Nil(t, comment)
+
+	unittest.AssertExistsAndLoadBean(t, &issues_model.Review{ID: requestReview.ID})
+}
+
+func TestAddReviewRequestPreservesClosedPRGuardScope(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	pull := unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{ID: 2})
+	assert.NoError(t, pull.LoadIssue(t.Context()))
+	issue := pull.Issue
+	assert.NoError(t, issue.LoadRepo(t.Context()))
+	doer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+
+	issue.IsClosed = true
+	assert.NoError(t, issues_model.UpdateIssueCols(t.Context(), issue, "is_closed"))
+
+	// The closed/merged guard only ever fired when the reviewer already had an
+	// approve/reject/request review; a reviewer whose only history is a comment
+	// never triggered it, closed PR or not. That pre-existing scope must not widen.
+	reviewerWithCommentOnly := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 12})
+	_, err := issues_model.CreateReview(t.Context(), issues_model.CreateReviewOptions{
+		Type:     issues_model.ReviewTypeComment,
+		Issue:    issue,
+		Reviewer: reviewerWithCommentOnly,
+		Content:  "just a comment",
+	})
+	assert.NoError(t, err)
+
+	comment, err := issues_model.AddReviewRequest(t.Context(), issue, reviewerWithCommentOnly, doer, false)
+	assert.NoError(t, err)
+	assert.NotNil(t, comment)
+
+	// A reviewer with a stale request row still has an approve/reject/request review
+	// on record, so the guard must still reject re-requesting on the closed PR.
+	reviewerWithStaleRequest := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 13})
+	staleRequest := &issues_model.Review{Type: issues_model.ReviewTypeRequest, IssueID: issue.ID, ReviewerID: reviewerWithStaleRequest.ID}
+	_, err = db.GetEngine(t.Context()).Insert(staleRequest)
+	assert.NoError(t, err)
+
+	newerComment := &issues_model.Review{Type: issues_model.ReviewTypeComment, IssueID: issue.ID, ReviewerID: reviewerWithStaleRequest.ID, Content: "looks good"}
+	_, err = db.GetEngine(t.Context()).Insert(newerComment)
+	assert.NoError(t, err)
+
+	_, err = issues_model.AddReviewRequest(t.Context(), issue, reviewerWithStaleRequest, doer, false)
+	assert.Error(t, err)
+	assert.True(t, issues_model.IsErrReviewRequestOnClosedPR(err))
 }
 
 func TestRecalculateReviewsOfficial(t *testing.T) {


### PR DESCRIPTION
## What changed

- Determine review-request idempotency from the reviewer's latest meaningful review by ID, including comment reviews.
- Lazily replace stale review-request rows when a newer comment, approval, or rejection exists.
- Preserve the existing lookup semantics for removing review requests and for closed or merged pull request guards.
- Add regression coverage for idempotency, stale request recovery, comment-only history, and closed pull request behavior.

## Why

Legacy or imported data can contain an old `ReviewTypeRequest` row alongside a newer `ReviewTypeComment` row. The sidebar treats the newer comment as the current state, while `AddReviewRequest` previously ignored comments and silently returned after finding the stale request. As a result, re-requesting a review appeared to do nothing.

This change repairs the inconsistent state through the normal application path without requiring a migration or a doctor command.

## Verification

- `go test ./models/issues/...`
- `go test ./models/...`
- `go test ./services/issue/...`
- `go build ./...`
- `go vet ./models/issues/...`
- `make fmt`
- `git diff --check`

`make lint-go` could not complete because the local `go-critic` ruleguard loader panics while loading `fmt`. The same panic reproduces on the unmodified base commit.

---
Generated by Codet