### PR TITLE
feat(release): allow setting tag date to the target commit's date #38714

### DIFF
--- a/modules/git/repo_tag.go
+++ b/modules/git/repo_tag.go
@@ -7,7 +7,9 @@ package git
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
+	"time"
 
 	"gitea.dev/modules/git/foreachref"
 	"gitea.dev/modules/git/gitcmd"
@@ -23,13 +25,20 @@ func (repo *Repository) CreateTag(ctx context.Context, name, revision string) er
 	return err
 }
 
-// CreateAnnotatedTag create one annotated tag in the repository
-func (repo *Repository) CreateAnnotatedTag(ctx context.Context, name, message, revision string) error {
-	_, _, err := gitcmd.NewCommand("tag", "-a", "-m").
+// CreateAnnotatedTag create one annotated tag in the repository.
+// If taggerDate is not nil, it is used as the tag's tagger date instead of the current time.
+func (repo *Repository) CreateAnnotatedTag(ctx context.Context, name, message, revision string, taggerDate *time.Time) error {
+	cmd := gitcmd.NewCommand("tag", "-a", "-m").
 		AddDynamicArguments(message).
 		AddDashesAndList(name, revision).
-		WithRepo(repo).
-		RunStdString(ctx)
+		WithRepo(repo)
+	if taggerDate != nil {
+		cmd = cmd.WithEnv(append(os.Environ(),
+			"GIT_AUTHOR_DATE="+taggerDate.Format(time.RFC3339),
+			"GIT_COMMITTER_DATE="+taggerDate.Format(time.RFC3339),
+		))
+	}
+	_, _, err := cmd.RunStdString(ctx)
 	return err
 }
 

--- a/modules/git/repo_tag_test.go
+++ b/modules/git/repo_tag_test.go
@@ -6,6 +6,7 @@ package git
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -78,7 +79,7 @@ func TestRepository_GetTag(t *testing.T) {
 	aTagMessage := "my annotated message \n - test two line"
 
 	// Create the annotated tag
-	err = bareRepo1.CreateAnnotatedTag(t.Context(), aTagName, aTagMessage, aTagCommitID)
+	err = bareRepo1.CreateAnnotatedTag(t.Context(), aTagName, aTagMessage, aTagCommitID, nil)
 	if err != nil {
 		assert.NoError(t, err, "Unable to create the annotated tag: %s for ID: %s. Error: %v", aTagName, aTagCommitID, err)
 		return
@@ -150,7 +151,7 @@ func TestRepository_GetAnnotatedTag(t *testing.T) {
 	aTagCommitID := "8006ff9adbf0cb94da7dad9e537e53817f9fa5c0"
 	aTagName := "annotatedTag"
 	aTagMessage := "my annotated message"
-	bareRepo1.CreateAnnotatedTag(t.Context(), aTagName, aTagMessage, aTagCommitID)
+	bareRepo1.CreateAnnotatedTag(t.Context(), aTagName, aTagMessage, aTagCommitID, nil)
 	aTagID, _ := bareRepo1.GetTagID(t.Context(), aTagName)
 
 	// Try an annotated tag
@@ -180,6 +181,32 @@ func TestRepository_GetAnnotatedTag(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(t, IsErrNotExist(err))
 	assert.Nil(t, tag4)
+}
+
+func TestRepository_CreateAnnotatedTag_WithTaggerDate(t *testing.T) {
+	bareRepo1Path := filepath.Join(testReposDir, "repo1_bare")
+
+	clonedPath, err := cloneRepo(t, bareRepo1Path)
+	require.NoError(t, err)
+
+	bareRepo1, err := OpenRepositoryLocal(t.Context(), clonedPath)
+	require.NoError(t, err)
+	defer bareRepo1.Close()
+
+	aTagCommitID := "8006ff9adbf0cb94da7dad9e537e53817f9fa5c0"
+	aTagName := "annotatedTagWithDate"
+	aTagMessage := "tag dated in the past"
+	taggerDate := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	require.NoError(t, bareRepo1.CreateAnnotatedTag(t.Context(), aTagName, aTagMessage, aTagCommitID, &taggerDate))
+
+	aTagID, err := bareRepo1.GetTagID(t.Context(), aTagName)
+	require.NoError(t, err)
+
+	tag, err := bareRepo1.GetAnnotatedTag(t.Context(), aTagID)
+	require.NoError(t, err)
+	require.NotNil(t, tag.Tagger)
+	assert.True(t, taggerDate.Equal(tag.Tagger.When), "expected tagger date %v, got %v", taggerDate, tag.Tagger.When)
 }
 
 func TestRepository_parseTagRef(t *testing.T) {

--- a/modules/structs/release.go
+++ b/modules/structs/release.go
@@ -59,6 +59,8 @@ type CreateReleaseOption struct {
 	IsDraft bool `json:"draft"`
 	// Whether to mark the release as a prerelease
 	IsPrerelease bool `json:"prerelease"`
+	// Use the target commit's date as the git tag's creation date instead of the current time
+	UseCommitDate bool `json:"use_commit_date"`
 }
 
 // EditReleaseOption options when editing a release

--- a/modules/structs/repo_tag.go
+++ b/modules/structs/repo_tag.go
@@ -58,6 +58,8 @@ type CreateTagOption struct {
 	Message string `json:"message"`
 	// The target commit SHA or branch name for the tag
 	Target string `json:"target"`
+	// Use the target commit's date as the git tag's creation date instead of the current time
+	UseCommitDate bool `json:"use_commit_date"`
 }
 
 // TagProtection represents a tag protection

--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -2660,6 +2660,8 @@
   "repo.release.downloads": "Downloads",
   "repo.release.download_count": "Downloads: %s",
   "repo.release.add_tag_msg": "Use the title and content of release as tag message.",
+  "repo.release.use_commit_date": "Use the target commit's date as the tag creation date.",
+  "repo.release.use_commit_date_helper": "Useful when retroactively creating a release for an older commit, so it doesn't appear as the most recent release.",
   "repo.release.add_tag": "Create Tag Only",
   "repo.release.releases_for": "Releases for %s",
   "repo.release.tags_for": "Tags for %s",

--- a/routers/api/v1/repo/release.go
+++ b/routers/api/v1/repo/release.go
@@ -274,7 +274,7 @@ func CreateRelease(ctx *context.APIContext) {
 		}
 		// GitHub doesn't have "tag_message", GitLab has: https://docs.gitlab.com/api/releases/#create-a-release
 		// It doesn't need to be the same as the "release note"
-		if err := release_service.CreateRelease(ctx, ctx.Repo.GitRepo, rel, nil, form.TagMessage); err != nil {
+		if err := release_service.CreateRelease(ctx, ctx.Repo.GitRepo, rel, nil, form.TagMessage, form.UseCommitDate); err != nil {
 			if repo_model.IsErrReleaseAlreadyExist(err) {
 				ctx.APIError(http.StatusConflict, err.Error())
 			} else if release_service.IsErrProtectedTagName(err) {

--- a/routers/api/v1/repo/tag.go
+++ b/routers/api/v1/repo/tag.go
@@ -207,7 +207,7 @@ func CreateTag(ctx *context.APIContext) {
 		return
 	}
 
-	if err := release_service.CreateNewTag(ctx, ctx.Doer, ctx.Repo.Repository, commit.ID.String(), form.TagName, form.Message); err != nil {
+	if err := release_service.CreateNewTag(ctx, ctx.Doer, ctx.Repo.Repository, commit.ID.String(), form.TagName, form.Message, form.UseCommitDate); err != nil {
 		if release_service.IsErrTagAlreadyExists(err) {
 			ctx.APIError(http.StatusConflict, err.Error())
 			return

--- a/routers/web/repo/branch.go
+++ b/routers/web/repo/branch.go
@@ -195,7 +195,7 @@ func CreateBranch(ctx *context.Context) {
 		if ctx.Repo.RefFullName.IsBranch() {
 			target = ctx.Repo.BranchName
 		}
-		err = release_service.CreateNewTag(ctx, ctx.Doer, ctx.Repo.Repository, target, form.NewBranchName, "")
+		err = release_service.CreateNewTag(ctx, ctx.Doer, ctx.Repo.Repository, target, form.NewBranchName, "", false)
 	} else if ctx.Repo.RefFullName.IsBranch() {
 		err = repo_service.CreateNewBranch(ctx, ctx.Doer, ctx.Repo.Repository, ctx.Repo.GitRepo, ctx.Repo.BranchName, form.NewBranchName)
 	} else {

--- a/routers/web/repo/release.go
+++ b/routers/web/repo/release.go
@@ -473,7 +473,7 @@ func NewReleasePost(ctx *context.Context) {
 
 	// no release, and tag only
 	if rel == nil && form.TagOnly {
-		if err = release_service.CreateNewTag(ctx, ctx.Doer, ctx.Repo.Repository, form.Target, form.TagName, newTagMsg); err != nil {
+		if err = release_service.CreateNewTag(ctx, ctx.Doer, ctx.Repo.Repository, form.Target, form.TagName, newTagMsg, form.UseCommitDate); err != nil {
 			handleTagReleaseError(err)
 			return
 		}
@@ -499,7 +499,7 @@ func NewReleasePost(ctx *context.Context) {
 			IsPrerelease: form.Prerelease,
 			IsTag:        false,
 		}
-		if err = release_service.CreateRelease(ctx, ctx.Repo.GitRepo, rel, attachmentUUIDs, newTagMsg); err != nil {
+		if err = release_service.CreateRelease(ctx, ctx.Repo.GitRepo, rel, attachmentUUIDs, newTagMsg, form.UseCommitDate); err != nil {
 			handleTagReleaseError(err)
 			return
 		}

--- a/services/forms/repo_form.go
+++ b/services/forms/repo_form.go
@@ -651,15 +651,16 @@ type UpdateAllowEditsForm struct {
 
 // NewReleaseForm form for creating release
 type NewReleaseForm struct {
-	TagName    string `binding:"Required;GitRefName;MaxSize(255)"`
-	Target     string `form:"tag_target" binding:"Required;MaxSize(255)"`
-	Title      string `binding:"MaxSize(255)"`
-	Content    string
-	Draft      bool
-	TagOnly    bool
-	Prerelease bool
-	AddTagMsg  bool
-	Files      []string
+	TagName       string `binding:"Required;GitRefName;MaxSize(255)"`
+	Target        string `form:"tag_target" binding:"Required;MaxSize(255)"`
+	Title         string `binding:"MaxSize(255)"`
+	Content       string
+	Draft         bool
+	TagOnly       bool
+	Prerelease    bool
+	AddTagMsg     bool
+	UseCommitDate bool
+	Files         []string
 }
 
 // Validate validates the fields

--- a/services/release/release.go
+++ b/services/release/release.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"gitea.dev/models/db"
 	git_model "gitea.dev/models/git"
@@ -65,7 +66,7 @@ func (err ErrProtectedTagName) Unwrap() error {
 	return util.ErrPermissionDenied
 }
 
-func createTag(ctx context.Context, gitRepo *git.Repository, rel *repo_model.Release, msg string) (bool, error) {
+func createTag(ctx context.Context, gitRepo *git.Repository, rel *repo_model.Release, msg string, useCommitDate bool) (bool, error) {
 	err := rel.LoadAttributes(ctx)
 	if err != nil {
 		return false, err
@@ -108,7 +109,11 @@ func createTag(ctx context.Context, gitRepo *git.Repository, rel *repo_model.Rel
 			}
 
 			if len(msg) > 0 {
-				if err = gitRepo.CreateAnnotatedTag(ctx, rel.TagName, msg, commit.ID.String()); err != nil {
+				var taggerDate *time.Time
+				if useCommitDate {
+					taggerDate = &commit.Committer.When
+				}
+				if err = gitRepo.CreateAnnotatedTag(ctx, rel.TagName, msg, commit.ID.String(), taggerDate); err != nil {
 					if strings.Contains(err.Error(), "is not a valid tag name") {
 						return false, ErrInvalidTagName{
 							TagName: rel.TagName,
@@ -167,7 +172,7 @@ func createTag(ctx context.Context, gitRepo *git.Repository, rel *repo_model.Rel
 }
 
 // CreateRelease creates a new release of repository.
-func CreateRelease(ctx context.Context, gitRepo *git.Repository, rel *repo_model.Release, attachmentUUIDs []string, msg string) error {
+func CreateRelease(ctx context.Context, gitRepo *git.Repository, rel *repo_model.Release, attachmentUUIDs []string, msg string, useCommitDate bool) error {
 	has, err := repo_model.IsReleaseExist(ctx, rel.RepoID, rel.TagName)
 	if err != nil {
 		return err
@@ -177,7 +182,7 @@ func CreateRelease(ctx context.Context, gitRepo *git.Repository, rel *repo_model
 		}
 	}
 
-	if _, err = createTag(ctx, gitRepo, rel, msg); err != nil {
+	if _, err = createTag(ctx, gitRepo, rel, msg, useCommitDate); err != nil {
 		return err
 	}
 
@@ -218,7 +223,7 @@ func (err ErrTagAlreadyExists) Unwrap() error {
 }
 
 // CreateNewTag creates a new repository tag
-func CreateNewTag(ctx context.Context, doer *user_model.User, repo *repo_model.Repository, commit, tagName, msg string) error {
+func CreateNewTag(ctx context.Context, doer *user_model.User, repo *repo_model.Repository, commit, tagName, msg string, useCommitDate bool) error {
 	has, err := repo_model.IsReleaseExist(ctx, repo.ID, tagName)
 	if err != nil {
 		return err
@@ -246,7 +251,7 @@ func CreateNewTag(ctx context.Context, doer *user_model.User, repo *repo_model.R
 		IsTag:        true,
 	}
 
-	if _, err = createTag(ctx, gitRepo, rel, msg); err != nil {
+	if _, err = createTag(ctx, gitRepo, rel, msg, useCommitDate); err != nil {
 		return err
 	}
 
@@ -263,7 +268,7 @@ func UpdateRelease(ctx context.Context, doer *user_model.User, gitRepo *git.Repo
 	if rel.ID == 0 {
 		return errors.New("UpdateRelease only accepts an exist release")
 	}
-	isTagCreated, err := createTag(ctx, gitRepo, rel, "")
+	isTagCreated, err := createTag(ctx, gitRepo, rel, "", false)
 	if err != nil {
 		return err
 	}

--- a/services/release/release_test.go
+++ b/services/release/release_test.go
@@ -49,7 +49,7 @@ func TestRelease_Create(t *testing.T) {
 		IsDraft:      false,
 		IsPrerelease: false,
 		IsTag:        false,
-	}, nil, ""))
+	}, nil, "", false))
 
 	assert.NoError(t, CreateRelease(t.Context(), gitRepo, &repo_model.Release{
 		RepoID:       repo.ID,
@@ -63,7 +63,7 @@ func TestRelease_Create(t *testing.T) {
 		IsDraft:      false,
 		IsPrerelease: false,
 		IsTag:        false,
-	}, nil, ""))
+	}, nil, "", false))
 
 	assert.NoError(t, CreateRelease(t.Context(), gitRepo, &repo_model.Release{
 		RepoID:       repo.ID,
@@ -77,7 +77,7 @@ func TestRelease_Create(t *testing.T) {
 		IsDraft:      false,
 		IsPrerelease: false,
 		IsTag:        false,
-	}, nil, ""))
+	}, nil, "", false))
 
 	assert.NoError(t, CreateRelease(t.Context(), gitRepo, &repo_model.Release{
 		RepoID:       repo.ID,
@@ -91,7 +91,7 @@ func TestRelease_Create(t *testing.T) {
 		IsDraft:      true,
 		IsPrerelease: false,
 		IsTag:        false,
-	}, nil, ""))
+	}, nil, "", false))
 
 	assert.NoError(t, CreateRelease(t.Context(), gitRepo, &repo_model.Release{
 		RepoID:       repo.ID,
@@ -105,7 +105,7 @@ func TestRelease_Create(t *testing.T) {
 		IsDraft:      false,
 		IsPrerelease: true,
 		IsTag:        false,
-	}, nil, ""))
+	}, nil, "", false))
 
 	testPlayload := "testtest"
 
@@ -129,7 +129,7 @@ func TestRelease_Create(t *testing.T) {
 		IsPrerelease: false,
 		IsTag:        true,
 	}
-	assert.NoError(t, CreateRelease(t.Context(), gitRepo, &release, []string{attach.UUID}, "test"))
+	assert.NoError(t, CreateRelease(t.Context(), gitRepo, &release, []string{attach.UUID}, "test", false))
 }
 
 func TestRelease_Update(t *testing.T) {
@@ -161,7 +161,7 @@ func TestRelease_Update(t *testing.T) {
 		IsDraft:      false,
 		IsPrerelease: false,
 		IsTag:        false,
-	}, nil, ""))
+	}, nil, "", false))
 	release, err := repo_model.GetRelease(t.Context(), repo.ID, "v1.1.1")
 	assert.NoError(t, err)
 	releaseCreatedUnix := release.CreatedUnix
@@ -185,7 +185,7 @@ func TestRelease_Update(t *testing.T) {
 		IsDraft:      true,
 		IsPrerelease: false,
 		IsTag:        false,
-	}, nil, ""))
+	}, nil, "", false))
 	release, err = repo_model.GetRelease(t.Context(), repo.ID, "v1.2.1")
 	assert.NoError(t, err)
 	releaseCreatedUnix = release.CreatedUnix
@@ -209,7 +209,7 @@ func TestRelease_Update(t *testing.T) {
 		IsDraft:      false,
 		IsPrerelease: true,
 		IsTag:        false,
-	}, nil, ""))
+	}, nil, "", false))
 	release, err = repo_model.GetRelease(t.Context(), repo.ID, "v1.3.1")
 	assert.NoError(t, err)
 	releaseCreatedUnix = release.CreatedUnix
@@ -235,7 +235,7 @@ func TestRelease_Update(t *testing.T) {
 		IsPrerelease: false,
 		IsTag:        false,
 	}
-	assert.NoError(t, CreateRelease(t.Context(), gitRepo, release, nil, ""))
+	assert.NoError(t, CreateRelease(t.Context(), gitRepo, release, nil, "", false))
 	assert.Positive(t, release.ID)
 
 	release.IsDraft = false
@@ -321,13 +321,13 @@ func TestRelease_createTag(t *testing.T) {
 		IsPrerelease: false,
 		IsTag:        false,
 	}
-	_, err = createTag(t.Context(), gitRepo, release, "")
+	_, err = createTag(t.Context(), gitRepo, release, "", false)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, release.CreatedUnix)
 	releaseCreatedUnix := release.CreatedUnix
 	advance()
 	release.Note = "Changed note"
-	_, err = createTag(t.Context(), gitRepo, release, "")
+	_, err = createTag(t.Context(), gitRepo, release, "", false)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(releaseCreatedUnix), int64(release.CreatedUnix))
 
@@ -345,12 +345,12 @@ func TestRelease_createTag(t *testing.T) {
 		IsPrerelease: false,
 		IsTag:        false,
 	}
-	_, err = createTag(t.Context(), gitRepo, release, "")
+	_, err = createTag(t.Context(), gitRepo, release, "", false)
 	assert.NoError(t, err)
 	releaseCreatedUnix = release.CreatedUnix
 	advance()
 	release.Title = "Changed title"
-	_, err = createTag(t.Context(), gitRepo, release, "")
+	_, err = createTag(t.Context(), gitRepo, release, "", false)
 	assert.NoError(t, err)
 	assert.Less(t, int64(releaseCreatedUnix), int64(release.CreatedUnix))
 
@@ -368,13 +368,13 @@ func TestRelease_createTag(t *testing.T) {
 		IsPrerelease: true,
 		IsTag:        false,
 	}
-	_, err = createTag(t.Context(), gitRepo, release, "")
+	_, err = createTag(t.Context(), gitRepo, release, "", false)
 	assert.NoError(t, err)
 	releaseCreatedUnix = release.CreatedUnix
 	advance()
 	release.Title = "Changed title"
 	release.Note = "Changed note"
-	_, err = createTag(t.Context(), gitRepo, release, "")
+	_, err = createTag(t.Context(), gitRepo, release, "", false)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(releaseCreatedUnix), int64(release.CreatedUnix))
 }
@@ -385,5 +385,26 @@ func TestCreateNewTag(t *testing.T) {
 	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
 
 	assert.NoError(t, CreateNewTag(t.Context(), user, repo, "master", "v2.0",
-		"v2.0 is released \n\n BUGFIX: .... \n\n 123"))
+		"v2.0 is released \n\n BUGFIX: .... \n\n 123", false))
+}
+
+func TestCreateNewTag_UseCommitDate(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+
+	gitRepo, err := git.OpenRepository(t.Context(), repo)
+	assert.NoError(t, err)
+	defer gitRepo.Close()
+
+	commit, err := gitRepo.GetBranchCommit(t.Context(), "master")
+	assert.NoError(t, err)
+
+	assert.NoError(t, CreateNewTag(t.Context(), user, repo, "master", "v2.0-dated",
+		"v2.0-dated is released using the commit date", true))
+
+	tag, err := gitRepo.GetTag(t.Context(), "v2.0-dated")
+	assert.NoError(t, err)
+	assert.NotNil(t, tag.Tagger)
+	assert.True(t, commit.Committer.When.Equal(tag.Tagger.When), "expected tagger date %v, got %v", commit.Committer.When, tag.Tagger.When)
 }

