### PR TITLE
fix(repo): avoid a repo-sized temp file for every bundle download

### DIFF
--- a/modules/git/archive.go
+++ b/modules/git/archive.go
@@ -39,7 +39,8 @@ func CreateArchive(ctx context.Context, repo RepositoryFacade, repoName, format 
 
 // CreateBundle create bundle content to the target path
 func CreateBundle(ctx context.Context, repo RepositoryFacade, commit string, out io.Writer) error {
-	// TODO: use the following steps instead of creating a temp file, also need to iterate and clean up outdated refs
+	// TODO: use the following steps instead of creating a temp repo, also need to iterate and clean up outdated refs
+	// the temp ref has to be under refs/heads/*, otherwise the bundle clones into an empty repository
 	// git update-ref refs/bundle/temp-{timestamp} {commit}
 	// git bundle create - refs/bundle/temp-{timestamp}
 	// git update-ref -d refs/bundle/temp-{timestamp}
@@ -69,18 +70,5 @@ func CreateBundle(ctx context.Context, repo RepositoryFacade, commit string, out
 		return err
 	}
 
-	tmpFile := filepath.Join(tmpDir, "bundle")
-	_, _, err = gitTmpCmd().AddArguments("bundle", "create").AddDynamicArguments(tmpFile, "bundle", "HEAD").RunStdString(ctx)
-	if err != nil {
-		return err
-	}
-
-	fi, err := os.Open(tmpFile)
-	if err != nil {
-		return err
-	}
-	defer fi.Close()
-
-	_, err = io.Copy(out, fi)
-	return err
+	return gitTmpCmd().AddArguments("bundle", "create", "-", "bundle", "HEAD").WithStdoutCopy(out).RunWithStderr(ctx)
 }

--- a/modules/git/archive.go
+++ b/modules/git/archive.go
@@ -40,10 +40,10 @@ func CreateArchive(ctx context.Context, repo RepositoryFacade, repoName, format 
 // CreateBundle create bundle content to the target path
 func CreateBundle(ctx context.Context, repo RepositoryFacade, commit string, out io.Writer) error {
 	// TODO: use the following steps instead of creating a temp repo, also need to iterate and clean up outdated refs
-	// the temp ref has to be under refs/heads/*, otherwise the bundle clones into an empty repository
-	// git update-ref refs/bundle/temp-{timestamp} {commit}
-	// git bundle create - refs/bundle/temp-{timestamp}
-	// git update-ref -d refs/bundle/temp-{timestamp}
+	// the temp ref has to be under refs/heads/*, and a clone only checks out with a HEAD, which needs the temp repo
+	// git update-ref refs/heads/bundle-temp-{timestamp} {commit}
+	// git bundle create - refs/heads/bundle-temp-{timestamp}
+	// git update-ref -d refs/heads/bundle-temp-{timestamp}
 	tmpDir, cleanup, err := setting.AppDataTempDir("git-repo-content").MkdirTempRandom("gitea-bundle")
 	if err != nil {
 		return err

--- a/modules/git/archive_test.go
+++ b/modules/git/archive_test.go
@@ -23,6 +23,7 @@ func TestCreateBundle(t *testing.T) {
 	header, _, ok := strings.Cut(buf.String(), "\n\n")
 	require.True(t, ok)
 	assert.Equal(t, "# v2 git bundle", strings.Split(header, "\n")[0])
-	// a bundle whose only ref sits outside refs/heads/* clones into an empty repository
+	// without a refs/heads/* ref and a HEAD, a clone of the bundle has no branch and no checkout
 	assert.Contains(t, header, "ce064814f4a0d337b333e646ece456cd39fab612 refs/heads/bundle")
+	assert.Contains(t, header, "ce064814f4a0d337b333e646ece456cd39fab612 HEAD")
 }

--- a/modules/git/archive_test.go
+++ b/modules/git/archive_test.go
@@ -1,0 +1,28 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package git
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"gitea.dev/modules/setting"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateBundle(t *testing.T) {
+	setting.AppDataPath = t.TempDir()
+
+	buf := &bytes.Buffer{}
+	require.NoError(t, CreateBundle(t.Context(), mockRepository("repo1_bare"), "ce064814f4a0d337b333e646ece456cd39fab612", buf))
+
+	header, _, ok := strings.Cut(buf.String(), "\n\n")
+	require.True(t, ok)
+	assert.Equal(t, "# v2 git bundle", strings.Split(header, "\n")[0])
+	// a bundle whose only ref sits outside refs/heads/* clones into an empty repository
+	assert.Contains(t, header, "ce064814f4a0d337b333e646ece456cd39fab612 refs/heads/bundle")
+}


### PR DESCRIPTION
Bundle downloads run `git bundle create` into a temp file under `data/tmp/git-repo-content` and copy it to the response, so every download puts a second, repo-sized copy on disk before the first byte is sent. If the process dies mid-request that copy is stranded: the startup sweep only drops files older than 3 days, and cannot remove a directory that still holds a newer file.

Streaming `git bundle create -` to the response removes that copy. `CreateArchive` above already uses the same gitcmd pattern, and the bundle bytes are unchanged (existing integration assertions on the exact length still pass).

One consequence: git can now fail after output starts, so a mid-stream failure truncates the body instead of returning an error.

I did not act on the TODO. A temp ref only works under `refs/heads/*`; with `refs/bundle/temp-*` the bundle carries no branch and clones empty, so I noted that on the TODO.

Fixes https://github.com/go-gitea/gitea/issues/38447

Assisted-by: Claude Code:claude-opus-5
