### PR TITLE
fix(pull): mark included pull requests as merged

### DIFF
--- a/routers/private/hook_post_receive_test.go
+++ b/routers/private/hook_post_receive_test.go
@@ -6,6 +6,7 @@ package private
 import (
 	"testing"
 
+	"gitea.dev/models/db"
 	issues_model "gitea.dev/models/issues"
 	pull_model "gitea.dev/models/pull"
 	repo_model "gitea.dev/models/repo"
@@ -45,4 +46,29 @@ func TestHandlePullRequestMerging(t *testing.T) {
 	assert.Equal(t, "01234567", pr.MergedCommitID)
 
 	unittest.AssertNotExistsBean(t, &pull_model.AutoMerge{ID: autoMerge.ID})
+}
+
+func TestHandlePullRequestMergingAlreadyClosed(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+	pr, err := issues_model.GetUnmergedPullRequest(t.Context(), 1, 1, "branch2", "master", issues_model.PullRequestFlowGithub)
+	assert.NoError(t, err)
+	assert.NoError(t, pr.LoadIssue(t.Context()))
+
+	pr.Issue.IsClosed = true
+	_, err = db.GetEngine(t.Context()).ID(pr.Issue.ID).Cols("is_closed").Update(pr.Issue)
+	assert.NoError(t, err)
+
+	ctx, resp := contexttest.MockPrivateContext(t, "/")
+	hookPostReceiveHandlePullRequestMerging(ctx, &private.HookOptions{
+		PullRequestID: pr.ID,
+		UserID:        2,
+	}, []*repo_module.PushUpdateOptions{
+		{NewCommitID: "01234567"},
+	})
+	assert.Empty(t, resp.Body.String())
+
+	pr, err = issues_model.GetPullRequestByID(t.Context(), pr.ID)
+	assert.NoError(t, err)
+	assert.True(t, pr.HasMerged)
+	assert.Equal(t, "01234567", pr.MergedCommitID)
 }

--- a/services/pull/check.go
+++ b/services/pull/check.go
@@ -436,6 +436,53 @@ func manuallyMerged(ctx context.Context, pr *issues_model.PullRequest) bool {
 	return true
 }
 
+func wasPullRequestPreviouslyNonEmpty(previousMergeBase, headCommitID string) bool {
+	return previousMergeBase != "" && headCommitID != "" && previousMergeBase != headCommitID
+}
+
+// mergedAsAncestor marks a previously non-empty pull request as merged when its
+// head is now already reachable from the base branch.
+func mergedAsAncestor(ctx context.Context, pr *issues_model.PullRequest) bool {
+	if !pr.IsAncestor() {
+		return false
+	}
+
+	if err := pr.LoadBaseRepo(ctx); err != nil {
+		log.Error("%-v LoadBaseRepo: %v", pr, err)
+		return false
+	}
+
+	gitRepo, err := git.OpenRepository(ctx, pr.BaseRepo)
+	if err != nil {
+		log.Error("%-v OpenRepository: %v", pr.BaseRepo, err)
+		return false
+	}
+	defer gitRepo.Close()
+
+	commit, err := gitRepo.GetCommit(ctx, pr.HeadCommitID)
+	if err != nil {
+		log.Error("%-v GetCommit[%s]: %v", pr, pr.HeadCommitID, err)
+		return false
+	}
+
+	merger, err := getMergerForManuallyMergedPullRequest(ctx, pr)
+	if err != nil {
+		log.Error("%-v getMergerForManuallyMergedPullRequest: %v", pr, err)
+		return false
+	}
+
+	if merged, err := SetMerged(ctx, pr, commit.ID.String(), timeutil.TimeStamp(commit.Author.When.Unix()), merger, issues_model.PullRequestStatusManuallyMerged); err != nil {
+		log.Error("%-v setMerged: %v", pr, err)
+		return false
+	} else if !merged {
+		return false
+	}
+
+	notify_service.MergePullRequest(ctx, merger, pr)
+	log.Info("mergedAsAncestor[%-v]: Marked as merged into %s/%s by commit id: %s", pr, pr.BaseRepo.Name, pr.BaseBranch, commit.ID.String())
+	return true
+}
+
 // InitializePullRequests checks and tests untested patches of pull requests.
 func InitializePullRequests(ctx context.Context) {
 	// If we prefer to delay the checks, then no need to do any check during startup, there should be not much difference
@@ -490,12 +537,17 @@ func checkPullRequestMergeable(id int64) {
 		return
 	}
 
+	previousMergeBase := pr.MergeBase
 	if err := checkPullRequestBranchMergeable(ctx, pr); err != nil {
 		log.Error("checkPullRequestBranchMergeable[%-v]: %v", pr, err)
 		pr.Status = issues_model.PullRequestStatusError
 		if err := pr.UpdateCols(ctx, "status"); err != nil {
 			log.Error("update pr [%-v] status to PullRequestStatusError failed: %v", pr, err)
 		}
+		return
+	}
+	if wasPullRequestPreviouslyNonEmpty(previousMergeBase, pr.HeadCommitID) && mergedAsAncestor(ctx, pr) {
+		log.Trace("%-v is merged as ancestor (status: %s, merge commit: %s)", pr, pr.Status, pr.MergedCommitID)
 		return
 	}
 	markPullRequestAsMergeable(ctx, pr)

--- a/services/pull/check_test.go
+++ b/services/pull/check_test.go
@@ -4,6 +4,7 @@
 package pull
 
 import (
+	"context"
 	"strconv"
 	"testing"
 	"time"
@@ -15,6 +16,7 @@ import (
 	repo_model "gitea.dev/models/repo"
 	"gitea.dev/models/unittest"
 	user_model "gitea.dev/models/user"
+	"gitea.dev/modules/git"
 	"gitea.dev/modules/graceful"
 	"gitea.dev/modules/queue"
 	"gitea.dev/modules/setting"
@@ -145,4 +147,37 @@ func TestMarkPullRequestAsMergeable(t *testing.T) {
 	case <-time.After(1 * time.Second):
 		assert.FailNow(t, "Timeout: nothing was added to automergequeue")
 	}
+}
+
+func TestCheckPullRequestMergeableMarksPreviouslyNonEmptyAncestorMerged(t *testing.T) {
+	require.NoError(t, unittest.PrepareTestDatabase())
+	ctx := t.Context()
+
+	pr := unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{ID: 2})
+	require.NoError(t, pr.LoadBaseRepo(ctx))
+	require.NoError(t, pr.LoadIssue(ctx))
+	require.False(t, pr.HasMerged)
+
+	baseRepo := pr.BaseRepo
+	baseCommitID, err := git.GetFullCommitID(ctx, baseRepo, git.BranchPrefix+pr.BaseBranch)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, git.UpdateRef(context.Background(), baseRepo, git.BranchPrefix+pr.BaseBranch, baseCommitID))
+	})
+
+	headCommitID, err := git.GetFullCommitID(ctx, baseRepo, pr.GetGitHeadRefName())
+	require.NoError(t, err)
+	require.NotEqual(t, pr.MergeBase, headCommitID)
+
+	require.NoError(t, git.UpdateRef(ctx, pr.BaseRepo, git.BranchPrefix+pr.BaseBranch, headCommitID))
+
+	checkPullRequestMergeable(pr.ID)
+
+	pr = unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{ID: 2})
+	assert.True(t, pr.HasMerged)
+	assert.Equal(t, headCommitID, pr.MergedCommitID)
+	assert.Equal(t, issues_model.PullRequestStatusManuallyMerged, pr.Status)
+
+	require.NoError(t, pr.LoadIssue(ctx))
+	assert.True(t, pr.Issue.IsClosed)
 }

