### PR TITLE
fix(api): return a single object for an exact git ref

### DIFF
--- a/routers/api/v1/repo/git_ref.go
+++ b/routers/api/v1/repo/git_ref.go
@@ -18,7 +18,8 @@ import (
 func GetGitAllRefs(ctx *context.APIContext) {
 	// swagger:operation GET /repos/{owner}/{repo}/git/refs repository repoListAllGitRefs
 	// ---
-	// summary: Get specified ref or filtered repository's refs
+	// summary: Get all the refs of a repository
+	// description: Always returns a list, even when the repository has only one reference.
 	// produces:
 	// - application/json
 	// parameters:
@@ -46,7 +47,15 @@ func GetGitAllRefs(ctx *context.APIContext) {
 func GetGitRefs(ctx *context.APIContext) {
 	// swagger:operation GET /repos/{owner}/{repo}/git/refs/{ref} repository repoListGitRefs
 	// ---
-	// summary: Get specified ref or filtered repository's refs
+	// summary: Get a specified ref or the refs matching a prefix
+	// description: |
+	//   The "ref" path parameter is matched against reference names without the leading "refs/",
+	//   so "heads/main" matches the reference "refs/heads/main".
+	//   When "ref" is the complete name of an existing reference, a single Reference object is returned.
+	//   Otherwise a list of all references starting with that prefix is returned.
+	//   The response shape only depends on "ref", never on the other references in the repository:
+	//   with the branches "main" and "main1", "heads/main" returns the single "refs/heads/main" object,
+	//   "heads/main1" returns the single "refs/heads/main1" object, and "heads/mai" returns both as a list.
 	// produces:
 	// - application/json
 	// parameters:
@@ -99,10 +108,20 @@ func getGitRefsInternal(ctx *context.APIContext, filter string) {
 			},
 		}
 	}
-	// If single reference is found and it matches filter exactly return it as object
-	if len(apiRefs) == 1 && apiRefs[0].Ref == filter {
-		ctx.JSON(http.StatusOK, &apiRefs[0])
-		return
+	// If the filter names an existing reference exactly, return that reference as an object.
+	// The filter never carries the "refs/" prefix here because utils.GetGitRefs prepends it before matching,
+	// while a reference name always has it.
+	// Only the filter decides the response shape, the other references in the repository never do:
+	// with the branches "main" and "main1", "heads/main" returns the "refs/heads/main" object,
+	// while "heads/mai" matches no reference exactly and returns both of them as a list.
+	if filter != "" {
+		fullRefName := "refs/" + filter
+		for _, apiRef := range apiRefs {
+			if apiRef.Ref == fullRefName {
+				ctx.JSON(http.StatusOK, apiRef)
+				return
+			}
+		}
 	}
 	ctx.JSON(http.StatusOK, &apiRefs)
 }

--- a/templates/swagger/v1-openapi3.generated.json
+++ b/templates/swagger/v1-openapi3.generated.json
@@ -20602,6 +20602,7 @@
     },
     "/repos/{owner}/{repo}/git/refs": {
       "get": {
+        "description": "Always returns a list, even when the repository has only one reference.",
         "operationId": "repoListAllGitRefs",
         "parameters": [
           {
@@ -20631,7 +20632,7 @@
             "$ref": "#/components/responses/notFound"
           }
         },
-        "summary": "Get specified ref or filtered repository's refs",
+        "summary": "Get all the refs of a repository",
         "tags": [
           "repository"
         ]
@@ -20639,6 +20640,7 @@
     },
     "/repos/{owner}/{repo}/git/refs/{ref}": {
       "get": {
+        "description": "The \"ref\" path parameter is matched against reference names without the leading \"refs/\",\nso \"heads/main\" matches the reference \"refs/heads/main\".\nWhen \"ref\" is the complete name of an existing reference, a single Reference object is returned.\nOtherwise a list of all references starting with that prefix is returned.\nThe response shape only depends on \"ref\", never on the other references in the repository:\nwith the branches \"main\" and \"main1\", \"heads/main\" returns the single \"refs/heads/main\" object,\n\"heads/main1\" returns the single \"refs/heads/main1\" object, and \"heads/mai\" returns both as a list.\n",
         "operationId": "repoListGitRefs",
         "parameters": [
           {
@@ -20677,7 +20679,7 @@
             "$ref": "#/components/responses/notFound"
           }
         },
-        "summary": "Get specified ref or filtered repository's refs",
+        "summary": "Get a specified ref or the refs matching a prefix",
         "tags": [
           "repository"
         ]

--- a/templates/swagger/v1-swagger.generated.json
+++ b/templates/swagger/v1-swagger.generated.json
@@ -9237,13 +9237,14 @@
     },
     "/repos/{owner}/{repo}/git/refs": {
       "get": {
+        "description": "Always returns a list, even when the repository has only one reference.",
         "produces": [
           "application/json"
         ],
         "tags": [
           "repository"
         ],
-        "summary": "Get specified ref or filtered repository's refs",
+        "summary": "Get all the refs of a repository",
         "operationId": "repoListAllGitRefs",
         "parameters": [
           {
@@ -9273,13 +9274,14 @@
     },
     "/repos/{owner}/{repo}/git/refs/{ref}": {
       "get": {
+        "description": "The \"ref\" path parameter is matched against reference names without the leading \"refs/\",\nso \"heads/main\" matches the reference \"refs/heads/main\".\nWhen \"ref\" is the complete name of an existing reference, a single Reference object is returned.\nOtherwise a list of all references starting with that prefix is returned.\nThe response shape only depends on \"ref\", never on the other references in the repository:\nwith the branches \"main\" and \"main1\", \"heads/main\" returns the single \"refs/heads/main\" object,\n\"heads/main1\" returns the single \"refs/heads/main1\" object, and \"heads/mai\" returns both as a list.\n",
         "produces": [
           "application/json"
         ],
         "tags": [
           "repository"
         ],
-        "summary": "Get specified ref or filtered repository's refs",
+        "summary": "Get a specified ref or the refs matching a prefix",
         "operationId": "repoListGitRefs",
         "parameters": [
           {

--- a/tests/integration/api_repo_git_ref_test.go
+++ b/tests/integration/api_repo_git_ref_test.go
@@ -8,9 +8,15 @@ import (
 	"testing"
 
 	auth_model "gitea.dev/models/auth"
+	repo_model "gitea.dev/models/repo"
 	"gitea.dev/models/unittest"
 	user_model "gitea.dev/models/user"
+	"gitea.dev/modules/git/gitcmd"
+	api "gitea.dev/modules/structs"
 	"gitea.dev/tests"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAPIReposGitRefs(t *testing.T) {
@@ -36,4 +42,57 @@ func TestAPIReposGitRefs(t *testing.T) {
 	req = NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/git/refs/heads/unknown", user.Name).
 		AddTokenAuth(token)
 	MakeRequest(t, req, http.StatusNotFound)
+
+	getRefNames := func(refs []*api.Reference) []string {
+		names := make([]string, 0, len(refs))
+		for _, ref := range refs {
+			names = append(names, ref.Ref)
+		}
+		return names
+	}
+
+	t.Run("FullRefNameReturnsObject", func(t *testing.T) {
+		req := NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/git/refs/heads/master", user.Name).
+			AddTokenAuth(token)
+		resp := MakeRequest(t, req, http.StatusOK)
+		ref := DecodeJSON(t, resp, api.Reference{})
+		assert.Equal(t, "refs/heads/master", ref.Ref)
+	})
+
+	t.Run("PartialRefNameReturnsList", func(t *testing.T) {
+		// "refs/heads/feature" is no reference, only "refs/heads/feature/1" starts with it
+		req := NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/git/refs/heads/feature", user.Name).
+			AddTokenAuth(token)
+		resp := MakeRequest(t, req, http.StatusOK)
+		refs := DecodeJSON(t, resp, []*api.Reference{})
+		assert.Equal(t, []string{"refs/heads/feature/1"}, getRefNames(refs))
+	})
+
+	t.Run("SharedPrefixDoesNotChangeResponse", func(t *testing.T) {
+		// "master1" starts with "master", the response of "heads/master" must stay a single object
+		repo1 := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{OwnerID: user.ID, Name: "repo1"})
+		_, _, runErr := gitcmd.NewCommand("update-ref").
+			AddDynamicArguments("refs/heads/master1", "refs/heads/master").
+			WithRepo(repo1).RunStdString(t.Context())
+		require.NoError(t, runErr)
+
+		req := NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/git/refs/heads/master", user.Name).
+			AddTokenAuth(token)
+		resp := MakeRequest(t, req, http.StatusOK)
+		ref := DecodeJSON(t, resp, api.Reference{})
+		assert.Equal(t, "refs/heads/master", ref.Ref)
+
+		req = NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/git/refs/heads/master1", user.Name).
+			AddTokenAuth(token)
+		resp = MakeRequest(t, req, http.StatusOK)
+		ref = DecodeJSON(t, resp, api.Reference{})
+		assert.Equal(t, "refs/heads/master1", ref.Ref)
+
+		// "heads/maste" is no reference, so both branches come back as a list
+		req = NewRequestf(t, "GET", "/api/v1/repos/%s/repo1/git/refs/heads/maste", user.Name).
+			AddTokenAuth(token)
+		resp = MakeRequest(t, req, http.StatusOK)
+		refs := DecodeJSON(t, resp, []*api.Reference{})
+		assert.ElementsMatch(t, []string{"refs/heads/master", "refs/heads/master1"}, getRefNames(refs))
+	})
 }


### PR DESCRIPTION
`GET /repos/{owner}/{repo}/git/refs/{ref}` returned an array even when the ref matched exactly, contradicting the documented behavior. The route passes the filter without the `refs/` prefix (`heads/main`) while the reference name is fully qualified (`refs/heads/main`), so the exact-match branch in `getGitRefsInternal` was dead code.

The check now also accepts `"refs/"+filter`; prefix filters such as `heads` keep returning a list. `TestAPIReposGitRefs` covers both cases.

Fixes #38190

AI was used to assist with this change.