### PR TITLE
fix(actions): stringify non-string expression results instead of panicking

### DIFF
--- a/modules/actions/jobparser/evaluator.go
+++ b/modules/actions/jobparser/evaluator.go
@@ -113,12 +113,7 @@ func (ee ExpressionEvaluator) Interpolate(in string) string {
 		return ""
 	}
 
-	value, ok := evaluated.(string)
-	if !ok {
-		panic(fmt.Sprintf("Expression %s did not evaluate to a string", expr))
-	}
-
-	return value
+	return toString(evaluated)
 }
 
 func escapeFormatString(in string) string {

--- a/modules/actions/jobparser/jobparser_test.go
+++ b/modules/actions/jobparser/jobparser_test.go
@@ -160,6 +160,23 @@ jobs:
 	}
 }
 
+func TestParseInterpolatesNonStringRunName(t *testing.T) {
+	// `run-name: ${{ true }}` evaluates to a bool; Interpolate must stringify it
+	// instead of panicking (a panic here dropped the whole workflow event).
+	for _, tt := range []struct{ name, runName, want string }{
+		{"bool", "${{ true }}", "true"},
+		{"int", "${{ 1 }}", "1"},
+		{"nil", "${{ null }}", ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Parse([]byte("name: t\nrun-name: " + tt.runName + "\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps: [{run: echo}]\n"))
+			require.NoError(t, err)
+			require.Len(t, result, 1)
+			assert.Equal(t, tt.want, result[0].RunName)
+		})
+	}
+}
+
 func TestExpandMatrixWithNeeds(t *testing.T) {
 	// matrixYAML is the YAML value of the `matrix:` key, so a case can replace the whole node.
 	expandMax := func(t *testing.T, matrixYAML string, maxCombinations int) ([]*Job, error) {


### PR DESCRIPTION
In `ExpressionEvaluator.Interpolate()`, an assertion `value, ok := evaluated.(string)` was used. If an expression evaluated to a non-string type (such as a boolean, number, or object), the server panicked. This caused workflow parse events to crash and destabilize the server.

Additionally, using a generic `fmt.Sprintf("%v", evaluated)` fallback would stringify `nil` expression values to `"<nil>"` instead of an empty string `""`.

## Solution
- Decoupled type conversion logic by calling the package-visible `toString()` helper (defined in `workflow_call.go`).
- This ensures non-string types are safely stringified, and `nil`/`null` expression values correctly evaluate to `""`.

## Verification
- Extended `TestParseInterpolatesNonStringRunName` in `jobparser_test.go` to cover `bool`, `int`, and `nil` expression cases.
- All tests pass successfully.
