### PR TITLE
feat(mirror): incremental LFS pointer discovery in mirrorSync

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -2750,6 +2750,8 @@ LEVEL = Info
 ;ENABLED_ISSUE_BY_LABEL = false
 ;; Enable issue by repository metrics; default is false
 ;ENABLED_ISSUE_BY_REPOSITORY = false
+;; Enable mirror sync duration metrics (high-cardinality: owner+repo+step); default is false
+;ENABLED_MIRROR_SYNC_DURATION = false
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -2736,6 +2736,8 @@ LEVEL = Info
 ;ENABLED_ISSUE_BY_LABEL = false
 ;; Enable issue by repository metrics; default is false
 ;ENABLED_ISSUE_BY_REPOSITORY = false
+;; Enable mirror sync duration metrics (high-cardinality: owner+repo+step); default is false
+;ENABLED_MIRROR_SYNC_DURATION = false
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pquerna/otp v1.5.0
 	github.com/prometheus/client_golang v1.24.1
+	github.com/prometheus/client_model v0.6.2
 	github.com/quasoft/websspi v1.1.2
 	github.com/redis/go-redis/v9 v9.22.0
 	github.com/rhysd/actionlint v1.7.12
@@ -235,7 +236,6 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pquerna/otp v1.5.0
 	github.com/prometheus/client_golang v1.24.1
+	github.com/prometheus/client_model v0.6.2
 	github.com/quasoft/websspi v1.1.2
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/rhysd/actionlint v1.7.12
@@ -241,7 +242,6 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/modelmigration/migrations.go
+++ b/modelmigration/migrations.go
@@ -420,6 +420,7 @@ func prepareMigrationTasks() []*migration {
 		newMigration(344, "Add deferred-matrix columns to ActionRunJob", v1_28.AddDeferredMatrixColumnsToActionRunJob),
 		newMigration(345, "Add block on CODEOWNERS reviews branch protection", v1_28.AddBlockOnCodeownerReviews),
 		newMigration(346, "Add license_path column to repo_license and backfill", v1_28.AddLicensePathToRepoLicense),
+		newMigration(347, "Add lfs_mirror_pending table and lfs_last_refs to mirror", v1_28.AddLFSMirrorPendingAndLFSLastRefsToMirror),
 	}
 	return preparedMigrations
 }

--- a/modelmigration/migrations.go
+++ b/modelmigration/migrations.go
@@ -426,6 +426,7 @@ func prepareMigrationTasks() []*migration {
 		newMigration(350, "Add published_unix column to release", v28.AddPublishedUnixToRelease),
 		newMigration(351, "Track transfer recipient access grants", v28.AddRecipientAccessGrantedToRepoTransfer),
 		newMigration(352, "Add token columns to deploy_key", v28.AddTokenToDeployKey),
+		newMigration(353, "Add lfs_mirror_pending table and lfs_last_refs to mirror", v28.AddLFSMirrorPendingAndLFSLastRefsToMirror),
 	}
 	return preparedMigrations
 }

--- a/modelmigration/v1_28/v347.go
+++ b/modelmigration/v1_28/v347.go
@@ -1,0 +1,28 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v1_28
+
+import (
+	"context"
+
+	"gitea.dev/modelmigration/base"
+)
+
+func AddLFSMirrorPendingAndLFSLastRefsToMirror(_ context.Context, x base.EngineMigration) error {
+	type LFSMirrorPending struct {
+		ID           int64  `xorm:"pk autoincr"`
+		RepositoryID int64  `xorm:"UNIQUE(s) INDEX NOT NULL"`
+		Oid          string `xorm:"UNIQUE(s) INDEX NOT NULL"`
+		Size         int64  `xorm:"NOT NULL"`
+		BlobSha      string `xorm:"NOT NULL DEFAULT ''"`
+		CreatedUnix  int64  `xorm:"created"`
+	}
+	type Mirror struct {
+		LFSLastRefs string `xorm:"lfs_last_refs TEXT"`
+	}
+	if err := x.Sync(new(LFSMirrorPending)); err != nil {
+		return err
+	}
+	return x.Sync(new(Mirror))
+}

--- a/modelmigration/v28/v353.go
+++ b/modelmigration/v28/v353.go
@@ -1,0 +1,28 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v28
+
+import (
+	"context"
+
+	"gitea.dev/modelmigration/base"
+)
+
+func AddLFSMirrorPendingAndLFSLastRefsToMirror(_ context.Context, x base.EngineMigration) error {
+	type LFSMirrorPending struct {
+		ID           int64  `xorm:"pk autoincr"`
+		RepositoryID int64  `xorm:"UNIQUE(s) INDEX NOT NULL"`
+		Oid          string `xorm:"UNIQUE(s) INDEX NOT NULL"`
+		Size         int64  `xorm:"NOT NULL"`
+		BlobSha      string `xorm:"NOT NULL DEFAULT ''"`
+		CreatedUnix  int64  `xorm:"created"`
+	}
+	type Mirror struct {
+		LFSLastRefs string `xorm:"lfs_last_refs TEXT"`
+	}
+	if err := x.Sync(new(LFSMirrorPending)); err != nil {
+		return err
+	}
+	return x.Sync(new(Mirror))
+}

--- a/models/git/lfs_mirror_pending.go
+++ b/models/git/lfs_mirror_pending.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package git
+
+import (
+	"context"
+
+	"gitea.dev/models/db"
+	"gitea.dev/modules/lfs"
+	"gitea.dev/modules/timeutil"
+)
+
+// LFSMirrorPending tracks LFS pointers discovered during mirror sync whose
+// content has not yet been successfully downloaded from upstream. This table is
+// separate from lfs_meta_object so that rollback to a prior binary version does
+// not leave phantom rows that the old code misinterprets as synced content.
+type LFSMirrorPending struct {
+	ID           int64              `xorm:"pk autoincr"`
+	RepositoryID int64              `xorm:"UNIQUE(s) INDEX NOT NULL"`
+	Oid          string             `xorm:"UNIQUE(s) INDEX NOT NULL"`
+	Size         int64              `xorm:"NOT NULL"`
+	BlobSha      string             `xorm:"NOT NULL DEFAULT ''"`
+	CreatedUnix  timeutil.TimeStamp `xorm:"created"`
+}
+
+func init() {
+	db.RegisterModel(new(LFSMirrorPending))
+}
+
+// AddLFSMirrorPending inserts a pending LFS pointer if it is not already
+// tracked (neither in lfs_mirror_pending nor in lfs_meta_object).
+// pointerBlob.Hash is the git object hash of the pointer file blob, used by gc_lfs to
+// check reachability without reconstructing the blob content.
+// Returns true if a new row was inserted.
+func AddLFSMirrorPending(ctx context.Context, repoID int64, pointerBlob lfs.PointerBlob) (bool, error) {
+	// Already fully synced in lfs_meta_object?
+	has, err := db.GetEngine(ctx).Where("repository_id = ? AND oid = ?", repoID, pointerBlob.Oid).
+		Exist(&LFSMetaObject{})
+	if err != nil {
+		return false, err
+	}
+	if has {
+		return false, nil
+	}
+
+	// Already pending?
+	has, err = db.GetEngine(ctx).Where("repository_id = ? AND oid = ?", repoID, pointerBlob.Oid).
+		Exist(&LFSMirrorPending{})
+	if err != nil {
+		return false, err
+	}
+	if has {
+		return false, nil
+	}
+
+	return true, db.Insert(ctx, &LFSMirrorPending{
+		RepositoryID: repoID,
+		Oid:          pointerBlob.Oid,
+		Size:         pointerBlob.Size,
+		BlobSha:      pointerBlob.Hash,
+	})
+}
+
+// CountLFSMirrorPendingByRepoID returns the number of pending LFS objects for a repository.
+func CountLFSMirrorPendingByRepoID(ctx context.Context, repoID int64) (int64, error) {
+	return db.GetEngine(ctx).Where("repository_id = ?", repoID).Count(&LFSMirrorPending{})
+}
+
+// GetLFSMirrorPendingByRepoID returns all pending LFS objects for a repository.
+func GetLFSMirrorPendingByRepoID(ctx context.Context, repoID int64) ([]*LFSMirrorPending, error) {
+	var objects []*LFSMirrorPending
+	err := db.GetEngine(ctx).Where("repository_id = ?", repoID).Find(&objects)
+	return objects, err
+}
+
+// RemoveLFSMirrorPending deletes a pending entry after successful download.
+func RemoveLFSMirrorPending(ctx context.Context, repoID int64, oid string) error {
+	_, err := db.GetEngine(ctx).Where("repository_id = ? AND oid = ?", repoID, oid).
+		Delete(&LFSMirrorPending{})
+	return err
+}

