### PR TITLE
fix(lfs): accept full 2xx range for successful LFS transfers

### DIFF
--- a/modules/lfs/http_client.go
+++ b/modules/lfs/http_client.go
@@ -249,7 +249,7 @@ func createRequest(ctx context.Context, method, url string, headers map[string]s
 }
 
 // performRequest sends a request, optionally performs a callback on the request and returns the response.
-// If the status code is 200, the response is returned, and it will contain a non-nil Body.
+// If the status code is in the 2xx range, the response is returned, and it will contain a non-nil Body.
 // Otherwise, it will return an error, and the Body will be nil or closed.
 func performRequest(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error) {
 	log.Trace("performRequest: %s", req.URL)
@@ -264,7 +264,7 @@ func performRequest(ctx context.Context, client *http.Client, req *http.Request)
 		return res, err
 	}
 
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		defer res.Body.Close()
 		return res, handleErrorResponse(res)
 	}


### PR DESCRIPTION
Fixes #38865

**Problem**: Gitea LFS push client (`modules/lfs/http_client.go`) accepted only HTTP 200 OK in `performRequest`. When an LFS server (e.g. Azure Repos) returns **201 Created** for a successful object upload with an empty response body, the code fell into the error-handling path. `handleErrorResponse` tried to decode the empty body as a JSON error, hit `io.EOF`, and returned `io.ErrUnexpectedEOF` — failing the whole push mirror.

**Fix**: Accept the full 2xx success range (`StatusOK` through `StatusCreated` etc.) in `performRequest`, treating any 2xx status as success. Also updated the doc comment to reflect the 2xx contract.

**Verification**: The Gitea LFS HTTP client spec (git-lfs batch API) allows any 2xx for successful transfers. This aligns Gitea with the LFS spec.