### PR TITLE
chore: rename `act_runner` references to `runner`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Get more information from [documentation](https://docs.gitea.com/contributing/lo
 
 ## Official and Third-Party Projects
 
-We provide an official [go-sdk](https://gitea.com/gitea/go-sdk), a CLI tool called [tea](https://gitea.com/gitea/tea) and an [action runner](https://gitea.com/gitea/act_runner) for Gitea Action.
+We provide an official [go-sdk](https://gitea.com/gitea/go-sdk), a CLI tool called [tea](https://gitea.com/gitea/tea) and an [action runner](https://gitea.com/gitea/runner) for Gitea Action.
 
 We maintain a list of Gitea-related projects at [gitea/awesome-gitea](https://gitea.com/gitea/awesome-gitea), where you can discover more third-party projects, including SDKs, plugins, themes, and more.
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -76,7 +76,7 @@
 
 ## 官方和第三方项目
 
-我们提供了一个官方的 [go-sdk](https://gitea.com/gitea/go-sdk)，一个名为 [tea](https://gitea.com/gitea/tea) 的 CLI 工具和一个 Gitea Action 的 [action runner](https://gitea.com/gitea/act_runner)。
+我们提供了一个官方的 [go-sdk](https://gitea.com/gitea/go-sdk)，一个名为 [tea](https://gitea.com/gitea/tea) 的 CLI 工具和一个 Gitea Action 的 [action runner](https://gitea.com/gitea/runner)。
 
 我们在 [gitea/awesome-gitea](https://gitea.com/gitea/awesome-gitea) 维护了一个 Gitea 相关项目的列表，您可以在那里发现更多的第三方项目，包括 SDK、插件、主题等。
 

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -76,7 +76,7 @@
 
 ## 官方和第三方項目
 
-我們提供了一個官方的 [go-sdk](https://gitea.com/gitea/go-sdk)，一個名為 [tea](https://gitea.com/gitea/tea) 的 CLI 工具和一個 Gitea Action 的 [action runner](https://gitea.com/gitea/act_runner)。
+我們提供了一個官方的 [go-sdk](https://gitea.com/gitea/go-sdk)，一個名為 [tea](https://gitea.com/gitea/tea) 的 CLI 工具和一個 Gitea Action 的 [action runner](https://gitea.com/gitea/runner)。
 
 我們在 [gitea/awesome-gitea](https://gitea.com/gitea/awesome-gitea) 維護了一個 Gitea 相關項目的列表，您可以在那裡發現更多的第三方項目，包括 SDK、插件、主題等。
 

--- a/modelmigration/v1_20/v248.go
+++ b/modelmigration/v1_20/v248.go
@@ -11,7 +11,7 @@ import (
 
 func AddVersionToActionRunner(_ context.Context, x base.EngineMigration) error {
 	type ActionRunner struct {
-		Version string `xorm:"VARCHAR(64)"` // the version of act_runner
+		Version string `xorm:"VARCHAR(64)"` // the version of the runner
 	}
 
 	return x.Sync(new(ActionRunner))

--- a/models/actions/runner.go
+++ b/models/actions/runner.go
@@ -58,7 +58,7 @@ type ActionRunner struct {
 	LastOnline timeutil.TimeStamp `xorm:"index"`
 	LastActive timeutil.TimeStamp `xorm:"index"`
 
-	// Store labels defined in state file (default: .runner file) of `act_runner`
+	// Store labels defined in state file (default: .runner file) of the `runner`
 	AgentLabels []string `xorm:"TEXT"`
 	// Store if this is a runner that only ever get one single job assigned
 	Ephemeral bool `xorm:"ephemeral NOT NULL DEFAULT false"`

--- a/routers/api/actions/artifacts.go
+++ b/routers/api/actions/artifacts.go
@@ -143,7 +143,7 @@ func ArtifactContexter() func(next http.Handler) http.Handler {
 				return
 			}
 
-			// New act_runner uses jwt to authenticate
+			// New runner uses jwt to authenticate
 			tID, err := actions_service.ParseAuthorizationToken(req)
 
 			var task *actions.ActionTask
@@ -160,7 +160,7 @@ func ArtifactContexter() func(next http.Handler) http.Handler {
 					return
 				}
 			} else {
-				// Old act_runner uses GITEA_TOKEN to authenticate
+				// Old runner uses GITEA_TOKEN to authenticate
 				authToken := strings.TrimPrefix(authHeader, "Bearer ")
 
 				task, err = actions.GetRunningTaskByToken(req.Context(), authToken)

--- a/routers/api/actions/artifacts_utils.go
+++ b/routers/api/actions/artifacts_utils.go
@@ -69,7 +69,7 @@ func validateArtifactHash(ctx *ArtifactContext, artifactName string) bool {
 func parseArtifactItemPath(ctx *ArtifactContext) (string, string, bool) {
 	// itemPath is generated from upload-artifact action
 	// it's formatted as {artifact_name}/{artfict_path_in_runner}
-	// act_runner in host mode on Windows, itemPath is joined by Windows slash '\'
+	// runner in host mode on Windows, itemPath is joined by Windows slash '\'
 	itemPath := util.PathJoinRelX(ctx.Req.URL.Query().Get("itemPath"))
 	artifactName := strings.Split(itemPath, "/")[0]
 	artifactPath := strings.TrimPrefix(itemPath, artifactName+"/")

--- a/services/actions/cleanup.go
+++ b/services/actions/cleanup.go
@@ -239,10 +239,10 @@ func DeleteRun(ctx context.Context, run *actions_model.ActionRun) error {
 
 	if err := db.WithTx(ctx, func(ctx context.Context) error {
 		// TODO: Deleting task records could break current ephemeral runner implementation. This is a temporary workaround suggested by ChristopherHX.
-		// Since you delete potentially the only task an ephemeral act_runner has ever run, please delete the affected runners first.
+		// Since you delete potentially the only task an ephemeral runner has ever run, please delete the affected runners first.
 		// one of
 		//    call cleanup ephemeral runners first
-		//    delete affected ephemeral act_runners
+		//    delete affected ephemeral runners
 		//    I would make ephemeral runners fully delete directly before formally finishing the task
 		//
 		// See also: https://github.com/go-gitea/gitea/pull/34337#issuecomment-2862222788

--- a/services/actions/job_emitter_test.go
+++ b/services/actions/job_emitter_test.go
@@ -101,7 +101,7 @@ jobs:
     needs: job1
     if: ${{ always() && needs.job1.result == 'success' }}
     steps:
-      - run: echo "will be checked by act_runner"
+      - run: echo "will be checked by runner"
 `)},
 			},
 			want: map[int64]actions_model.Status{2: actions_model.StatusWaiting},
@@ -120,7 +120,7 @@ jobs:
     needs: job1
     if: ${{ always() && needs.job1.result == 'failure' }}
     steps:
-      - run: echo "will be checked by act_runner"
+      - run: echo "will be checked by runner"
 `)},
 			},
 			want: map[int64]actions_model.Status{2: actions_model.StatusWaiting},


### PR DESCRIPTION
The runner repository moved to https://gitea.com/gitea/runner, update references.

I left out the change from https://github.com/go-gitea/gitea/pull/38783 here, so these can land together.