--- a/templates/repo/release/new.tmpl
+++ b/templates/repo/release/new.tmpl
@@ -105,6 +105,13 @@
 						<label><strong>{{ctx.Locale.Tr "repo.release.add_tag_msg"}}</strong></label>
 					</div>
 				</div>
+				<div class="field">
+					<div class="ui checkbox">
+						<input type="checkbox" name="use_commit_date">
+						<label><strong>{{ctx.Locale.Tr "repo.release.use_commit_date"}}</strong></label>
+					</div>
+					<div class="help tw-block tw-ml-[21px]">{{ctx.Locale.Tr "repo.release.use_commit_date_helper"}}</div>
+				</div>
 			{{else}}
 				<input type="hidden" name="add_tag_msg" value="false">
 			{{end}}

--- a/templates/swagger/v1-openapi3.generated.json
+++ b/templates/swagger/v1-openapi3.generated.json
@@ -4576,6 +4576,11 @@
             "description": "The target commitish for the release",
             "type": "string",
             "x-go-name": "Target"
+          },
+          "use_commit_date": {
+            "description": "Use the target commit's date as the git tag's creation date instead of the current time",
+            "type": "boolean",
+            "x-go-name": "UseCommitDate"
           }
         },
         "required": [
@@ -4712,6 +4717,11 @@
             "description": "The target commit SHA or branch name for the tag",
             "type": "string",
             "x-go-name": "Target"
+          },
+          "use_commit_date": {
+            "description": "Use the target commit's date as the git tag's creation date instead of the current time",
+            "type": "boolean",
+            "x-go-name": "UseCommitDate"
           }
         },
         "required": [

--- a/templates/swagger/v1-swagger.generated.json
+++ b/templates/swagger/v1-swagger.generated.json
@@ -24993,6 +24993,11 @@
           "description": "The target commitish for the release",
           "type": "string",
           "x-go-name": "Target"
+        },
+        "use_commit_date": {
+          "description": "Use the target commit's date as the git tag's creation date instead of the current time",
+          "type": "boolean",
+          "x-go-name": "UseCommitDate"
         }
       },
       "x-go-package": "gitea.dev/modules/structs"