--- a/services/pull/merge.go
+++ b/services/pull/merge.go
@@ -720,9 +720,10 @@ func SetMerged(ctx context.Context, pr *issues_model.PullRequest, mergedCommitID
 			return false, fmt.Errorf("DeleteScheduledAutoMerge[%d]: %v", pr.ID, err)
 		}
 
-		// Set issue as closed
-		if _, err := issues_model.SetIssueAsClosed(ctx, pr.Issue, pr.Merger, true); err != nil {
-			return false, fmt.Errorf("ChangeIssueStatus: %w", err)
+		if !pr.Issue.IsClosed {
+			if _, err := issues_model.SetIssueAsClosed(ctx, pr.Issue, pr.Merger, true); err != nil {
+				return false, fmt.Errorf("ChangeIssueStatus: %w", err)
+			}
 		}
 
 		// We need to save all of the data used to compute this merge as it may have already been changed by checkPullRequestBranchMergeable. FIXME: need to set some state to prevent checkPullRequestBranchMergeable from running whilst we are merging.

--- a/services/pull/merge_test.go
+++ b/services/pull/merge_test.go
@@ -6,8 +6,40 @@ package pull
 import (
 	"testing"
 
+	"gitea.dev/models/db"
+	issues_model "gitea.dev/models/issues"
+	"gitea.dev/models/unittest"
+	user_model "gitea.dev/models/user"
+	"gitea.dev/modules/timeutil"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestSetMergedMarksAlreadyClosedPullRequest(t *testing.T) {
+	require.NoError(t, unittest.PrepareTestDatabase())
+
+	ctx := t.Context()
+	pr := unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{ID: 2})
+	require.NoError(t, pr.LoadIssue(ctx))
+
+	pr.Issue.IsClosed = true
+	_, err := db.GetEngine(ctx).ID(pr.Issue.ID).Cols("is_closed").Update(pr.Issue)
+	require.NoError(t, err)
+
+	merger := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 1})
+	merged, err := SetMerged(ctx, pr, "0123456789012345678901234567890123456789", timeutil.TimeStampNow(), merger, issues_model.PullRequestStatusManuallyMerged)
+	require.NoError(t, err)
+	require.True(t, merged)
+
+	pr = unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{ID: 2})
+	assert.True(t, pr.HasMerged)
+	assert.Equal(t, "0123456789012345678901234567890123456789", pr.MergedCommitID)
+	assert.Equal(t, merger.ID, pr.MergerID)
+
+	issue := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{ID: pr.IssueID})
+	assert.True(t, issue.IsClosed)
+}
 
 func Test_expandDefaultMergeMessage(t *testing.T) {
 	type args struct {


### PR DESCRIPTION
## Summary

When an open pull request previously had changes, and the base branch later advances so that the pull request head is already reachable from the base branch, mark the pull request as merged instead of leaving it open with nothing to merge.

This keeps deliberately empty pull requests intact by only applying the automatic merged state when the pull request had a prior merge base different from the current head.

The change also lets `SetMerged` persist pull request merged metadata when the issue row was already closed before the pull_request row was updated.

A real-world example of the stale state is OSGeo PostGIS PR 641: the public API reports it open/unmerged with zero commits, while both `master` and the PR head point at the same commit.

## Testing

- `make fmt`
- `go test -run '^(TestCheckPullRequestMergeableMarksPreviouslyNonEmptyAncestorMerged|TestMarkPullRequestAsMergeable|TestSetMergedMarksAlreadyClosedPullRequest)$' ./services/pull`
- `go test ./services/pull ./routers/private`

I also tried `go test -run '^TestPullCreate_EmptyChangesWithSameCommits$' ./tests/integration`, but that local integration run failed before reaching this code path with `GET /user2/repo1/compare/master...empty-pr-branch` returning 404.

## AI disclosure

This change was prepared with assistance from Codex. I reviewed the resulting code and tests before opening the pull request.