### PR TITLE
fix(web): attachment remove control renders as javascript:undefined link

### DIFF
--- a/web_src/css/features/dropzone.css
+++ b/web_src/css/features/dropzone.css
@@ -52,6 +52,14 @@
   filter: opacity(0.5) !important;
 }
 
+.dropzone .dz-preview .dz-remove {
+  width: 100%;
+  padding: 0;
+  background: none;
+  color: var(--color-primary);
+  font-family: inherit;
+}
+
 .ui .field .dropzone .dz-preview .dz-progress {
   /* by default the progress-bar is vertically centered (top: 50%), it's better to put it after the "details (size, filename)",
   then the layout from top to bottom is: size, filename, progress */

--- a/web_src/js/features/dropzone.ts
+++ b/web_src/js/features/dropzone.ts
@@ -8,7 +8,7 @@ import {errorMessage} from '../modules/errors.ts';
 import {isImageFile, isVideoFile} from '../utils.ts';
 import type Dropzone from '@deltablot/dropzone';
 
-type CustomDropzoneFile = Dropzone.DropzoneFile & {uuid: string};
+type CustomDropzoneFile = Dropzone.DropzoneFile & {uuid: string, _removeLink?: HTMLElement};
 
 // dropzone has its owner event dispatcher (emitter)
 export const DropzoneCustomEventReloadFiles = 'dropzone-custom-reload-files';
@@ -57,6 +57,14 @@ function addCopyLink(file: Partial<CustomDropzoneFile>) {
   file.previewTemplate!.append(copyLinkEl);
 }
 
+function addRemoveButton(dzInst: Dropzone, file: CustomDropzoneFile, dictRemoveFile: string) {
+  // dropzone's own "addRemoveLinks" renders an anchor with href="javascript:undefined;", so render the control here instead
+  const removeEl = createElementFromHTML<HTMLButtonElement>(html`<button type="button" class="dz-remove">${dictRemoveFile}</button>`);
+  removeEl.addEventListener('click', () => dzInst.removeFile(file));
+  file._removeLink = removeEl; // dropzone swaps this element's text between "cancel upload" and "remove file"
+  file.previewTemplate.append(removeEl);
+}
+
 type FileUuidDict = Record<string, {submitted: boolean}>;
 
 /**
@@ -72,7 +80,6 @@ export async function initDropzone(dropzoneEl: HTMLElement) {
   const opts: Record<string, any> = {
     url: dropzoneEl.getAttribute('data-upload-url'),
     acceptedFiles: ['*/*', ''].includes(dropzoneEl.getAttribute('data-accepts')!) ? null : dropzoneEl.getAttribute('data-accepts'),
-    addRemoveLinks: true,
     dictDefaultMessage: dropzoneEl.getAttribute('data-default-message'),
     dictInvalidFileType: dropzoneEl.getAttribute('data-invalid-input-type'),
     dictFileTooBig: dropzoneEl.getAttribute('data-file-too-big'),
@@ -89,6 +96,8 @@ export async function initDropzone(dropzoneEl: HTMLElement) {
   // "http://localhost:3000/owner/repo/issues/[object%20Event]"
   // the reason is that the preview "callback(dataURL)" is assign to "img.onerror" then "thumbnail" uses the error object as the dataURL and generates '<img src="[object Event]">'
   const dzInst = await createDropzone(dropzoneEl, opts);
+  dzInst.on('addedfile', (file: CustomDropzoneFile) => addRemoveButton(dzInst, file, opts.dictRemoveFile));
+
   dzInst.on('success', (file: CustomDropzoneFile, resp: any) => {
     file.uuid = resp.uuid;
     fileUuidDict[file.uuid] = {submitted: false};


### PR DESCRIPTION
Issue https://github.com/go-gitea/gitea/issues/38802

Dropzone's addRemoveLinks option hardcodes the remove control as an anchor with href="javascript:undefined;", which shows a meaningless URL on hover and announces a fake link to assistive technology. Render the control as a real button instead and keep the file._removeLink reference so dropzone can still swap its label during uploads.

<!--
Before submitting:
- Target the `main` branch; release branches are for backports only.
- Use a Conventional Commits title, e.g. `fix(repo): handle empty branch names`.
- Read the contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
- Documentation changes go to https://gitea.com/gitea/docs

Describe your change below and link any issue it fixes.
-->

Before:
<img width="2200" height="1800" alt="before-hover" src="https://github.com/user-attachments/assets/40f7b250-bdef-4bb0-8a85-d69a80045cfc" />

After:
<img width="2200" height="1800" alt="after-hover" src="https://github.com/user-attachments/assets/fda7f6ca-8d23-4c32-811e-b3e28dc750cf" />

Assisted-by: Claude Code:claude-opus-5