### PR TITLE
fix(lfs): accept successful transfer responses

### DIFF
--- a/modules/lfs/http_client.go
+++ b/modules/lfs/http_client.go
@@ -249,7 +249,7 @@ func createRequest(ctx context.Context, method, url string, headers map[string]s
 }
 
 // performRequest sends a request, optionally performs a callback on the request and returns the response.
-// If the status code is 200, the response is returned, and it will contain a non-nil Body.
+// If the status code is in the 2xx range, the response is returned, and it will contain a non-nil Body.
 // Otherwise, it will return an error, and the Body will be nil or closed.
 func performRequest(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error) {
 	log.Trace("performRequest: %s", req.URL)
@@ -264,7 +264,7 @@ func performRequest(ctx context.Context, client *http.Client, req *http.Request)
 		return res, err
 	}
 
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
 		defer res.Body.Close()
 		return res, handleErrorResponse(res)
 	}

--- a/modules/lfs/http_client.go
+++ b/modules/lfs/http_client.go
@@ -264,7 +264,7 @@ func performRequest(ctx context.Context, client *http.Client, req *http.Request)
 		return res, err
 	}
 
-	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		defer res.Body.Close()
 		return res, handleErrorResponse(res)
 	}

--- a/modules/lfs/transferadapter_test.go
+++ b/modules/lfs/transferadapter_test.go
@@ -135,6 +135,15 @@ func TestBasicTransferAdapter(t *testing.T) {
 		}
 	})
 
+	t.Run("Upload created", func(t *testing.T) {
+		client := &http.Client{Transport: RoundTripFunc(func(req *http.Request) *http.Response {
+			return &http.Response{StatusCode: http.StatusCreated, Body: io.NopCloser(strings.NewReader(""))}
+		})}
+		adapter := &BasicTransferAdapter{client: client}
+		err := adapter.Upload(t.Context(), &Link{Href: "https://upload-created-request.io"}, p, strings.NewReader("dummy"))
+		assert.NoError(t, err)
+	})
+
 	t.Run("Verify", func(t *testing.T) {
 		cases := []struct {
 			link          *Link


### PR DESCRIPTION
Accept all 2xx LFS transfer responses so uploads returning 201 Created are not handled as errors and decoded as empty error bodies.

Fixes https://github.com/go-gitea/gitea/issues/38865.

----

Co-authored-by: waterWang <waterWang@users.noreply.github.com>