### PR TITLE
chore: update pnpm settings

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,6 @@
 savePrefix: ''
-dedupePeerDependents: false
 updateNotifier: false
+ignoreScripts: true
 minimumReleaseAge: 0
-
-allowBuilds:
-  '@scarf/scarf': false
-  core-js: false
-  esbuild: true
-  unrs-resolver: true
+confirmModulesPurge: false
+verifyDepsBeforeRun: false


### PR DESCRIPTION
- drop `dedupePeerDependents` which is a no-op (produces same lockfile)
- replace `allowBuilds` with `ignoreScripts`, no dependency needs any builds, on any platform
- disable `confirmModulesPurge`, related to https://github.com/pnpm/pnpm/issues/11562
- disable `verifyDepsBeforeRun`, `make` already ensures `node_modules` are up to date, this saves around 150ms per `pnpm exec` and reduces pnpm spam.