### PR TITLE
fix: never render an empty pull request merge box fragment

### DIFF
--- a/templates/repo/issue/view_content/pull_merge_box.tmpl
+++ b/templates/repo/issue/view_content/pull_merge_box.tmpl
@@ -79,4 +79,6 @@
 		</div>
 	</div>
 </div>
+{{else}}
+<div class="pull-merge-box tw-hidden" data-global-init="initRepoPullMergeBox"></div>
 {{end}}

--- a/tests/integration/pull_merge_test.go
+++ b/tests/integration/pull_merge_test.go
@@ -309,6 +309,12 @@ func TestPullCleanUpAfterMerge(t *testing.T) {
 		htmlDoc := NewHTMLParser(t, resp.Body)
 		resultMsg := strings.TrimSpace(htmlDoc.doc.Find(".ui.message.flash-message").Text())
 		assert.Equal(t, `Branch "user1/repo1:feature/test" has been deleted.`, resultMsg)
+
+		// the fragment must always contain exactly one merge box element
+		req = NewRequest(t, "GET", fmt.Sprintf("/%s/%s/pulls/%s/merge_box", elem[1], elem[2], elem[4]))
+		resp = session.MakeRequest(t, req, http.StatusOK)
+		mergeBoxDoc := NewHTMLParser(t, resp.Body)
+		assert.Equal(t, 1, mergeBoxDoc.doc.Find(".pull-merge-box").Length())
 	})
 }
 

--- a/web_src/js/features/repo-issue-pull.test.ts
+++ b/web_src/js/features/repo-issue-pull.test.ts
@@ -1,0 +1,21 @@
+import {applyMergeBoxRefresh} from './repo-issue-pull.ts';
+
+test('applyMergeBoxRefresh replaces the element with the refreshed HTML', () => {
+  document.body.innerHTML = '<div class="pull-merge-box">old</div><span>after</span>';
+  const el = document.querySelector('.pull-merge-box')!;
+
+  const replaced = applyMergeBoxRefresh(el, '<div class="pull-merge-box">new</div>');
+
+  expect(replaced).toBe(true);
+  expect(document.body.innerHTML).toEqual('<div class="pull-merge-box">new</div><span>after</span>');
+});
+
+test('applyMergeBoxRefresh keeps the existing element when the response body is empty', () => {
+  document.body.innerHTML = '<div class="pull-merge-box">old</div><span>after</span>';
+  const el = document.querySelector('.pull-merge-box')!;
+
+  const replaced = applyMergeBoxRefresh(el, '');
+
+  expect(replaced).toBe(false);
+  expect(document.body.innerHTML).toEqual('<div class="pull-merge-box">old</div><span>after</span>');
+});

--- a/web_src/js/features/repo-issue-pull.ts
+++ b/web_src/js/features/repo-issue-pull.ts
@@ -1,7 +1,7 @@
 import {createApp} from 'vue';
 import {GET} from '../modules/fetch.ts';
 import {fomanticQuery} from '../modules/fomantic/base.ts';
-import {createElementFromHTML, activePageTimerRefresh} from '../utils/dom.ts';
+import {createElementFromHTMLOrNull, activePageTimerRefresh} from '../utils/dom.ts';
 import {registerGlobalEventFunc} from '../modules/observer.ts';
 
 export function initRepoPullRequestUpdate(el: HTMLElement) {
@@ -35,6 +35,15 @@ async function initRepoPullRequestMergeForm(box: HTMLElement) {
   view.mount(el); // TODO: can unmount when reloaded?
 }
 
+export function applyMergeBoxRefresh(el: Element, html: string): boolean {
+  const newEl = createElementFromHTMLOrNull(html);
+  if (!newEl) return false; // unexpected empty response, keep the old element instead of destroying it
+  const scrollTop = el.querySelector<HTMLElement>('.commit-status-list')?.scrollTop;
+  el.replaceWith(newEl); // don't morph, do full replacement to make sure data-global-init and Vue components are re-initialized
+  if (scrollTop) newEl.querySelector<HTMLElement>('.commit-status-list')?.scrollTo({top: scrollTop, behavior: 'instant'});
+  return true;
+}
+
 function initRepoPullMergeBoxRefresh(el: Element) {
   // The merge box has complex buttons & form, if the user has interacted with any element, don't refresh.
   // Otherwise, the user won't be able to merge or schedule a merge (auto-merge) when the PR status is not ready.
@@ -52,10 +61,7 @@ function initRepoPullMergeBoxRefresh(el: Element) {
       const pullLink = el.getAttribute('data-pull-link')!;
       const resp = await GET(`${pullLink}/merge_box`);
       if (!resp.ok) return;
-      const newEl = createElementFromHTML(await resp.text());
-      const scrollTop = el.querySelector<HTMLElement>('.commit-status-list')?.scrollTop;
-      el.replaceWith(newEl); // don't morph, do full replacement to make sure data-global-init and Vue components are re-initialized
-      if (scrollTop) newEl.querySelector<HTMLElement>('.commit-status-list')?.scrollTo({top: scrollTop, behavior: 'instant'});
+      applyMergeBoxRefresh(el, await resp.text());
     },
   });
 }

--- a/web_src/js/utils/dom.test.ts
+++ b/web_src/js/utils/dom.test.ts
@@ -1,5 +1,5 @@
 import {
-  createElementFromAttrs, createElementFromHTML,
+  createElementFromAttrs, createElementFromHTML, createElementFromHTMLOrNull,
   queryElemChildren, querySingleVisibleElem,
   protectMorphElements, recoverMorphElements,
   toggleElem,
@@ -10,6 +10,14 @@ test('createElementFromHTML', () => {
   expect(createElementFromHTML('<tr data-x="1"><td>foo</td></tr>').outerHTML).toEqual('<tr data-x="1"><td>foo</td></tr>');
   expect(createElementFromHTML('<TR data-x="1"><td>foo</td></TR>').outerHTML).toEqual('<tr data-x="1"><td>foo</td></tr>');
   expect(createElementFromHTML('<trx></trx>').outerHTML).toEqual('<trx></trx>');
+  expect(() => createElementFromHTML('')).toThrow('Failed to create element from HTML');
+  expect(() => createElementFromHTML(' '.repeat(3))).toThrow('Failed to create element from HTML');
+});
+
+test('createElementFromHTMLOrNull', () => {
+  expect(createElementFromHTMLOrNull('<a>foo</a>')!.outerHTML).toEqual('<a>foo</a>');
+  expect(createElementFromHTMLOrNull('')).toBeNull();
+  expect(createElementFromHTMLOrNull(' '.repeat(3))).toBeNull();
 });
 
 test('createElementFromAttrs', () => {

--- a/web_src/js/utils/dom.ts
+++ b/web_src/js/utils/dom.ts
@@ -265,7 +265,7 @@ export function isElemVisible(el: HTMLElement): boolean {
   return Boolean(!el.classList.contains('tw-hidden') && (el.offsetWidth || el.offsetHeight || el.getClientRects().length) && el.style.display !== 'none');
 }
 
-export function createElementFromHTML<T extends Element>(htmlString: string): T {
+export function createElementFromHTMLOrNull<T extends Element>(htmlString: string): T | null {
   htmlString = htmlString.trim();
   const isLetter = (code: number) => (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
   const startsWithTag = (s: string, tag: string) => {
@@ -277,11 +277,17 @@ export function createElementFromHTML<T extends Element>(htmlString: string): T 
   if (startsWithTag(htmlString, 'tr')) {
     const container = document.createElement('table');
     container.innerHTML = htmlString;
-    return container.querySelector<T>('tr')!;
+    return container.querySelector<T>('tr');
   }
   const div = document.createElement('div');
   div.innerHTML = htmlString;
-  return div.firstChild as T;
+  return div.firstChild as T | null;
+}
+
+export function createElementFromHTML<T extends Element>(htmlString: string): T {
+  const el = createElementFromHTMLOrNull<T>(htmlString);
+  if (!el) throw new Error(`Failed to create element from HTML: ${htmlString}`);
+  return el;
 }
 
 export function createElementFromAttrs<T extends HTMLElement>(tagName: string, attrs: Record<string, any> | null, ...children: (Node | string)[]): T {


### PR DESCRIPTION
Fixes https://github.com/go-gitea/gitea/issues/38738

While a pull request is waiting for its status checks, the page refreshes the merge box every few seconds. The merge box template rendered nothing at all when there was no merge box to show (a merged pull request whose head branch is no longer deletable), so the refresh got an empty `200` response. `createElementFromHTML()` returns `null` for an empty body, and `replaceWith(null)` converts `null` to the string `"null"`, so the merge box was replaced by a literal `null` text node in the timeline and never came back until a page reload.

The fragment now always renders exactly one merge box element, using a hidden placeholder when there is nothing to show, and the refresh keeps the current element instead of destroying it if a response can ever not be parsed. `createElementFromHTML()` now throws instead of silently returning nothing, and `createElementFromHTMLOrNull()` covers the cases where an empty result is expected.

---
Generated by Codet
