### PR TITLE
fix(gitdiff): guard against empty DiffLine.Content to avoid template …

### DIFF
--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -168,6 +168,11 @@ func (d *DiffLine) GetCommentSide() string {
 
 // GetLineTypeMarker returns the line type marker
 func (d *DiffLine) GetLineTypeMarker() string {
+	// Defensive: if Content is empty (can happen when truncating lines to max characters),
+	// avoid indexing into the string to prevent a runtime panic.
+	if len(d.Content) == 0 {
+		return ""
+	}
 	if strings.IndexByte(" +-", d.Content[0]) > -1 {
 		return d.Content[0:1]
 	}


### PR DESCRIPTION
…panic\n\nWhen diff lines are truncated (e.g. MaxGitDiffLineCharacters set to 0) a DiffLine.Content can become an empty string. GetLineTypeMarker referenced d.Content[0] without checking length causing an index-out-of-range panic during template rendering.\n\nThis change adds a defensive len(d.Content) == 0 check and returns an empty marker when content is empty.\n\nTests: ran services/gitdiff TestParsePatch suite locally (all tests passed).

<!--
Before submitting:
- Target the `main` branch; release branches are for backports only.
- Use a Conventional Commits title, e.g. `fix(repo): handle empty branch names`.
- Read the contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
- Documentation changes go to https://gitea.com/gitea/docs

Describe your change below and link any issue it fixes.
-->
