### PR TITLE
feat(metrics): add scheduled per-pository metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -211,6 +211,7 @@ require (
 	github.com/kevinburke/ssh_config v1.6.0 // indirect
 	github.com/klauspost/crc32 v1.3.0 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/libdns/libdns v1.1.1 // indirect
 	github.com/markbates/going v1.0.3 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect

--- a/go.mod
+++ b/go.mod
@@ -205,6 +205,7 @@ require (
 	github.com/klauspost/cpuid/v2 v2.4.0 // indirect
 	github.com/klauspost/crc32 v1.3.0 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/libdns/libdns v1.1.1 // indirect
 	github.com/markbates/going v1.0.3 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect

--- a/modules/setting/metrics.go
+++ b/modules/setting/metrics.go
@@ -9,11 +9,15 @@ var Metrics = struct {
 	Token                    string
 	EnabledIssueByLabel      bool
 	EnabledIssueByRepository bool
+	EnabledRefCount          bool
+	EnabledObjectCount       bool
 }{
 	Enabled:                  false,
 	Token:                    "",
 	EnabledIssueByLabel:      false,
 	EnabledIssueByRepository: false,
+	EnabledRefCount:          true,
+	EnabledObjectCount:       true,
 }
 
 func loadMetricsFrom(rootCfg ConfigProvider) {

--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -3060,6 +3060,8 @@
   "admin.dashboard.sync_tag.started": "Tags Sync started",
   "admin.dashboard.rebuild_issue_indexer": "Rebuild issue indexer",
   "admin.dashboard.sync_repo_licenses": "Sync repo licenses",
+  "admin.dashboard.collect_repo_ref_counts": "Collect repository ref counts",
+  "admin.dashboard.collect_repo_object_counts": "Collect repository object counts",
   "admin.users.user_manage_panel": "User Account Management",
   "admin.users.new_account": "Create User Account",
   "admin.users.name": "Username",

--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -3023,6 +3023,8 @@
   "admin.dashboard.sync_tag.started": "Tags Sync started",
   "admin.dashboard.rebuild_issue_indexer": "Rebuild issue indexer",
   "admin.dashboard.sync_repo_licenses": "Sync repo licenses",
+  "admin.dashboard.collect_repo_ref_counts": "Collect repository ref counts",
+  "admin.dashboard.collect_repo_object_counts": "Collect repository object counts",
   "admin.users.user_manage_panel": "User Account Management",
   "admin.users.new_account": "Create User Account",
   "admin.users.name": "Username",

--- a/services/cron/tasks_basic.go
+++ b/services/cron/tasks_basic.go
@@ -166,6 +166,28 @@ func registerSyncRepoLicenses() {
 	})
 }
 
+func registerCollectRepoRefCounts() {
+	RegisterTaskFatal("collect_repo_ref_counts", &BaseConfig{
+		Enabled:    true,
+		RunAtStart: false,
+		Schedule:   "@every 1h",
+	}, func(ctx context.Context, _ *user_model.User, _ Config) error {
+		mirror_service.CollectRepoRefCounts(ctx)
+		return nil
+	})
+}
+
+func registerCollectRepoObjectCounts() {
+	RegisterTaskFatal("collect_repo_object_counts", &BaseConfig{
+		Enabled:    true,
+		RunAtStart: false,
+		Schedule:   "@every 1h",
+	}, func(ctx context.Context, _ *user_model.User, _ Config) error {
+		mirror_service.CollectRepoObjectCounts(ctx)
+		return nil
+	})
+}
+
 func initBasicTasks() {
 	if setting.Mirror.Enabled {
 		registerUpdateMirrorTask()
@@ -183,4 +205,10 @@ func initBasicTasks() {
 		registerCleanupPackages()
 	}
 	registerSyncRepoLicenses()
+	if setting.Metrics.Enabled && setting.Metrics.EnabledRefCount {
+		registerCollectRepoRefCounts()
+	}
+	if setting.Metrics.Enabled && setting.Metrics.EnabledObjectCount {
+		registerCollectRepoObjectCounts()
+	}
 }

--- a/services/cron/tasks_basic.go
+++ b/services/cron/tasks_basic.go
@@ -159,6 +159,28 @@ func registerSyncRepoLicenses() {
 	})
 }
 
