### PR TITLE
fix: bad path escape in subpath archive download

### DIFF
--- a/templates/repo/view_content.tmpl
+++ b/templates/repo/view_content.tmpl
@@ -97,8 +97,8 @@
 					</a>
 					{{if and (not $.DisableDownloadSourceArchives) $.RefFullName}}
 						<div class="divider"></div>
-						<a class="item muted archive-link" href="{{$.RepoLink}}/archive/{{PathEscapeSegments $.RefFullName.ShortName}}.zip?path={{PathEscapeSegments .TreePath}}" rel="nofollow">{{svg "octicon-file-zip"}}{{ctx.Locale.Tr "repo.download_directory_as" "ZIP"}}</a>
-						<a class="item muted archive-link" href="{{$.RepoLink}}/archive/{{PathEscapeSegments $.RefFullName.ShortName}}.tar.gz?path={{PathEscapeSegments .TreePath}}" rel="nofollow">{{svg "octicon-file-zip"}}{{ctx.Locale.Tr "repo.download_directory_as" "TAR.GZ"}}</a>
+						<a class="item muted archive-link" href="{{$.RepoLink}}/archive/{{PathEscapeSegments $.RefFullName.ShortName}}.zip?path={{.TreePath}}" rel="nofollow">{{svg "octicon-file-zip"}}{{ctx.Locale.Tr "repo.download_directory_as" "ZIP"}}</a>
+						<a class="item muted archive-link" href="{{$.RepoLink}}/archive/{{PathEscapeSegments $.RefFullName.ShortName}}.tar.gz?path={{.TreePath}}" rel="nofollow">{{svg "octicon-file-zip"}}{{ctx.Locale.Tr "repo.download_directory_as" "TAR.GZ"}}</a>
 					{{end}}
 					{{if and .Repository.CanContentChange (not $isTreePathRoot)}}
 						<div class="divider"></div>


### PR DESCRIPTION
it prevented users from downloading paths with whitespace in names

fixes: https://github.com/go-gitea/gitea/issues/38745

