### PR TITLE
feat(auth): add id_token_hint to OIDC RP-Initiated Logout

### DIFF
--- a/modules/session/key.go
+++ b/modules/session/key.go
@@ -15,4 +15,8 @@ const (
 	KeySignInMethod = "signInMethod"
 
 	SignInMethodOAuth2 = "oauth2"
+
+	// KeyOIDCIDToken holds the raw id_token returned by the OIDC provider at sign-in,
+	// so logout can pass it back as id_token_hint per the RP-Initiated Logout spec.
+	KeyOIDCIDToken = "oidcIDToken"
 )

--- a/routers/web/auth/auth.go
+++ b/routers/web/auth/auth.go
@@ -119,9 +119,13 @@ func autoSignIn(ctx *context.Context) (bool, error) {
 
 	ctx.SetSiteCookie(setting.CookieRememberName, nt.ID+":"+token, setting.LogInRememberDays*timeutil.Day)
 
+	// clear even if unset: a stale OAuth2 sign-in method/id_token from an earlier session
+	// on this browser must not survive an auto sign-in from the remember-me cookie
 	if err := regenerateSession(ctx, map[string]any{
 		session.KeyUID:                  u.ID,
 		session.KeyUserHasTwoFactorAuth: userHasTwoFactorAuth,
+		session.KeySignInMethod:         "",
+		session.KeyOIDCIDToken:          "",
 	}); err != nil {
 		return false, fmt.Errorf("unable to updateSession: %w", err)
 	}
@@ -339,7 +343,12 @@ func SignInPost(ctx *context.Context) {
 		return
 	}
 
-	handleTwoFactorRequired(ctx, u, form.Remember, nil)
+	// clear even if unset: a stale OAuth2 sign-in method/id_token from an earlier session
+	// on this browser must not survive into a password-initiated 2FA flow
+	handleTwoFactorRequired(ctx, u, form.Remember, map[string]any{
+		session.KeySignInMethod: "",
+		session.KeyOIDCIDToken:  "",
+	})
 }
 
 func handleTwoFactorRequired(ctx *context.Context, u *user_model.User, remember bool, extra map[string]any) {
@@ -387,10 +396,22 @@ func handleSignInFull(ctx *context.Context, u *user_model.User, remember bool) {
 		return
 	}
 
+	// a pending 2FA (twofaUid set) means handleTwoFactorRequired already resolved
+	// KeySignInMethod/KeyOIDCIDToken for this flow (real OIDC values, or explicitly
+	// cleared) — carry that forward. Otherwise this is a direct, non-2FA sign-in, so
+	// any leftover value from an unrelated earlier session must not survive.
+	var signInMethod, idToken string
+	if ctx.Session.Get("twofaUid") != nil {
+		signInMethod, _ = ctx.Session.Get(session.KeySignInMethod).(string)
+		idToken, _ = ctx.Session.Get(session.KeyOIDCIDToken).(string)
+	}
+
 	auth_service.ClearSessionKeysForSignIn(ctx.Session)
 	if err := regenerateSession(ctx, map[string]any{
 		session.KeyUID:                  u.ID,
 		session.KeyUserHasTwoFactorAuth: userHasTwoFactorAuth,
+		session.KeySignInMethod:         signInMethod,
+		session.KeyOIDCIDToken:          idToken,
 	}); err != nil {
 		ctx.ServerError("RegenerateSession", err)
 		return

--- a/routers/web/auth/auth_test.go
+++ b/routers/web/auth/auth_test.go
@@ -171,6 +171,63 @@ func TestWebAuthOAuth2(t *testing.T) {
 			assert.Equal(t, "https://example.com/oidc-logout", u.String())
 		})
 
+		t.Run("OAuth2SignInIncludesIDTokenHint", func(t *testing.T) {
+			mockOpt := contexttest.MockContextOption{SessionStore: session.NewMockMemStore("dummy-sid-oauth-idtoken")}
+			ctx, resp := contexttest.MockContext(t, "/user/logout", mockOpt)
+			ctx.Doer = oauthUser
+			require.NoError(t, ctx.Session.Set(session.KeySignInMethod, session.SignInMethodOAuth2))
+			require.NoError(t, ctx.Session.Set(session.KeyOIDCIDToken, "mock-id-token"))
+			SignOut(ctx)
+			assert.Equal(t, http.StatusSeeOther, resp.Code)
+			u, err := url.Parse(test.RedirectURL(resp))
+			require.NoError(t, err)
+			expectedValues := url.Values{"oidc-key": []string{"oidc-val"}, "post_logout_redirect_uri": []string{setting.AppURL}, "client_id": []string{"mock-client-id"}, "id_token_hint": []string{"mock-id-token"}}
+			assert.Equal(t, expectedValues, u.Query())
+		})
+
+		t.Run("OAuth2CallbackStoresIDTokenForLogout", func(t *testing.T) {
+			defer test.MockVariableValue(&gothic.CompleteUserAuth, func(res http.ResponseWriter, req *http.Request) (goth.User, error) {
+				return goth.User{Provider: "oidc-auth-source", UserID: "oidc-new-user", Email: "oidc-new-user@example.com", IDToken: "real-flow-id-token"}, nil
+			})()
+
+			mockOpt := contexttest.MockContextOption{SessionStore: session.NewMockMemStore("dummy-sid-oidc-callback")}
+			ctx, resp := contexttest.MockContext(t, "/user/oauth2/..../callback?code=dummy-code", mockOpt)
+			ctx.SetPathParamRaw("provider", "oidc-auth-source")
+			SignInOAuthCallback(ctx)
+			require.Equal(t, http.StatusSeeOther, resp.Code)
+			assert.Equal(t, "real-flow-id-token", ctx.Session.Get(session.KeyOIDCIDToken))
+
+			// signing out the same session must carry the id_token through as id_token_hint
+			ctx, resp = contexttest.MockContext(t, "/user/logout", mockOpt)
+			ctx.Doer = oauthUser
+			SignOut(ctx)
+			assert.Equal(t, http.StatusSeeOther, resp.Code)
+			u, err := url.Parse(test.RedirectURL(resp))
+			require.NoError(t, err)
+			assert.Equal(t, "real-flow-id-token", u.Query().Get("id_token_hint"))
+		})
+
+		t.Run("OAuth2CallbackWithoutIDTokenOmitsHint", func(t *testing.T) {
+			defer test.MockVariableValue(&gothic.CompleteUserAuth, func(res http.ResponseWriter, req *http.Request) (goth.User, error) {
+				return goth.User{Provider: "oidc-auth-source", UserID: "oidc-new-user-2", Email: "oidc-new-user-2@example.com"}, nil
+			})()
+
+			mockOpt := contexttest.MockContextOption{SessionStore: session.NewMockMemStore("dummy-sid-oidc-callback-no-token")}
+			ctx, resp := contexttest.MockContext(t, "/user/oauth2/..../callback?code=dummy-code", mockOpt)
+			ctx.SetPathParamRaw("provider", "oidc-auth-source")
+			SignInOAuthCallback(ctx)
+			require.Equal(t, http.StatusSeeOther, resp.Code)
+			assert.Nil(t, ctx.Session.Get(session.KeyOIDCIDToken))
+
+			ctx, resp = contexttest.MockContext(t, "/user/logout", mockOpt)
+			ctx.Doer = oauthUser
+			SignOut(ctx)
+			assert.Equal(t, http.StatusSeeOther, resp.Code)
+			u, err := url.Parse(test.RedirectURL(resp))
+			require.NoError(t, err)
+			assert.Empty(t, u.Query().Get("id_token_hint"))
+		})
+
 		t.Run("PasswordSignInSkipsOIDC", func(t *testing.T) {
 			// OAuth2-linked account signed in via password form must not hit end_session_endpoint.
 			mockOpt := contexttest.MockContextOption{SessionStore: session.NewMockMemStore("dummy-sid-password")}

--- a/routers/web/auth/auth_test.go
+++ b/routers/web/auth/auth_test.go
@@ -17,6 +17,7 @@ import (
 	"gitea.dev/modules/setting"
 	"gitea.dev/modules/test"
 	"gitea.dev/modules/util"
+	auth_service "gitea.dev/services/auth"
 	"gitea.dev/services/auth/source/oauth2"
 	"gitea.dev/services/contexttest"
 
@@ -218,7 +219,7 @@ func TestWebAuthOAuth2(t *testing.T) {
 			ctx.SetPathParamRaw("provider", "oidc-auth-source")
 			SignInOAuthCallback(ctx)
 			require.Equal(t, http.StatusSeeOther, resp.Code)
-			assert.Nil(t, ctx.Session.Get(session.KeyOIDCIDToken))
+			assert.Empty(t, ctx.Session.Get(session.KeyOIDCIDToken))
 
 			ctx, resp = contexttest.MockContext(t, "/user/logout", mockOpt)
 			ctx.Doer = oauthUser
@@ -227,6 +228,91 @@ func TestWebAuthOAuth2(t *testing.T) {
 			u, err := url.Parse(test.RedirectURL(resp))
 			require.NoError(t, err)
 			assert.Empty(t, u.Query().Get("id_token_hint"))
+		})
+
+		t.Run("OAuth2CallbackClearsStaleIDTokenOnRegen", func(t *testing.T) {
+			// simulates a user who signed in before with an id_token (stale value already
+			// in the session), then signs in again via a callback that yields no id_token
+			mockOpt := contexttest.MockContextOption{SessionStore: session.NewMockMemStore("dummy-sid-oidc-stale-token")}
+			ctx, resp := contexttest.MockContext(t, "/user/oauth2/..../callback?code=dummy-code", mockOpt)
+			require.NoError(t, ctx.Session.Set(session.KeyOIDCIDToken, "stale-id-token-from-prior-login"))
+			ctx.Doer = oauthUser
+			handleOAuth2SignIn(ctx, authSource, oauthUser, goth.User{Provider: "oidc-auth-source", UserID: "oauth-user"})
+			require.Equal(t, http.StatusSeeOther, resp.Code)
+			assert.Empty(t, ctx.Session.Get(session.KeyOIDCIDToken), "stale id_token from a prior session must not survive regenerateSession")
+
+			ctx, resp = contexttest.MockContext(t, "/user/logout", mockOpt)
+			ctx.Doer = oauthUser
+			SignOut(ctx)
+			assert.Equal(t, http.StatusSeeOther, resp.Code)
+			u, err := url.Parse(test.RedirectURL(resp))
+			require.NoError(t, err)
+			assert.Empty(t, u.Query().Get("id_token_hint"), "logout must not reuse a stale id_token as id_token_hint")
+		})
+
+		t.Run("OAuth2CallbackClearsStaleIDTokenOnRegenWith2FA", func(t *testing.T) {
+			// same as OAuth2CallbackClearsStaleIDTokenOnRegen, but through the 2FA-required
+			// branch in handleOAuth2SignIn, a separate call site from the !needs2FA one
+			tfa := &auth_model.TwoFactor{UID: oauthUser.ID}
+			require.NoError(t, auth_model.NewTwoFactor(t.Context(), tfa))
+			t.Cleanup(func() { _ = auth_model.DeleteTwoFactorByID(t.Context(), tfa.ID, oauthUser.ID) })
+
+			mockOpt := contexttest.MockContextOption{SessionStore: session.NewMockMemStore("dummy-sid-oidc-stale-token-2fa")}
+			ctx, resp := contexttest.MockContext(t, "/user/oauth2/..../callback?code=dummy-code", mockOpt)
+			require.NoError(t, ctx.Session.Set(session.KeyOIDCIDToken, "stale-id-token-from-prior-login"))
+			ctx.Doer = oauthUser
+			handleOAuth2SignIn(ctx, authSource, oauthUser, goth.User{Provider: "oidc-auth-source", UserID: "oauth-user"})
+			require.Equal(t, http.StatusSeeOther, resp.Code)
+			assert.Equal(t, "/user/two_factor", test.RedirectURL(resp))
+			assert.Empty(t, ctx.Session.Get(session.KeyOIDCIDToken), "stale id_token must not survive the 2FA-required regeneration branch")
+		})
+
+		t.Run("PasswordSignInAfterOIDCClearsStaleIDTokenAndMethod", func(t *testing.T) {
+			// a session that previously authenticated via OIDC (KeySignInMethod + KeyOIDCIDToken
+			// set) must not keep redirecting to end_session_endpoint with a stale hint once the
+			// same browser session re-authenticates via password: handleSignInFull's regenerateSession
+			// call doesn't pass either key, so ClearSessionKeysForSignIn must be the one clearing them
+			mockOpt := contexttest.MockContextOption{SessionStore: session.NewMockMemStore("dummy-sid-password-after-oidc")}
+			ctx, _ := contexttest.MockContext(t, "/user/login", mockOpt)
+			require.NoError(t, ctx.Session.Set(session.KeySignInMethod, session.SignInMethodOAuth2))
+			require.NoError(t, ctx.Session.Set(session.KeyOIDCIDToken, "stale-id-token-from-prior-oidc-login"))
+
+			handleSignInFull(ctx, oauthUser, false)
+			assert.NotEqual(t, session.SignInMethodOAuth2, ctx.Session.Get(session.KeySignInMethod), "password sign-in must not leave a stale OAuth2 sign-in method behind")
+			assert.Empty(t, ctx.Session.Get(session.KeyOIDCIDToken), "password sign-in must not leave a stale id_token behind")
+
+			ctx, resp := contexttest.MockContext(t, "/user/logout", mockOpt)
+			ctx.Doer = oauthUser
+			SignOut(ctx)
+			assert.Equal(t, http.StatusSeeOther, resp.Code)
+			assert.Equal(t, "/", test.RedirectURL(resp), "must not redirect to the OIDC end_session_endpoint after a password sign-in")
+		})
+
+		t.Run("OIDCIDTokenSurvives2FACompletion", func(t *testing.T) {
+			// counterpart to PasswordSignInAfterOIDCClearsStaleIDTokenAndMethod: an OIDC sign-in
+			// that required 2FA sets KeySignInMethod/KeyOIDCIDToken via handleTwoFactorRequired
+			// *before* the 2FA step; handleSignIn (called on successful 2FA) must preserve them,
+			// not just blindly clear on every sign-in completion
+			mockOpt := contexttest.MockContextOption{SessionStore: session.NewMockMemStore("dummy-sid-oidc-2fa-completion")}
+			ctx, _ := contexttest.MockContext(t, "/user/oauth2/..../callback?code=dummy-code", mockOpt)
+			handleTwoFactorRequired(ctx, oauthUser, false, map[string]any{
+				session.KeySignInMethod: session.SignInMethodOAuth2,
+				session.KeyOIDCIDToken:  "real-id-token-pending-2fa",
+			})
+
+			// simulates what TwoFactorPost does on a correct passcode
+			ctx, _ = contexttest.MockContext(t, "/user/twofa", mockOpt)
+			handleSignIn(ctx, oauthUser, false)
+			assert.Equal(t, session.SignInMethodOAuth2, ctx.Session.Get(session.KeySignInMethod), "completing 2FA must not lose the OAuth2 sign-in method recorded before the 2FA step")
+			assert.Equal(t, "real-id-token-pending-2fa", ctx.Session.Get(session.KeyOIDCIDToken), "completing 2FA must not lose the id_token recorded before the 2FA step")
+
+			ctx, resp := contexttest.MockContext(t, "/user/logout", mockOpt)
+			ctx.Doer = oauthUser
+			SignOut(ctx)
+			assert.Equal(t, http.StatusSeeOther, resp.Code)
+			u, err := url.Parse(test.RedirectURL(resp))
+			require.NoError(t, err)
+			assert.Equal(t, "real-id-token-pending-2fa", u.Query().Get("id_token_hint"), "logout after 2FA completion must still include the id_token_hint from the original OIDC sign-in")
 		})
 
 		t.Run("PasswordSignInSkipsOIDC", func(t *testing.T) {
@@ -247,12 +333,36 @@ func TestOpenIDRequireTwoFactor(t *testing.T) {
 
 	user32 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 32}) // has a webauthn credential
 	ctx, resp := contexttest.MockContext(t, "/user/openid/connect", mockOpt)
+	require.NoError(t, ctx.Session.Set(session.KeySignInMethod, session.SignInMethodOAuth2))
+	require.NoError(t, ctx.Session.Set(session.KeyOIDCIDToken, "stale-id-token-from-prior-oidc-login"))
 	openIDRequireTwoFactor(ctx, user32, false, "https://example.com/id")
 	assert.Equal(t, "/user/webauthn", test.RedirectURL(resp))
 	unittest.AssertNotExistsBean(t, &user_model.UserOpenID{UID: user32.ID}) // not attached before the key answered
+	assert.Empty(t, ctx.Session.Get(session.KeyOIDCIDToken), "legacy OpenID 2FA flow must not carry forward a stale id_token from an earlier OIDC session")
+	assert.NotEqual(t, session.SignInMethodOAuth2, ctx.Session.Get(session.KeySignInMethod))
 
 	user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
 	ctx, _ = contexttest.MockContext(t, "/user/openid/connect", mockOpt)
 	openIDRequireTwoFactor(ctx, user2, false, "https://example.com/id")
 	assert.False(t, ctx.Written())
+}
+
+func TestAutoSignInClearsStaleOIDCState(t *testing.T) {
+	require.NoError(t, unittest.PrepareTestDatabase())
+	user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+
+	nt, token, err := auth_service.CreateAuthTokenForUserID(t.Context(), user2.ID)
+	require.NoError(t, err)
+
+	mockOpt := contexttest.MockContextOption{SessionStore: session.NewMockMemStore("dummy-sid-autologin")}
+	ctx, _ := contexttest.MockContext(t, "/user/login", mockOpt)
+	require.NoError(t, ctx.Session.Set(session.KeySignInMethod, session.SignInMethodOAuth2))
+	require.NoError(t, ctx.Session.Set(session.KeyOIDCIDToken, "stale-id-token-from-prior-oidc-login"))
+	ctx.Req.AddCookie(&http.Cookie{Name: setting.CookieRememberName, Value: nt.ID + ":" + token})
+
+	succeeded, err := autoSignIn(ctx)
+	require.NoError(t, err)
+	require.True(t, succeeded)
+	assert.Empty(t, ctx.Session.Get(session.KeyOIDCIDToken), "auto sign-in via remember-me cookie must not carry forward a stale id_token")
+	assert.NotEqual(t, session.SignInMethodOAuth2, ctx.Session.Get(session.KeySignInMethod))
 }

--- a/routers/web/auth/auth_test.go
+++ b/routers/web/auth/auth_test.go
@@ -172,6 +172,63 @@ func TestWebAuthOAuth2(t *testing.T) {
 			assert.Equal(t, "https://example.com/oidc-logout", u.String())
 		})
 
+		t.Run("OAuth2SignInIncludesIDTokenHint", func(t *testing.T) {
+			mockOpt := contexttest.MockContextOption{SessionStore: session.NewMockMemStore("dummy-sid-oauth-idtoken")}
+			ctx, resp := contexttest.MockContext(t, "/user/logout", mockOpt)
+			ctx.Doer = oauthUser
+			require.NoError(t, ctx.Session.Set(session.KeySignInMethod, session.SignInMethodOAuth2))
+			require.NoError(t, ctx.Session.Set(session.KeyOIDCIDToken, "mock-id-token"))
+			SignOut(ctx)
+			assert.Equal(t, http.StatusSeeOther, resp.Code)
+			u, err := url.Parse(test.RedirectURL(resp))
+			require.NoError(t, err)
+			expectedValues := url.Values{"oidc-key": []string{"oidc-val"}, "post_logout_redirect_uri": []string{setting.AppURL}, "client_id": []string{"mock-client-id"}, "id_token_hint": []string{"mock-id-token"}}
+			assert.Equal(t, expectedValues, u.Query())
+		})
+
+		t.Run("OAuth2CallbackStoresIDTokenForLogout", func(t *testing.T) {
+			defer test.MockVariableValue(&gothic.CompleteUserAuth, func(res http.ResponseWriter, req *http.Request) (goth.User, error) {
+				return goth.User{Provider: "oidc-auth-source", UserID: "oidc-new-user", Email: "oidc-new-user@example.com", IDToken: "real-flow-id-token"}, nil
+			})()
+
+			mockOpt := contexttest.MockContextOption{SessionStore: session.NewMockMemStore("dummy-sid-oidc-callback")}
+			ctx, resp := contexttest.MockContext(t, "/user/oauth2/..../callback?code=dummy-code", mockOpt)
+			ctx.SetPathParamRaw("provider", "oidc-auth-source")
+			SignInOAuthCallback(ctx)
+			require.Equal(t, http.StatusSeeOther, resp.Code)
+			assert.Equal(t, "real-flow-id-token", ctx.Session.Get(session.KeyOIDCIDToken))
+
+			// signing out the same session must carry the id_token through as id_token_hint
+			ctx, resp = contexttest.MockContext(t, "/user/logout", mockOpt)
+			ctx.Doer = oauthUser
+			SignOut(ctx)
+			assert.Equal(t, http.StatusSeeOther, resp.Code)
+			u, err := url.Parse(test.RedirectURL(resp))
+			require.NoError(t, err)
+			assert.Equal(t, "real-flow-id-token", u.Query().Get("id_token_hint"))
+		})
+
+		t.Run("OAuth2CallbackWithoutIDTokenOmitsHint", func(t *testing.T) {
+			defer test.MockVariableValue(&gothic.CompleteUserAuth, func(res http.ResponseWriter, req *http.Request) (goth.User, error) {
+				return goth.User{Provider: "oidc-auth-source", UserID: "oidc-new-user-2", Email: "oidc-new-user-2@example.com"}, nil
+			})()
+
+			mockOpt := contexttest.MockContextOption{SessionStore: session.NewMockMemStore("dummy-sid-oidc-callback-no-token")}
+			ctx, resp := contexttest.MockContext(t, "/user/oauth2/..../callback?code=dummy-code", mockOpt)
+			ctx.SetPathParamRaw("provider", "oidc-auth-source")
+			SignInOAuthCallback(ctx)
+			require.Equal(t, http.StatusSeeOther, resp.Code)
+			assert.Nil(t, ctx.Session.Get(session.KeyOIDCIDToken))
+
+			ctx, resp = contexttest.MockContext(t, "/user/logout", mockOpt)
+			ctx.Doer = oauthUser
+			SignOut(ctx)
+			assert.Equal(t, http.StatusSeeOther, resp.Code)
+			u, err := url.Parse(test.RedirectURL(resp))
+			require.NoError(t, err)
+			assert.Empty(t, u.Query().Get("id_token_hint"))
+		})
+
 		t.Run("PasswordSignInSkipsOIDC", func(t *testing.T) {
 			// OAuth2-linked account signed in via password form must not hit end_session_endpoint.
 			mockOpt := contexttest.MockContextOption{SessionStore: session.NewMockMemStore("dummy-sid-password")}

--- a/routers/web/auth/linkaccount.go
+++ b/routers/web/auth/linkaccount.go
@@ -170,13 +170,17 @@ func oauth2LinkAccount(ctx *context.Context, u *user_model.User, linkAccountData
 		return
 	}
 
-	if err := regenerateSession(ctx, map[string]any{
-		// User needs to use 2FA, save data and redirect to 2FA page.
+	// User needs to use 2FA, save data and redirect to 2FA page.
+	sessionData := map[string]any{
 		"twofaUid":              u.ID,
 		"twofaRemember":         remember,
 		"linkAccount":           true,
 		session.KeySignInMethod: session.SignInMethodOAuth2,
-	}); err != nil {
+	}
+	if linkAccountData.GothUser.IDToken != "" {
+		sessionData[session.KeyOIDCIDToken] = linkAccountData.GothUser.IDToken
+	}
+	if err := regenerateSession(ctx, sessionData); err != nil {
 		ctx.ServerError("RegenerateSession", err)
 		return
 	}

--- a/routers/web/auth/linkaccount.go
+++ b/routers/web/auth/linkaccount.go
@@ -168,10 +168,14 @@ func oauth2LinkAccount(ctx *context.Context, u *user_model.User, linkAccountData
 		return
 	}
 
-	handleTwoFactorRequired(ctx, u, remember, map[string]any{
+	extra := map[string]any{
 		"linkAccount":           true,
 		session.KeySignInMethod: session.SignInMethodOAuth2,
-	})
+	}
+	if linkAccountData.GothUser.IDToken != "" {
+		extra[session.KeyOIDCIDToken] = linkAccountData.GothUser.IDToken
+	}
+	handleTwoFactorRequired(ctx, u, remember, extra)
 }
 
 // LinkAccountPostRegister handle the creation of a new account for an external account using signUp

--- a/routers/web/auth/linkaccount.go
+++ b/routers/web/auth/linkaccount.go
@@ -168,14 +168,11 @@ func oauth2LinkAccount(ctx *context.Context, u *user_model.User, linkAccountData
 		return
 	}
 
-	extra := map[string]any{
+	handleTwoFactorRequired(ctx, u, remember, map[string]any{
 		"linkAccount":           true,
 		session.KeySignInMethod: session.SignInMethodOAuth2,
-	}
-	if linkAccountData.GothUser.IDToken != "" {
-		extra[session.KeyOIDCIDToken] = linkAccountData.GothUser.IDToken
-	}
-	handleTwoFactorRequired(ctx, u, remember, extra)
+		session.KeyOIDCIDToken:  linkAccountData.GothUser.IDToken, // set even if "": clears any stale token regenerateSession would otherwise carry over
+	})
 }
 
 // LinkAccountPostRegister handle the creation of a new account for an external account using signUp

--- a/routers/web/auth/oauth.go
+++ b/routers/web/auth/oauth.go
@@ -428,11 +428,15 @@ func handleOAuth2SignIn(ctx *context.Context, authSource *auth.Source, u *user_m
 			return
 		}
 
-		if err := regenerateSession(ctx, map[string]any{
+		sessionData := map[string]any{
 			session.KeyUID:                  u.ID,
 			session.KeyUserHasTwoFactorAuth: userHasTwoFactorAuth,
 			session.KeySignInMethod:         session.SignInMethodOAuth2,
-		}); err != nil {
+		}
+		if gothUser.IDToken != "" {
+			sessionData[session.KeyOIDCIDToken] = gothUser.IDToken
+		}
+		if err := regenerateSession(ctx, sessionData); err != nil {
 			ctx.ServerError("updateSession", err)
 			return
 		}
@@ -453,12 +457,16 @@ func handleOAuth2SignIn(ctx *context.Context, authSource *auth.Source, u *user_m
 		}
 	}
 
-	if err := regenerateSession(ctx, map[string]any{
-		// User needs to use 2FA, save data and redirect to 2FA page.
+	// User needs to use 2FA, save data and redirect to 2FA page.
+	sessionData := map[string]any{
 		"twofaUid":              u.ID,
 		"twofaRemember":         false,
 		session.KeySignInMethod: session.SignInMethodOAuth2,
-	}); err != nil {
+	}
+	if gothUser.IDToken != "" {
+		sessionData[session.KeyOIDCIDToken] = gothUser.IDToken
+	}
+	if err := regenerateSession(ctx, sessionData); err != nil {
 		ctx.ServerError("updateSession", err)
 		return
 	}
@@ -596,6 +604,13 @@ func buildOIDCEndSessionURL(ctx *context.Context, doer *user_model.User) string 
 	// https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
 	params := endSessionURL.Query()
 	params.Set("client_id", oauth2Cfg.ClientID)
+
+	// id_token_hint lets the IdP end the session without re-prompting for account
+	// selection; some providers (e.g. Dex) require it. Only present for sessions
+	// that authenticated via OIDC and received an id_token.
+	if idToken, ok := ctx.Session.Get(session.KeyOIDCIDToken).(string); ok && idToken != "" {
+		params.Set("id_token_hint", idToken)
+	}
 
 	// AWS Cognito uses "logout_uri" instead of the standard "post_logout_redirect_uri"
 	redirectURI := httplib.GuessCurrentAppURL(ctx)

--- a/routers/web/auth/oauth.go
+++ b/routers/web/auth/oauth.go
@@ -429,11 +429,15 @@ func handleOAuth2SignIn(ctx *context.Context, authSource *auth.Source, u *user_m
 			return
 		}
 
-		if err := regenerateSession(ctx, map[string]any{
+		sessionData := map[string]any{
 			session.KeyUID:                  u.ID,
 			session.KeyUserHasTwoFactorAuth: userHasTwoFactorAuth,
 			session.KeySignInMethod:         session.SignInMethodOAuth2,
-		}); err != nil {
+		}
+		if gothUser.IDToken != "" {
+			sessionData[session.KeyOIDCIDToken] = gothUser.IDToken
+		}
+		if err := regenerateSession(ctx, sessionData); err != nil {
 			ctx.ServerError("updateSession", err)
 			return
 		}
@@ -454,7 +458,11 @@ func handleOAuth2SignIn(ctx *context.Context, authSource *auth.Source, u *user_m
 		}
 	}
 
-	handleTwoFactorRequired(ctx, u, false, map[string]any{session.KeySignInMethod: session.SignInMethodOAuth2})
+	extra := map[string]any{session.KeySignInMethod: session.SignInMethodOAuth2}
+	if gothUser.IDToken != "" {
+		extra[session.KeyOIDCIDToken] = gothUser.IDToken
+	}
+	handleTwoFactorRequired(ctx, u, false, extra)
 }
 
 // OAuth2UserLoginCallback attempts to handle the callback from the OAuth2 provider and if successful
@@ -580,6 +588,13 @@ func buildOIDCEndSessionURL(ctx *context.Context, doer *user_model.User) string 
 	// https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
 	params := endSessionURL.Query()
 	params.Set("client_id", oauth2Cfg.ClientID)
+
+	// id_token_hint lets the IdP end the session without re-prompting for account
+	// selection; some providers (e.g. Dex) require it. Only present for sessions
+	// that authenticated via OIDC and received an id_token.
+	if idToken, ok := ctx.Session.Get(session.KeyOIDCIDToken).(string); ok && idToken != "" {
+		params.Set("id_token_hint", idToken)
+	}
 
 	// AWS Cognito uses "logout_uri" instead of the standard "post_logout_redirect_uri"
 	redirectURI := httplib.GuessCurrentAppURL(ctx)

--- a/routers/web/auth/oauth.go
+++ b/routers/web/auth/oauth.go
@@ -429,15 +429,12 @@ func handleOAuth2SignIn(ctx *context.Context, authSource *auth.Source, u *user_m
 			return
 		}
 
-		sessionData := map[string]any{
+		if err := regenerateSession(ctx, map[string]any{
 			session.KeyUID:                  u.ID,
 			session.KeyUserHasTwoFactorAuth: userHasTwoFactorAuth,
 			session.KeySignInMethod:         session.SignInMethodOAuth2,
-		}
-		if gothUser.IDToken != "" {
-			sessionData[session.KeyOIDCIDToken] = gothUser.IDToken
-		}
-		if err := regenerateSession(ctx, sessionData); err != nil {
+			session.KeyOIDCIDToken:          gothUser.IDToken, // set even if "": clears any stale token regenerateSession would otherwise carry over
+		}); err != nil {
 			ctx.ServerError("updateSession", err)
 			return
 		}
@@ -458,11 +455,10 @@ func handleOAuth2SignIn(ctx *context.Context, authSource *auth.Source, u *user_m
 		}
 	}
 
-	extra := map[string]any{session.KeySignInMethod: session.SignInMethodOAuth2}
-	if gothUser.IDToken != "" {
-		extra[session.KeyOIDCIDToken] = gothUser.IDToken
-	}
-	handleTwoFactorRequired(ctx, u, false, extra)
+	handleTwoFactorRequired(ctx, u, false, map[string]any{
+		session.KeySignInMethod: session.SignInMethodOAuth2,
+		session.KeyOIDCIDToken:  gothUser.IDToken, // set even if "": see regenerateSession call above
+	})
 }
 
 // OAuth2UserLoginCallback attempts to handle the callback from the OAuth2 provider and if successful

--- a/routers/web/auth/openid.go
+++ b/routers/web/auth/openid.go
@@ -12,6 +12,7 @@ import (
 	user_model "gitea.dev/models/user"
 	"gitea.dev/modules/auth/openid"
 	"gitea.dev/modules/log"
+	"gitea.dev/modules/session"
 	"gitea.dev/modules/setting"
 	"gitea.dev/modules/templates"
 	"gitea.dev/modules/util"
@@ -37,7 +38,13 @@ func openIDRequireTwoFactor(ctx *context.Context, u *user_model.User, remember b
 	if !hasTwoFactor {
 		return
 	}
-	handleTwoFactorRequired(ctx, u, remember, map[string]any{"openidPendingURI": pendingURI})
+	// clear even if unset: a stale OAuth2 sign-in method/id_token from an earlier session
+	// on this browser must not survive a legacy-OpenID-initiated 2FA flow
+	handleTwoFactorRequired(ctx, u, remember, map[string]any{
+		"openidPendingURI":      pendingURI,
+		session.KeySignInMethod: "",
+		session.KeyOIDCIDToken:  "",
+	})
 }
 
 func openIDConnectFromContext(ctx *context.Context, u *user_model.User) error {

--- a/routers/web/auth/password.go
+++ b/routers/web/auth/password.go
@@ -12,6 +12,7 @@ import (
 	"gitea.dev/modules/auth/password"
 	"gitea.dev/modules/log"
 	"gitea.dev/modules/optional"
+	"gitea.dev/modules/session"
 	"gitea.dev/modules/setting"
 	"gitea.dev/modules/templates"
 	"gitea.dev/modules/timeutil"
@@ -246,7 +247,12 @@ func ResetPasswdPost(ctx *context.Context) {
 			return
 		}
 		if hasWebAuthn {
-			handleTwoFactorRequired(ctx, u, remember, nil)
+			// clear even if unset: a stale OAuth2 sign-in method/id_token from an earlier
+			// session on this browser must not survive a password-reset-initiated 2FA flow
+			handleTwoFactorRequired(ctx, u, remember, map[string]any{
+				session.KeySignInMethod: "",
+				session.KeyOIDCIDToken:  "",
+			})
 			return
 		}
 	}


### PR DESCRIPTION
The OIDC RP-Initiated Logout redirect built in `buildOIDCEndSessionURL`
only sent `client_id` and `post_logout_redirect_uri` to the provider's
`end_session_endpoint`. Some OIDC providers (e.g. Dex) require
`id_token_hint` to complete logout per the [RP-Initiated Logout
spec](https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout),
so logout against those providers couldn't be completed correctly.

This stores the `id_token` returned by the provider at sign-in in the
session (`session.KeyOIDCIDToken`), and passes it back as
`id_token_hint` on logout when present. Sessions that predate this
change, or providers that don't return an `id_token`, keep the
previous behavior — the parameter is only added when a token is
actually available.

Testing

    Unit tests covering: a real OAuth2 callback with an id_token
    populates the session and the logout redirect includes
    id_token_hint; a callback without an id_token omits the parameter
    entirely; existing OIDC-logout and password-login-skips-OIDC
    behavior is unchanged
    Verified end-to-end against a live Keycloak instance: before this
    change the logout redirect omitted id_token_hint, after, it's
    present as a valid JWT matching the session
    make lint-go, make fmt

Closes https://github.com/go-gitea/gitea/issues/38692.