+func registerCollectRepoRefCounts() {
+	RegisterTaskFatal("collect_repo_ref_counts", &BaseConfig{
+		Enabled:    true,
+		RunAtStart: false,
+		Schedule:   "@every 1h",
+	}, func(ctx context.Context, _ *user_model.User, _ *BaseConfig) error {
+		mirror_service.CollectRepoRefCounts(ctx)
+		return nil
+	})
+}
+
+func registerCollectRepoObjectCounts() {
+	RegisterTaskFatal("collect_repo_object_counts", &BaseConfig{
+		Enabled:    true,
+		RunAtStart: false,
+		Schedule:   "@every 1h",
+	}, func(ctx context.Context, _ *user_model.User, _ *BaseConfig) error {
+		mirror_service.CollectRepoObjectCounts(ctx)
+		return nil
+	})
+}
+
 func initBasicTasks() {
 	if setting.Mirror.Enabled {
 		registerUpdateMirrorTask()
@@ -176,4 +198,10 @@ func initBasicTasks() {
 		registerCleanupPackages()
 	}
 	registerSyncRepoLicenses()
+	if setting.Metrics.Enabled && setting.Metrics.EnabledRefCount {
+		registerCollectRepoRefCounts()
+	}
+	if setting.Metrics.Enabled && setting.Metrics.EnabledObjectCount {
+		registerCollectRepoObjectCounts()
+	}
 }

--- a/services/mirror/repo_object_metrics.go
+++ b/services/mirror/repo_object_metrics.go
@@ -1,0 +1,104 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package mirror
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"time"
+
+	"gitea.dev/models/db"
+	repo_model "gitea.dev/models/repo"
+	"gitea.dev/modules/git/gitcmd"
+	"gitea.dev/modules/git/gitrepo"
+	"gitea.dev/modules/log"
+	"gitea.dev/modules/setting"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var repoObjectCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: "gitea",
+	Name:      "object_count",
+	Help:      "Number of git objects per repository, labeled by object type (blob, commit, tree).",
+}, []string{"owner", "repo", "type"})
+
+var repoObjectCountCollectionDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+	Namespace: "gitea",
+	Name:      "object_count_collection_duration_ms",
+	Help:      "Duration in milliseconds to collect object_count metrics across all repositories.",
+	Buckets:   prometheus.DefBuckets,
+})
+
+func init() {
+	prometheus.MustRegister(repoObjectCount)
+	prometheus.MustRegister(repoObjectCountCollectionDuration)
+}
+
+type objectMetricsConfig struct {
+	Enabled            bool
+	EnabledObjectCount bool
+}
+
+// CollectRepoObjectCounts walks every repository and updates the gitea_object_count
+// gauge with blob, commit, and tree counts per repo using git cat-file --batch-check.
+func CollectRepoObjectCounts(ctx context.Context) {
+	collectRepoObjectCountsWith(ctx, objectMetricsConfig{
+		Enabled:            setting.Metrics.Enabled,
+		EnabledObjectCount: setting.Metrics.EnabledObjectCount,
+	})
+}
+
+func collectRepoObjectCountsWith(ctx context.Context, cfg objectMetricsConfig) {
+	if !cfg.Enabled || !cfg.EnabledObjectCount {
+		return
+	}
+
+	start := time.Now()
+	defer func() {
+		repoObjectCountCollectionDuration.Observe(float64(time.Since(start).Milliseconds()))
+	}()
+
+	if err := db.Iterate[repo_model.Repository](ctx, nil, func(ctx context.Context, repo *repo_model.Repository) error {
+		blobs, commits, trees := countObjects(ctx, repo)
+		repoObjectCount.WithLabelValues(repo.OwnerName, repo.Name, "blob").Set(float64(blobs))
+		repoObjectCount.WithLabelValues(repo.OwnerName, repo.Name, "commit").Set(float64(commits))
+		repoObjectCount.WithLabelValues(repo.OwnerName, repo.Name, "tree").Set(float64(trees))
+		return nil
+	}); err != nil {
+		log.Error("CollectRepoObjectCounts: failed to iterate repositories: %v", err)
+	}
+}
+
+// countObjects runs git cat-file --batch-check --batch-all-objects and counts
+// blob, commit, and tree objects for the bare repository.
+func countObjects(ctx context.Context, repo gitrepo.RepositoryFacade) (blobs, commits, trees int) {
+	stdout, stderr, err := gitcmd.NewCommand("cat-file", "--batch-check", "--batch-all-objects").
+		WithRepo(repo).RunStdBytes(ctx)
+	if err != nil {
+		log.Warn("countObjects: cat-file failed for %s: %v - %s", repo.LogString(), err, string(stderr))
+		return 0, 0, 0
+	}
+
+	var buf bytes.Buffer
+	buf.Write(stdout)
+
+	scanner := bufio.NewScanner(&buf)
+	for scanner.Scan() {
+		fields := bytes.Fields(scanner.Bytes())
+		if len(fields) < 2 {
+			continue
+		}
+		switch string(fields[1]) {
+		case "blob":
+			blobs++
+		case "commit":
+			commits++
+		case "tree":
+			trees++
+		}
+	}
+	return blobs, commits, trees
+}