--- a/models/git/lfs_mirror_pending_test.go
+++ b/models/git/lfs_mirror_pending_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package git_test
+
+import (
+	"bytes"
+	"testing"
+
+	git_model "gitea.dev/models/git"
+	"gitea.dev/models/unittest"
+	"gitea.dev/modules/lfs"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAddLFSMirrorPending_SharedOIDAcrossRepos ensures two different repositories
+// can both have a pending row for the same OID. The unique constraint must be
+// composite (repository_id, oid), not global on oid alone.
+func TestAddLFSMirrorPending_SharedOIDAcrossRepos(t *testing.T) {
+	require.NoError(t, unittest.PrepareTestDatabase())
+
+	pointer, err := lfs.GeneratePointer(bytes.NewReader([]byte("shared lfs content")))
+	require.NoError(t, err)
+	pointerBlob := lfs.PointerBlob{Hash: "abc123", Pointer: pointer}
+
+	added, err := git_model.AddLFSMirrorPending(t.Context(), 1, pointerBlob)
+	require.NoError(t, err)
+	assert.True(t, added)
+
+	// Same OID, different repo — must not hit a unique constraint violation.
+	added, err = git_model.AddLFSMirrorPending(t.Context(), 2, pointerBlob)
+	require.NoError(t, err)
+	assert.True(t, added)
+}
+
+// TestAddLFSMirrorPending_Idempotent ensures inserting the same (repo, oid) twice
+// is a no-op and does not return an error.
+func TestAddLFSMirrorPending_Idempotent(t *testing.T) {
+	require.NoError(t, unittest.PrepareTestDatabase())
+
+	pointer, err := lfs.GeneratePointer(bytes.NewReader([]byte("idempotent content")))
+	require.NoError(t, err)
+	pointerBlob := lfs.PointerBlob{Hash: "abc123", Pointer: pointer}
+
+	added, err := git_model.AddLFSMirrorPending(t.Context(), 1, pointerBlob)
+	require.NoError(t, err)
+	assert.True(t, added)
+
+	added, err = git_model.AddLFSMirrorPending(t.Context(), 1, pointerBlob)
+	require.NoError(t, err)
+	assert.False(t, added)
+}

--- a/models/repo/mirror.go
+++ b/models/repo/mirror.go
@@ -33,6 +33,7 @@ type Mirror struct {
 
 	LFS         bool   `xorm:"lfs_enabled NOT NULL DEFAULT false"`
 	LFSEndpoint string `xorm:"lfs_endpoint TEXT"`
+	LFSLastRefs string `xorm:"lfs_last_refs TEXT"`
 
 	RemoteAddress string `xorm:"VARCHAR(2048)"`
 }

--- a/modules/lfs/pointer_scanner_gogit.go
+++ b/modules/lfs/pointer_scanner_gogit.go
@@ -14,6 +14,16 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
+// SearchPointerBlobsInRange scans objects reachable from headRefs but not
+// excludeRefs for LFS pointer files. For the gogit build this falls back to a
+// full scan since go-git does not easily support rev-list range queries.
+func SearchPointerBlobsInRange(ctx context.Context, repo *git.Repository, headRefs, excludeRefs []string, pointerChan chan<- PointerBlob, errChan chan<- error) {
+	if err := SearchPointerBlobs(ctx, repo, pointerChan); err != nil {
+		errChan <- err
+	}
+	close(errChan)
+}
+
 // SearchPointerBlobs scans the whole repository for LFS pointer files
 func SearchPointerBlobs(ctx context.Context, repo *git.Repository, pointerChan chan<- PointerBlob) error {
 	gitRepo := repo.GoGitRepo()

--- a/modules/lfs/pointer_scanner_nogogit.go
+++ b/modules/lfs/pointer_scanner_nogogit.go
@@ -7,6 +7,7 @@ package lfs
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -56,6 +57,66 @@ func SearchPointerBlobs(ctx context.Context, repo *git.Repository, pointerChan c
 	err := wg.Wait()
 	close(pointerChan)
 	return err
+}
+
+// SearchPointerBlobsInRange scans only the objects reachable from headRefs but
+// not from excludeRefs for LFS pointer files. This is used for incremental
+// mirror sync to avoid scanning the entire repository.
+func SearchPointerBlobsInRange(ctx context.Context, repo *git.Repository, headRefs, excludeRefs []string, pointerChan chan<- PointerBlob, errChan chan<- error) {
+	// Feed refs via stdin to avoid ARG_MAX limits on large repositories.
+	var stdinBuf bytes.Buffer
+	for _, ref := range headRefs {
+		stdinBuf.WriteString(ref)
+		stdinBuf.WriteByte('\n')
+	}
+	for _, ref := range excludeRefs {
+		stdinBuf.WriteByte('^')
+		stdinBuf.WriteString(ref)
+		stdinBuf.WriteByte('\n')
+	}
+
+	cmdRevList := gitcmd.NewCommand()
+	cmdBatchCheck := gitcmd.NewCommand()
+	cmdBatchContent := gitcmd.NewCommand()
+
+	revListStdout, revListClose := cmdRevList.MakeStdoutPipe()
+	defer revListClose()
+
+	batchCheckIn, batchCheckOut, batchCheckClose := cmdBatchCheck.MakeStdinStdoutPipe()
+	defer batchCheckClose()
+
+	batchContentIn, batchContentOut, batchContentClose := cmdBatchContent.MakeStdinStdoutPipe()
+	defer batchContentClose()
+
+	wg := errgroup.Group{}
+	wg.Go(func() error {
+		return createPointerResultsFromCatFileBatch(batchContentOut, pointerChan)
+	})
+	wg.Go(func() error {
+		return pipeline.CatFileBatch(ctx, cmdBatchContent, repo)
+	})
+	wg.Go(func() error {
+		return pipeline.BlobsLessThan1024FromCatFileBatchCheck(batchCheckOut, batchContentIn)
+	})
+	wg.Go(func() error {
+		return pipeline.CatFileBatchCheck(ctx, cmdBatchCheck, repo)
+	})
+	wg.Go(func() error {
+		return pipeline.BlobsFromRevListObjects(revListStdout, batchCheckIn)
+	})
+	wg.Go(func() error {
+		return cmdRevList.AddArguments("rev-list", "--objects", "--ignore-missing", "--stdin").
+			WithStdinBytes(stdinBuf.Bytes()).
+			WithRepo(repo).
+			RunWithStderr(ctx)
+	})
+
+	err := wg.Wait()
+	close(pointerChan)
+	if err != nil {
+		errChan <- err
+	}
+	close(errChan)
 }
 
 func createPointerResultsFromCatFileBatch(catFileBatchReader io.ReadCloser, pointerChan chan<- PointerBlob) error {

--- a/modules/repository/lfs_mirror_test.go
+++ b/modules/repository/lfs_mirror_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package repository
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	git_model "gitea.dev/models/git"
+	repo_model "gitea.dev/models/repo"
+	"gitea.dev/models/unittest"
+	"gitea.dev/modules/lfs"
+	"gitea.dev/modules/setting"
+	"gitea.dev/modules/storage"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockLFSClient is a controllable lfs.Client for exercising the mirror LFS
+// download paths without talking to a real upstream.
+type mockLFSClient struct {
+	batchSize int
+	// download is invoked for each batch; it decides what the callback sees.
+	download func(ctx context.Context, objects []lfs.Pointer, cb lfs.DownloadCallback) error
+}
+
+func (c *mockLFSClient) BatchSize() int {
+	if c.batchSize == 0 {
+		return 20
+	}
+	return c.batchSize
+}
+
+func (c *mockLFSClient) Download(ctx context.Context, objects []lfs.Pointer, cb lfs.DownloadCallback) error {
+	return c.download(ctx, objects, cb)
+}
+
+func (c *mockLFSClient) Upload(ctx context.Context, objects []lfs.Pointer, cb lfs.UploadCallback) error {
+	return nil
+}
+
+// feedPointers returns a channel pre-loaded with the given pointers and closed,
+// mimicking the output of SearchPointerBlobs(InRange).
+func feedPointers(pointers ...lfs.Pointer) <-chan lfs.PointerBlob {
+	ch := make(chan lfs.PointerBlob, len(pointers))
+	for _, p := range pointers {
+		ch <- lfs.PointerBlob{Hash: p.Oid, Pointer: p}
+	}
+	close(ch)
+	return ch
+}
+
+func newTestPointer(t *testing.T, content string) lfs.Pointer {
+	t.Helper()
+	p, err := lfs.GeneratePointer(bytes.NewReader([]byte(content)))
+	require.NoError(t, err)
+	return p
+}
+
+func newTempContentStore(t *testing.T) *lfs.ContentStore {
+	t.Helper()
+	localStore, err := storage.NewLocalStorage(t.Context(), &setting.Storage{Path: t.TempDir()})
+	require.NoError(t, err)
+	return &lfs.ContentStore{ObjectStorage: localStore}
+}
+
+// Test_processLFSPointerChan_DownloadErrorPropagates ensures a genuine download
+// failure is returned (not swallowed), so callers such as runSync will not
+// advance the mirror's LFSLastRefs watermark past unfetched objects.
+func Test_processLFSPointerChan_DownloadErrorPropagates(t *testing.T) {
+	unittest.PrepareTestEnv(t)
+
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+	pointer := newTestPointer(t, "download-error")
+
+	wantErr := errors.New("upstream boom")
+	client := &mockLFSClient{
+		download: func(ctx context.Context, objects []lfs.Pointer, cb lfs.DownloadCallback) error {
+			// Surface a hard per-object error through the callback, mirroring
+			// how performSingleOperation propagates a batch object error.
+			for _, o := range objects {
+				if err := cb(o, nil, wantErr); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+
+	err := processLFSPointerChan(t.Context(), repo, newTempContentStore(t), client, feedPointers(pointer))
+	assert.ErrorIs(t, err, wantErr)
+}
+
+// Test_processLFSPointerChan_CancelledContextPropagates ensures a cancelled sync
+// returns a non-nil error rather than reporting success, which would otherwise
+// let the caller advance LFSLastRefs past an incompletely-scanned range.
+func Test_processLFSPointerChan_CancelledContextPropagates(t *testing.T) {
+	unittest.PrepareTestEnv(t)
+
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+	pointer := newTestPointer(t, "cancelled")
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	client := &mockLFSClient{
+		download: func(dlCtx context.Context, objects []lfs.Pointer, cb lfs.DownloadCallback) error {
+			// Simulate the real client observing the parent cancellation: the
+			// errgroup returns the context error.
+			cancel()
+			return dlCtx.Err()
+		},
+	}
+
+	// AddLFSMirrorPending records the pointer first; the download then fails due
+	// to cancellation. We must still see a non-nil error out of the function.
+	err := processLFSPointerChan(ctx, repo, newTempContentStore(t), client, feedPointers(pointer))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// Test_processLFSPointerChan_HappyPath ensures a successful download promotes the
+// pointer to lfs_meta_object and clears the pending row.
+func Test_processLFSPointerChan_HappyPath(t *testing.T) {
+	unittest.PrepareTestEnv(t)
+
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+	content := "happy-path-content"
+	pointer := newTestPointer(t, content)
+
+	client := &mockLFSClient{
+		download: func(ctx context.Context, objects []lfs.Pointer, cb lfs.DownloadCallback) error {
+			for _, o := range objects {
+				rc := io.NopCloser(bytes.NewReader([]byte(content)))
+				if err := cb(o, rc, nil); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+
+	err := processLFSPointerChan(t.Context(), repo, newTempContentStore(t), client, feedPointers(pointer))
+	require.NoError(t, err)
+
+	// Promoted to a real meta object...
+	_, err = git_model.GetLFSMetaObjectByOid(t.Context(), repo.ID, pointer.Oid)
+	assert.NoError(t, err)
+
+	// ...and no longer pending.
+	pending, err := git_model.GetLFSMirrorPendingByRepoID(t.Context(), repo.ID)
+	assert.NoError(t, err)
+	for _, p := range pending {
+		assert.NotEqual(t, pointer.Oid, p.Oid, "pointer should have been removed from pending")
+	}
+}

--- a/modules/repository/repo.go
+++ b/modules/repository/repo.go
@@ -57,7 +57,8 @@ func SyncRepoTags(ctx context.Context, repoID int64) error {
 	return err
 }
 
-// StoreMissingLfsObjectsInRepository downloads missing LFS objects
+// StoreMissingLfsObjectsInRepository downloads missing LFS objects using a full
+// repository scan. Used for initial mirror sync and migrations.
 func StoreMissingLfsObjectsInRepository(ctx context.Context, repo *repo_model.Repository, gitRepo *git.Repository, lfsClient lfs.Client) error {
 	contentStore := lfs.NewContentStore()
 
@@ -67,10 +68,72 @@ func StoreMissingLfsObjectsInRepository(ctx context.Context, repo *repo_model.Re
 		errChan <- lfs.SearchPointerBlobs(ctx, gitRepo, pointerChan)
 	}()
 
+	if err := processLFSPointerChan(ctx, repo, contentStore, lfsClient, pointerChan); err != nil {
+		return err
+	}
+
+	err, has := <-errChan
+	if has {
+		log.Error("Repo[%-v]: Error enumerating LFS objects for repository: %v", repo, err)
+		return err
+	}
+
+	return nil
+}
+
+// SyncMirrorLfsObjects performs an incremental LFS sync for a pull mirror. It
+// scans only objects reachable from current refs but not from lastRefs (the ref
+// tips recorded after the previous successful sync), then retries any previously
+// discovered pointers whose content was unavailable upstream.
+// Returns the current ref tips to be stored for the next sync.
+func SyncMirrorLfsObjects(ctx context.Context, repo *repo_model.Repository, gitRepo *git.Repository, lfsClient lfs.Client, lastRefs []string) (currentRefs []string, err error) {
+	contentStore := lfs.NewContentStore()
+
+	currentRefs, err = getCurrentRefSHAs(ctx, gitRepo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current refs: %w", err)
+	}
+
+	if len(lastRefs) == 0 {
+		log.Trace("Repo[%-v]: No previous LFS ref state, performing full scan", repo)
+		if err := StoreMissingLfsObjectsInRepository(ctx, repo, gitRepo, lfsClient); err != nil {
+			return nil, err
+		}
+		return currentRefs, nil
+	}
+
+	// Incremental scan: only look at objects new since last sync
+	pointerChan := make(chan lfs.PointerBlob)
+	errChan := make(chan error, 1)
+	go lfs.SearchPointerBlobsInRange(ctx, gitRepo, currentRefs, lastRefs, pointerChan, errChan)
+
+	if err := processLFSPointerChan(ctx, repo, contentStore, lfsClient, pointerChan); err != nil {
+		return nil, err
+	}
+
+	scanErr, has := <-errChan
+	if has {
+		log.Error("Repo[%-v]: Error in incremental LFS scan: %v", repo, scanErr)
+		return nil, scanErr
+	}
+
+	// Retry previously failed (pending) objects
+	if err := retryPendingLFSObjects(ctx, repo, contentStore, lfsClient); err != nil {
+		return nil, err
+	}
+
+	return currentRefs, nil
+}
+
+// processLFSPointerChan processes discovered LFS pointers: records them as
+// pending in lfs_mirror_pending, then attempts to download their content from
+// the upstream LFS server. Successfully downloaded objects are promoted to
+// lfs_meta_object and removed from the pending table.
+func processLFSPointerChan(ctx context.Context, repo *repo_model.Repository, contentStore *lfs.ContentStore, lfsClient lfs.Client, pointerChan <-chan lfs.PointerBlob) error {
 	downloadObjects := func(pointers []lfs.Pointer) error {
 		err := lfsClient.Download(ctx, pointers, func(p lfs.Pointer, content io.ReadCloser, objectError error) error {
 			if errors.Is(objectError, lfs.ErrObjectNotExist) {
-				log.Warn("Ignoring missing upstream LFS object %-v: %v", p, objectError)
+				log.Warn("Repo[%-v]: Upstream missing LFS object %-v: %v", repo, p, objectError)
 				return nil
 			}
 
@@ -80,45 +143,40 @@ func StoreMissingLfsObjectsInRepository(ctx context.Context, repo *repo_model.Re
 
 			defer content.Close()
 
-			_, err := git_model.NewLFSMetaObject(ctx, repo.ID, p)
-			if err != nil {
+			if err := contentStore.Put(p, content); err != nil {
+				log.Error("Repo[%-v]: Error storing content for LFS meta object %-v: %v", repo, p, err)
+				return err
+			}
+			if _, err := git_model.NewLFSMetaObject(ctx, repo.ID, p); err != nil {
 				log.Error("Repo[%-v]: Error creating LFS meta object %-v: %v", repo, p, err)
 				return err
 			}
-
-			if err := contentStore.Put(p, content); err != nil {
-				log.Error("Repo[%-v]: Error storing content for LFS meta object %-v: %v", repo, p, err)
-				if _, err2 := git_model.RemoveLFSMetaObjectByOid(ctx, repo.ID, p.Oid); err2 != nil {
-					log.Error("Repo[%-v]: Error removing LFS meta object %-v: %v", repo, p, err2)
-				}
+			if err := git_model.RemoveLFSMirrorPending(ctx, repo.ID, p.Oid); err != nil {
+				log.Error("Repo[%-v]: Error removing pending LFS object %-v: %v", repo, p, err)
 				return err
 			}
 			return nil
 		})
-		if err != nil {
-			select {
-			case <-ctx.Done():
-				return nil
-			default:
-			}
-		}
+		// err may be a context-cancellation error if the parent context was
+		// killed; nil on the happy path, a real error otherwise. We deliberately
+		// return it unmodified so a cancelled/failed sync does not advance the
+		// mirror's LFSLastRefs watermark (see runSync).
 		return err
 	}
 
 	var batch []lfs.Pointer
 	for pointerBlob := range pointerChan {
-		meta, err := git_model.GetLFSMetaObjectByOid(ctx, repo.ID, pointerBlob.Oid)
-		if err != nil && err != git_model.ErrLFSObjectNotExist {
-			log.Error("Repo[%-v]: Error querying LFS meta object %-v: %v", repo, pointerBlob.Pointer, err)
+		// Record as pending if not already tracked
+		isNew, err := git_model.AddLFSMirrorPending(ctx, repo.ID, pointerBlob)
+		if err != nil {
+			log.Error("Repo[%-v]: Error recording pending LFS object %-v: %v", repo, pointerBlob.Pointer, err)
 			return err
 		}
-		if meta != nil {
-			log.Trace("Repo[%-v]: Skipping unknown LFS meta object %-v", repo, pointerBlob.Pointer)
+		if !isNew {
 			continue
 		}
 
-		log.Trace("Repo[%-v]: LFS object %-v not present in repository", repo, pointerBlob.Pointer)
-
+		// Check if content already exists in the local store
 		exist, err := contentStore.Exists(pointerBlob.Pointer)
 		if err != nil {
 			log.Error("Repo[%-v]: Error checking if LFS object %-v exists: %v", repo, pointerBlob.Pointer, err)
@@ -127,9 +185,12 @@ func StoreMissingLfsObjectsInRepository(ctx context.Context, repo *repo_model.Re
 
 		if exist {
 			log.Trace("Repo[%-v]: LFS object %-v already present; creating meta object", repo, pointerBlob.Pointer)
-			_, err := git_model.NewLFSMetaObject(ctx, repo.ID, pointerBlob.Pointer)
-			if err != nil {
+			if _, err := git_model.NewLFSMetaObject(ctx, repo.ID, pointerBlob.Pointer); err != nil {
 				log.Error("Repo[%-v]: Error creating LFS meta object %-v: %v", repo, pointerBlob.Pointer, err)
+				return err
+			}
+			if err := git_model.RemoveLFSMirrorPending(ctx, repo.ID, pointerBlob.Oid); err != nil {
+				log.Error("Repo[%-v]: Error removing pending LFS object %-v: %v", repo, pointerBlob.Pointer, err)
 				return err
 			}
 		} else {
@@ -152,13 +213,87 @@ func StoreMissingLfsObjectsInRepository(ctx context.Context, repo *repo_model.Re
 			return err
 		}
 	}
+	return nil
+}
 
-	err := <-errChan
+// retryPendingLFSObjects re-attempts download of LFS objects that were
+// previously discovered but whose content was unavailable upstream.
+func retryPendingLFSObjects(ctx context.Context, repo *repo_model.Repository, contentStore *lfs.ContentStore, lfsClient lfs.Client) error {
+	pending, err := git_model.GetLFSMirrorPendingByRepoID(ctx, repo.ID)
 	if err != nil {
-		log.Error("Repo[%-v]: Error enumerating LFS objects for repository: %v", repo, err)
+		log.Error("Repo[%-v]: Error getting pending LFS objects: %v", repo, err)
+		return err
+	}
+	if len(pending) == 0 {
+		return nil
 	}
 
-	return err
+	log.Trace("Repo[%-v]: Retrying %d pending LFS objects", repo, len(pending))
+
+	downloadObjects := func(pointers []lfs.Pointer) error {
+		err := lfsClient.Download(ctx, pointers, func(p lfs.Pointer, content io.ReadCloser, objectError error) error {
+			if errors.Is(objectError, lfs.ErrObjectNotExist) {
+				log.Trace("Repo[%-v]: Upstream still missing LFS object %-v", repo, p)
+				return nil
+			}
+			if objectError != nil {
+				return objectError
+			}
+
+			defer content.Close()
+
+			if err := contentStore.Put(p, content); err != nil {
+				log.Error("Repo[%-v]: Error storing content for LFS object %-v: %v", repo, p, err)
+				return err
+			}
+			if _, err := git_model.NewLFSMetaObject(ctx, repo.ID, p); err != nil {
+				log.Error("Repo[%-v]: Error creating LFS meta object %-v: %v", repo, p, err)
+				return err
+			}
+			if err := git_model.RemoveLFSMirrorPending(ctx, repo.ID, p.Oid); err != nil {
+				log.Error("Repo[%-v]: Error removing pending LFS object %-v: %v", repo, p, err)
+				return err
+			}
+			return nil
+		})
+		// See processLFSPointerChan: return err unmodified (including any
+		// context-cancellation error) so a cancelled retry does not let the
+		// caller advance LFSLastRefs past objects that were never downloaded.
+		return err
+	}
+
+	var batch []lfs.Pointer
+	for _, obj := range pending {
+		if setting.LFS.MaxFileSize > 0 && obj.Size > setting.LFS.MaxFileSize {
+			continue
+		}
+		batch = append(batch, lfs.Pointer{Oid: obj.Oid, Size: obj.Size})
+		if len(batch) >= lfsClient.BatchSize() {
+			if err := downloadObjects(batch); err != nil {
+				return err
+			}
+			batch = nil
+		}
+	}
+	if len(batch) > 0 {
+		if err := downloadObjects(batch); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// getCurrentRefSHAs returns the SHA of every ref in the repository.
+func getCurrentRefSHAs(ctx context.Context, gitRepo *git.Repository) ([]string, error) {
+	allRefs, err := gitRepo.GetRefs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	refs := make([]string, 0, len(allRefs))
+	for _, ref := range allRefs {
+		refs = append(refs, ref.Object.String())
+	}
+	return refs, nil
 }
 
 // shortRelease to reduce load memory, this struct can replace repo_model.Release

--- a/modules/repository/repo.go
+++ b/modules/repository/repo.go
@@ -56,7 +56,8 @@ func SyncRepoTags(ctx context.Context, repoID int64) error {
 	return err
 }
 
-// StoreMissingLfsObjectsInRepository downloads missing LFS objects
+// StoreMissingLfsObjectsInRepository downloads missing LFS objects using a full
+// repository scan. Used for initial mirror sync and migrations.
 func StoreMissingLfsObjectsInRepository(ctx context.Context, repo *repo_model.Repository, gitRepo *git.Repository, lfsClient lfs.Client) error {
 	contentStore := lfs.NewContentStore()
 
@@ -66,10 +67,72 @@ func StoreMissingLfsObjectsInRepository(ctx context.Context, repo *repo_model.Re
 		errChan <- lfs.SearchPointerBlobs(ctx, gitRepo, pointerChan)
 	}()
 
+	if err := processLFSPointerChan(ctx, repo, contentStore, lfsClient, pointerChan); err != nil {
+		return err
+	}
+
+	err, has := <-errChan
+	if has {
+		log.Error("Repo[%-v]: Error enumerating LFS objects for repository: %v", repo, err)
+		return err
+	}
+
+	return nil
+}
+
+// SyncMirrorLfsObjects performs an incremental LFS sync for a pull mirror. It
+// scans only objects reachable from current refs but not from lastRefs (the ref
+// tips recorded after the previous successful sync), then retries any previously
+// discovered pointers whose content was unavailable upstream.
+// Returns the current ref tips to be stored for the next sync.
+func SyncMirrorLfsObjects(ctx context.Context, repo *repo_model.Repository, gitRepo *git.Repository, lfsClient lfs.Client, lastRefs []string) (currentRefs []string, err error) {
+	contentStore := lfs.NewContentStore()
+
+	currentRefs, err = getCurrentRefSHAs(ctx, gitRepo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current refs: %w", err)
+	}
+
+	if len(lastRefs) == 0 {
+		log.Trace("Repo[%-v]: No previous LFS ref state, performing full scan", repo)
+		if err := StoreMissingLfsObjectsInRepository(ctx, repo, gitRepo, lfsClient); err != nil {
+			return nil, err
+		}
+		return currentRefs, nil
+	}
+
+	// Incremental scan: only look at objects new since last sync
+	pointerChan := make(chan lfs.PointerBlob)
+	errChan := make(chan error, 1)
+	go lfs.SearchPointerBlobsInRange(ctx, gitRepo, currentRefs, lastRefs, pointerChan, errChan)
+
+	if err := processLFSPointerChan(ctx, repo, contentStore, lfsClient, pointerChan); err != nil {
+		return nil, err
+	}
+
+	scanErr, has := <-errChan
+	if has {
+		log.Error("Repo[%-v]: Error in incremental LFS scan: %v", repo, scanErr)
+		return nil, scanErr
+	}
+
+	// Retry previously failed (pending) objects
+	if err := retryPendingLFSObjects(ctx, repo, contentStore, lfsClient); err != nil {
+		return nil, err
+	}
+
+	return currentRefs, nil
+}
+
+// processLFSPointerChan processes discovered LFS pointers: records them as
+// pending in lfs_mirror_pending, then attempts to download their content from
+// the upstream LFS server. Successfully downloaded objects are promoted to
+// lfs_meta_object and removed from the pending table.
+func processLFSPointerChan(ctx context.Context, repo *repo_model.Repository, contentStore *lfs.ContentStore, lfsClient lfs.Client, pointerChan <-chan lfs.PointerBlob) error {
 	downloadObjects := func(pointers []lfs.Pointer) error {
 		err := lfsClient.Download(ctx, pointers, func(p lfs.Pointer, content io.ReadCloser, objectError error) error {
 			if errors.Is(objectError, lfs.ErrObjectNotExist) {
-				log.Warn("Ignoring missing upstream LFS object %-v: %v", p, objectError)
+				log.Warn("Repo[%-v]: Upstream missing LFS object %-v: %v", repo, p, objectError)
 				return nil
 			}
 
@@ -79,45 +142,40 @@ func StoreMissingLfsObjectsInRepository(ctx context.Context, repo *repo_model.Re
 
 			defer content.Close()
 
-			_, err := git_model.NewLFSMetaObject(ctx, repo.ID, p)
-			if err != nil {
+			if err := contentStore.Put(p, content); err != nil {
+				log.Error("Repo[%-v]: Error storing content for LFS meta object %-v: %v", repo, p, err)
+				return err
+			}
+			if _, err := git_model.NewLFSMetaObject(ctx, repo.ID, p); err != nil {
 				log.Error("Repo[%-v]: Error creating LFS meta object %-v: %v", repo, p, err)
 				return err
 			}
-
-			if err := contentStore.Put(p, content); err != nil {
-				log.Error("Repo[%-v]: Error storing content for LFS meta object %-v: %v", repo, p, err)
-				if _, err2 := git_model.RemoveLFSMetaObjectByOid(ctx, repo.ID, p.Oid); err2 != nil {
-					log.Error("Repo[%-v]: Error removing LFS meta object %-v: %v", repo, p, err2)
-				}
+			if err := git_model.RemoveLFSMirrorPending(ctx, repo.ID, p.Oid); err != nil {
+				log.Error("Repo[%-v]: Error removing pending LFS object %-v: %v", repo, p, err)
 				return err
 			}
 			return nil
 		})
-		if err != nil {
-			select {
-			case <-ctx.Done():
-				return nil
-			default:
-			}
-		}
+		// err may be a context-cancellation error if the parent context was
+		// killed; nil on the happy path, a real error otherwise. We deliberately
+		// return it unmodified so a cancelled/failed sync does not advance the
+		// mirror's LFSLastRefs watermark (see runSync).
 		return err
 	}
 
 	var batch []lfs.Pointer
 	for pointerBlob := range pointerChan {
-		meta, err := git_model.GetLFSMetaObjectByOid(ctx, repo.ID, pointerBlob.Oid)
-		if err != nil && err != git_model.ErrLFSObjectNotExist {
-			log.Error("Repo[%-v]: Error querying LFS meta object %-v: %v", repo, pointerBlob.Pointer, err)
+		// Record as pending if not already tracked
+		isNew, err := git_model.AddLFSMirrorPending(ctx, repo.ID, pointerBlob)
+		if err != nil {
+			log.Error("Repo[%-v]: Error recording pending LFS object %-v: %v", repo, pointerBlob.Pointer, err)
 			return err
 		}
-		if meta != nil {
-			log.Trace("Repo[%-v]: Skipping unknown LFS meta object %-v", repo, pointerBlob.Pointer)
+		if !isNew {
 			continue
 		}
 
-		log.Trace("Repo[%-v]: LFS object %-v not present in repository", repo, pointerBlob.Pointer)
-
+		// Check if content already exists in the local store
 		exist, err := contentStore.Exists(pointerBlob.Pointer)
 		if err != nil {
 			log.Error("Repo[%-v]: Error checking if LFS object %-v exists: %v", repo, pointerBlob.Pointer, err)
@@ -126,9 +184,12 @@ func StoreMissingLfsObjectsInRepository(ctx context.Context, repo *repo_model.Re
 
 		if exist {
 			log.Trace("Repo[%-v]: LFS object %-v already present; creating meta object", repo, pointerBlob.Pointer)
-			_, err := git_model.NewLFSMetaObject(ctx, repo.ID, pointerBlob.Pointer)
-			if err != nil {
+			if _, err := git_model.NewLFSMetaObject(ctx, repo.ID, pointerBlob.Pointer); err != nil {
 				log.Error("Repo[%-v]: Error creating LFS meta object %-v: %v", repo, pointerBlob.Pointer, err)
+				return err
+			}
+			if err := git_model.RemoveLFSMirrorPending(ctx, repo.ID, pointerBlob.Oid); err != nil {
+				log.Error("Repo[%-v]: Error removing pending LFS object %-v: %v", repo, pointerBlob.Pointer, err)
 				return err
 			}
 		} else {
@@ -151,13 +212,87 @@ func StoreMissingLfsObjectsInRepository(ctx context.Context, repo *repo_model.Re
 			return err
 		}
 	}
+	return nil
+}
 
-	err := <-errChan
+// retryPendingLFSObjects re-attempts download of LFS objects that were
+// previously discovered but whose content was unavailable upstream.
+func retryPendingLFSObjects(ctx context.Context, repo *repo_model.Repository, contentStore *lfs.ContentStore, lfsClient lfs.Client) error {
+	pending, err := git_model.GetLFSMirrorPendingByRepoID(ctx, repo.ID)
 	if err != nil {
-		log.Error("Repo[%-v]: Error enumerating LFS objects for repository: %v", repo, err)
+		log.Error("Repo[%-v]: Error getting pending LFS objects: %v", repo, err)
+		return err
+	}
+	if len(pending) == 0 {
+		return nil
 	}
 
-	return err
+	log.Trace("Repo[%-v]: Retrying %d pending LFS objects", repo, len(pending))
+
+	downloadObjects := func(pointers []lfs.Pointer) error {
+		err := lfsClient.Download(ctx, pointers, func(p lfs.Pointer, content io.ReadCloser, objectError error) error {
+			if errors.Is(objectError, lfs.ErrObjectNotExist) {
+				log.Trace("Repo[%-v]: Upstream still missing LFS object %-v", repo, p)
+				return nil
+			}
+			if objectError != nil {
+				return objectError
+			}
+
+			defer content.Close()
+
+			if err := contentStore.Put(p, content); err != nil {
+				log.Error("Repo[%-v]: Error storing content for LFS object %-v: %v", repo, p, err)
+				return err
+			}
+			if _, err := git_model.NewLFSMetaObject(ctx, repo.ID, p); err != nil {
+				log.Error("Repo[%-v]: Error creating LFS meta object %-v: %v", repo, p, err)
+				return err
+			}
+			if err := git_model.RemoveLFSMirrorPending(ctx, repo.ID, p.Oid); err != nil {
+				log.Error("Repo[%-v]: Error removing pending LFS object %-v: %v", repo, p, err)
+				return err
+			}
+			return nil
+		})
+		// See processLFSPointerChan: return err unmodified (including any
+		// context-cancellation error) so a cancelled retry does not let the
+		// caller advance LFSLastRefs past objects that were never downloaded.
+		return err
+	}
+
+	var batch []lfs.Pointer
+	for _, obj := range pending {
+		if setting.LFS.MaxFileSize > 0 && obj.Size > setting.LFS.MaxFileSize {
+			continue
+		}
+		batch = append(batch, lfs.Pointer{Oid: obj.Oid, Size: obj.Size})
+		if len(batch) >= lfsClient.BatchSize() {
+			if err := downloadObjects(batch); err != nil {
+				return err
+			}
+			batch = nil
+		}
+	}
+	if len(batch) > 0 {
+		if err := downloadObjects(batch); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// getCurrentRefSHAs returns the SHA of every ref in the repository.
+func getCurrentRefSHAs(ctx context.Context, gitRepo *git.Repository) ([]string, error) {
+	allRefs, err := gitRepo.GetRefs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	refs := make([]string, 0, len(allRefs))
+	for _, ref := range allRefs {
+		refs = append(refs, ref.Object.String())
+	}
+	return refs, nil
 }
 
 // shortRelease to reduce load memory, this struct can replace repo_model.Release

--- a/modules/setting/metrics.go
+++ b/modules/setting/metrics.go
@@ -5,15 +5,17 @@ package setting
 
 // Metrics settings
 var Metrics = struct {
-	Enabled                  bool
-	Token                    string
-	EnabledIssueByLabel      bool
-	EnabledIssueByRepository bool
+	Enabled                   bool
+	Token                     string
+	EnabledIssueByLabel       bool
+	EnabledIssueByRepository  bool
+	EnabledMirrorSyncDuration bool
 }{
-	Enabled:                  false,
-	Token:                    "",
-	EnabledIssueByLabel:      false,
-	EnabledIssueByRepository: false,
+	Enabled:                   false,
+	Token:                     "",
+	EnabledIssueByLabel:       false,
+	EnabledIssueByRepository:  false,
+	EnabledMirrorSyncDuration: false,
 }
 
 func loadMetricsFrom(rootCfg ConfigProvider) {

--- a/services/mirror/mirror_pull.go
+++ b/services/mirror/mirror_pull.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	git_model "gitea.dev/models/git"
 	repo_model "gitea.dev/models/repo"
 	system_model "gitea.dev/models/system"
 	"gitea.dev/modules/git"
@@ -184,8 +185,28 @@ func runSync(ctx context.Context, m *repo_model.Mirror) ([]*repo_module.SyncResu
 		lfsClient, err := lfs.NewClientFromEndpoint(remoteURL.String(), m.LFSEndpoint, migrations.NewMigrationHTTPTransport())
 		if err != nil {
 			log.Error("SyncMirrors [repo: %-v]: failed to initialize LFS client: %v", m.Repo.FullName(), err)
-		} else if err = repo_module.StoreMissingLfsObjectsInRepository(ctx, m.Repo, gitRepo, lfsClient); err != nil {
-			log.Error("SyncMirrors [repo: %-v]: failed to synchronize LFS objects for repository: %v", m.Repo.FullName(), err)
+		} else {
+			var lastRefs []string
+			if m.LFSLastRefs != "" {
+				lastRefs = strings.Split(m.LFSLastRefs, "\n")
+			}
+
+			currentRefs, lfsErr := repo_module.SyncMirrorLfsObjects(ctx, m.Repo, gitRepo, lfsClient, lastRefs)
+			if lfsErr != nil {
+				log.Error("SyncMirrors [repo: %-v]: failed to synchronize LFS objects for repository: %v", m.Repo, lfsErr)
+			} else if len(currentRefs) > 0 {
+				m.LFSLastRefs = strings.Join(currentRefs, "\n")
+				if err = repo_model.UpdateMirror(ctx, m); err != nil {
+					log.Error("SyncMirrors [repo: %-v]: failed to update mirror LFS refs: %v", m.Repo, err)
+				}
+			}
+
+			pendingCount, pendingErr := git_model.CountLFSMirrorPendingByRepoID(ctx, m.Repo.ID)
+			if pendingErr != nil {
+				log.Error("SyncMirrors [repo: %-v]: failed to get pending LFS count: %v", m.Repo, pendingErr)
+			} else {
+				recordMirrorLFSPending(m.Repo.OwnerName, m.Repo.Name, pendingCount)
+			}
 		}
 	}
 

--- a/services/mirror/mirror_pull_metrics.go
+++ b/services/mirror/mirror_pull_metrics.go
@@ -1,0 +1,34 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package mirror
+
+import (
+	"gitea.dev/modules/log"
+	"gitea.dev/modules/setting"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var mirrorLFSPendingGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: "gitea",
+	Subsystem: "mirror",
+	Name:      "lfs_pending_objects",
+	Help:      "Current number of LFS objects pending download from upstream.",
+}, []string{"owner", "repo"})
+
+func init() {
+	prometheus.MustRegister(mirrorLFSPendingGauge)
+}
+
+func recordMirrorLFSPending(owner, repo string, count int64) {
+	if !setting.Metrics.Enabled || !setting.Metrics.EnabledMirrorSyncDuration {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("mirror.recordMirrorLFSPending panic: %v", r)
+		}
+	}()
+	mirrorLFSPendingGauge.WithLabelValues(owner, repo).Set(float64(count))
+}

--- a/services/mirror/mirror_pull_metrics_test.go
+++ b/services/mirror/mirror_pull_metrics_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package mirror
+
+import (
+	"testing"
+
+	"gitea.dev/modules/setting"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func getGaugeValue(t *testing.T, owner, repo string) float64 {
+	t.Helper()
+	gauge, err := mirrorLFSPendingGauge.GetMetricWithLabelValues(owner, repo)
+	require.NoError(t, err)
+	var m dto.Metric
+	writer, ok := gauge.(interface{ Write(*dto.Metric) error })
+	require.True(t, ok)
+	require.NoError(t, writer.Write(&m))
+	return m.GetGauge().GetValue()
+}
+
+func TestRecordMirrorLFSPendingDisabledWhenMetricsOff(t *testing.T) {
+	orig := setting.Metrics
+	defer func() { setting.Metrics = orig }()
+
+	setting.Metrics.Enabled = false
+	setting.Metrics.EnabledMirrorSyncDuration = true
+
+	recordMirrorLFSPending("org", "repo", 42)
+
+	assert.InDelta(t, float64(0), getGaugeValue(t, "org", "repo"), 1e-9)
+}
+
+func TestRecordMirrorLFSPendingDisabledWhenDurationOff(t *testing.T) {
+	orig := setting.Metrics
+	defer func() { setting.Metrics = orig }()
+
+	setting.Metrics.Enabled = true
+	setting.Metrics.EnabledMirrorSyncDuration = false
+
+	recordMirrorLFSPending("org2", "repo2", 7)
+
+	assert.InDelta(t, float64(0), getGaugeValue(t, "org2", "repo2"), 1e-9)
+}
+
+func TestRecordMirrorLFSPendingEnabled(t *testing.T) {
+	orig := setting.Metrics
+	defer func() { setting.Metrics = orig }()
+
+	setting.Metrics.Enabled = true
+	setting.Metrics.EnabledMirrorSyncDuration = true
+
+	recordMirrorLFSPending("enabled-org", "enabled-repo", 5)
+	assert.InDelta(t, float64(5), getGaugeValue(t, "enabled-org", "enabled-repo"), 1e-9)
+
+	recordMirrorLFSPending("enabled-org", "enabled-repo", 3)
+	assert.InDelta(t, float64(3), getGaugeValue(t, "enabled-org", "enabled-repo"), 1e-9)
+}

--- a/services/mirror/mirror_pull_metrics_test.go
+++ b/services/mirror/mirror_pull_metrics_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package mirror
+
+import (
+	"testing"
+
+	"gitea.dev/modules/setting"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func getGaugeValue(t *testing.T, owner, repo string) float64 {
+	t.Helper()
+	gauge, err := mirrorLFSPendingGauge.GetMetricWithLabelValues(owner, repo)
+	require.NoError(t, err)
+	var m dto.Metric
+	require.NoError(t, gauge.(interface{ Write(*dto.Metric) error }).Write(&m))
+	return m.GetGauge().GetValue()
+}
+
+func TestRecordMirrorLFSPendingDisabledWhenMetricsOff(t *testing.T) {
+	orig := setting.Metrics
+	defer func() { setting.Metrics = orig }()
+
+	setting.Metrics.Enabled = false
+	setting.Metrics.EnabledMirrorSyncDuration = true
+
+	recordMirrorLFSPending("org", "repo", 42)
+
+	assert.InDelta(t, float64(0), getGaugeValue(t, "org", "repo"), 1e-9)
+}
+
+func TestRecordMirrorLFSPendingDisabledWhenDurationOff(t *testing.T) {
+	orig := setting.Metrics
+	defer func() { setting.Metrics = orig }()
+
+	setting.Metrics.Enabled = true
+	setting.Metrics.EnabledMirrorSyncDuration = false
+
+	recordMirrorLFSPending("org2", "repo2", 7)
+
+	assert.InDelta(t, float64(0), getGaugeValue(t, "org2", "repo2"), 1e-9)
+}
+
+func TestRecordMirrorLFSPendingEnabled(t *testing.T) {
+	orig := setting.Metrics
+	defer func() { setting.Metrics = orig }()
+
+	setting.Metrics.Enabled = true
+	setting.Metrics.EnabledMirrorSyncDuration = true
+
+	recordMirrorLFSPending("enabled-org", "enabled-repo", 5)
+	assert.InDelta(t, float64(5), getGaugeValue(t, "enabled-org", "enabled-repo"), 1e-9)
+
+	recordMirrorLFSPending("enabled-org", "enabled-repo", 3)
+	assert.InDelta(t, float64(3), getGaugeValue(t, "enabled-org", "enabled-repo"), 1e-9)
+}

--- a/services/repository/lfs.go
+++ b/services/repository/lfs.go
@@ -132,5 +132,23 @@ func GarbageCollectLFSMetaObjectsForRepo(ctx context.Context, repo *repo_model.R
 	} else if err != nil {
 		return err
 	}
+
+	// Clean up orphaned lfs_mirror_pending rows whose pointer blobs have been
+	// garbage-collected (e.g. after a branch deletion and git gc).
+	if opts.AutoFix {
+		pending, err := git_model.GetLFSMirrorPendingByRepoID(ctx, repo.ID)
+		if err != nil {
+			return err
+		}
+		for _, pointerBlob := range pending {
+			if pointerBlob.BlobSha == "" || gitRepo.IsObjectExist(ctx, pointerBlob.BlobSha) {
+				continue
+			}
+			if err := git_model.RemoveLFSMirrorPending(ctx, repo.ID, pointerBlob.Oid); err != nil {
+				log.Error("Unable to remove orphaned pending LFS object %s in %s: %v", pointerBlob.Oid, repo.FullName(), err)
+			}
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
When lfs server is enabled for a mirror repository, each mirror sync attempt will run cat-file over *every object in the mirror*. This is very expensive for large repositories.

This branch introduces a significant performance improvement for mirrorSync times for larger repositories by:
1. only running the cat-file check for discovering lfs files over the *delta* of refs synced during that iteration, as opposed to the whole repository every sync
2. appending discovered lfs pointers to a new `lfs_mirror_pending` table to track missing oids across subsequent runs (for instance when a client failed to `git lfs push`, we want to retry on subsequent syncs)
3. adds a prometheus metric labelled per repository which counts the number of missing lfs files

I chose to make this a new table instead of adding a column to `lfs_meta_object` (which currently stores the lfs pointer metadata) for two reasons:
1) rollback: the behavior this way is that you could roll back to a prior gitea version, and simply inherit the prior behavior where lfs pointer discovery scanned the whole repo every mirrorSync. If it was a column on the existing table, rollback would require reverting the database change
2) there are quite a few apis for serving lfs files which treat any row/entry in `lfs_meta_object` as authoritative that the lfs file existed. I would have had to sprinkle conditionals all throughout `services/lfs/server.go`, `repo/view.go,`, `repo/download.go`, `api/v1/repo/file.go`, probably elsewhere. This change was already big enough.

Using https://github.com/go-gitea/gitea/pull/38153 to track sync times for various steps, this took the 'lfs' step for one of our very large repositories from ~40 minutes on average down to ~20 seconds. This is not round-trip time to the upstream lfs server, this is purely the time taken to cat-file all the objects in the repository with the fastest disk available in our cloud-provider and plenty of compute headroom.

I could see potentially extending this functionality in the future with some configurable backoff algorithm for missing lfs files. At my company, we tend to have branches that stick around for a long time and will basically never get their missing lfs files ever pushed, retrying them every mirrorSync is rude to our lfs upstream. We could default to something like exponential backoff and store the 'last attempted' time in this new table. Again, this change was big enough, so I didn't include that this first round.
