### PR TITLE
ci: pin containers to digest, enable more zizmor rules

### DIFF
--- a/.github/workflows/cache-prune.yml
+++ b/.github/workflows/cache-prune.yml
@@ -9,8 +9,7 @@ on:
   workflow_dispatch:
   workflow_call:
 
-permissions:
-  actions: write # to delete caches
+permissions: {}
 
 concurrency:
   group: cache-prune
@@ -19,6 +18,8 @@ jobs:
   prune:
     runs-on: ubuntu-latest
     if: github.repository == 'go-gitea/gitea'
+    permissions:
+      actions: write # to delete caches
     env:
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}

--- a/.github/workflows/cache-seeder.yml
+++ b/.github/workflows/cache-seeder.yml
@@ -69,9 +69,10 @@ jobs:
       - run: make generate-go
         env:
           TAGS: ${{ matrix.tags }}
-      - run: make ${{ matrix.target }}
+      - run: make "$TARGET"
         env:
           TAGS: ${{ matrix.tags }}
+          TARGET: ${{ matrix.target }}
 
   # reclaims the caches this run superseded, so the next save still fits in the allowance
   prune:

--- a/.github/workflows/cron-licenses.yml
+++ b/.github/workflows/cron-licenses.yml
@@ -5,6 +5,8 @@ on:
   #   - cron: "7 0 * * 1" # every Monday at 00:07 UTC
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   cron-licenses:
     runs-on: ubuntu-latest

--- a/.github/workflows/cron-translations.yml
+++ b/.github/workflows/cron-translations.yml
@@ -5,6 +5,8 @@ on:
     - cron: "7 0 * * *" # every day at 00:07 UTC
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   crowdin-pull:
     runs-on: ubuntu-latest

