### PR TITLE
fix(ui): change underlines to default browser style (#38819)

### DIFF
--- a/web_src/css/base.css
+++ b/web_src/css/base.css
@@ -273,12 +273,10 @@ a {
   color: var(--color-primary);
   cursor: pointer;
   text-decoration-line: none;
-  text-decoration-skip-ink: all;
 }
 
 a:hover {
   text-decoration-line: underline;
-  text-underline-position: under; /* necessary for CJK fonts, otherwise, default "auto" makes the underline cross-over the CJK text bottom */
 }
 
 /* a = always colored, underlined on hover */


### PR DESCRIPTION
Backport of https://github.com/go-gitea/gitea/pull/38819

The `web_src/css/features/console.css` hunk is omitted, this branch has no `text-underline-position` override there.