--- a/services/mirror/repo_object_metrics_test.go
+++ b/services/mirror/repo_object_metrics_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package mirror
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"gitea.dev/modules/git"
+	"gitea.dev/modules/git/gitrepo"
+	"gitea.dev/modules/setting"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testRunObjectMetrics(m *testing.M) error {
+	gitHomePath, err := os.MkdirTemp(os.TempDir(), "git-home")
+	if err != nil {
+		return fmt.Errorf("unable to create temp dir: %w", err)
+	}
+	defer os.RemoveAll(gitHomePath)
+	setting.Git.HomePath = gitHomePath
+
+	if err = git.InitFull(); err != nil {
+		return fmt.Errorf("failed to call git.InitFull: %w", err)
+	}
+
+	exitCode := m.Run()
+	if exitCode != 0 {
+		return fmt.Errorf("test run failed, ExitCode=%d", exitCode)
+	}
+	return nil
+}
+
+func TestMain(m *testing.M) {
+	if err := testRunObjectMetrics(m); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Test failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func TestCollectRepoObjectCountsDisabledWhenMetricsOff(t *testing.T) {
+	cfg := objectMetricsConfig{Enabled: false, EnabledObjectCount: true}
+
+	before := testutil.CollectAndCount(repoObjectCount)
+	collectRepoObjectCountsWith(context.Background(), cfg)
+	after := testutil.CollectAndCount(repoObjectCount)
+
+	assert.Equal(t, before, after, "gauge series count should not change when Metrics.Enabled is false")
+}
+
+func TestCollectRepoObjectCountsDisabledWhenObjectCountOff(t *testing.T) {
+	cfg := objectMetricsConfig{Enabled: true, EnabledObjectCount: false}
+
+	before := testutil.CollectAndCount(repoObjectCount)
+	collectRepoObjectCountsWith(context.Background(), cfg)
+	after := testutil.CollectAndCount(repoObjectCount)
+
+	assert.Equal(t, before, after, "gauge series count should not change when EnabledObjectCount is false")
+}
+
+// makeTestBareRepo creates a bare git repo with one commit so there is at
+// least one blob, one tree, and one commit object to count.
+func makeTestBareRepo(t *testing.T) string {
+	t.Helper()
+
+	workDir := t.TempDir()
+	bareDir := filepath.Join(t.TempDir(), "repo.git")
+
+	mustGit := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+
+	mustGit(workDir, "init", "-b", "main")
+	mustGit(workDir, "config", "user.email", "test@example.com")
+	mustGit(workDir, "config", "user.name", "Test")
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "file.txt"), []byte("hello\n"), 0o644))
+	mustGit(workDir, "add", "file.txt")
+	mustGit(workDir, "commit", "-m", "initial commit")
+	mustGit(workDir, "clone", "--bare", workDir, bareDir)
+
+	return bareDir
+}
+
+func TestCountObjects_EmptyRepo(t *testing.T) {
+	bareDir := t.TempDir()
+	mustGit := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = bareDir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+	mustGit("init", "--bare", "-b", "main", bareDir)
+
+	blobs, commits, trees := countObjects(context.Background(), gitrepo.RepositoryUnmanaged(bareDir))
+	assert.Equal(t, 0, blobs)
+	assert.Equal(t, 0, commits)
+	assert.Equal(t, 0, trees)
+}
+
+func TestCountObjects_WithObjects(t *testing.T) {
+	bareDir := makeTestBareRepo(t)
+
+	blobs, commits, trees := countObjects(context.Background(), gitrepo.RepositoryUnmanaged(bareDir))
+	assert.GreaterOrEqual(t, blobs, 1, "expected at least one blob")
+	assert.GreaterOrEqual(t, commits, 1, "expected at least one commit")
+	assert.GreaterOrEqual(t, trees, 1, "expected at least one tree")
+}
+
+func TestCountObjects_InvalidRepo(t *testing.T) {
+	blobs, commits, trees := countObjects(context.Background(), gitrepo.RepositoryUnmanaged(filepath.Join(t.TempDir(), "nonexistent")))
+	assert.Equal(t, 0, blobs)
+	assert.Equal(t, 0, commits)
+	assert.Equal(t, 0, trees)
+}

