### PR TITLE
ci: skip disk cleanup when unnecessary

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -7,6 +7,11 @@ runs:
   steps:
     - shell: bash
       run: |
+        avail=$(df --output=avail -BG / | tr -dc '0-9')
+        if [ "$avail" -ge 50 ]; then
+          echo "skipping cleanup, ${avail}G free"
+          exit 0
+        fi
         echo "free space before cleanup:"
         df -h /
         for dir in /usr/local/lib/android /usr/local/.ghcup /opt/ghc /usr/share/dotnet; do


### PR DESCRIPTION
Speed up all go jobs by ~58s by not cleaning the disk when there's at least 50GB available.

The job was added because some runners only have like 15GB available (I assume self-hosted), but on regular GHA runners which have about 90GB free, this job will now always skip.