@@ -25136,6 +25141,11 @@
           "description": "The target commit SHA or branch name for the tag",
           "type": "string",
           "x-go-name": "Target"
+        },
+        "use_commit_date": {
+          "description": "Use the target commit's date as the git tag's creation date instead of the current time",
+          "type": "boolean",
+          "x-go-name": "UseCommitDate"
         }
       },
       "x-go-package": "gitea.dev/modules/structs"

--- a/tests/integration/actions_trigger_test.go
+++ b/tests/integration/actions_trigger_test.go
@@ -497,7 +497,7 @@ jobs:
 		assert.NotNil(t, run)
 
 		// create a tag
-		err = release_service.CreateNewTag(t.Context(), user2, repo, branch.CommitID, "test-create-tag", "test create tag event")
+		err = release_service.CreateNewTag(t.Context(), user2, repo, branch.CommitID, "test-create-tag", "test create tag event", false)
 		assert.NoError(t, err)
 		run = unittest.AssertExistsAndLoadBean(t, &actions_model.ActionRun{
 			Title:      "add workflow",

--- a/tests/integration/api_repo_git_tags_test.go
+++ b/tests/integration/api_repo_git_tags_test.go
@@ -40,7 +40,7 @@ func TestAPIGitTags(t *testing.T) {
 
 	aTagName := "annotatedTag"
 	aTagMessage := "my annotated message"
-	gitRepo.CreateAnnotatedTag(t.Context(), aTagName, aTagMessage, commit.ID.String())
+	gitRepo.CreateAnnotatedTag(t.Context(), aTagName, aTagMessage, commit.ID.String(), nil)
 	aTag, _ := gitRepo.GetTag(t.Context(), aTagName)
 
 	// SHOULD work for annotated tags

--- a/tests/integration/api_repo_tags_test.go
+++ b/tests/integration/api_repo_tags_test.go
@@ -9,8 +9,10 @@ import (
 	"testing"
 
 	auth_model "gitea.dev/models/auth"
+	repo_model "gitea.dev/models/repo"
 	"gitea.dev/models/unittest"
 	user_model "gitea.dev/models/user"
+	"gitea.dev/modules/git"
 	"gitea.dev/modules/setting"
 	api "gitea.dev/modules/structs"
 	"gitea.dev/tests"
@@ -80,4 +82,37 @@ func createNewTagUsingAPI(t *testing.T, token, ownerName, repoName, name, target
 
 	respObj := DecodeJSON(t, resp, &api.Tag{})
 	return respObj
+}
+
+func TestAPIRepoTagCreateWithUseCommitDate(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	session := loginUser(t, user.Name)
+	token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteRepository)
+
+	repoName := "repo1"
+	target := "65f1bf27bc3bf70f64657658635e66094edbcb4d"
+
+	gitRepo, err := git.OpenRepository(t.Context(), &repo_model.Repository{OwnerName: user.Name, Name: repoName})
+	require.NoError(t, err)
+	defer gitRepo.Close()
+	commit, err := gitRepo.GetCommit(t.Context(), target)
+	require.NoError(t, err)
+
+	urlStr := fmt.Sprintf("/api/v1/repos/%s/%s/tags", user.Name, repoName)
+	req := NewRequestWithJSON(t, "POST", urlStr, &api.CreateTagOption{
+		TagName:       "use-commit-date-tag",
+		Message:       "tagged with commit date",
+		Target:        target,
+		UseCommitDate: true,
+	}).AddTokenAuth(token)
+	resp := MakeRequest(t, req, http.StatusCreated)
+
+	newTag := DecodeJSON(t, resp, &api.Tag{})
+	assert.True(t, commit.Committer.When.Equal(newTag.Commit.Created), "expected tag commit date %v, got %v", commit.Committer.When, newTag.Commit.Created)
+
+	// cleanup
+	delReq := NewRequestf(t, "DELETE", "/api/v1/repos/%s/%s/tags/%s", user.Name, repoName, newTag.Name).
+		AddTokenAuth(token)
+	MakeRequest(t, delReq, http.StatusNoContent)
 }

--- a/tests/integration/api_repo_tags_test.go
+++ b/tests/integration/api_repo_tags_test.go
@@ -109,7 +109,11 @@ func TestAPIRepoTagCreateWithUseCommitDate(t *testing.T) {
 	resp := MakeRequest(t, req, http.StatusCreated)
 
 	newTag := DecodeJSON(t, resp, &api.Tag{})
-	assert.True(t, commit.Committer.When.Equal(newTag.Commit.Created), "expected tag commit date %v, got %v", commit.Committer.When, newTag.Commit.Created)
+
+	tagObj, err := gitRepo.GetTag(t.Context(), newTag.Name)
+	require.NoError(t, err)
+	require.NotNil(t, tagObj.Tagger)
+	assert.True(t, commit.Committer.When.Equal(tagObj.Tagger.When), "expected tagger date %v, got %v", commit.Committer.When, tagObj.Tagger.When)
 
 	// cleanup
 	delReq := NewRequestf(t, "DELETE", "/api/v1/repos/%s/%s/tags/%s", user.Name, repoName, newTag.Name).

--- a/tests/integration/mirror_pull_test.go
+++ b/tests/integration/mirror_pull_test.go
@@ -92,7 +92,7 @@ func TestMirrorPull(t *testing.T) {
 		IsDraft:      false,
 		IsPrerelease: false,
 		IsTag:        true,
-	}, nil, ""))
+	}, nil, "", false))
 
 	_, err = repo_model.GetMirrorByRepoID(ctx, mirrorRepo.ID)
 	assert.NoError(t, err)