--- a/services/mirror/repo_ref_metrics.go
+++ b/services/mirror/repo_ref_metrics.go
@@ -1,0 +1,120 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package mirror
+
+import (
+	"bufio"
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gitea.dev/models/db"
+	repo_model "gitea.dev/models/repo"
+	"gitea.dev/modules/git/gitrepo"
+	"gitea.dev/modules/log"
+	"gitea.dev/modules/setting"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var repoRefCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: "gitea",
+	Name:      "ref_count",
+	Help:      "Number of git refs per repository, labeled by ref storage type (packed or loose).",
+}, []string{"owner", "repo", "type"})
+
+var repoRefCountCollectionDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+	Namespace: "gitea",
+	Name:      "ref_count_collection_duration_ms",
+	Help:      "Duration in milliseconds to collect ref_count metrics across all repositories.",
+	Buckets:   prometheus.DefBuckets,
+})
+
+func init() {
+	prometheus.MustRegister(repoRefCount)
+	prometheus.MustRegister(repoRefCountCollectionDuration)
+}
+
+type refMetricsConfig struct {
+	Enabled         bool
+	EnabledRefCount bool
+}
+
+// CollectRepoRefCounts walks every repository on disk and updates the
+// gitea_ref_count gauge with packed and loose ref counts per repo.
+func CollectRepoRefCounts(ctx context.Context) {
+	collectRepoRefCountsWith(ctx, refMetricsConfig{
+		Enabled:         setting.Metrics.Enabled,
+		EnabledRefCount: setting.Metrics.EnabledRefCount,
+	})
+}
+
+func collectRepoRefCountsWith(ctx context.Context, cfg refMetricsConfig) {
+	if !cfg.Enabled || !cfg.EnabledRefCount {
+		return
+	}
+
+	start := time.Now()
+	defer func() {
+		repoRefCountCollectionDuration.Observe(float64(time.Since(start).Milliseconds()))
+	}()
+
+	if err := db.Iterate[repo_model.Repository](ctx, nil, func(ctx context.Context, repo *repo_model.Repository) error {
+		repoPath := gitrepo.RepoLocalPath(repo)
+		packed, loose := countRefs(repoPath)
+		repoRefCount.WithLabelValues(repo.OwnerName, repo.Name, "packed").Set(float64(packed))
+		repoRefCount.WithLabelValues(repo.OwnerName, repo.Name, "loose").Set(float64(loose))
+		return nil
+	}); err != nil {
+		log.Error("CollectRepoRefCounts: failed to iterate repositories: %v", err)
+	}
+}
+
+// countRefs returns the number of packed refs (from packed-refs) and loose refs
+// (files under refs/) for the bare repository at repoPath.
+func countRefs(repoPath string) (packed, loose int) {
+	packed = countPackedRefs(filepath.Join(repoPath, "packed-refs"))
+	loose = countLooseRefs(filepath.Join(repoPath, "refs"))
+	return packed, loose
+}
+
+// countPackedRefs counts lines in packed-refs that begin with a hex SHA
+// (skipping the header line and peeled-tag '^' lines).
+func countPackedRefs(packedRefsPath string) int {
+	f, err := os.Open(packedRefsPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Warn("countPackedRefs: cannot open %s: %v", packedRefsPath, err)
+		}
+		return 0
+	}
+	defer f.Close()
+
+	count := 0
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if len(line) > 0 && (line[0] >= '0' && line[0] <= '9' || line[0] >= 'a' && line[0] <= 'f') {
+			count++
+		}
+	}
+	return count
+}
+
+// countLooseRefs counts regular files under the refs/ directory tree.
+func countLooseRefs(refsDir string) int {
+	count := 0
+	_ = filepath.WalkDir(refsDir, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip unreadable entries
+		}
+		if !d.IsDir() {
+			count++
+		}
+		return nil
+	})
+	return count
+}

