### PR TITLE
fix(ui): anchor navbar admin badge to the avatar corner

### DIFF
--- a/web_src/css/modules/navbar.css
+++ b/web_src/css/modules/navbar.css
@@ -144,8 +144,9 @@
 
 #navbar .item .navbar-admin-badge {
   position: absolute;
-  bottom: calc(100% - 29px);
-  left: calc(100% - 18px);
+  left: auto;
+  right: -7px;
+  bottom: -5px;
   padding: 1.5px;
 }
 


### PR DESCRIPTION
Fix regression from https://github.com/go-gitea/gitea/pull/38614:

`.navbar-avatar` positions the badge, and its width used to include the avatar's `tw-mr-2`. https://github.com/go-gitea/gitea/pull/38614 dropped that margin, shrinking the box by 8px and pulling the badge onto the avatar face. Offset from the corner instead, so the position no longer depends on the container width.

<img width="71" height="47" alt="image" src="https://github.com/user-attachments/assets/dd821f2e-f484-4375-939f-986d6ae6abdd" />

Fixes: https://github.com/go-gitea/gitea/issues/38820