--- a/tests/integration/release_test.go
+++ b/tests/integration/release_test.go
@@ -11,6 +11,7 @@ import (
 	repo_model "gitea.dev/models/repo"
 	"gitea.dev/models/unittest"
 	user_model "gitea.dev/models/user"
+	"gitea.dev/modules/git"
 	"gitea.dev/modules/setting"
 	"gitea.dev/modules/test"
 	"gitea.dev/modules/translation"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func createNewRelease(t *testing.T, session *TestSession, repoURL, tag, title string, preRelease, draft bool) {
@@ -82,6 +84,41 @@ func TestCreateRelease(t *testing.T) {
 	createNewRelease(t, session, "/user2/repo1", "v0.0.1", "v0.0.1", false, false)
 
 	checkLatestReleaseAndCount(t, session, "/user2/repo1", "v0.0.1", translation.NewLocale("en-US").TrString("repo.release.stable"), 4)
+}
+
+func TestCreateReleaseUseCommitDate(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+	gitRepo, err := git.OpenRepository(t.Context(), repo)
+	require.NoError(t, err)
+	defer gitRepo.Close()
+	commit, err := gitRepo.GetBranchCommit(t.Context(), "master")
+	require.NoError(t, err)
+
+	session := loginUser(t, "user2")
+
+	req := NewRequest(t, "GET", "/user2/repo1/releases/new")
+	resp := session.MakeRequest(t, req, http.StatusOK)
+	htmlDoc := NewHTMLParser(t, resp.Body)
+	link, exists := htmlDoc.doc.Find("form.ui.form").Attr("action")
+	assert.True(t, exists, "The template has changed")
+
+	req = NewRequestWithValues(t, "POST", link, map[string]string{
+		"tag_name":        "v0.0.1-use-commit-date",
+		"tag_target":      "master",
+		"title":           "v0.0.1-use-commit-date",
+		"content":         "release note",
+		"add_tag_msg":     "on",
+		"use_commit_date": "on",
+	})
+	resp = session.MakeRequest(t, req, http.StatusOK)
+	assert.NotEmpty(t, test.ParseJSONRedirect(resp.Body.Bytes()))
+
+	tag, err := gitRepo.GetTag(t.Context(), "v0.0.1-use-commit-date")
+	require.NoError(t, err)
+	require.NotNil(t, tag.Tagger)
+	assert.True(t, commit.Committer.When.Equal(tag.Tagger.When), "expected tagger date %v, got %v", commit.Committer.When, tag.Tagger.When)
 }
 
 func TestCreateReleasePreRelease(t *testing.T) {

--- a/tests/integration/repo_tag_test.go
+++ b/tests/integration/repo_tag_test.go
@@ -33,14 +33,14 @@ func TestCreateNewTagProtected(t *testing.T) {
 	t.Run("Code", func(t *testing.T) {
 		defer tests.PrintCurrentTest(t)()
 
-		err := release.CreateNewTag(t.Context(), owner, repo, "master", "t-first", "first tag")
+		err := release.CreateNewTag(t.Context(), owner, repo, "master", "t-first", "first tag", false)
 		assert.NoError(t, err)
 
-		err = release.CreateNewTag(t.Context(), owner, repo, "master", "v-2", "second tag")
+		err = release.CreateNewTag(t.Context(), owner, repo, "master", "v-2", "second tag", false)
 		assert.Error(t, err)
 		assert.True(t, release.IsErrProtectedTagName(err))
 
-		err = release.CreateNewTag(t.Context(), owner, repo, "master", "v-1.1", "third tag")
+		err = release.CreateNewTag(t.Context(), owner, repo, "master", "v-1.1", "third tag", false)
 		assert.NoError(t, err)
 	})
 


### PR DESCRIPTION
When manually creating a tag or release on an older commit, the tag's
creation date defaulted to the current time, which pushed retroactively
created releases to the top of the "latest release" list instead of
preserving their historical position.

Adds an opt-in `use_commit_date` option (unchecked by default, so existing
behavior is unchanged) that stamps the tag's tagger date with the target
commit's date instead of the current time. Available from:
- the "New Release" web form
- `POST /repos/{owner}/{repo}/tags`
- `POST /repos/{owner}/{repo}/releases`

This only affects annotated tags (tags created with a message). Lightweight
tags have no independent tagger date — they already resolve to the target
commit's date, so no changes were needed there.

Fixes #38714