### PR TITLE
fix: remove the pull merge box from UI when the refreshed page doesn't contain it (#38742)

### DIFF
--- a/web_src/js/features/repo-issue-pull.ts
+++ b/web_src/js/features/repo-issue-pull.ts
@@ -80,7 +80,13 @@ export function initRepoPullMergeBox(el: HTMLElement) {
       return;
     }
     document.removeEventListener('visibilitychange', onVisibilityChange);
-    const newElem = createElementFromHTML(await resp.text());
+
+    const respText = (await resp.text()).trim();
+    if (!respText) {
+      el.remove(); // merge box might not exist if the PR has changed (e.g.: merged and the head branch has been deleted)
+      return;
+    }
+    const newElem = createElementFromHTML(respText);
     el.replaceWith(newElem);
   };
 


### PR DESCRIPTION
backport #38742