--- a/services/mirror/repo_ref_metrics_test.go
+++ b/services/mirror/repo_ref_metrics_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package mirror
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectRepoRefCountsDisabledWhenMetricsOff(t *testing.T) {
+	cfg := refMetricsConfig{Enabled: false, EnabledRefCount: true}
+
+	before := testutil.CollectAndCount(repoRefCount)
+	collectRepoRefCountsWith(context.Background(), cfg)
+	after := testutil.CollectAndCount(repoRefCount)
+
+	assert.Equal(t, before, after, "gauge series count should not change when Enabled is false")
+}
+
+func TestCollectRepoRefCountsDisabledWhenRefCountOff(t *testing.T) {
+	cfg := refMetricsConfig{Enabled: true, EnabledRefCount: false}
+
+	before := testutil.CollectAndCount(repoRefCount)
+	collectRepoRefCountsWith(context.Background(), cfg)
+	after := testutil.CollectAndCount(repoRefCount)
+
+	assert.Equal(t, before, after, "gauge series count should not change when EnabledRefCount is false")
+}
+
+func TestCountPackedRefs_Missing(t *testing.T) {
+	count := countPackedRefs(filepath.Join(t.TempDir(), "packed-refs"))
+	assert.Equal(t, 0, count)
+}
+
+func TestCountPackedRefs_HeaderOnly(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "packed-refs")
+	require.NoError(t, os.WriteFile(path, []byte("# pack-refs with: peeled fully-peeled sorted\n"), 0o644))
+	assert.Equal(t, 0, countPackedRefs(path))
+}
+
+func TestCountPackedRefs_WithRefs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "packed-refs")
+	content := "# pack-refs with: peeled fully-peeled sorted\n" +
+		"abc123def456abc123def456abc123def456abc123 refs/heads/main\n" +
+		"^abc123def456abc123def456abc123def456abc124\n" +
+		"def456abc123def456abc123def456abc123def456 refs/tags/v1.0\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	assert.Equal(t, 2, countPackedRefs(path))
+}
+
+func TestCountLooseRefs_Missing(t *testing.T) {
+	count := countLooseRefs(filepath.Join(t.TempDir(), "refs"))
+	assert.Equal(t, 0, count)
+}
+
+func TestCountLooseRefs_Empty(t *testing.T) {
+	assert.Equal(t, 0, countLooseRefs(t.TempDir()))
+}
+
+func TestCountLooseRefs_WithFiles(t *testing.T) {
+	refsDir := filepath.Join(t.TempDir(), "refs", "heads")
+	require.NoError(t, os.MkdirAll(refsDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(refsDir, "main"), []byte("abc123\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(refsDir, "feature"), []byte("def456\n"), 0o644))
+	assert.Equal(t, 2, countLooseRefs(filepath.Dir(refsDir)))
+}


### PR DESCRIPTION
Some more observability metrics similar to [#38153](https://github.com/go-gitea/gitea/pull/38153). This adds a default-disabled hourly cron which iterates over all repositories and emits prometheus metrics of:
* gitea_ref_count gauge metric for packed and loose refs per repository
* gitea_object_count gauge metric for commit/tree/blob metrics per repository
* _collection_duration_ms histogram/sum for each of those

`gitea_ref_count` is very fast. `gitea_object_count` can be slow for large repositories (for ours, tens of minutes).