--- a/.github/workflows/giteabot.yml
+++ b/.github/workflows/giteabot.yml
@@ -40,11 +40,7 @@ on:
         required: false
         default: labels,merge_queue,lock,feedback,last_call,milestones,lgtm,translation_comment,pr_actions
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
-  statuses: write
+permissions: {}
 
 concurrency:
   group: ${{ format('{0}-{1}', github.workflow, (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review') && format('pr-{0}', github.event.pull_request.number) || 'maintenance') }}
@@ -55,6 +51,11 @@ jobs:
     if: github.repository == 'go-gitea/gitea'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      statuses: write
     steps:
       # pull_request_review runs without repository secrets on fork PRs, so fall
       # back to the workflow token for the non-backport checks handled here.

--- a/.github/workflows/pull-db-tests.yml
+++ b/.github/workflows/pull-db-tests.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 50
     services:
       pgsql:
-        image: postgres:14
+        image: postgres:14@sha256:caf49e3b10d377aa2cfee478591d623808527beb27125d38797b418013f72d81
         env:
           POSTGRES_DB: test
           POSTGRES_PASSWORD: postgres
@@ -35,7 +35,7 @@ jobs:
       minio:
         # as github actions doesn't support "entrypoint", we need to use a non-official image
         # that has a custom entrypoint set to "minio server /data"
-        image: bitnamilegacy/minio:2025.7.23
+        image: bitnamilegacy/minio:2025.7.23@sha256:8935e75fa5d11295c17171e4aa49efe390a1193cd7f12e4d21b92af9ffef09d7
         env:
           MINIO_ROOT_USER: 123456
           MINIO_ROOT_PASSWORD: 12345678
@@ -57,7 +57,7 @@ jobs:
     timeout-minutes: 50
     services:
       pgsql:
-        image: postgres:14
+        image: postgres:14@sha256:caf49e3b10d377aa2cfee478591d623808527beb27125d38797b418013f72d81
         env:
           POSTGRES_DB: test
           POSTGRES_PASSWORD: postgres
@@ -71,7 +71,7 @@ jobs:
       minio:
         # as github actions doesn't support "entrypoint", we need to use a non-official image
         # that has a custom entrypoint set to "minio server /data"
-        image: bitnamilegacy/minio:2025.7.23
+        image: bitnamilegacy/minio:2025.7.23@sha256:8935e75fa5d11295c17171e4aa49efe390a1193cd7f12e4d21b92af9ffef09d7
         env:
           MINIO_ROOT_USER: 123456
           MINIO_ROOT_PASSWORD: 12345678
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15@sha256:aeda96cd85b0cadeb3a3b900789f3b85e902c994052dadbaf8dd99a539e2ef93
         env:
           discovery.type: single-node
           xpack.security.enabled: false
@@ -125,7 +125,7 @@ jobs:
         ports:
           - "9200:9200"
       meilisearch:
-        image: getmeili/meilisearch:v1
+        image: getmeili/meilisearch:v1@sha256:d36e713e8f89483af1ab0d72011bbd503f5ab100b68ccbfad51c39e3f0a0567d
         env:
           MEILI_ENV: development # disable auth
         ports:
@@ -140,7 +140,7 @@ jobs:
         ports:
           - 6379:6379
       minio:
-        image: bitnamilegacy/minio:2025.7.23
+        image: bitnamilegacy/minio:2025.7.23@sha256:8935e75fa5d11295c17171e4aa49efe390a1193cd7f12e4d21b92af9ffef09d7
         env:
           MINIO_ROOT_USER: 123456
           MINIO_ROOT_PASSWORD: 12345678
@@ -182,7 +182,7 @@ jobs:
     services:
       mysql:
         # the bitnami mysql image has more options than the official one, it's easier to customize
-        image: bitnamilegacy/mysql:8.4
+        image: bitnamilegacy/mysql:8.4@sha256:7089d796fc9b4629a628bd445e4afabe607351ee665444c3197bdeaed812ea65
         env:
           ALLOW_EMPTY_PASSWORD: true
           MYSQL_DATABASE: testgitea
@@ -191,7 +191,7 @@ jobs:
         options: >-
           --mount type=tmpfs,destination=/bitnami/mysql/data
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15@sha256:aeda96cd85b0cadeb3a3b900789f3b85e902c994052dadbaf8dd99a539e2ef93
         env:
           discovery.type: single-node
           xpack.security.enabled: false
@@ -229,7 +229,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mssql:
-        image: mcr.microsoft.com/mssql/server:2019-latest
+        image: mcr.microsoft.com/mssql/server:2019-latest@sha256:46f719fd3457d4e7e8e5845fe00c35c20e7bae7ff1e8b9fe595f2a81029f5ba8
         env:
           ACCEPT_EULA: Y
           MSSQL_PID: Standard

--- a/.github/workflows/pull-labeler.yml
+++ b/.github/workflows/pull-labeler.yml
@@ -10,6 +10,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   labeler:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-nightly-snapcraft.yml
+++ b/.github/workflows/release-nightly-snapcraft.yml
@@ -31,10 +31,11 @@ jobs:
       - name: Publish snap
         run: |
           for attempt in 1 2 3 4 5; do
-            snapcraft upload "${{ steps.build.outputs.snap }}" --release latest/edge && exit 0
+            snapcraft upload "$SNAP" --release latest/edge && exit 0
             echo "::warning::snap upload attempt $attempt failed, retrying in 15s"
             sleep 15
           done
           exit 1
         env:
+          SNAP: ${{ steps.build.outputs.snap }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -8,6 +8,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   nightly-binary:
     runs-on: namespace-profile-gitea-release-binary

--- a/.github/workflows/release-tag-rc.yml
+++ b/.github/workflows/release-tag-rc.yml
@@ -9,6 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   binary:
     runs-on: namespace-profile-gitea-release-binary

--- a/.github/workflows/release-tag-version.yml
+++ b/.github/workflows/release-tag-version.yml
@@ -11,6 +11,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   binary:
     runs-on: namespace-profile-gitea-release-binary

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,7 +1,7 @@
 rules:
   anonymous-definition:
-    disable: true # jobs are identified by id, display names add nothing
+    disable: true
   undocumented-permissions:
-    disable: true # only non-obvious permissions carry a comment
+    disable: true
   concurrency-limits:
-    disable: true # cron workflows are serialized by their schedule
+    disable: true

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+rules:
+  anonymous-definition:
+    disable: true # jobs are identified by id, display names add nothing
+  undocumented-permissions:
+    disable: true # only non-obvious permissions carry a comment
+  concurrency-limits:
+    disable: true # cron workflows are serialized by their schedule

--- a/Makefile
+++ b/Makefile
@@ -348,7 +348,7 @@ lint-editorconfig:
 .PHONY: lint-actions
 lint-actions: .venv ## lint action workflow files
 	@$(GO) run $(ACTIONLINT_PACKAGE)
-	@uv run --frozen zizmor --quiet --min-confidence=medium .github
+	@uv run --frozen zizmor --quiet --persona=pedantic --min-confidence=medium .github
 
 .PHONY: lint-shell
 lint-shell: ## lint shell scripts

--- a/renovate.json5
+++ b/renovate.json5
@@ -101,6 +101,10 @@
       "allowedVersions": "/^2019($|[.-])/", // pin to oldest in extended support
     },
     {
+      "matchPackageNames": ["docker.elastic.co/elasticsearch/elasticsearch"],
+      "allowedVersions": "/^8($|[.-])/", // pin to oldest supported major
+    },
+    {
       "matchManagers": ["gomod"],
       "postUpdateOptions": ["gomodUpdateImportPaths"],
     },


### PR DESCRIPTION
Enable more strict "pedantic" zizmor rules and fix issues. Service containers are pinned to hash and renovate will update them. Enabled rules:

- https://docs.zizmor.sh/audits/#excessive-permissions
- https://docs.zizmor.sh/audits/#unpinned-images
- https://docs.zizmor.sh/audits/#template-injection