### PR TITLE
fix(migrations): use all configured GitHub tokens (#38841)

### DIFF
--- a/services/migrations/github.go
+++ b/services/migrations/github.go
@@ -152,9 +152,7 @@ func (g *GithubDownloaderV3) waitAndPickClient(ctx context.Context) {
 	var recentIdx int
 	var maxRemaining int
 	for i := 0; i < len(g.clients); i++ {
-		// Probe each client at least once so its rate limit is known. Otherwise,
-		// clients after the first one stay nil forever and are never selected.
-		if g.rates[i] == nil {
+		if g.rates[i] == nil { // probe unknown clients once, else their rate never gets learned
 			g.curClientIdx = i
 			return
 		}

--- a/services/migrations/github.go
+++ b/services/migrations/github.go
@@ -152,12 +152,18 @@ func (g *GithubDownloaderV3) waitAndPickClient(ctx context.Context) {
 	var recentIdx int
 	var maxRemaining int
 	for i := 0; i < len(g.clients); i++ {
-		if g.rates[i] != nil && g.rates[i].Remaining > maxRemaining {
+		// Probe each client at least once so its rate limit is known. Otherwise,
+		// clients after the first one stay nil forever and are never selected.
+		if g.rates[i] == nil {
+			g.curClientIdx = i
+			return
+		}
+		if g.rates[i].Remaining > maxRemaining {
 			maxRemaining = g.rates[i].Remaining
 			recentIdx = i
 		}
 	}
-	g.curClientIdx = recentIdx // if no max remain, it will always pick the first client.
+	g.curClientIdx = recentIdx
 
 	for g.rates[g.curClientIdx] != nil && g.rates[g.curClientIdx].Remaining <= GithubLimitRateRemaining {
 		timer := time.NewTimer(time.Until(g.rates[g.curClientIdx].Reset.Time))

--- a/services/migrations/github_test.go
+++ b/services/migrations/github_test.go
@@ -14,6 +14,7 @@ import (
 	"gitea.dev/models/unittest"
 	base "gitea.dev/modules/migration"
 
+	"github.com/google/go-github/v89/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -472,4 +473,26 @@ func TestGithubMultiToken(t *testing.T) {
 			assert.Equal(t, tC.expectedCloneURL, cloneURL)
 		})
 	}
+}
+
+func TestGithubMultiTokenClientSelection(t *testing.T) {
+	downloader := &GithubDownloaderV3{
+		clients: make([]*github.Client, 3),
+		rates:   make([]*github.Rate, 3),
+	}
+
+	downloader.waitAndPickClient(t.Context())
+	assert.Equal(t, 0, downloader.curClientIdx)
+
+	downloader.rates[0] = &github.Rate{Remaining: 100}
+	downloader.waitAndPickClient(t.Context())
+	assert.Equal(t, 1, downloader.curClientIdx)
+
+	downloader.rates[1] = &github.Rate{Remaining: 200}
+	downloader.waitAndPickClient(t.Context())
+	assert.Equal(t, 2, downloader.curClientIdx)
+
+	downloader.rates[2] = &github.Rate{Remaining: 50}
+	downloader.waitAndPickClient(t.Context())
+	assert.Equal(t, 1, downloader.curClientIdx)
 }

--- a/services/migrations/github_test.go
+++ b/services/migrations/github_test.go
@@ -14,7 +14,7 @@ import (
 	"gitea.dev/models/unittest"
 	base "gitea.dev/modules/migration"
 
-	"github.com/google/go-github/v89/github"
+	"github.com/google/go-github/v88/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
Backport of https://github.com/go-gitea/gitea/pull/38841

The test import needs `go-github/v88` here, because this branch pins v88 while main is on v89. The rest applies unchanged.