### PR TITLE
docs: add Zenith Hosting deploy option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ For accessing free Gitea service (with a limited number of repositories), you ca
 To quickly deploy your own dedicated Gitea instance on Gitea Cloud, you can start a free trial at [cloud.gitea.com](https://cloud.gitea.com),
 or use container (docker/podman/etc) to deploy on your own server with the [official image](https://hub.docker.com/r/gitea/gitea).
 
+Third-party managed hosting is also available, with storage, backups and a subdomain included:
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/gitea)
+
 ## Documentation
 
 You can find comprehensive documentation on our official [documentation website](https://docs.gitea.com/).


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Gitea to our marketplace, so this PR adds a small "Deploy with Zenith" badge under the deployment options in the Purpose section (links to https://zenith.hosting/host/gitea).

what it does: one line of README, right after the existing Gitea Cloud and container options, for people who want a managed Gitea but are not going to run a server themselves. storage, backups, TLS and a free subdomain are included, custom domains work too.

no UI changes, so no screenshots. docs-only, one file.

i know the README points third-party projects at gitea.com/gitea/awesome-gitea, and i'm happy to move this there instead if that's the preference (i just don't have a gitea.com account yet). i put it here because it's a deployment option for users rather than a project or integration.

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting
