### PR TITLE
fix(ui): change underlines to default browser style

### DIFF
--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -273,7 +273,6 @@ a {
   color: var(--color-primary);
   cursor: pointer;
   text-decoration-line: none;
-  text-decoration-skip-ink: all;
 }
 
 a:hover {

--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -278,7 +278,6 @@ a {
 
 a:hover {
   text-decoration-line: underline;
-  text-underline-position: under; /* necessary for CJK fonts, otherwise, default "auto" makes the underline cross-over the CJK text bottom */
 }
 
 /* a = always colored, underlined on hover */

--- a/web_src/css/features/console.css
+++ b/web_src/css/features/console.css
@@ -18,7 +18,6 @@
 }
 .console a:hover {
   color: var(--color-primary);
-  text-underline-position: auto; /* the global "a:hover" sets "under", which would shift the underline */
 }
 
 @keyframes blink-animation {


### PR DESCRIPTION
In https://github.com/go-gitea/gitea/pull/38070#issuecomment-4679451574 the link underline was moved futher away from the text with `under` which causes invisible underlines with `overflow: hidden`. At certain zoom levels some of these links lose the underline because of a subpixel bug:

<img width="200" height="72" alt="Screenshot 2026-08-07 at 10 08 05" src="https://github.com/user-attachments/assets/629ecc32-cf99-4408-825d-5d22dac91588" />

Fix: Restore default underline position:

<img width="202" height="79" alt="Screenshot 2026-08-07 at 10 17 23" src="https://github.com/user-attachments/assets/90d22801-4307-482a-bd0f-46542b0b5526" />

With CJK:

<img width="481" height="73" alt="Screenshot 2026-08-07 at 10 16 45" src="https://github.com/user-attachments/assets/a210f27f-1d05-4573-a31a-22606e919693" />

I was unable to reproduce the crossover CJK issue. We already set [`text-decoration-skip-ink: all`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-decoration-skip-ink#all) so crossovers can never happen if the browser supports that option (which all recent ones do).

Also I like the closer underline better.
