### PR TITLE
test: run tests against the vue build we ship

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,8 @@ export default defineConfig({
       concurrent: true,
     },
   },
+  // vitest would otherwise resolve the node build, which ships the runtime compiler
+  resolve: {alias: {vue: 'vue/dist/vue.runtime.esm-bundler.js'}},
   define: vueDefines,
   plugins: sharedPlugins(),
 });


### PR DESCRIPTION
vitest resolves `vue` through the `node` export condition, so tests load `dist/vue.cjs.js`, the full build including the runtime compiler. The browser gets `dist/vue.runtime.esm-bundler.js`. The alias makes both use the same build.

No test uses runtime template compilation, so nothing changes for the suite today.