### PR TITLE
fix: sync PR head ref on the actual reopen path

### DIFF
--- a/routers/web/repo/issue_comment.go
+++ b/routers/web/repo/issue_comment.go
@@ -17,7 +17,6 @@ import (
 	"gitea.dev/modules/git"
 	"gitea.dev/modules/log"
 	"gitea.dev/modules/markup/markdown"
-	repo_module "gitea.dev/modules/repository"
 	"gitea.dev/modules/setting"
 	api "gitea.dev/modules/structs"
 	"gitea.dev/modules/util"
@@ -89,6 +88,7 @@ func NewComment(ctx *context.Context) {
 		!(issue.IsPull && issue.PullRequest.HasMerged) {
 		// Duplication and conflict check should apply to reopen pull request.
 		var branchOtherUnmergedPR *issues_model.PullRequest
+		canReopen := true
 		var err error
 		if form.Status == "reopen" && issue.IsPull {
 			pull := issue.PullRequest
@@ -102,58 +102,53 @@ func NewComment(ctx *context.Context) {
 			if branchOtherUnmergedPR != nil {
 				ctx.Flash.Error(ctx.Tr("repo.pulls.open_unmerged_pull_exists", branchOtherUnmergedPR.Index))
 			} else {
-				// Regenerate patch and test conflict.
-				issue.PullRequest.HeadCommitID = ""
-				pull_service.StartPullRequestCheckImmediately(ctx, issue.PullRequest)
-			}
-
-			// check whether the ref of PR <refs/pulls/pr_index/head> in base repo is consistent with the head commit of head branch in the head repo
-			// get head commit of PR
-			if branchOtherUnmergedPR != nil && pull.Flow == issues_model.PullRequestFlowGithub {
-				prHeadRef := pull.GetGitHeadRefName()
-				if err := pull.LoadBaseRepo(ctx); err != nil {
-					ctx.ServerError("Unable to load base repo", err)
-					return
-				}
-				prHeadCommitID, err := git.GetFullCommitID(ctx, pull.BaseRepo, prHeadRef)
-				if err != nil {
-					ctx.ServerError("Get head commit Id of pr fail", err)
-					return
-				}
-
-				// get head commit of branch in the head repo
-				if err := pull.LoadHeadRepo(ctx); err != nil {
-					ctx.ServerError("Unable to load head repo", err)
-					return
-				}
-				if exist, _ := git_model.IsBranchExist(ctx, pull.HeadRepo.ID, pull.BaseBranch); !exist {
-					ctx.Flash.Error("The origin branch is delete, cannot reopen.")
-					return
-				}
-				headBranchRef := git.RefNameFromBranch(pull.HeadBranch)
-				headBranchCommitID, err := git.GetFullCommitID(ctx, pull.HeadRepo, headBranchRef.String())
-				if err != nil {
-					ctx.ServerError("Get head commit Id of head branch fail", err)
-					return
-				}
-
-				err = pull.LoadIssue(ctx)
-				if err != nil {
-					ctx.ServerError("load the issue of pull request error", err)
-					return
-				}
-
-				if prHeadCommitID != headBranchCommitID {
-					// force push to base repo
-					err := git.PushManaged(ctx, pull.HeadRepo, pull.BaseRepo, git.PushOptions{
-						Branch: pull.HeadBranch + ":" + prHeadRef,
-						Force:  true,
-						Env:    repo_module.InternalPushingEnvironment(pull.Issue.Poster, pull.BaseRepo),
-					})
-					if err != nil {
-						ctx.ServerError("force push error", err)
+				// check whether the ref of PR <refs/pulls/pr_index/head> in base repo is consistent with the head commit of head branch in the head repo
+				if pull.Flow == issues_model.PullRequestFlowGithub {
+					if err := pull.LoadBaseRepo(ctx); err != nil {
+						ctx.ServerError("Unable to load base repo", err)
 						return
 					}
+					if err := pull.LoadHeadRepo(ctx); err != nil {
+						ctx.ServerError("Unable to load head repo", err)
+						return
+					}
+
+					// LoadHeadRepo swallows ErrRepoNotExist, so a deleted fork leaves HeadRepo nil.
+					headBranchExists := pull.HeadRepo != nil
+					if headBranchExists {
+						headBranchExists, _ = git_model.IsBranchExist(ctx, pull.HeadRepo.ID, pull.HeadBranch)
+					}
+					if !headBranchExists {
+						ctx.Flash.Error("The origin branch is delete, cannot reopen.")
+						canReopen = false
+					} else {
+						prHeadRef := pull.GetGitHeadRefName()
+						prHeadCommitID, err := git.GetFullCommitID(ctx, pull.BaseRepo, prHeadRef)
+						if err != nil {
+							ctx.ServerError("Get head commit Id of pr fail", err)
+							return
+						}
+
+						headBranchRef := git.RefNameFromBranch(pull.HeadBranch)
+						headBranchCommitID, err := git.GetFullCommitID(ctx, pull.HeadRepo, headBranchRef.String())
+						if err != nil {
+							ctx.ServerError("Get head commit Id of head branch fail", err)
+							return
+						}
+
+						if prHeadCommitID != headBranchCommitID {
+							if err := pull_service.PushToBaseRepo(ctx, pull); err != nil {
+								ctx.ServerError("force push error", err)
+								return
+							}
+						}
+					}
+				}
+
+				if canReopen {
+					// Regenerate patch and test conflict.
+					issue.PullRequest.HeadCommitID = ""
+					pull_service.StartPullRequestCheckImmediately(ctx, issue.PullRequest)
 				}
 			}
 		}
@@ -175,7 +170,7 @@ func NewComment(ctx *context.Context) {
 				}
 				log.Trace("Issue [%d] status changed to closed: %v", issue.ID, issue.IsClosed)
 			}
-		} else if form.Status == "reopen" && issue.IsClosed && branchOtherUnmergedPR == nil {
+		} else if form.Status == "reopen" && issue.IsClosed && branchOtherUnmergedPR == nil && canReopen {
 			if err := issue_service.ReopenIssue(ctx, issue, ctx.Doer, ""); err != nil {
 				log.Error("ReopenIssue: %v", err)
 				ctx.Flash.Error("Unable to reopen.")

--- a/tests/integration/pull_review_test.go
+++ b/tests/integration/pull_review_test.go
@@ -381,7 +381,7 @@ func TestPullView_GivenApproveOrRejectReviewOnClosedPR(t *testing.T) {
 			resp := testPullCreate(t, user1Session, "user1", "repo1", false, "master", "a-test-branch", "This is a pull title")
 			elem := strings.Split(test.RedirectURL(resp), "/")
 			assert.Equal(t, "pulls", elem[3])
-			testIssueClose(t, user1Session, elem[1], elem[2], elem[4])
+			testIssueChangeStatus(t, user1Session, elem[1], elem[2], elem[4], "close")
 
 			// Submit an approve review on the PR.
 			testSubmitReview(t, user2Session, "user2", "repo1", elem[4], "", "approve", http.StatusUnprocessableEntity)
@@ -404,13 +404,13 @@ func testSubmitReview(t *testing.T, session *TestSession, owner, repo, pullNumbe
 	return session.MakeRequest(t, req, expectedSubmitStatus)
 }
 
-func testIssueClose(t *testing.T, session *TestSession, owner, repo, issueNumber string) *httptest.ResponseRecorder {
-	closeURL := "/" + path.Join(owner, repo, "issues", issueNumber, "comments")
+func testIssueChangeStatus(t *testing.T, session *TestSession, owner, repo, issueNumber, status string) *httptest.ResponseRecorder {
+	commentsURL := "/" + path.Join(owner, repo, "issues", issueNumber, "comments")
 
 	options := map[string]string{
-		"status": "close",
+		"status": status,
 	}
 
-	req := NewRequestWithValues(t, "POST", closeURL, options)
+	req := NewRequestWithValues(t, "POST", commentsURL, options)
 	return session.MakeRequest(t, req, http.StatusOK)
 }

--- a/tests/integration/pull_update_test.go
+++ b/tests/integration/pull_update_test.go
@@ -6,6 +6,7 @@ package integration
 import (
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -212,6 +213,65 @@ func TestAPIPullUpdateStyleSettings(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 0, diffCount.Behind)
 		assert.Equal(t, 2, diffCount.Ahead)
+	})
+}
+
+// TestPullReopenSyncsHeadRef checks that reopening a PR force-pushes the head branch into refs/pull/<index>/head.
+func TestPullReopenSyncsHeadRef(t *testing.T) {
+	onGiteaRun(t, func(t *testing.T, giteaURL *url.URL) {
+		pr := setupOutdatedPRWithConfig(t, nil)
+		issueIndex := strconv.FormatInt(pr.Issue.Index, 10)
+
+		session := loginUser(t, "user2")
+		testIssueChangeStatus(t, session, pr.BaseRepo.OwnerName, pr.BaseRepo.Name, issueIndex, "close")
+
+		closedIssue := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{ID: pr.IssueID})
+		require.True(t, closedIssue.IsClosed)
+
+		user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+		_, err := files_service.ChangeRepoFiles(t.Context(), pr.HeadRepo, user2, &files_service.ChangeRepoFilesOptions{
+			Files: []*files_service.ChangeRepoFile{
+				{
+					Operation:     "create",
+					TreePath:      "File_C",
+					ContentReader: strings.NewReader("File C"),
+				},
+			},
+			Message:   "Add File C while PR is closed",
+			OldBranch: pr.HeadBranch,
+			NewBranch: pr.HeadBranch,
+			Author: &files_service.IdentityOptions{
+				GitUserName:  user2.Name,
+				GitUserEmail: user2.Email,
+			},
+			Committer: &files_service.IdentityOptions{
+				GitUserName:  user2.Name,
+				GitUserEmail: user2.Email,
+			},
+			Dates: &files_service.CommitDateOptions{
+				Author:    time.Now(),
+				Committer: time.Now(),
+			},
+		})
+		require.NoError(t, err)
+
+		headBranchRef := git.RefNameFromBranch(pr.HeadBranch)
+		headBranchCommitID, err := git.GetFullCommitID(t.Context(), pr.HeadRepo, headBranchRef.String())
+		require.NoError(t, err)
+
+		prHeadRef := pr.GetGitHeadRefName()
+		staleCommitID, err := git.GetFullCommitID(t.Context(), pr.BaseRepo, prHeadRef)
+		require.NoError(t, err)
+		require.NotEqual(t, headBranchCommitID, staleCommitID)
+
+		testIssueChangeStatus(t, session, pr.BaseRepo.OwnerName, pr.BaseRepo.Name, issueIndex, "reopen")
+
+		reopenedIssue := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{ID: pr.IssueID})
+		assert.False(t, reopenedIssue.IsClosed)
+
+		syncedCommitID, err := git.GetFullCommitID(t.Context(), pr.BaseRepo, prHeadRef)
+		require.NoError(t, err)
+		assert.Equal(t, headBranchCommitID, syncedCommitID)
 	})
 }
 

--- a/tests/integration/repo_branch_test.go
+++ b/tests/integration/repo_branch_test.go
@@ -192,12 +192,12 @@ func prepareRepoPR(t *testing.T, baseSession, headSession *TestSession, baseRepo
 	// create closed PR
 	testCreateBranch(t, headSession, headRepo.OwnerName, headRepo.Name, "branch/new-commit", "closed-pr", http.StatusSeeOther)
 	prID := testCreatePullToDefaultBranch(t, baseSession, baseRepo, headRepo, "closed-pr", "closed pr")
-	testIssueClose(t, baseSession, baseRepo.OwnerName, baseRepo.Name, prID)
+	testIssueChangeStatus(t, baseSession, baseRepo.OwnerName, baseRepo.Name, prID, "close")
 
 	// create closed PR with deleted branch
 	testCreateBranch(t, headSession, headRepo.OwnerName, headRepo.Name, "branch/new-commit", "closed-pr-deleted", http.StatusSeeOther)
 	prID = testCreatePullToDefaultBranch(t, baseSession, baseRepo, headRepo, "closed-pr-deleted", "closed pr with deleted branch")
-	testIssueClose(t, baseSession, baseRepo.OwnerName, baseRepo.Name, prID)
+	testIssueChangeStatus(t, baseSession, baseRepo.OwnerName, baseRepo.Name, prID, "close")
 	testUIDeleteBranch(t, headSession, headRepo.OwnerName, headRepo.Name, "closed-pr-deleted")
 
 	// create merged PR


### PR DESCRIPTION
The GitHub-flow head-ref consistency check in `NewComment` is gated on `branchOtherUnmergedPR != nil`. That value is non-nil exactly when another open unmerged PR already exists for the same head/base branches, which is when the reopen is refused and `ReopenIssue` is never called. The gate was introduced by 7b17234945; before that the block ran on every reopen attempt.

So the check runs in both wrong directions:

- A genuine reopen never refreshes `refs/pull/<index>/head`, so a PR whose head branch moved while it was closed is reopened against a stale ref.
- A refused reopen force-pushes into the base repo for a PR that stays closed, changing what that closed PR shows.

This moves the block onto the path where the PR is actually reopened, and syncs the ref before `StartPullRequestCheckImmediately` so the patch is regenerated against the correct ref.

Two related fixes in the same block:

- The head-branch existence check queried the head repo with `pull.BaseBranch` instead of `pull.HeadBranch`. A fork without a branch named like the base branch got a bogus "cannot reopen" refusal, while a deleted head branch slipped through into a 500.
- `LoadHeadRepo` deliberately swallows `ErrRepoNotExist`, leaving `HeadRepo` nil when the fork was deleted. Since the block now runs on the common reopen path, that is guarded and treated like a missing head branch.

The refusal path sets a flash and suppresses the reopen instead of returning without a body, which the `form-fetch-action` caller cannot handle.

The force-push now reuses `pull_service.PushToBaseRepo`, still behind the commit-ID comparison so nothing is pushed when the ref is already in sync.

Reported as go-gitea/gitea#38718. The security claim in that report does not hold: `NewComment` is only reachable via the web `/comments` route, which enables neither `AllowBasic` nor `AllowOAuth2`, so a public-only token cannot authenticate it and the missing `TokenIsPublicOnly` check there is not exploitable. The reopen regression above is the real defect.

`TestPullReopenSyncsHeadRef` covers it and fails without the router change.

---
Generated by Codet
