### PR TITLE
test(setting): table-driven harness for config load tests

### DIFF
--- a/modules/setting/actions_test.go
+++ b/modules/setting/actions_test.go
@@ -5,307 +5,209 @@ package setting
 
 import (
 	"path/filepath"
-	"slices"
 	"testing"
 
 	"gitea.dev/modules/test"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_getStorageInheritNameSectionTypeForActions(t *testing.T) {
-	iniStr := `
-	[storage]
-	STORAGE_TYPE = minio
-	`
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-	assert.NoError(t, loadActionsFrom(cfg))
+	defer test.MockVariableValue(&Actions)()
 
-	assert.EqualValues(t, "minio", Actions.LogStorage.Type)
-	assert.Equal(t, "actions_log/", Actions.LogStorage.MinioConfig.BasePath)
-	assert.EqualValues(t, "minio", Actions.ArtifactStorage.Type)
-	assert.Equal(t, "actions_artifacts/", Actions.ArtifactStorage.MinioConfig.BasePath)
+	logType := func() StorageType { return Actions.LogStorage.Type }
+	logBasePath := func() string { return Actions.LogStorage.MinioConfig.BasePath }
+	logDir := func() string { return filepath.Base(Actions.LogStorage.Path) }
+	artifactType := func() StorageType { return Actions.ArtifactStorage.Type }
+	artifactBasePath := func() string { return Actions.ArtifactStorage.MinioConfig.BasePath }
+	artifactDir := func() string { return filepath.Base(Actions.ArtifactStorage.Path) }
 
-	iniStr = `
-[storage.actions_log]
-STORAGE_TYPE = minio
-`
-	cfg, err = NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-	assert.NoError(t, loadActionsFrom(cfg))
-
-	assert.EqualValues(t, "minio", Actions.LogStorage.Type)
-	assert.Equal(t, "actions_log/", Actions.LogStorage.MinioConfig.BasePath)
-	assert.EqualValues(t, "local", Actions.ArtifactStorage.Type)
-	assert.Equal(t, "actions_artifacts", filepath.Base(Actions.ArtifactStorage.Path))
-
-	iniStr = `
-[storage.actions_log]
-STORAGE_TYPE = my_storage
-
-[storage.my_storage]
-STORAGE_TYPE = minio
-`
-	cfg, err = NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-	assert.NoError(t, loadActionsFrom(cfg))
-
-	assert.EqualValues(t, "minio", Actions.LogStorage.Type)
-	assert.Equal(t, "actions_log/", Actions.LogStorage.MinioConfig.BasePath)
-	assert.EqualValues(t, "local", Actions.ArtifactStorage.Type)
-	assert.Equal(t, "actions_artifacts", filepath.Base(Actions.ArtifactStorage.Path))
-
-	iniStr = `
-[storage.actions_artifacts]
-STORAGE_TYPE = my_storage
-
-[storage.my_storage]
-STORAGE_TYPE = minio
-`
-	cfg, err = NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-	assert.NoError(t, loadActionsFrom(cfg))
-
-	assert.EqualValues(t, "local", Actions.LogStorage.Type)
-	assert.Equal(t, "actions_log", filepath.Base(Actions.LogStorage.Path))
-	assert.EqualValues(t, "minio", Actions.ArtifactStorage.Type)
-	assert.Equal(t, "actions_artifacts/", Actions.ArtifactStorage.MinioConfig.BasePath)
-
-	iniStr = `
-[storage.actions_artifacts]
-STORAGE_TYPE = my_storage
-
-[storage.my_storage]
-STORAGE_TYPE = minio
-`
-	cfg, err = NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-	assert.NoError(t, loadActionsFrom(cfg))
-
-	assert.EqualValues(t, "local", Actions.LogStorage.Type)
-	assert.Equal(t, "actions_log", filepath.Base(Actions.LogStorage.Path))
-	assert.EqualValues(t, "minio", Actions.ArtifactStorage.Type)
-	assert.Equal(t, "actions_artifacts/", Actions.ArtifactStorage.MinioConfig.BasePath)
-
-	iniStr = ``
-	cfg, err = NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-	assert.NoError(t, loadActionsFrom(cfg))
-
-	assert.EqualValues(t, "local", Actions.LogStorage.Type)
-	assert.Equal(t, "actions_log", filepath.Base(Actions.LogStorage.Path))
-	assert.EqualValues(t, "local", Actions.ArtifactStorage.Type)
-	assert.Equal(t, "actions_artifacts", filepath.Base(Actions.ArtifactStorage.Path))
+	testConfigLoad(t, []any{loadActionsFrom}, []configTestCase{
+		{
+			name: "both inherit the global [storage]",
+			ini:  "[storage]\nSTORAGE_TYPE = minio",
+			want: []configCheck{
+				fieldOf("STORAGE_TYPE", logType, MinioStorageType),
+				fieldOf("MINIO_BASE_PATH", logBasePath, "actions_log/"),
+				fieldOf("STORAGE_TYPE", artifactType, MinioStorageType),
+				fieldOf("MINIO_BASE_PATH", artifactBasePath, "actions_artifacts/"),
+			},
+		},
+		{
+			name: "[storage.actions_log] only affects the log storage",
+			ini:  "[storage.actions_log]\nSTORAGE_TYPE = minio",
+			want: []configCheck{
+				fieldOf("STORAGE_TYPE", logType, MinioStorageType),
+				fieldOf("MINIO_BASE_PATH", logBasePath, "actions_log/"),
+				fieldOf("STORAGE_TYPE", artifactType, LocalStorageType),
+				fieldOf("PATH", artifactDir, "actions_artifacts"),
+			},
+		},
+		{
+			name: "the log storage can name another storage",
+			ini:  "[storage.actions_log]\nSTORAGE_TYPE = my_storage\n\n[storage.my_storage]\nSTORAGE_TYPE = minio",
+			want: []configCheck{
+				fieldOf("STORAGE_TYPE", logType, MinioStorageType),
+				fieldOf("MINIO_BASE_PATH", logBasePath, "actions_log/"),
+				fieldOf("STORAGE_TYPE", artifactType, LocalStorageType),
+				fieldOf("PATH", artifactDir, "actions_artifacts"),
+			},
+		},
+		{
+			name: "the artifact storage can name another storage",
+			ini:  "[storage.actions_artifacts]\nSTORAGE_TYPE = my_storage\n\n[storage.my_storage]\nSTORAGE_TYPE = minio",
+			want: []configCheck{
+				fieldOf("STORAGE_TYPE", logType, LocalStorageType),
+				fieldOf("PATH", logDir, "actions_log"),
+				fieldOf("STORAGE_TYPE", artifactType, MinioStorageType),
+				fieldOf("MINIO_BASE_PATH", artifactBasePath, "actions_artifacts/"),
+			},
+		},
+		{
+			name: "both default to local",
+			want: []configCheck{
+				fieldOf("STORAGE_TYPE", logType, LocalStorageType),
+				fieldOf("PATH", logDir, "actions_log"),
+				fieldOf("STORAGE_TYPE", artifactType, LocalStorageType),
+				fieldOf("PATH", artifactDir, "actions_artifacts"),
+			},
+		},
+	})
 }
 
 func Test_WorkflowDirs(t *testing.T) {
-	oldActions := Actions
-	defer func() {
-		Actions = oldActions
-	}()
+	defer test.MockVariableValue(&Actions)()
 
-	tests := []struct {
-		name     string
-		iniStr   string
-		wantDirs []string
-		wantErr  bool
-	}{
+	testConfigLoad(t, []any{loadActionsFrom}, []configTestCase{
 		{
-			name:     "default",
-			iniStr:   `[actions]`,
-			wantDirs: []string{".gitea/workflows", ".github/workflows"},
+			name: "default",
+			ini:  "[actions]",
+			want: []configCheck{field("WORKFLOW_DIRS", &Actions.WorkflowDirs, []string{".gitea/workflows", ".github/workflows"})},
 		},
 		{
-			name:     "single dir",
-			iniStr:   "[actions]\nWORKFLOW_DIRS = .github/workflows",
-			wantDirs: []string{".github/workflows"},
+			name: "single dir",
+			ini:  "[actions]\nWORKFLOW_DIRS = .github/workflows",
+			want: []configCheck{field("WORKFLOW_DIRS", &Actions.WorkflowDirs, []string{".github/workflows"})},
 		},
 		{
-			name:     "custom order",
-			iniStr:   "[actions]\nWORKFLOW_DIRS = .github/workflows,.gitea/workflows",
-			wantDirs: []string{".github/workflows", ".gitea/workflows"},
+			name: "custom order",
+			ini:  "[actions]\nWORKFLOW_DIRS = .github/workflows,.gitea/workflows",
+			want: []configCheck{field("WORKFLOW_DIRS", &Actions.WorkflowDirs, []string{".github/workflows", ".gitea/workflows"})},
 		},
 		{
-			name:     "whitespace trimming",
-			iniStr:   "[actions]\nWORKFLOW_DIRS = .gitea/workflows , .github/workflows ",
-			wantDirs: []string{".gitea/workflows", ".github/workflows"},
+			name: "whitespace trimming",
+			ini:  "[actions]\nWORKFLOW_DIRS = .gitea/workflows , .github/workflows ",
+			want: []configCheck{field("WORKFLOW_DIRS", &Actions.WorkflowDirs, []string{".gitea/workflows", ".github/workflows"})},
 		},
 		{
-			name:     "trailing slash normalization",
-			iniStr:   "[actions]\nWORKFLOW_DIRS = .gitea/workflows/,.github/workflows/",
-			wantDirs: []string{".gitea/workflows", ".github/workflows"},
+			name: "trailing slash normalization",
+			ini:  "[actions]\nWORKFLOW_DIRS = .gitea/workflows/,.github/workflows/",
+			want: []configCheck{field("WORKFLOW_DIRS", &Actions.WorkflowDirs, []string{".gitea/workflows", ".github/workflows"})},
 		},
 		{
 			name:    "only commas and whitespace",
-			iniStr:  "[actions]\nWORKFLOW_DIRS = , , ,",
-			wantErr: true,
+			ini:     "[actions]\nWORKFLOW_DIRS = , , ,",
+			wantErr: assert.Error,
+			want:    []configCheck{guard(&Actions.WorkflowDirs)},
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := NewConfigProviderFromData(tt.iniStr)
-			require.NoError(t, err)
-			err = loadActionsFrom(cfg)
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantDirs, Actions.WorkflowDirs)
-		})
-	}
+	})
 }
 
 func Test_getDefaultActionsURLForActions(t *testing.T) {
-	oldActions := Actions
-	oldAppURL := AppURL
-	defer func() {
-		Actions = oldActions
-		AppURL = oldAppURL
-	}()
+	defer test.MockVariableValue(&Actions)()
+	defer test.MockVariableValue(&AppURL, "http://test_get_default_actions_url_for_actions:3000/")()
 
-	AppURL = "http://test_get_default_actions_url_for_actions:3000/"
+	actionsURL := func() string { return Actions.DefaultActionsURL.URL() }
 
-	tests := []struct {
-		name    string
-		iniStr  string
-		wantErr assert.ErrorAssertionFunc
-		wantURL string
-	}{
+	testConfigLoad(t, []any{loadActionsFrom}, []configTestCase{
 		{
 			name: "default",
-			iniStr: `
-[actions]
-`,
-			wantErr: assert.NoError,
-			wantURL: "https://github.com",
+			ini:  "[actions]",
+			want: []configCheck{fieldOf("DEFAULT_ACTIONS_URL", actionsURL, "https://github.com")},
 		},
 		{
 			name: "github",
-			iniStr: `
-[actions]
-DEFAULT_ACTIONS_URL = github
-`,
-			wantErr: assert.NoError,
-			wantURL: "https://github.com",
+			ini:  "[actions]\nDEFAULT_ACTIONS_URL = github",
+			want: []configCheck{fieldOf("DEFAULT_ACTIONS_URL", actionsURL, "https://github.com")},
 		},
 		{
 			name: "self",
-			iniStr: `
-[actions]
-DEFAULT_ACTIONS_URL = self
-`,
-			wantErr: assert.NoError,
-			wantURL: "http://test_get_default_actions_url_for_actions:3000",
+			ini:  "[actions]\nDEFAULT_ACTIONS_URL = self",
+			want: []configCheck{fieldOf("DEFAULT_ACTIONS_URL", actionsURL, "http://test_get_default_actions_url_for_actions:3000")},
 		},
 		{
-			name: "custom url",
-			iniStr: `
-[actions]
-DEFAULT_ACTIONS_URL = https://gitea.com
-`,
-			wantErr: assert.NoError,
-			wantURL: "https://github.com",
+			name: "custom url falls back to github",
+			ini:  "[actions]\nDEFAULT_ACTIONS_URL = https://gitea.com",
+			want: []configCheck{fieldOf("DEFAULT_ACTIONS_URL", actionsURL, "https://github.com")},
 		},
 		{
-			name: "custom urls",
-			iniStr: `
-[actions]
-DEFAULT_ACTIONS_URL = https://gitea.com,https://github.com
-`,
-			wantErr: assert.NoError,
-			wantURL: "https://github.com",
+			name: "custom urls fall back to github",
+			ini:  "[actions]\nDEFAULT_ACTIONS_URL = https://gitea.com,https://github.com",
+			want: []configCheck{fieldOf("DEFAULT_ACTIONS_URL", actionsURL, "https://github.com")},
 		},
 		{
-			name: "invalid",
-			iniStr: `
-[actions]
-DEFAULT_ACTIONS_URL = gitea
-`,
+			name:    "invalid",
+			ini:     "[actions]\nDEFAULT_ACTIONS_URL = gitea",
 			wantErr: assert.Error,
-			wantURL: "https://github.com",
+			want: []configCheck{
+				guard(&Actions.DefaultActionsURL),
+				fieldOf("DEFAULT_ACTIONS_URL", actionsURL, "https://github.com"),
+			},
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := NewConfigProviderFromData(tt.iniStr)
-			require.NoError(t, err)
-			if !tt.wantErr(t, loadActionsFrom(cfg)) {
-				return
-			}
-			assert.Equal(t, tt.wantURL, Actions.DefaultActionsURL.URL())
-		})
-	}
+	})
 }
 
 func Test_ScopedWorkflowDirs(t *testing.T) {
 	defer test.MockVariableValue(&Actions)()
 
-	defaultWorkflowDirs := []string{".gitea/workflows", ".github/workflows"}
-	defaultScopedDirs := []string{".gitea/scoped_workflows"}
+	// WORKFLOW_DIRS is guarded rather than asserted: MapTo keeps the current value for an absent
+	// key, so without it a case that sets WORKFLOW_DIRS would leak into the next one
+	scoped := func(want []string) []configCheck {
+		return []configCheck{
+			guard(&Actions.WorkflowDirs),
+			field("SCOPED_WORKFLOW_DIRS", &Actions.ScopedWorkflowDirs, want),
+		}
+	}
+	overlapping := []configCheck{guard(&Actions.WorkflowDirs), guard(&Actions.ScopedWorkflowDirs)}
 
-	tests := []struct {
-		name       string
-		iniStr     string
-		wantScoped []string
-		wantErr    bool
-	}{
+	testConfigLoad(t, []any{loadActionsFrom}, []configTestCase{
 		{
-			name:       "default",
-			iniStr:     `[actions]`,
-			wantScoped: defaultScopedDirs,
+			name: "default",
+			ini:  "[actions]",
+			want: scoped([]string{".gitea/scoped_workflows"}),
 		},
 		{
-			name:       "custom dir",
-			iniStr:     "[actions]\nSCOPED_WORKFLOW_DIRS = .gitea/my-scoped",
-			wantScoped: []string{".gitea/my-scoped"},
+			name: "custom dir",
+			ini:  "[actions]\nSCOPED_WORKFLOW_DIRS = .gitea/my-scoped",
+			want: scoped([]string{".gitea/my-scoped"}),
 		},
 		{
-			name:       "empty disables the feature",
-			iniStr:     "[actions]\nSCOPED_WORKFLOW_DIRS = , ,",
-			wantScoped: []string{},
+			name: "empty disables the feature",
+			ini:  "[actions]\nSCOPED_WORKFLOW_DIRS = , ,",
+			want: scoped([]string{}),
 		},
 		{
 			name:    "overlap equal with workflow dir",
-			iniStr:  "[actions]\nWORKFLOW_DIRS = .gitea/workflows\nSCOPED_WORKFLOW_DIRS = .gitea/workflows",
-			wantErr: true,
+			ini:     "[actions]\nWORKFLOW_DIRS = .gitea/workflows\nSCOPED_WORKFLOW_DIRS = .gitea/workflows",
+			wantErr: assert.Error,
+			want:    overlapping,
 		},
 		{
 			name:    "scoped dir nested under workflow dir",
-			iniStr:  "[actions]\nWORKFLOW_DIRS = .gitea/workflows\nSCOPED_WORKFLOW_DIRS = .gitea/workflows/scoped",
-			wantErr: true,
+			ini:     "[actions]\nWORKFLOW_DIRS = .gitea/workflows\nSCOPED_WORKFLOW_DIRS = .gitea/workflows/scoped",
+			wantErr: assert.Error,
+			want:    overlapping,
 		},
 		{
 			name:    "workflow dir nested under scoped dir",
-			iniStr:  "[actions]\nWORKFLOW_DIRS = .gitea/workflows/ci\nSCOPED_WORKFLOW_DIRS = .gitea/workflows",
-			wantErr: true,
+			ini:     "[actions]\nWORKFLOW_DIRS = .gitea/workflows/ci\nSCOPED_WORKFLOW_DIRS = .gitea/workflows",
+			wantErr: assert.Error,
+			want:    overlapping,
 		},
 		{
-			name:       "no overlap",
-			iniStr:     "[actions]\nSCOPED_WORKFLOW_DIRS = .gitea/scoped",
-			wantScoped: []string{".gitea/scoped"},
+			name: "no overlap",
+			ini:  "[actions]\nSCOPED_WORKFLOW_DIRS = .gitea/scoped",
+			want: scoped([]string{".gitea/scoped"}),
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// reset to defaults so MapTo starts clean (absent keys keep the defaults)
-			Actions.WorkflowDirs = slices.Clone(defaultWorkflowDirs)
-			Actions.ScopedWorkflowDirs = slices.Clone(defaultScopedDirs)
-
-			cfg, err := NewConfigProviderFromData(tt.iniStr)
-			require.NoError(t, err)
-			err = loadActionsFrom(cfg)
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantScoped, Actions.ScopedWorkflowDirs)
-		})
-	}
+	})
 }

--- a/modules/setting/attachment_test.go
+++ b/modules/setting/attachment_test.go
@@ -4,13 +4,19 @@
 package setting
 
 import (
+	"slices"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"gitea.dev/modules/test"
 )
 
-func Test_getStorageCustomType(t *testing.T) {
-	iniStr := `
+func Test_getStorageAttachment(t *testing.T) {
+	defer test.MockVariableValue(&Attachment)()
+
+	testConfigLoad(t, []any{loadAttachmentFrom}, []configTestCase{
+		{
+			name: "a custom named storage keeps the section bucket",
+			ini: `
 [attachment]
 STORAGE_TYPE = my_minio
 MINIO_BUCKET = gitea-attachment
@@ -18,20 +24,15 @@ MINIO_BUCKET = gitea-attachment
 [storage.my_minio]
 STORAGE_TYPE = minio
 MINIO_ENDPOINT = my_minio:9000
-`
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-
-	assert.NoError(t, loadAttachmentFrom(cfg))
-
-	assert.EqualValues(t, "minio", Attachment.Storage.Type)
-	assert.Equal(t, "my_minio:9000", Attachment.Storage.MinioConfig.Endpoint)
-	assert.Equal(t, "gitea-attachment", Attachment.Storage.MinioConfig.Bucket)
-	assert.Equal(t, "attachments/", Attachment.Storage.MinioConfig.BasePath)
-}
-
-func Test_getStorageTypeSectionOverridesStorageSection(t *testing.T) {
-	iniStr := `
+`,
+			want: slices.Concat(
+				minioStorage("attachment", &Attachment.Storage, "gitea-attachment", "attachments/"),
+				[]configCheck{fieldOf("MINIO_ENDPOINT", func() string { return Attachment.Storage.MinioConfig.Endpoint }, "my_minio:9000")},
+			),
+		},
+		{
+			name: "[storage.minio] overrides [storage]",
+			ini: `
 [attachment]
 STORAGE_TYPE = minio
 
@@ -40,19 +41,12 @@ MINIO_BUCKET = gitea-minio
 
 [storage]
 MINIO_BUCKET = gitea
-`
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-
-	assert.NoError(t, loadAttachmentFrom(cfg))
-
-	assert.EqualValues(t, "minio", Attachment.Storage.Type)
-	assert.Equal(t, "gitea-minio", Attachment.Storage.MinioConfig.Bucket)
-	assert.Equal(t, "attachments/", Attachment.Storage.MinioConfig.BasePath)
-}
-
-func Test_getStorageSpecificOverridesStorage(t *testing.T) {
-	iniStr := `
+`,
+			want: minioStorage("attachment", &Attachment.Storage, "gitea-minio", "attachments/"),
+		},
+		{
+			name: "the [attachment] section wins over [storage.attachments]",
+			ini: `
 [attachment]
 STORAGE_TYPE = minio
 MINIO_BUCKET = gitea-attachment
@@ -62,42 +56,27 @@ MINIO_BUCKET = gitea
 
 [storage]
 STORAGE_TYPE = local
-`
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-
-	assert.NoError(t, loadAttachmentFrom(cfg))
-
-	assert.EqualValues(t, "minio", Attachment.Storage.Type)
-	assert.Equal(t, "gitea-attachment", Attachment.Storage.MinioConfig.Bucket)
-	assert.Equal(t, "attachments/", Attachment.Storage.MinioConfig.BasePath)
-}
-
-func Test_getStorageGetDefaults(t *testing.T) {
-	cfg, err := NewConfigProviderFromData("")
-	assert.NoError(t, err)
-
-	assert.NoError(t, loadAttachmentFrom(cfg))
-
-	// default storage is local, so bucket is empty
-	assert.Empty(t, Attachment.Storage.MinioConfig.Bucket)
-}
-
-func Test_getStorageInheritNameSectionType(t *testing.T) {
-	iniStr := `
-[storage.attachments]
-STORAGE_TYPE = minio
-`
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-
-	assert.NoError(t, loadAttachmentFrom(cfg))
-
-	assert.EqualValues(t, "minio", Attachment.Storage.Type)
-}
-
-func Test_AttachmentStorage(t *testing.T) {
-	iniStr := `
+`,
+			want: minioStorage("attachment", &Attachment.Storage, "gitea-attachment", "attachments/"),
+		},
+		{
+			name: "the default storage is local, so the bucket stays empty",
+			want: []configCheck{
+				guard(&Attachment.Storage),
+				fieldOf("MINIO_BUCKET", func() string { return Attachment.Storage.MinioConfig.Bucket }, ""),
+			},
+		},
+		{
+			name: "[storage.attachments] alone sets the type",
+			ini:  "[storage.attachments]\nSTORAGE_TYPE = minio",
+			want: []configCheck{
+				guard(&Attachment.Storage),
+				fieldOf("STORAGE_TYPE", func() StorageType { return Attachment.Storage.Type }, MinioStorageType),
+			},
+		},
+		{
+			name: "a fully configured [storage] section",
+			ini: `
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 [storage]
 STORAGE_TYPE            = minio
@@ -107,27 +86,17 @@ MINIO_LOCATION          = homenet
 MINIO_USE_SSL           = true
 MINIO_ACCESS_KEY_ID     = correct_key
 MINIO_SECRET_ACCESS_KEY = correct_key
-`
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-
-	assert.NoError(t, loadAttachmentFrom(cfg))
-	storage := Attachment.Storage
-
-	assert.EqualValues(t, "minio", storage.Type)
-	assert.Equal(t, "gitea", storage.MinioConfig.Bucket)
-}
-
-func Test_AttachmentStorage1(t *testing.T) {
-	iniStr := `
-[storage]
-STORAGE_TYPE = minio
-`
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-
-	assert.NoError(t, loadAttachmentFrom(cfg))
-	assert.EqualValues(t, "minio", Attachment.Storage.Type)
-	assert.Equal(t, "gitea", Attachment.Storage.MinioConfig.Bucket)
-	assert.Equal(t, "attachments/", Attachment.Storage.MinioConfig.BasePath)
+`,
+			want: []configCheck{
+				guard(&Attachment.Storage),
+				fieldOf("STORAGE_TYPE", func() StorageType { return Attachment.Storage.Type }, MinioStorageType),
+				fieldOf("MINIO_BUCKET", func() string { return Attachment.Storage.MinioConfig.Bucket }, "gitea"),
+			},
+		},
+		{
+			name: "the global [storage] type is inherited",
+			ini:  "[storage]\nSTORAGE_TYPE = minio",
+			want: minioStorage("attachment", &Attachment.Storage, "gitea", "attachments/"),
+		},
+	})
 }

--- a/modules/setting/cache_test.go
+++ b/modules/setting/cache_test.go
@@ -7,65 +7,32 @@ import (
 	"testing"
 
 	"gitea.dev/modules/test"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCacheRedisSharedConnFallback(t *testing.T) {
-	tests := []struct {
-		name     string
-		iniStr   string
-		wantConn string
-	}{
+	defer test.MockVariableValue(&CacheService)()
+	defer test.MockVariableValue(&Redis)()
+
+	testConfigLoad(t, []any{loadRedisFrom, loadCacheFrom}, []configTestCase{
 		{
 			name: "redis adapter with empty HOST falls back to shared [redis]",
-			iniStr: `
-[redis]
-CONN_STR = redis://127.0.0.1:6379/0
-[cache]
-ADAPTER = redis
-`,
-			wantConn: "redis://127.0.0.1:6379/0",
+			ini:  "[redis]\nCONN_STR = redis://127.0.0.1:6379/0\n[cache]\nADAPTER = redis",
+			want: []configCheck{field("HOST", &CacheService.Conn, "redis://127.0.0.1:6379/0")},
 		},
 		{
 			name: "cache HOST wins over shared [redis]",
-			iniStr: `
-[redis]
-CONN_STR = redis://127.0.0.1:6379/0
-[cache]
-ADAPTER = redis
-HOST = redis://10.0.0.1:6379/1
-`,
-			wantConn: "redis://10.0.0.1:6379/1",
+			ini:  "[redis]\nCONN_STR = redis://127.0.0.1:6379/0\n[cache]\nADAPTER = redis\nHOST = redis://10.0.0.1:6379/1",
+			want: []configCheck{field("HOST", &CacheService.Conn, "redis://10.0.0.1:6379/1")},
 		},
 		{
 			name: "no shared [redis] keeps previous behavior (empty conn)",
-			iniStr: `
-[cache]
-ADAPTER = redis
-`,
-			wantConn: "",
+			ini:  "[cache]\nADAPTER = redis",
+			want: []configCheck{field("HOST", &CacheService.Conn, "")},
 		},
 		{
 			name: "memcache adapter is never affected by shared [redis]",
-			iniStr: `
-[redis]
-CONN_STR = redis://127.0.0.1:6379/0
-[cache]
-ADAPTER = memcache
-`,
-			wantConn: "",
+			ini:  "[redis]\nCONN_STR = redis://127.0.0.1:6379/0\n[cache]\nADAPTER = memcache",
+			want: []configCheck{field("HOST", &CacheService.Conn, "")},
 		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			defer test.MockVariableValue(&Redis)()
-			cfg, err := NewConfigProviderFromData(tt.iniStr)
-			assert.NoError(t, err)
-
-			loadRedisFrom(cfg)
-			loadCacheFrom(cfg)
-			assert.Equal(t, tt.wantConn, CacheService.Conn)
-		})
-	}
+	})
 }

--- a/modules/setting/git_test.go
+++ b/modules/setting/git_test.go
@@ -7,57 +7,57 @@ import (
 	"testing"
 
 	"gitea.dev/modules/test"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGitConfig(t *testing.T) {
-	oldGit := Git
-	oldGitConfig := GitConfig
-	defer func() {
-		Git = oldGit
-		GitConfig = oldGitConfig
-	}()
+	defer test.MockVariableValue(&Git)()
+	defer test.MockVariableValue(&GitConfig)()
 
-	cfg, err := NewConfigProviderFromData(`
-[git.config]
-a.b = 1
-`)
-	assert.NoError(t, err)
-	loadGitFrom(cfg)
-	assert.Equal(t, "1", GitConfig.Options["a.b"])
-	assert.Equal(t, "histogram", GitConfig.Options["diff.algorithm"])
+	// GitConfig.Options is a map, so it is read through a getter rather than addressed directly
+	option := func(name string) func() string {
+		return func() string { return GitConfig.Options[name] }
+	}
 
-	cfg, err = NewConfigProviderFromData(`
-[git.config]
-diff.algorithm = other
-`)
-	assert.NoError(t, err)
-	loadGitFrom(cfg)
-	assert.Equal(t, "other", GitConfig.Options["diff.algorithm"])
+	testConfigLoad(t, []any{loadGitFrom}, []configTestCase{
+		{
+			name: "unrelated option keeps the default diff algorithm",
+			ini:  "[git.config]\na.b = 1",
+			want: []configCheck{
+				fieldOf("a.b", option("a.b"), "1"),
+				fieldOf("diff.algorithm", option("diff.algorithm"), "histogram"),
+			},
+		},
+		{
+			name: "diff algorithm can be overridden",
+			ini:  "[git.config]\ndiff.algorithm = other",
+			want: []configCheck{fieldOf("diff.algorithm", option("diff.algorithm"), "other")},
+		},
+	})
 }
 
 func TestGitReflog(t *testing.T) {
-	defer test.MockVariableValue(&Git)
-	defer test.MockVariableValue(&GitConfig)
+	defer test.MockVariableValue(&Git)()
+	defer test.MockVariableValue(&GitConfig)()
 
-	// default reflog config without legacy options
-	cfg, err := NewConfigProviderFromData(``)
-	assert.NoError(t, err)
-	loadGitFrom(cfg)
+	option := func(name string) func() string {
+		return func() string { return GitConfig.GetOption(name) }
+	}
 
-	assert.Equal(t, "true", GitConfig.GetOption("core.logAllRefUpdates"))
-	assert.Equal(t, "90", GitConfig.GetOption("gc.reflogExpire"))
-
-	// custom reflog config by legacy options
-	cfg, err = NewConfigProviderFromData(`
-[git.reflog]
-ENABLED = false
-EXPIRATION = 123
-`)
-	assert.NoError(t, err)
-	loadGitFrom(cfg)
-
-	assert.Equal(t, "false", GitConfig.GetOption("core.logAllRefUpdates"))
-	assert.Equal(t, "123", GitConfig.GetOption("gc.reflogExpire"))
+	testConfigLoad(t, []any{loadGitFrom}, []configTestCase{
+		{
+			name: "default reflog config without legacy options",
+			want: []configCheck{
+				fieldOf("core.logAllRefUpdates", option("core.logAllRefUpdates"), "true"),
+				fieldOf("gc.reflogExpire", option("gc.reflogExpire"), "90"),
+			},
+		},
+		{
+			name: "custom reflog config by legacy options",
+			ini:  "[git.reflog]\nENABLED = false\nEXPIRATION = 123",
+			want: []configCheck{
+				fieldOf("core.logAllRefUpdates", option("core.logAllRefUpdates"), "false"),
+				fieldOf("gc.reflogExpire", option("gc.reflogExpire"), "123"),
+			},
+		},
+	})
 }

--- a/modules/setting/global_lock_test.go
+++ b/modules/setting/global_lock_test.go
@@ -7,68 +7,40 @@ import (
 	"testing"
 
 	"gitea.dev/modules/test"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestLoadGlobalLockConfig(t *testing.T) {
-	t.Run("DefaultGlobalLockConfig", func(t *testing.T) {
-		defer test.MockVariableValue(&Redis)()
-		iniStr := ``
-		cfg, err := NewConfigProviderFromData(iniStr)
-		assert.NoError(t, err)
-		loadRedisFrom(cfg)
-		loadGlobalLockFrom(cfg)
-		assert.Equal(t, "memory", GlobalLock.ServiceType)
-	})
+	defer test.MockVariableValue(&GlobalLock)()
+	defer test.MockVariableValue(&Redis)()
 
-	t.Run("RedisGlobalLockConfig", func(t *testing.T) {
-		defer test.MockVariableValue(&Redis)()
-		iniStr := `
-[global_lock]
-SERVICE_TYPE = redis
-SERVICE_CONN_STR = addrs=127.0.0.1:6379 db=0
-`
-		cfg, err := NewConfigProviderFromData(iniStr)
-		assert.NoError(t, err)
-		loadRedisFrom(cfg)
-		loadGlobalLockFrom(cfg)
-		assert.Equal(t, "redis", GlobalLock.ServiceType)
-		assert.Equal(t, "addrs=127.0.0.1:6379 db=0", GlobalLock.ServiceConnStr)
-	})
-
-	t.Run("RedisGlobalLockFallsBackToSharedRedis", func(t *testing.T) {
-		defer test.MockVariableValue(&Redis)()
-		iniStr := `
-[redis]
-CONN_STR = redis://127.0.0.1:6379/0
-[global_lock]
-SERVICE_TYPE = redis
-`
-		cfg, err := NewConfigProviderFromData(iniStr)
-		assert.NoError(t, err)
-
-		loadRedisFrom(cfg)
-		loadGlobalLockFrom(cfg)
-		assert.Equal(t, "redis", GlobalLock.ServiceType)
-		assert.Equal(t, "redis://127.0.0.1:6379/0", GlobalLock.ServiceConnStr)
-	})
-
-	t.Run("RedisGlobalLockOwnConnWinsOverSharedRedis", func(t *testing.T) {
-		defer test.MockVariableValue(&Redis)()
-		iniStr := `
-[redis]
-CONN_STR = redis://127.0.0.1:6379/0
-[global_lock]
-SERVICE_TYPE = redis
-SERVICE_CONN_STR = redis://10.0.0.1:6379/1
-`
-		cfg, err := NewConfigProviderFromData(iniStr)
-		assert.NoError(t, err)
-
-		loadRedisFrom(cfg)
-		loadGlobalLockFrom(cfg)
-		assert.Equal(t, "redis", GlobalLock.ServiceType)
-		assert.Equal(t, "redis://10.0.0.1:6379/1", GlobalLock.ServiceConnStr)
+	testConfigLoad(t, []any{loadRedisFrom, loadGlobalLockFrom}, []configTestCase{
+		{
+			name: "defaults to memory",
+			want: []configCheck{field("SERVICE_TYPE", &GlobalLock.ServiceType, "memory")},
+		},
+		{
+			name: "redis with its own conn str",
+			ini:  "[global_lock]\nSERVICE_TYPE = redis\nSERVICE_CONN_STR = addrs=127.0.0.1:6379 db=0",
+			want: []configCheck{
+				field("SERVICE_TYPE", &GlobalLock.ServiceType, "redis"),
+				field("SERVICE_CONN_STR", &GlobalLock.ServiceConnStr, "addrs=127.0.0.1:6379 db=0"),
+			},
+		},
+		{
+			name: "redis falls back to the shared [redis] section",
+			ini:  "[redis]\nCONN_STR = redis://127.0.0.1:6379/0\n[global_lock]\nSERVICE_TYPE = redis",
+			want: []configCheck{
+				field("SERVICE_TYPE", &GlobalLock.ServiceType, "redis"),
+				field("SERVICE_CONN_STR", &GlobalLock.ServiceConnStr, "redis://127.0.0.1:6379/0"),
+			},
+		},
+		{
+			name: "own conn str wins over the shared one",
+			ini:  "[redis]\nCONN_STR = redis://127.0.0.1:6379/0\n[global_lock]\nSERVICE_TYPE = redis\nSERVICE_CONN_STR = redis://10.0.0.1:6379/1",
+			want: []configCheck{
+				field("SERVICE_TYPE", &GlobalLock.ServiceType, "redis"),
+				field("SERVICE_CONN_STR", &GlobalLock.ServiceConnStr, "redis://10.0.0.1:6379/1"),
+			},
+		},
 	})
 }

--- a/modules/setting/lfs_test.go
+++ b/modules/setting/lfs_test.go
@@ -6,125 +6,90 @@ package setting
 import (
 	"testing"
 
+	"gitea.dev/modules/test"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_getStorageInheritNameSectionTypeForLFS(t *testing.T) {
-	iniStr := `
-	[storage]
-	STORAGE_TYPE = minio
-	`
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-	assert.NoError(t, loadLFSFrom(cfg))
+	defer test.MockVariableValue(&LFS)()
 
-	assert.EqualValues(t, "minio", LFS.Storage.Type)
-	assert.Equal(t, "lfs/", LFS.Storage.MinioConfig.BasePath)
+	localPath := func(want string) func(t *testing.T) {
+		return func(t *testing.T) {
+			assert.Equal(t, LocalStorageType, LFS.Storage.Type)
+			assert.Contains(t, LFS.Storage.Path, want)
+		}
+	}
 
-	iniStr = `
-[server]
-LFS_CONTENT_PATH = path_ignored
-[lfs]
-PATH = path_used
-`
-	cfg, err = NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-	assert.NoError(t, loadLFSFrom(cfg))
-
-	assert.EqualValues(t, "local", LFS.Storage.Type)
-	assert.Contains(t, LFS.Storage.Path, "path_used")
-
-	iniStr = `
-[server]
-LFS_CONTENT_PATH = deprecatedpath
-`
-	cfg, err = NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-	assert.NoError(t, loadLFSFrom(cfg))
-
-	assert.EqualValues(t, "local", LFS.Storage.Type)
-	assert.Contains(t, LFS.Storage.Path, "deprecatedpath")
-
-	iniStr = `
-[storage.lfs]
-STORAGE_TYPE = minio
-`
-	cfg, err = NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-	assert.NoError(t, loadLFSFrom(cfg))
-
-	assert.EqualValues(t, "minio", LFS.Storage.Type)
-	assert.Equal(t, "lfs/", LFS.Storage.MinioConfig.BasePath)
-
-	iniStr = `
-[lfs]
-STORAGE_TYPE = my_minio
-
-[storage.my_minio]
-STORAGE_TYPE = minio
-`
-	cfg, err = NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-	assert.NoError(t, loadLFSFrom(cfg))
-
-	assert.EqualValues(t, "minio", LFS.Storage.Type)
-	assert.Equal(t, "lfs/", LFS.Storage.MinioConfig.BasePath)
-
-	iniStr = `
-[lfs]
-STORAGE_TYPE = my_minio
-MINIO_BASE_PATH = my_lfs/
-
-[storage.my_minio]
-STORAGE_TYPE = minio
-`
-	cfg, err = NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-	assert.NoError(t, loadLFSFrom(cfg))
-
-	assert.EqualValues(t, "minio", LFS.Storage.Type)
-	assert.Equal(t, "my_lfs/", LFS.Storage.MinioConfig.BasePath)
+	testConfigLoad(t, []any{loadLFSFrom}, []configTestCase{
+		{
+			name: "inherits the global [storage] type",
+			ini:  "[storage]\nSTORAGE_TYPE = minio",
+			want: minioStorageAt("lfs", &LFS.Storage, "lfs/"),
+		},
+		{
+			name:  "[lfs].PATH wins over the deprecated [server].LFS_CONTENT_PATH",
+			ini:   "[server]\nLFS_CONTENT_PATH = path_ignored\n[lfs]\nPATH = path_used",
+			want:  []configCheck{guard(&LFS.Storage)},
+			check: localPath("path_used"),
+		},
+		{
+			name:  "the deprecated [server].LFS_CONTENT_PATH is still honoured alone",
+			ini:   "[server]\nLFS_CONTENT_PATH = deprecatedpath",
+			want:  []configCheck{guard(&LFS.Storage)},
+			check: localPath("deprecatedpath"),
+		},
+		{
+			name: "[storage.lfs] configures lfs directly",
+			ini:  "[storage.lfs]\nSTORAGE_TYPE = minio",
+			want: minioStorageAt("lfs", &LFS.Storage, "lfs/"),
+		},
+		{
+			name: "[lfs].STORAGE_TYPE can name another storage",
+			ini:  "[lfs]\nSTORAGE_TYPE = my_minio\n\n[storage.my_minio]\nSTORAGE_TYPE = minio",
+			want: minioStorageAt("lfs", &LFS.Storage, "lfs/"),
+		},
+		{
+			name: "[lfs].MINIO_BASE_PATH overrides the named storage",
+			ini:  "[lfs]\nSTORAGE_TYPE = my_minio\nMINIO_BASE_PATH = my_lfs/\n\n[storage.my_minio]\nSTORAGE_TYPE = minio",
+			want: minioStorageAt("lfs", &LFS.Storage, "my_lfs/"),
+		},
+	})
 }
 
 func Test_LFSStorage1(t *testing.T) {
-	iniStr := `
-[storage]
-STORAGE_TYPE = minio
-`
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
+	defer test.MockVariableValue(&LFS)()
 
-	assert.NoError(t, loadLFSFrom(cfg))
-	assert.EqualValues(t, "minio", LFS.Storage.Type)
-	assert.Equal(t, "gitea", LFS.Storage.MinioConfig.Bucket)
-	assert.Equal(t, "lfs/", LFS.Storage.MinioConfig.BasePath)
+	testConfigLoad(t, []any{loadLFSFrom}, []configTestCase{
+		{
+			name: "the default bucket is inherited",
+			ini:  "[storage]\nSTORAGE_TYPE = minio",
+			want: minioStorage("lfs", &LFS.Storage, "gitea", "lfs/"),
+		},
+	})
 }
 
 func Test_LFSClientServerConfigs(t *testing.T) {
-	iniStr := `
-[server]
-LFS_MAX_BATCH_SIZE = 100
-[lfs_client]
-# will default to 20
-BATCH_SIZE = 0
-`
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
+	defer test.MockVariableValue(&LFS)()
+	defer test.MockVariableValue(&LFSClient)()
 
-	assert.NoError(t, loadLFSFrom(cfg))
-	assert.Equal(t, 100, LFS.MaxBatchSize)
-	assert.Equal(t, 20, LFSClient.BatchSize)
-	assert.Equal(t, 8, LFSClient.BatchOperationConcurrency)
-
-	iniStr = `
-[lfs_client]
-BATCH_SIZE = 50
-BATCH_OPERATION_CONCURRENCY = 10
-`
-	cfg, err = NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-
-	assert.NoError(t, loadLFSFrom(cfg))
-	assert.Equal(t, 50, LFSClient.BatchSize)
-	assert.Equal(t, 10, LFSClient.BatchOperationConcurrency)
+	testConfigLoad(t, []any{loadLFSFrom}, []configTestCase{
+		{
+			name: "a zero batch size falls back to the default",
+			ini:  "[server]\nLFS_MAX_BATCH_SIZE = 100\n[lfs_client]\n# will default to 20\nBATCH_SIZE = 0",
+			want: []configCheck{
+				field("LFS_MAX_BATCH_SIZE", &LFS.MaxBatchSize, 100),
+				field("BATCH_SIZE", &LFSClient.BatchSize, 20),
+				field("BATCH_OPERATION_CONCURRENCY", &LFSClient.BatchOperationConcurrency, 8),
+			},
+		},
+		{
+			name: "explicit client values",
+			ini:  "[lfs_client]\nBATCH_SIZE = 50\nBATCH_OPERATION_CONCURRENCY = 10",
+			want: []configCheck{
+				field("BATCH_SIZE", &LFSClient.BatchSize, 50),
+				field("BATCH_OPERATION_CONCURRENCY", &LFSClient.BatchOperationConcurrency, 10),
+			},
+		},
+	})
 }

--- a/modules/setting/mailer_test.go
+++ b/modules/setting/mailer_test.go
@@ -7,46 +7,45 @@ import (
 	"testing"
 
 	"gitea.dev/modules/test"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_loadMailerFrom(t *testing.T) {
-	kases := map[string]*Mailer{
-		"smtp.mydomain.test": {
-			SMTPAddr: "smtp.mydomain.test",
-			SMTPPort: "465",
-		},
-		"smtp.mydomain.test:123": {
-			SMTPAddr: "smtp.mydomain.test",
-			SMTPPort: "123",
-		},
-		":123": {
-			SMTPAddr: "127.0.0.1",
-			SMTPPort: "123",
-		},
-	}
-	for host, kase := range kases {
-		t.Run(host, func(t *testing.T) {
-			cfg, _ := NewConfigProviderFromData("")
-			sec := cfg.Section("mailer")
-			sec.NewKey("ENABLED", "true")
-			sec.NewKey("HOST", host)
+	defer test.MockVariableValue(&MailService)()
 
-			// Check mailer setting
-			loadMailerFrom(cfg)
-
-			assert.Equal(t, kase.SMTPAddr, MailService.SMTPAddr)
-			assert.Equal(t, kase.SMTPPort, MailService.SMTPPort)
-		})
+	smtp := func(addr, port string) []configCheck {
+		return []configCheck{
+			fieldOf("HOST", func() string { return MailService.SMTPAddr }, addr),
+			fieldOf("HOST", func() string { return MailService.SMTPPort }, port),
+		}
 	}
+
+	testConfigLoad(t, []any{loadMailerFrom}, []configTestCase{
+		{
+			name: "host without a port",
+			ini:  "[mailer]\nENABLED = true\nHOST = smtp.mydomain.test",
+			want: smtp("smtp.mydomain.test", "465"),
+		},
+		{
+			name: "host with a port",
+			ini:  "[mailer]\nENABLED = true\nHOST = smtp.mydomain.test:123",
+			want: smtp("smtp.mydomain.test", "123"),
+		},
+		{
+			name: "port only",
+			ini:  "[mailer]\nENABLED = true\nHOST = :123",
+			want: smtp("127.0.0.1", "123"),
+		},
+	})
 }
 
 func TestLoadSettingsForInstallMailServiceFlags(t *testing.T) {
 	defer test.MockVariableValue(&Service)()
 	defer test.MockVariableValue(&MailService)()
 
-	cfg, err := NewConfigProviderFromData(`
+	testConfigLoad(t, []any{loadDBSetting, loadServiceFrom, loadMailsFrom}, []configTestCase{
+		{
+			name: "a configured mailer enables the mail services",
+			ini: `
 [database]
 DB_TYPE = postgres
 
@@ -59,12 +58,11 @@ FROM = noreply@example.com
 [service]
 REGISTER_EMAIL_CONFIRM = true
 ENABLE_NOTIFY_MAIL = true
-`)
-	assert.NoError(t, err)
-	loadDBSetting(cfg)
-	loadServiceFrom(cfg)
-	loadMailsFrom(cfg)
-
-	assert.True(t, Service.RegisterEmailConfirm)
-	assert.True(t, Service.EnableNotifyMail)
+`,
+			want: []configCheck{
+				field("REGISTER_EMAIL_CONFIRM", &Service.RegisterEmailConfirm, true),
+				field("ENABLE_NOTIFY_MAIL", &Service.EnableNotifyMail, true),
+			},
+		},
+	})
 }

--- a/modules/setting/markup_test.go
+++ b/modules/setting/markup_test.go
@@ -6,46 +6,41 @@ package setting
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"gitea.dev/modules/test"
 )
 
 func TestLoadMarkup(t *testing.T) {
-	cfg, _ := NewConfigProviderFromData(``)
-	loadMarkupFrom(cfg)
-	assert.Equal(t, MarkdownMathCodeBlockOptions{ParseInlineDollar: true, ParseBlockDollar: true}, Markdown.MathCodeBlockOptions)
-	assert.Equal(t, MarkdownRenderOptions{NewLineHardBreak: true, ShortIssuePattern: true}, Markdown.RenderOptionsComment)
-	assert.Equal(t, MarkdownRenderOptions{ShortIssuePattern: true}, Markdown.RenderOptionsWiki)
-	assert.Equal(t, MarkdownRenderOptions{}, Markdown.RenderOptionsRepoFile)
+	defer test.MockVariableValue(&Markdown)()
 
-	t.Run("Math", func(t *testing.T) {
-		cfg, _ = NewConfigProviderFromData(`
-[markdown]
-MATH_CODE_BLOCK_DETECTION = none
-`)
-		loadMarkupFrom(cfg)
-		assert.Equal(t, MarkdownMathCodeBlockOptions{}, Markdown.MathCodeBlockOptions)
-
-		cfg, _ = NewConfigProviderFromData(`
-[markdown]
-MATH_CODE_BLOCK_DETECTION = inline-dollar, inline-parentheses, block-dollar, block-square-brackets
-`)
-		loadMarkupFrom(cfg)
-		assert.Equal(t, MarkdownMathCodeBlockOptions{ParseInlineDollar: true, ParseInlineParentheses: true, ParseBlockDollar: true, ParseBlockSquareBrackets: true}, Markdown.MathCodeBlockOptions)
-	})
-
-	t.Run("Render", func(t *testing.T) {
-		cfg, _ = NewConfigProviderFromData(`
-[markdown]
-RENDER_OPTIONS_COMMENT = none
-`)
-		loadMarkupFrom(cfg)
-		assert.Equal(t, MarkdownRenderOptions{}, Markdown.RenderOptionsComment)
-
-		cfg, _ = NewConfigProviderFromData(`
-[markdown]
-RENDER_OPTIONS_REPO_FILE = short-issue-pattern, new-line-hard-break
-`)
-		loadMarkupFrom(cfg)
-		assert.Equal(t, MarkdownRenderOptions{NewLineHardBreak: true, ShortIssuePattern: true}, Markdown.RenderOptionsRepoFile)
+	testConfigLoad(t, []any{loadMarkupFrom}, []configTestCase{
+		{
+			name: "defaults",
+			want: []configCheck{
+				field("MATH_CODE_BLOCK_DETECTION", &Markdown.MathCodeBlockOptions, MarkdownMathCodeBlockOptions{ParseInlineDollar: true, ParseBlockDollar: true}),
+				field("RENDER_OPTIONS_COMMENT", &Markdown.RenderOptionsComment, MarkdownRenderOptions{NewLineHardBreak: true, ShortIssuePattern: true}),
+				field("RENDER_OPTIONS_WIKI", &Markdown.RenderOptionsWiki, MarkdownRenderOptions{ShortIssuePattern: true}),
+				field("RENDER_OPTIONS_REPO_FILE", &Markdown.RenderOptionsRepoFile, MarkdownRenderOptions{}),
+			},
+		},
+		{
+			name: "math detection none",
+			ini:  "[markdown]\nMATH_CODE_BLOCK_DETECTION = none",
+			want: []configCheck{field("MATH_CODE_BLOCK_DETECTION", &Markdown.MathCodeBlockOptions, MarkdownMathCodeBlockOptions{})},
+		},
+		{
+			name: "math detection all delimiters",
+			ini:  "[markdown]\nMATH_CODE_BLOCK_DETECTION = inline-dollar, inline-parentheses, block-dollar, block-square-brackets",
+			want: []configCheck{field("MATH_CODE_BLOCK_DETECTION", &Markdown.MathCodeBlockOptions, MarkdownMathCodeBlockOptions{ParseInlineDollar: true, ParseInlineParentheses: true, ParseBlockDollar: true, ParseBlockSquareBrackets: true})},
+		},
+		{
+			name: "comment render options none",
+			ini:  "[markdown]\nRENDER_OPTIONS_COMMENT = none",
+			want: []configCheck{field("RENDER_OPTIONS_COMMENT", &Markdown.RenderOptionsComment, MarkdownRenderOptions{})},
+		},
+		{
+			name: "repo file render options",
+			ini:  "[markdown]\nRENDER_OPTIONS_REPO_FILE = short-issue-pattern, new-line-hard-break",
+			want: []configCheck{field("RENDER_OPTIONS_REPO_FILE", &Markdown.RenderOptionsRepoFile, MarkdownRenderOptions{NewLineHardBreak: true, ShortIssuePattern: true})},
+		},
 	})
 }

--- a/modules/setting/oauth2_test.go
+++ b/modules/setting/oauth2_test.go
@@ -60,19 +60,22 @@ func TestGetGeneralSigningSecretSave(t *testing.T) {
 }
 
 func TestOauth2DefaultApplications(t *testing.T) {
-	cfg, _ := NewConfigProviderFromData(``)
-	loadOAuth2From(cfg)
-	assert.Equal(t, []string{"git-credential-oauth", "git-credential-manager", "tea"}, OAuth2.DefaultApplications)
+	defer test.MockVariableValue(&OAuth2)()
 
-	cfg, _ = NewConfigProviderFromData(`[oauth2]
-DEFAULT_APPLICATIONS = tea
-`)
-	loadOAuth2From(cfg)
-	assert.Equal(t, []string{"tea"}, OAuth2.DefaultApplications)
-
-	cfg, _ = NewConfigProviderFromData(`[oauth2]
-DEFAULT_APPLICATIONS =
-`)
-	loadOAuth2From(cfg)
-	assert.Nil(t, OAuth2.DefaultApplications)
+	testConfigLoad(t, []any{loadOAuth2From}, []configTestCase{
+		{
+			name: "defaults",
+			want: []configCheck{field("DEFAULT_APPLICATIONS", &OAuth2.DefaultApplications, []string{"git-credential-oauth", "git-credential-manager", "tea"})},
+		},
+		{
+			name: "a single application",
+			ini:  "[oauth2]\nDEFAULT_APPLICATIONS = tea",
+			want: []configCheck{field("DEFAULT_APPLICATIONS", &OAuth2.DefaultApplications, []string{"tea"})},
+		},
+		{
+			name: "an empty value disables them all",
+			ini:  "[oauth2]\nDEFAULT_APPLICATIONS =",
+			want: []configCheck{field("DEFAULT_APPLICATIONS", &OAuth2.DefaultApplications, []string(nil))},
+		},
+	})
 }

--- a/modules/setting/packages_test.go
+++ b/modules/setting/packages_test.go
@@ -4,7 +4,10 @@
 package setting
 
 import (
+	"slices"
 	"testing"
+
+	"gitea.dev/modules/test"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -31,69 +34,36 @@ func TestMustBytes(t *testing.T) {
 }
 
 func Test_getStorageInheritNameSectionTypeForPackages(t *testing.T) {
-	// packages storage inherits from storage if nothing configured
-	iniStr := `
-[storage]
-STORAGE_TYPE = minio
-`
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-	assert.NoError(t, loadPackagesFrom(cfg))
+	defer test.MockVariableValue(&Packages)()
 
-	assert.EqualValues(t, "minio", Packages.Storage.Type)
-	assert.Equal(t, "packages/", Packages.Storage.MinioConfig.BasePath)
-
-	// we can also configure packages storage directly
-	iniStr = `
-[storage.packages]
-STORAGE_TYPE = minio
-`
-	cfg, err = NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-	assert.NoError(t, loadPackagesFrom(cfg))
-
-	assert.EqualValues(t, "minio", Packages.Storage.Type)
-	assert.Equal(t, "packages/", Packages.Storage.MinioConfig.BasePath)
-
-	// or we can indicate the storage type in the packages section
-	iniStr = `
-[packages]
-STORAGE_TYPE = my_minio
-
-[storage.my_minio]
-STORAGE_TYPE = minio
-`
-	cfg, err = NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-	assert.NoError(t, loadPackagesFrom(cfg))
-
-	assert.EqualValues(t, "minio", Packages.Storage.Type)
-	assert.Equal(t, "packages/", Packages.Storage.MinioConfig.BasePath)
-
-	// or we can indicate the storage type  and minio base path in the packages section
-	iniStr = `
-[packages]
-STORAGE_TYPE = my_minio
-MINIO_BASE_PATH = my_packages/
-
-[storage.my_minio]
-STORAGE_TYPE = minio
-`
-	cfg, err = NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-	assert.NoError(t, loadPackagesFrom(cfg))
-
-	assert.EqualValues(t, "minio", Packages.Storage.Type)
-	assert.Equal(t, "my_packages/", Packages.Storage.MinioConfig.BasePath)
+	testConfigLoad(t, []any{loadPackagesFrom}, []configTestCase{
+		{
+			name: "inherits from [storage] if nothing is configured",
+			ini:  "[storage]\nSTORAGE_TYPE = minio",
+			want: minioStorageAt("packages", &Packages.Storage, "packages/"),
+		},
+		{
+			name: "[storage.packages] configures it directly",
+			ini:  "[storage.packages]\nSTORAGE_TYPE = minio",
+			want: minioStorageAt("packages", &Packages.Storage, "packages/"),
+		},
+		{
+			name: "[packages].STORAGE_TYPE can name another storage",
+			ini:  "[packages]\nSTORAGE_TYPE = my_minio\n\n[storage.my_minio]\nSTORAGE_TYPE = minio",
+			want: minioStorageAt("packages", &Packages.Storage, "packages/"),
+		},
+		{
+			name: "[packages].MINIO_BASE_PATH overrides the named storage",
+			ini:  "[packages]\nSTORAGE_TYPE = my_minio\nMINIO_BASE_PATH = my_packages/\n\n[storage.my_minio]\nSTORAGE_TYPE = minio",
+			want: minioStorageAt("packages", &Packages.Storage, "my_packages/"),
+		},
+	})
 }
 
-func Test_PackageStorage1(t *testing.T) {
-	iniStr := `
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-[packages]
-MINIO_BASE_PATH = packages/
-SERVE_DIRECT = true
-[storage]
+func Test_PackageStorage(t *testing.T) {
+	defer test.MockVariableValue(&Packages)()
+
+	minioSection := `
 STORAGE_TYPE            = minio
 MINIO_ENDPOINT          = s3.my-domain.net
 MINIO_BUCKET            = gitea
@@ -102,97 +72,33 @@ MINIO_USE_SSL           = true
 MINIO_ACCESS_KEY_ID     = correct_key
 MINIO_SECRET_ACCESS_KEY = correct_key
 `
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
+	served := func(basePath string) []configCheck {
+		return slices.Concat(
+			minioStorage("packages", &Packages.Storage, "gitea", basePath),
+			[]configCheck{fieldOf("SERVE_DIRECT", func() bool { return Packages.Storage.MinioConfig.ServeDirect }, true)},
+		)
+	}
 
-	assert.NoError(t, loadPackagesFrom(cfg))
-	storage := Packages.Storage
-
-	assert.EqualValues(t, "minio", storage.Type)
-	assert.Equal(t, "gitea", storage.MinioConfig.Bucket)
-	assert.Equal(t, "packages/", storage.MinioConfig.BasePath)
-	assert.True(t, storage.MinioConfig.ServeDirect)
-}
-
-func Test_PackageStorage2(t *testing.T) {
-	iniStr := `
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-[storage.packages]
-MINIO_BASE_PATH = packages/
-SERVE_DIRECT = true
-[storage]
-STORAGE_TYPE            = minio
-MINIO_ENDPOINT          = s3.my-domain.net
-MINIO_BUCKET            = gitea
-MINIO_LOCATION          = homenet
-MINIO_USE_SSL           = true
-MINIO_ACCESS_KEY_ID     = correct_key
-MINIO_SECRET_ACCESS_KEY = correct_key
-`
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-
-	assert.NoError(t, loadPackagesFrom(cfg))
-	storage := Packages.Storage
-
-	assert.EqualValues(t, "minio", storage.Type)
-	assert.Equal(t, "gitea", storage.MinioConfig.Bucket)
-	assert.Equal(t, "packages/", storage.MinioConfig.BasePath)
-	assert.True(t, storage.MinioConfig.ServeDirect)
-}
-
-func Test_PackageStorage3(t *testing.T) {
-	iniStr := `
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-[packages]
-STORAGE_TYPE            = my_cfg
-MINIO_BASE_PATH = my_packages/
-SERVE_DIRECT = true
-[storage.my_cfg]
-STORAGE_TYPE            = minio
-MINIO_ENDPOINT          = s3.my-domain.net
-MINIO_BUCKET            = gitea
-MINIO_LOCATION          = homenet
-MINIO_USE_SSL           = true
-MINIO_ACCESS_KEY_ID     = correct_key
-MINIO_SECRET_ACCESS_KEY = correct_key
-`
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-
-	assert.NoError(t, loadPackagesFrom(cfg))
-	storage := Packages.Storage
-
-	assert.EqualValues(t, "minio", storage.Type)
-	assert.Equal(t, "gitea", storage.MinioConfig.Bucket)
-	assert.Equal(t, "my_packages/", storage.MinioConfig.BasePath)
-	assert.True(t, storage.MinioConfig.ServeDirect)
-}
-
-func Test_PackageStorage4(t *testing.T) {
-	iniStr := `
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-[storage.packages]
-STORAGE_TYPE            = my_cfg
-MINIO_BASE_PATH = my_packages/
-SERVE_DIRECT = true
-[storage.my_cfg]
-STORAGE_TYPE            = minio
-MINIO_ENDPOINT          = s3.my-domain.net
-MINIO_BUCKET            = gitea
-MINIO_LOCATION          = homenet
-MINIO_USE_SSL           = true
-MINIO_ACCESS_KEY_ID     = correct_key
-MINIO_SECRET_ACCESS_KEY = correct_key
-`
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-
-	assert.NoError(t, loadPackagesFrom(cfg))
-	storage := Packages.Storage
-
-	assert.EqualValues(t, "minio", storage.Type)
-	assert.Equal(t, "gitea", storage.MinioConfig.Bucket)
-	assert.Equal(t, "my_packages/", storage.MinioConfig.BasePath)
-	assert.True(t, storage.MinioConfig.ServeDirect)
+	testConfigLoad(t, []any{loadPackagesFrom}, []configTestCase{
+		{
+			name: "[packages] over a global [storage]",
+			ini:  ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;\n[packages]\nMINIO_BASE_PATH = packages/\nSERVE_DIRECT = true\n[storage]" + minioSection,
+			want: served("packages/"),
+		},
+		{
+			name: "[storage.packages] over a global [storage]",
+			ini:  ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;\n[storage.packages]\nMINIO_BASE_PATH = packages/\nSERVE_DIRECT = true\n[storage]" + minioSection,
+			want: served("packages/"),
+		},
+		{
+			name: "[packages] pointing at a named storage",
+			ini:  ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;\n[packages]\nSTORAGE_TYPE            = my_cfg\nMINIO_BASE_PATH = my_packages/\nSERVE_DIRECT = true\n[storage.my_cfg]" + minioSection,
+			want: served("my_packages/"),
+		},
+		{
+			name: "[storage.packages] pointing at a named storage",
+			ini:  ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;\n[storage.packages]\nSTORAGE_TYPE            = my_cfg\nMINIO_BASE_PATH = my_packages/\nSERVE_DIRECT = true\n[storage.my_cfg]" + minioSection,
+			want: served("my_packages/"),
+		},
+	})
 }

--- a/modules/setting/repository_archive_test.go
+++ b/modules/setting/repository_archive_test.go
@@ -6,70 +6,40 @@ package setting
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"gitea.dev/modules/test"
 )
 
 func Test_getStorageInheritNameSectionTypeForRepoArchive(t *testing.T) {
-	// packages storage inherits from storage if nothing configured
-	iniStr := `
-[storage]
-STORAGE_TYPE = minio
-`
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-	assert.NoError(t, loadRepoArchiveFrom(cfg))
+	defer test.MockVariableValue(&RepoArchive)()
 
-	assert.EqualValues(t, "minio", RepoArchive.Storage.Type)
-	assert.Equal(t, "repo-archive/", RepoArchive.Storage.MinioConfig.BasePath)
-
-	// we can also configure packages storage directly
-	iniStr = `
-[storage.repo-archive]
-STORAGE_TYPE = minio
-`
-	cfg, err = NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-	assert.NoError(t, loadRepoArchiveFrom(cfg))
-
-	assert.EqualValues(t, "minio", RepoArchive.Storage.Type)
-	assert.Equal(t, "repo-archive/", RepoArchive.Storage.MinioConfig.BasePath)
-
-	// or we can indicate the storage type in the packages section
-	iniStr = `
-[repo-archive]
-STORAGE_TYPE = my_minio
-
-[storage.my_minio]
-STORAGE_TYPE = minio
-`
-	cfg, err = NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-	assert.NoError(t, loadRepoArchiveFrom(cfg))
-
-	assert.EqualValues(t, "minio", RepoArchive.Storage.Type)
-	assert.Equal(t, "repo-archive/", RepoArchive.Storage.MinioConfig.BasePath)
-
-	// or we can indicate the storage type  and minio base path in the packages section
-	iniStr = `
-[repo-archive]
-STORAGE_TYPE = my_minio
-MINIO_BASE_PATH = my_archive/
-
-[storage.my_minio]
-STORAGE_TYPE = minio
-`
-	cfg, err = NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-	assert.NoError(t, loadRepoArchiveFrom(cfg))
-
-	assert.EqualValues(t, "minio", RepoArchive.Storage.Type)
-	assert.Equal(t, "my_archive/", RepoArchive.Storage.MinioConfig.BasePath)
+	testConfigLoad(t, []any{loadRepoArchiveFrom}, []configTestCase{
+		{
+			name: "inherits from [storage] if nothing is configured",
+			ini:  "[storage]\nSTORAGE_TYPE = minio",
+			want: minioStorageAt("repo-archive", &RepoArchive.Storage, "repo-archive/"),
+		},
+		{
+			name: "[storage.repo-archive] configures it directly",
+			ini:  "[storage.repo-archive]\nSTORAGE_TYPE = minio",
+			want: minioStorageAt("repo-archive", &RepoArchive.Storage, "repo-archive/"),
+		},
+		{
+			name: "[repo-archive].STORAGE_TYPE can name another storage",
+			ini:  "[repo-archive]\nSTORAGE_TYPE = my_minio\n\n[storage.my_minio]\nSTORAGE_TYPE = minio",
+			want: minioStorageAt("repo-archive", &RepoArchive.Storage, "repo-archive/"),
+		},
+		{
+			name: "[repo-archive].MINIO_BASE_PATH overrides the named storage",
+			ini:  "[repo-archive]\nSTORAGE_TYPE = my_minio\nMINIO_BASE_PATH = my_archive/\n\n[storage.my_minio]\nSTORAGE_TYPE = minio",
+			want: minioStorageAt("repo-archive", &RepoArchive.Storage, "my_archive/"),
+		},
+	})
 }
 
 func Test_RepoArchiveStorage(t *testing.T) {
-	iniStr := `
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-[storage]
+	defer test.MockVariableValue(&RepoArchive)()
+
+	minioSection := `
 STORAGE_TYPE            = minio
 MINIO_ENDPOINT          = s3.my-domain.net
 MINIO_BUCKET            = gitea
@@ -78,34 +48,22 @@ MINIO_USE_SSL           = true
 MINIO_ACCESS_KEY_ID     = correct_key
 MINIO_SECRET_ACCESS_KEY = correct_key
 `
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
+	bucket := []configCheck{
+		guard(&RepoArchive.Storage),
+		fieldOf("STORAGE_TYPE", func() StorageType { return RepoArchive.Storage.Type }, MinioStorageType),
+		fieldOf("MINIO_BUCKET", func() string { return RepoArchive.Storage.MinioConfig.Bucket }, "gitea"),
+	}
 
-	assert.NoError(t, loadRepoArchiveFrom(cfg))
-	storage := RepoArchive.Storage
-
-	assert.EqualValues(t, "minio", storage.Type)
-	assert.Equal(t, "gitea", storage.MinioConfig.Bucket)
-
-	iniStr = `
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-[storage.repo-archive]
-STORAGE_TYPE = s3
-[storage.s3]
-STORAGE_TYPE            = minio
-MINIO_ENDPOINT          = s3.my-domain.net
-MINIO_BUCKET            = gitea
-MINIO_LOCATION          = homenet
-MINIO_USE_SSL           = true
-MINIO_ACCESS_KEY_ID     = correct_key
-MINIO_SECRET_ACCESS_KEY = correct_key
-`
-	cfg, err = NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-
-	assert.NoError(t, loadRepoArchiveFrom(cfg))
-	storage = RepoArchive.Storage
-
-	assert.EqualValues(t, "minio", storage.Type)
-	assert.Equal(t, "gitea", storage.MinioConfig.Bucket)
+	testConfigLoad(t, []any{loadRepoArchiveFrom}, []configTestCase{
+		{
+			name: "a fully configured [storage] section",
+			ini:  ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;\n[storage]" + minioSection,
+			want: bucket,
+		},
+		{
+			name: "an indirection through a named storage",
+			ini:  ";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;\n[storage.repo-archive]\nSTORAGE_TYPE = s3\n[storage.s3]" + minioSection,
+			want: bucket,
+		},
+	})
 }

--- a/modules/setting/repository_test.go
+++ b/modules/setting/repository_test.go
@@ -7,60 +7,45 @@ import (
 	"testing"
 
 	"gitea.dev/modules/test"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestLoadRepositoryCreationLimits(t *testing.T) {
-	defer test.MockVariableValue(&Repository.MaxCreationLimit)()
-	defer test.MockVariableValue(&Repository.UserMaxCreationLimit)()
-	defer test.MockVariableValue(&Repository.OrgMaxCreationLimit)()
+	defer test.MockVariableValue(&Repository)()
 
-	t.Run("ShortcutPropagatesToBoth", func(t *testing.T) {
-		cfg, err := NewConfigProviderFromData(`
-[repository]
-MAX_CREATION_LIMIT = 5
-`)
-		assert.NoError(t, err)
-		loadRepositoryFrom(cfg)
-		assert.Equal(t, 5, Repository.MaxCreationLimit)
-		assert.Equal(t, 5, Repository.UserMaxCreationLimit)
-		assert.Equal(t, 5, Repository.OrgMaxCreationLimit)
-	})
-
-	t.Run("PerTypeKeysOverrideShortcut", func(t *testing.T) {
-		cfg, err := NewConfigProviderFromData(`
-[repository]
-MAX_CREATION_LIMIT = 5
-USER_MAX_CREATION_LIMIT = 0
-ORG_MAX_CREATION_LIMIT = -1
-`)
-		assert.NoError(t, err)
-		loadRepositoryFrom(cfg)
-		assert.Equal(t, 0, Repository.UserMaxCreationLimit)
-		assert.Equal(t, -1, Repository.OrgMaxCreationLimit)
-	})
-
-	t.Run("PartialOverrideOtherInheritsShortcut", func(t *testing.T) {
-		cfg, err := NewConfigProviderFromData(`
-[repository]
-MAX_CREATION_LIMIT = 7
-ORG_MAX_CREATION_LIMIT = -1
-`)
-		assert.NoError(t, err)
-		loadRepositoryFrom(cfg)
-		assert.Equal(t, 7, Repository.UserMaxCreationLimit)
-		assert.Equal(t, -1, Repository.OrgMaxCreationLimit)
-	})
-
-	t.Run("NoKeyDefaultsToNoLimit", func(t *testing.T) {
-		cfg, err := NewConfigProviderFromData(`
-[repository]
-`)
-		assert.NoError(t, err)
-		loadRepositoryFrom(cfg)
-		assert.Equal(t, -1, Repository.MaxCreationLimit)
-		assert.Equal(t, -1, Repository.UserMaxCreationLimit)
-		assert.Equal(t, -1, Repository.OrgMaxCreationLimit)
+	testConfigLoad(t, []any{loadRepositoryFrom}, []configTestCase{
+		{
+			name: "shortcut propagates to both",
+			ini:  "[repository]\nMAX_CREATION_LIMIT = 5",
+			want: []configCheck{
+				field("MAX_CREATION_LIMIT", &Repository.MaxCreationLimit, 5),
+				field("USER_MAX_CREATION_LIMIT", &Repository.UserMaxCreationLimit, 5),
+				field("ORG_MAX_CREATION_LIMIT", &Repository.OrgMaxCreationLimit, 5),
+			},
+		},
+		{
+			name: "per-type keys override the shortcut",
+			ini:  "[repository]\nMAX_CREATION_LIMIT = 5\nUSER_MAX_CREATION_LIMIT = 0\nORG_MAX_CREATION_LIMIT = -1",
+			want: []configCheck{
+				field("USER_MAX_CREATION_LIMIT", &Repository.UserMaxCreationLimit, 0),
+				field("ORG_MAX_CREATION_LIMIT", &Repository.OrgMaxCreationLimit, -1),
+			},
+		},
+		{
+			name: "partial override, the other inherits the shortcut",
+			ini:  "[repository]\nMAX_CREATION_LIMIT = 7\nORG_MAX_CREATION_LIMIT = -1",
+			want: []configCheck{
+				field("USER_MAX_CREATION_LIMIT", &Repository.UserMaxCreationLimit, 7),
+				field("ORG_MAX_CREATION_LIMIT", &Repository.OrgMaxCreationLimit, -1),
+			},
+		},
+		{
+			name: "no key means no limit",
+			ini:  "[repository]",
+			want: []configCheck{
+				field("MAX_CREATION_LIMIT", &Repository.MaxCreationLimit, -1),
+				field("USER_MAX_CREATION_LIMIT", &Repository.UserMaxCreationLimit, -1),
+				field("ORG_MAX_CREATION_LIMIT", &Repository.OrgMaxCreationLimit, -1),
+			},
+		},
 	})
 }

--- a/modules/setting/security_test.go
+++ b/modules/setting/security_test.go
@@ -6,24 +6,34 @@ package setting
 import (
 	"testing"
 
+	"gitea.dev/modules/test"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestLoadSecurityFrom(t *testing.T) {
+	defer test.MockVariableValue(&Security)()
+
+	// the package defaults, before any config is loaded
 	assert.Equal(t, "SAMEORIGIN", Security.XFrameOptions)
 	assert.Equal(t, "nosniff", Security.XContentTypeOptions)
 	assert.Equal(t, "external", Security.AllowedHostList)
 
-	cfg, err := NewConfigProviderFromData(`[security]
+	testConfigLoad(t, []any{loadSecurityFrom}, []configTestCase{
+		{
+			name: "keys override the defaults",
+			ini: `[security]
 X_FRAME_OPTIONS = DENY
 X_CONTENT_TYPE_OPTIONS = unset
 ALLOWED_HOST_LIST = foo
 CONTENT_SECURITY_POLICY_GENERAL = "script-src *; foo"
-`)
-	assert.NoError(t, err)
-	loadSecurityFrom(cfg)
-	assert.Equal(t, "DENY", Security.XFrameOptions)
-	assert.Equal(t, "unset", Security.XContentTypeOptions)
-	assert.Equal(t, "foo", Security.AllowedHostList)
-	assert.Equal(t, `"script-src *`, Security.ContentSecurityPolicyGeneral) // holy shit ini package bug
+`,
+			want: []configCheck{
+				field("X_FRAME_OPTIONS", &Security.XFrameOptions, "DENY"),
+				field("X_CONTENT_TYPE_OPTIONS", &Security.XContentTypeOptions, "unset"),
+				field("ALLOWED_HOST_LIST", &Security.AllowedHostList, "foo"),
+				field("CONTENT_SECURITY_POLICY_GENERAL", &Security.ContentSecurityPolicyGeneral, `"script-src *`), // holy shit ini package bug
+			},
+		},
+	})
 }

--- a/modules/setting/service_test.go
+++ b/modules/setting/service_test.go
@@ -54,107 +54,100 @@ func TestLoadServiceVisibilityModes(t *testing.T) {
 		}
 		return ret
 	}
-	testCases := map[string]func(){
-		`
-[service]
-DEFAULT_USER_VISIBILITY = public
-ALLOWED_USER_VISIBILITY_MODES = public,limited,private
-`: func() {
-			assert.Equal(t, structs.VisibleTypePublic, Service.DefaultUserVisibilityMode)
-			assert.Equal(t, visibleTypeSlice("public", "limited", "private"), Service.AllowedUserVisibilityModesSlice.ToVisibleTypeSlice())
-		},
-		`
-		[service]
-		DEFAULT_USER_VISIBILITY = public
-		`: func() {
-			assert.Equal(t, structs.VisibleTypePublic, Service.DefaultUserVisibilityMode)
-			assert.Equal(t, visibleTypeSlice("public", "limited", "private"), Service.AllowedUserVisibilityModesSlice.ToVisibleTypeSlice())
-		},
-		`
-		[service]
-		DEFAULT_USER_VISIBILITY = limited
-		`: func() {
-			assert.Equal(t, structs.VisibleTypeLimited, Service.DefaultUserVisibilityMode)
-			assert.Equal(t, visibleTypeSlice("public", "limited", "private"), Service.AllowedUserVisibilityModesSlice.ToVisibleTypeSlice())
-		},
-		`
-[service]
-ALLOWED_USER_VISIBILITY_MODES = public,limited,private
-`: func() {
-			assert.Equal(t, structs.VisibleTypePublic, Service.DefaultUserVisibilityMode)
-			assert.Equal(t, visibleTypeSlice("public", "limited", "private"), Service.AllowedUserVisibilityModesSlice.ToVisibleTypeSlice())
-		},
-		`
-[service]
-DEFAULT_USER_VISIBILITY = public
-ALLOWED_USER_VISIBILITY_MODES = limited,private
-`: func() {
-			assert.Equal(t, structs.VisibleTypeLimited, Service.DefaultUserVisibilityMode)
-			assert.Equal(t, visibleTypeSlice("limited", "private"), Service.AllowedUserVisibilityModesSlice.ToVisibleTypeSlice())
-		},
-		`
-[service]
-DEFAULT_USER_VISIBILITY = my_type
-ALLOWED_USER_VISIBILITY_MODES = limited,private
-`: func() {
-			assert.Equal(t, structs.VisibleTypeLimited, Service.DefaultUserVisibilityMode)
-			assert.Equal(t, visibleTypeSlice("limited", "private"), Service.AllowedUserVisibilityModesSlice.ToVisibleTypeSlice())
-		},
-		`
-[service]
-DEFAULT_USER_VISIBILITY = my_type
-`: func() {
-			assert.Equal(t, structs.VisibleTypePublic, Service.DefaultUserVisibilityMode)
-			assert.Equal(t, visibleTypeSlice("public", "limited", "private"), Service.AllowedUserVisibilityModesSlice.ToVisibleTypeSlice())
-		},
-		`
-[service]
-DEFAULT_USER_VISIBILITY = public
-ALLOWED_USER_VISIBILITY_MODES = public, limit, privated
-`: func() {
-			assert.Equal(t, structs.VisibleTypePublic, Service.DefaultUserVisibilityMode)
-			assert.Equal(t, visibleTypeSlice("public"), Service.AllowedUserVisibilityModesSlice.ToVisibleTypeSlice())
-		},
-	}
+	allowedModes := func() []structs.VisibleType { return Service.AllowedUserVisibilityModesSlice.ToVisibleTypeSlice() }
+	allVisible := visibleTypeSlice("public", "limited", "private")
 
-	for tc, fn := range testCases {
-		t.Run(tc, func(t *testing.T) {
-			Service.AllowedUserVisibilityModesSlice = []bool{true, true, true}
-			Service.DefaultUserVisibilityMode = structs.VisibleTypePublic
-			cfg, err := NewConfigProviderFromData(tc)
-			assert.NoError(t, err)
-			loadServiceFrom(cfg)
-			fn()
-		})
-	}
+	testConfigLoad(t, []any{loadServiceFrom}, []configTestCase{
+		{
+			ini: "[service]\nDEFAULT_USER_VISIBILITY = public\nALLOWED_USER_VISIBILITY_MODES = public,limited,private",
+			want: []configCheck{
+				field("DEFAULT_USER_VISIBILITY", &Service.DefaultUserVisibilityMode, structs.VisibleTypePublic),
+				fieldOf("ALLOWED_USER_VISIBILITY_MODES", allowedModes, allVisible),
+			},
+		},
+		{
+			ini: "[service]\nDEFAULT_USER_VISIBILITY = public",
+			want: []configCheck{
+				field("DEFAULT_USER_VISIBILITY", &Service.DefaultUserVisibilityMode, structs.VisibleTypePublic),
+				fieldOf("ALLOWED_USER_VISIBILITY_MODES", allowedModes, allVisible),
+			},
+		},
+		{
+			ini: "[service]\nDEFAULT_USER_VISIBILITY = limited",
+			want: []configCheck{
+				field("DEFAULT_USER_VISIBILITY", &Service.DefaultUserVisibilityMode, structs.VisibleTypeLimited),
+				fieldOf("ALLOWED_USER_VISIBILITY_MODES", allowedModes, allVisible),
+			},
+		},
+		{
+			ini: "[service]\nALLOWED_USER_VISIBILITY_MODES = public,limited,private",
+			want: []configCheck{
+				field("DEFAULT_USER_VISIBILITY", &Service.DefaultUserVisibilityMode, structs.VisibleTypePublic),
+				fieldOf("ALLOWED_USER_VISIBILITY_MODES", allowedModes, allVisible),
+			},
+		},
+		{
+			name: "the default falls back to the first allowed mode",
+			ini:  "[service]\nDEFAULT_USER_VISIBILITY = public\nALLOWED_USER_VISIBILITY_MODES = limited,private",
+			want: []configCheck{
+				field("DEFAULT_USER_VISIBILITY", &Service.DefaultUserVisibilityMode, structs.VisibleTypeLimited),
+				fieldOf("ALLOWED_USER_VISIBILITY_MODES", allowedModes, visibleTypeSlice("limited", "private")),
+			},
+		},
+		{
+			name: "an unknown default falls back to the first allowed mode",
+			ini:  "[service]\nDEFAULT_USER_VISIBILITY = my_type\nALLOWED_USER_VISIBILITY_MODES = limited,private",
+			want: []configCheck{
+				field("DEFAULT_USER_VISIBILITY", &Service.DefaultUserVisibilityMode, structs.VisibleTypeLimited),
+				fieldOf("ALLOWED_USER_VISIBILITY_MODES", allowedModes, visibleTypeSlice("limited", "private")),
+			},
+		},
+		{
+			name: "an unknown default alone falls back to public",
+			ini:  "[service]\nDEFAULT_USER_VISIBILITY = my_type",
+			want: []configCheck{
+				field("DEFAULT_USER_VISIBILITY", &Service.DefaultUserVisibilityMode, structs.VisibleTypePublic),
+				fieldOf("ALLOWED_USER_VISIBILITY_MODES", allowedModes, allVisible),
+			},
+		},
+		{
+			name: "unknown allowed modes are dropped",
+			ini:  "[service]\nDEFAULT_USER_VISIBILITY = public\nALLOWED_USER_VISIBILITY_MODES = public, limit, privated",
+			want: []configCheck{
+				field("DEFAULT_USER_VISIBILITY", &Service.DefaultUserVisibilityMode, structs.VisibleTypePublic),
+				fieldOf("ALLOWED_USER_VISIBILITY_MODES", allowedModes, visibleTypeSlice("public")),
+			},
+		},
+	})
 }
 
 func TestLoadServiceRequireSignInView(t *testing.T) {
 	defer test.MockVariableValue(&Service)()
 
-	cfg, err := NewConfigProviderFromData(`
-[service]
-`)
-	assert.NoError(t, err)
-	loadServiceFrom(cfg)
-	assert.False(t, Service.RequireSignInViewStrict)
-	assert.False(t, Service.BlockAnonymousAccessExpensive)
-
-	cfg, err = NewConfigProviderFromData(`
-[service]
-REQUIRE_SIGNIN_VIEW = true
-`)
-	assert.NoError(t, err)
-	loadServiceFrom(cfg)
-	assert.True(t, Service.RequireSignInViewStrict)
-	assert.False(t, Service.BlockAnonymousAccessExpensive)
-
-	cfg, err = NewConfigProviderFromData(`
-[service]
-REQUIRE_SIGNIN_VIEW = expensive
-`)
-	assert.NoError(t, err)
-	loadServiceFrom(cfg)
-	assert.False(t, Service.RequireSignInViewStrict)
-	assert.True(t, Service.BlockAnonymousAccessExpensive)
+	testConfigLoad(t, []any{loadServiceFrom}, []configTestCase{
+		{
+			name: "unset",
+			ini:  "[service]",
+			want: []configCheck{
+				field("REQUIRE_SIGNIN_VIEW", &Service.RequireSignInViewStrict, false),
+				field("REQUIRE_SIGNIN_VIEW", &Service.BlockAnonymousAccessExpensive, false),
+			},
+		},
+		{
+			name: "true is strict",
+			ini:  "[service]\nREQUIRE_SIGNIN_VIEW = true",
+			want: []configCheck{
+				field("REQUIRE_SIGNIN_VIEW", &Service.RequireSignInViewStrict, true),
+				field("REQUIRE_SIGNIN_VIEW", &Service.BlockAnonymousAccessExpensive, false),
+			},
+		},
+		{
+			name: "expensive blocks anonymous access instead",
+			ini:  "[service]\nREQUIRE_SIGNIN_VIEW = expensive",
+			want: []configCheck{
+				field("REQUIRE_SIGNIN_VIEW", &Service.RequireSignInViewStrict, false),
+				field("REQUIRE_SIGNIN_VIEW", &Service.BlockAnonymousAccessExpensive, true),
+			},
+		},
+	})
 }

--- a/modules/setting/session_test.go
+++ b/modules/setting/session_test.go
@@ -12,68 +12,40 @@ import (
 )
 
 func TestSessionRedisSharedConnFallback(t *testing.T) {
-	tests := []struct {
-		name        string
-		iniStr      string
-		wantContain string
-		wantMissing string
-	}{
-		{
-			name: "redis provider with empty PROVIDER_CONFIG falls back to shared [redis]",
-			iniStr: `
-[redis]
-CONN_STR = redis://127.0.0.1:6379/0
-[session]
-PROVIDER = redis
-`,
-			wantContain: "redis://127.0.0.1:6379/0",
-		},
-		{
-			name: "session PROVIDER_CONFIG wins over shared [redis]",
-			iniStr: `
-[redis]
-CONN_STR = redis://127.0.0.1:6379/0
-[session]
-PROVIDER = redis
-PROVIDER_CONFIG = redis://10.0.0.1:6379/1
-`,
-			wantContain: "redis://10.0.0.1:6379/1",
-			wantMissing: "127.0.0.1",
-		},
-		{
-			name: "no shared [redis]",
-			iniStr: `
-[session]
-PROVIDER = redis
-`,
-			wantContain: "",
-			wantMissing: "redis://",
-		},
-		{
-			name: "file provider default path is untouched by shared [redis]",
-			iniStr: `
-[redis]
-CONN_STR = redis://127.0.0.1:6379/0
-[session]
-PROVIDER = file
-`,
-			wantContain: "sessions",
-			wantMissing: "redis://",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			defer test.MockVariableValue(&Redis)()
-			cfg, err := NewConfigProviderFromData(tt.iniStr)
-			assert.NoError(t, err)
+	defer test.MockVariableValue(&SessionConfig)()
+	defer test.MockVariableValue(&Redis)()
 
-			loadRedisFrom(cfg)
-			loadSessionFrom(cfg)
-			// ProviderConfig is shadowed into a JSON blob at the end of loadSessionFrom
-			assert.Contains(t, SessionConfig.ProviderConfig, tt.wantContain)
-			if tt.wantMissing != "" {
-				assert.NotContains(t, SessionConfig.ProviderConfig, tt.wantMissing)
+	// ProviderConfig is shadowed into a JSON blob at the end of loadSessionFrom, so it is matched
+	// by substring rather than compared with field
+	providerConfig := func(want, missing string) func(t *testing.T) {
+		return func(t *testing.T) {
+			assert.Contains(t, SessionConfig.ProviderConfig, want)
+			if missing != "" {
+				assert.NotContains(t, SessionConfig.ProviderConfig, missing)
 			}
-		})
+		}
 	}
+
+	testConfigLoad(t, []any{loadRedisFrom, loadSessionFrom}, []configTestCase{
+		{
+			name:  "redis provider with empty PROVIDER_CONFIG falls back to shared [redis]",
+			ini:   "[redis]\nCONN_STR = redis://127.0.0.1:6379/0\n[session]\nPROVIDER = redis",
+			check: providerConfig("redis://127.0.0.1:6379/0", ""),
+		},
+		{
+			name:  "session PROVIDER_CONFIG wins over shared [redis]",
+			ini:   "[redis]\nCONN_STR = redis://127.0.0.1:6379/0\n[session]\nPROVIDER = redis\nPROVIDER_CONFIG = redis://10.0.0.1:6379/1",
+			check: providerConfig("redis://10.0.0.1:6379/1", "127.0.0.1"),
+		},
+		{
+			name:  "no shared [redis]",
+			ini:   "[session]\nPROVIDER = redis",
+			check: providerConfig("", "redis://"),
+		},
+		{
+			name:  "file provider default path is untouched by shared [redis]",
+			ini:   "[redis]\nCONN_STR = redis://127.0.0.1:6379/0\n[session]\nPROVIDER = file",
+			check: providerConfig("sessions", "redis://"),
+		},
+	})
 }

--- a/modules/setting/storage_test.go
+++ b/modules/setting/storage_test.go
@@ -5,13 +5,76 @@ package setting
 
 import (
 	"path/filepath"
+	"slices"
 	"testing"
 
+	"gitea.dev/modules/test"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+// localStorageCheck expects a storage to be local and rooted at a given absolute path.
+type localStorageCheck struct {
+	name     string
+	ptr      **Storage
+	wantPath string
+}
+
+func (c *localStorageCheck) snapshot() func() { return test.MockVariableValue(c.ptr) }
+
+func (c *localStorageCheck) check(t *testing.T) {
+	t.Helper()
+	s := *c.ptr
+	assert.Equal(t, LocalStorageType, s.Type, "storage %s type", c.name)
+	assert.True(t, filepath.IsAbs(s.Path), "storage %s path %q is not absolute", c.name, s.Path)
+	assert.Equal(t, filepath.Clean(c.wantPath), filepath.Clean(s.Path), "storage %s path", c.name)
+}
+
+func localStorage(name string, ptr **Storage, wantPath string) configCheck {
+	return &localStorageCheck{name: name, ptr: ptr, wantPath: wantPath}
+}
+
+// minioStorageAt expects a minio storage at a base path, guarding the pointer the loader replaces.
+func minioStorageAt(name string, ptr **Storage, basePath string) []configCheck {
+	return []configCheck{
+		guard(ptr),
+		fieldOf(name+" STORAGE_TYPE", func() StorageType { return (*ptr).Type }, MinioStorageType),
+		fieldOf(name+" MINIO_BASE_PATH", func() string { return (*ptr).MinioConfig.BasePath }, basePath),
+	}
+}
+
+// minioStorage is minioStorageAt with the bucket asserted too.
+func minioStorage(name string, ptr **Storage, bucket, basePath string) []configCheck {
+	return slices.Concat(minioStorageAt(name, ptr, basePath), []configCheck{
+		fieldOf(name+" MINIO_BUCKET", func() string { return (*ptr).MinioConfig.Bucket }, bucket),
+	})
+}
+
+// azureBlobStorage expects an azureblob storage, guarding the pointer the loader replaces.
+func azureBlobStorage(name string, ptr **Storage, container, basePath string) []configCheck {
+	return []configCheck{
+		guard(ptr),
+		fieldOf(name+" STORAGE_TYPE", func() StorageType { return (*ptr).Type }, AzureBlobStorageType),
+		fieldOf(name+" AZURE_BLOB_CONTAINER", func() string { return (*ptr).AzureBlobConfig.Container }, container),
+		fieldOf(name+" AZURE_BLOB_BASE_PATH", func() string { return (*ptr).AzureBlobConfig.BasePath }, basePath),
+	}
+}
+
+var allStorageLoaders = []any{
+	loadAttachmentFrom, loadLFSFrom, loadActionsFrom, loadPackagesFrom,
+	loadRepoArchiveFrom, loadAvatarsFrom, loadRepoAvatarFrom,
+}
+
 func Test_getStorageMultipleName(t *testing.T) {
-	iniStr := `
+	defer test.MockVariableValue(&Attachment)()
+	defer test.MockVariableValue(&LFS)()
+	defer test.MockVariableValue(&Avatar)()
+
+	testConfigLoad(t, []any{loadAttachmentFrom, loadLFSFrom, loadAvatarsFrom}, []configTestCase{
+		{
+			name: "each section keeps its own bucket, the rest inherit [storage]",
+			ini: `
 [lfs]
 MINIO_BUCKET = gitea-lfs
 
@@ -21,572 +84,346 @@ MINIO_BUCKET = gitea-attachment
 [storage]
 STORAGE_TYPE = minio
 MINIO_BUCKET = gitea-storage
-`
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-
-	assert.NoError(t, loadAttachmentFrom(cfg))
-	assert.Equal(t, "gitea-attachment", Attachment.Storage.MinioConfig.Bucket)
-	assert.Equal(t, "attachments/", Attachment.Storage.MinioConfig.BasePath)
-
-	assert.NoError(t, loadLFSFrom(cfg))
-	assert.Equal(t, "gitea-lfs", LFS.Storage.MinioConfig.Bucket)
-	assert.Equal(t, "lfs/", LFS.Storage.MinioConfig.BasePath)
-
-	assert.NoError(t, loadAvatarsFrom(cfg))
-	assert.Equal(t, "gitea-storage", Avatar.Storage.MinioConfig.Bucket)
-	assert.Equal(t, "avatars/", Avatar.Storage.MinioConfig.BasePath)
+`,
+			want: slices.Concat(
+				minioStorage("attachment", &Attachment.Storage, "gitea-attachment", "attachments/"),
+				minioStorage("lfs", &LFS.Storage, "gitea-lfs", "lfs/"),
+				minioStorage("avatar", &Avatar.Storage, "gitea-storage", "avatars/"),
+			),
+		},
+	})
 }
 
 func Test_getStorageUseOtherNameAsType(t *testing.T) {
-	iniStr := `
+	defer test.MockVariableValue(&Attachment)()
+	defer test.MockVariableValue(&LFS)()
+
+	testConfigLoad(t, []any{loadAttachmentFrom, loadLFSFrom}, []configTestCase{
+		{
+			name: "attachment borrows the lfs storage but keeps its own base path",
+			ini: `
 [attachment]
 STORAGE_TYPE = lfs
 
 [storage.lfs]
 STORAGE_TYPE = minio
 MINIO_BUCKET = gitea-storage
-`
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-
-	assert.NoError(t, loadAttachmentFrom(cfg))
-	assert.Equal(t, "gitea-storage", Attachment.Storage.MinioConfig.Bucket)
-	assert.Equal(t, "attachments/", Attachment.Storage.MinioConfig.BasePath)
-
-	assert.NoError(t, loadLFSFrom(cfg))
-	assert.Equal(t, "gitea-storage", LFS.Storage.MinioConfig.Bucket)
-	assert.Equal(t, "lfs/", LFS.Storage.MinioConfig.BasePath)
+`,
+			want: slices.Concat(
+				minioStorage("attachment", &Attachment.Storage, "gitea-storage", "attachments/"),
+				minioStorage("lfs", &LFS.Storage, "gitea-storage", "lfs/"),
+			),
+		},
+	})
 }
 
 func Test_getStorageInheritStorageType(t *testing.T) {
-	iniStr := `
-[storage]
-STORAGE_TYPE = minio
-`
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
+	defer test.MockVariableValue(&Packages)()
+	defer test.MockVariableValue(&RepoArchive)()
+	defer test.MockVariableValue(&Actions)()
+	defer test.MockVariableValue(&Avatar)()
+	defer test.MockVariableValue(&RepoAvatar)()
 
-	assert.NoError(t, loadPackagesFrom(cfg))
-	assert.EqualValues(t, "minio", Packages.Storage.Type)
-	assert.Equal(t, "gitea", Packages.Storage.MinioConfig.Bucket)
-	assert.Equal(t, "packages/", Packages.Storage.MinioConfig.BasePath)
-
-	assert.NoError(t, loadRepoArchiveFrom(cfg))
-	assert.EqualValues(t, "minio", RepoArchive.Storage.Type)
-	assert.Equal(t, "gitea", RepoArchive.Storage.MinioConfig.Bucket)
-	assert.Equal(t, "repo-archive/", RepoArchive.Storage.MinioConfig.BasePath)
-
-	assert.NoError(t, loadActionsFrom(cfg))
-	assert.EqualValues(t, "minio", Actions.LogStorage.Type)
-	assert.Equal(t, "gitea", Actions.LogStorage.MinioConfig.Bucket)
-	assert.Equal(t, "actions_log/", Actions.LogStorage.MinioConfig.BasePath)
-
-	assert.EqualValues(t, "minio", Actions.ArtifactStorage.Type)
-	assert.Equal(t, "gitea", Actions.ArtifactStorage.MinioConfig.Bucket)
-	assert.Equal(t, "actions_artifacts/", Actions.ArtifactStorage.MinioConfig.BasePath)
-
-	assert.NoError(t, loadAvatarsFrom(cfg))
-	assert.EqualValues(t, "minio", Avatar.Storage.Type)
-	assert.Equal(t, "gitea", Avatar.Storage.MinioConfig.Bucket)
-	assert.Equal(t, "avatars/", Avatar.Storage.MinioConfig.BasePath)
-
-	assert.NoError(t, loadRepoAvatarFrom(cfg))
-	assert.EqualValues(t, "minio", RepoAvatar.Storage.Type)
-	assert.Equal(t, "gitea", RepoAvatar.Storage.MinioConfig.Bucket)
-	assert.Equal(t, "repo-avatars/", RepoAvatar.Storage.MinioConfig.BasePath)
-}
-
-func Test_getStorageInheritStorageTypeAzureBlob(t *testing.T) {
-	iniStr := `
-[storage]
-STORAGE_TYPE = azureblob
-`
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-
-	assert.NoError(t, loadPackagesFrom(cfg))
-	assert.EqualValues(t, "azureblob", Packages.Storage.Type)
-	assert.Equal(t, "gitea", Packages.Storage.AzureBlobConfig.Container)
-	assert.Equal(t, "packages/", Packages.Storage.AzureBlobConfig.BasePath)
-
-	assert.NoError(t, loadRepoArchiveFrom(cfg))
-	assert.EqualValues(t, "azureblob", RepoArchive.Storage.Type)
-	assert.Equal(t, "gitea", RepoArchive.Storage.AzureBlobConfig.Container)
-	assert.Equal(t, "repo-archive/", RepoArchive.Storage.AzureBlobConfig.BasePath)
-
-	assert.NoError(t, loadActionsFrom(cfg))
-	assert.EqualValues(t, "azureblob", Actions.LogStorage.Type)
-	assert.Equal(t, "gitea", Actions.LogStorage.AzureBlobConfig.Container)
-	assert.Equal(t, "actions_log/", Actions.LogStorage.AzureBlobConfig.BasePath)
-
-	assert.EqualValues(t, "azureblob", Actions.ArtifactStorage.Type)
-	assert.Equal(t, "gitea", Actions.ArtifactStorage.AzureBlobConfig.Container)
-	assert.Equal(t, "actions_artifacts/", Actions.ArtifactStorage.AzureBlobConfig.BasePath)
-
-	assert.NoError(t, loadAvatarsFrom(cfg))
-	assert.EqualValues(t, "azureblob", Avatar.Storage.Type)
-	assert.Equal(t, "gitea", Avatar.Storage.AzureBlobConfig.Container)
-	assert.Equal(t, "avatars/", Avatar.Storage.AzureBlobConfig.BasePath)
-
-	assert.NoError(t, loadRepoAvatarFrom(cfg))
-	assert.EqualValues(t, "azureblob", RepoAvatar.Storage.Type)
-	assert.Equal(t, "gitea", RepoAvatar.Storage.AzureBlobConfig.Container)
-	assert.Equal(t, "repo-avatars/", RepoAvatar.Storage.AzureBlobConfig.BasePath)
-}
-
-type testLocalStoragePathCase struct {
-	loader       func(rootCfg ConfigProvider) error
-	storagePtr   **Storage
-	expectedPath string
-}
-
-func testLocalStoragePath(t *testing.T, appDataPath, iniStr string, cases []testLocalStoragePathCase) {
-	cfg, err := NewConfigProviderFromData(iniStr)
-	assert.NoError(t, err)
-	AppDataPath = appDataPath
-	for _, c := range cases {
-		assert.NoError(t, c.loader(cfg))
-		storage := *c.storagePtr
-
-		assert.EqualValues(t, "local", storage.Type)
-		assert.True(t, filepath.IsAbs(storage.Path))
-		assert.Equal(t, filepath.Clean(c.expectedPath), filepath.Clean(storage.Path))
-	}
+	testConfigLoad(t, []any{loadPackagesFrom, loadRepoArchiveFrom, loadActionsFrom, loadAvatarsFrom, loadRepoAvatarFrom}, []configTestCase{
+		{
+			name: "minio",
+			ini:  "[storage]\nSTORAGE_TYPE = minio",
+			want: slices.Concat(
+				minioStorage("packages", &Packages.Storage, "gitea", "packages/"),
+				minioStorage("repo-archive", &RepoArchive.Storage, "gitea", "repo-archive/"),
+				minioStorage("actions_log", &Actions.LogStorage, "gitea", "actions_log/"),
+				minioStorage("actions_artifacts", &Actions.ArtifactStorage, "gitea", "actions_artifacts/"),
+				minioStorage("avatar", &Avatar.Storage, "gitea", "avatars/"),
+				minioStorage("repo-avatar", &RepoAvatar.Storage, "gitea", "repo-avatars/"),
+			),
+		},
+		{
+			name: "azureblob",
+			ini:  "[storage]\nSTORAGE_TYPE = azureblob",
+			want: slices.Concat(
+				azureBlobStorage("packages", &Packages.Storage, "gitea", "packages/"),
+				azureBlobStorage("repo-archive", &RepoArchive.Storage, "gitea", "repo-archive/"),
+				azureBlobStorage("actions_log", &Actions.LogStorage, "gitea", "actions_log/"),
+				azureBlobStorage("actions_artifacts", &Actions.ArtifactStorage, "gitea", "actions_artifacts/"),
+				azureBlobStorage("avatar", &Avatar.Storage, "gitea", "avatars/"),
+				azureBlobStorage("repo-avatar", &RepoAvatar.Storage, "gitea", "repo-avatars/"),
+			),
+		},
+	})
 }
 
 func Test_getStorageInheritStorageTypeLocal(t *testing.T) {
-	testLocalStoragePath(t, "/appdata", `
-[storage]
-STORAGE_TYPE = local
-`, []testLocalStoragePathCase{
-		{loadAttachmentFrom, &Attachment.Storage, "/appdata/attachments"},
-		{loadLFSFrom, &LFS.Storage, "/appdata/lfs"},
-		{loadActionsFrom, &Actions.ArtifactStorage, "/appdata/actions_artifacts"},
-		{loadPackagesFrom, &Packages.Storage, "/appdata/packages"},
-		{loadRepoArchiveFrom, &RepoArchive.Storage, "/appdata/repo-archive"},
-		{loadActionsFrom, &Actions.LogStorage, "/appdata/actions_log"},
-		{loadAvatarsFrom, &Avatar.Storage, "/appdata/avatars"},
-		{loadRepoAvatarFrom, &RepoAvatar.Storage, "/appdata/repo-avatars"},
+	defer test.MockVariableValue(&AppDataPath, "/appdata")()
+	defer test.MockVariableValue(&Attachment)()
+	defer test.MockVariableValue(&LFS)()
+	defer test.MockVariableValue(&Actions)()
+	defer test.MockVariableValue(&Packages)()
+	defer test.MockVariableValue(&RepoArchive)()
+	defer test.MockVariableValue(&Avatar)()
+	defer test.MockVariableValue(&RepoAvatar)()
+
+	// every case asserts all storages, archive overriding only the repo-archive one
+	under := func(root, archive string) []configCheck {
+		if archive == "" {
+			archive = root + "/repo-archive"
+		}
+		return []configCheck{
+			localStorage("attachment", &Attachment.Storage, root+"/attachments"),
+			localStorage("lfs", &LFS.Storage, root+"/lfs"),
+			localStorage("actions_artifacts", &Actions.ArtifactStorage, root+"/actions_artifacts"),
+			localStorage("packages", &Packages.Storage, root+"/packages"),
+			localStorage("repo-archive", &RepoArchive.Storage, archive),
+			localStorage("actions_log", &Actions.LogStorage, root+"/actions_log"),
+			localStorage("avatar", &Avatar.Storage, root+"/avatars"),
+			localStorage("repo-avatar", &RepoAvatar.Storage, root+"/repo-avatars"),
+		}
+	}
+
+	testConfigLoad(t, allStorageLoaders, []configTestCase{
+		{
+			name: "everything under APP_DATA_PATH",
+			ini:  "[storage]\nSTORAGE_TYPE = local",
+			want: under("/appdata", ""),
+		},
+		{
+			name: "an absolute [storage].PATH becomes the root",
+			ini:  "[storage]\nSTORAGE_TYPE = local\nPATH = /data/gitea",
+			want: under("/data/gitea", ""),
+		},
+		{
+			name: "a relative [storage].PATH is resolved against APP_DATA_PATH",
+			ini:  "[storage]\nSTORAGE_TYPE = local\nPATH = storages",
+			want: under("/appdata/storages", ""),
+		},
+		{
+			name: "an absolute [repo-archive].PATH overrides only that storage",
+			ini:  "[storage]\nSTORAGE_TYPE = local\nPATH = /data/gitea\n\n[repo-archive]\nPATH = /data/gitea/the-archives-dir",
+			want: under("/data/gitea", "/data/gitea/the-archives-dir"),
+		},
+		{
+			name: "an empty [repo-archive] changes nothing",
+			ini:  "[storage]\nSTORAGE_TYPE = local\nPATH = /data/gitea\n\n[repo-archive]",
+			want: under("/data/gitea", ""),
+		},
+		{
+			name: "a relative [repo-archive].PATH is resolved against the root",
+			ini:  "[storage]\nSTORAGE_TYPE = local\nPATH = /data/gitea\n\n[repo-archive]\nPATH = the-archives-dir",
+			want: under("/data/gitea", "/data/gitea/the-archives-dir"),
+		},
+		{
+			name: "an absolute [storage.repo-archive].PATH overrides only that storage",
+			ini:  "[storage.repo-archive]\nSTORAGE_TYPE = local\nPATH = /data/gitea/archives",
+			want: under("/appdata", "/data/gitea/archives"),
+		},
+		{
+			name: "a relative [storage.repo-archive].PATH is resolved against APP_DATA_PATH",
+			ini:  "[storage.repo-archive]\nSTORAGE_TYPE = local\nPATH = a-relative-path",
+			want: under("/appdata", "/appdata/a-relative-path"),
+		},
+		{
+			name: "[repo-archive].PATH wins over [storage.repo-archive].PATH",
+			ini:  "[storage.repo-archive]\nSTORAGE_TYPE = local\nPATH = /data/gitea/archives\n\n[repo-archive]\nPATH = /tmp/gitea/archives",
+			want: under("/appdata", "/tmp/gitea/archives"),
+		},
+		{
+			name: "an empty [repo-archive] keeps [storage.repo-archive].PATH",
+			ini:  "[storage.repo-archive]\nSTORAGE_TYPE = local\nPATH = /data/gitea/archives\n\n[repo-archive]",
+			want: under("/appdata", "/data/gitea/archives"),
+		},
+		{
+			name:    "a relative [repo-archive].PATH alone is resolved against APP_DATA_PATH",
+			ini:     "[repo-archive]\nSTORAGE_TYPE = local\nPATH = archives",
+			loaders: []any{loadRepoArchiveFrom},
+			want:    []configCheck{localStorage("repo-archive", &RepoArchive.Storage, "/appdata/archives")},
+		},
+		{
+			name:    "an empty [storage.repo-archive] falls back to the default dir",
+			ini:     "[storage.repo-archive]",
+			loaders: []any{loadRepoArchiveFrom},
+			want:    []configCheck{localStorage("repo-archive", &RepoArchive.Storage, "/appdata/repo-archive")},
+		},
+		{
+			name:    "a relative [storage.repo-archive].PATH without a type is still local",
+			ini:     "[storage.repo-archive]\nPATH = archives",
+			loaders: []any{loadRepoArchiveFrom},
+			want:    []configCheck{localStorage("repo-archive", &RepoArchive.Storage, "/appdata/archives")},
+		},
 	})
 }
 
-func Test_getStorageInheritStorageTypeLocalPath(t *testing.T) {
-	testLocalStoragePath(t, "/appdata", `
-[storage]
-STORAGE_TYPE = local
-PATH = /data/gitea
-`, []testLocalStoragePathCase{
-		{loadAttachmentFrom, &Attachment.Storage, "/data/gitea/attachments"},
-		{loadLFSFrom, &LFS.Storage, "/data/gitea/lfs"},
-		{loadActionsFrom, &Actions.ArtifactStorage, "/data/gitea/actions_artifacts"},
-		{loadPackagesFrom, &Packages.Storage, "/data/gitea/packages"},
-		{loadRepoArchiveFrom, &RepoArchive.Storage, "/data/gitea/repo-archive"},
-		{loadActionsFrom, &Actions.LogStorage, "/data/gitea/actions_log"},
-		{loadAvatarsFrom, &Avatar.Storage, "/data/gitea/avatars"},
-		{loadRepoAvatarFrom, &RepoAvatar.Storage, "/data/gitea/repo-avatars"},
-	})
-}
-
-func Test_getStorageInheritStorageTypeLocalRelativePath(t *testing.T) {
-	testLocalStoragePath(t, "/appdata", `
-[storage]
-STORAGE_TYPE = local
-PATH = storages
-`, []testLocalStoragePathCase{
-		{loadAttachmentFrom, &Attachment.Storage, "/appdata/storages/attachments"},
-		{loadLFSFrom, &LFS.Storage, "/appdata/storages/lfs"},
-		{loadActionsFrom, &Actions.ArtifactStorage, "/appdata/storages/actions_artifacts"},
-		{loadPackagesFrom, &Packages.Storage, "/appdata/storages/packages"},
-		{loadRepoArchiveFrom, &RepoArchive.Storage, "/appdata/storages/repo-archive"},
-		{loadActionsFrom, &Actions.LogStorage, "/appdata/storages/actions_log"},
-		{loadAvatarsFrom, &Avatar.Storage, "/appdata/storages/avatars"},
-		{loadRepoAvatarFrom, &RepoAvatar.Storage, "/appdata/storages/repo-avatars"},
-	})
-}
-
-func Test_getStorageInheritStorageTypeLocalPathOverride(t *testing.T) {
-	testLocalStoragePath(t, "/appdata", `
-[storage]
-STORAGE_TYPE = local
-PATH = /data/gitea
-
-[repo-archive]
-PATH = /data/gitea/the-archives-dir
-`, []testLocalStoragePathCase{
-		{loadAttachmentFrom, &Attachment.Storage, "/data/gitea/attachments"},
-		{loadLFSFrom, &LFS.Storage, "/data/gitea/lfs"},
-		{loadActionsFrom, &Actions.ArtifactStorage, "/data/gitea/actions_artifacts"},
-		{loadPackagesFrom, &Packages.Storage, "/data/gitea/packages"},
-		{loadRepoArchiveFrom, &RepoArchive.Storage, "/data/gitea/the-archives-dir"},
-		{loadActionsFrom, &Actions.LogStorage, "/data/gitea/actions_log"},
-		{loadAvatarsFrom, &Avatar.Storage, "/data/gitea/avatars"},
-		{loadRepoAvatarFrom, &RepoAvatar.Storage, "/data/gitea/repo-avatars"},
-	})
-}
-
-func Test_getStorageInheritStorageTypeLocalPathOverrideEmpty(t *testing.T) {
-	testLocalStoragePath(t, "/appdata", `
-[storage]
-STORAGE_TYPE = local
-PATH = /data/gitea
-
-[repo-archive]
-`, []testLocalStoragePathCase{
-		{loadAttachmentFrom, &Attachment.Storage, "/data/gitea/attachments"},
-		{loadLFSFrom, &LFS.Storage, "/data/gitea/lfs"},
-		{loadActionsFrom, &Actions.ArtifactStorage, "/data/gitea/actions_artifacts"},
-		{loadPackagesFrom, &Packages.Storage, "/data/gitea/packages"},
-		{loadRepoArchiveFrom, &RepoArchive.Storage, "/data/gitea/repo-archive"},
-		{loadActionsFrom, &Actions.LogStorage, "/data/gitea/actions_log"},
-		{loadAvatarsFrom, &Avatar.Storage, "/data/gitea/avatars"},
-		{loadRepoAvatarFrom, &RepoAvatar.Storage, "/data/gitea/repo-avatars"},
-	})
-}
-
-func Test_getStorageInheritStorageTypeLocalRelativePathOverride(t *testing.T) {
-	testLocalStoragePath(t, "/appdata", `
-[storage]
-STORAGE_TYPE = local
-PATH = /data/gitea
-
-[repo-archive]
-PATH = the-archives-dir
-`, []testLocalStoragePathCase{
-		{loadAttachmentFrom, &Attachment.Storage, "/data/gitea/attachments"},
-		{loadLFSFrom, &LFS.Storage, "/data/gitea/lfs"},
-		{loadActionsFrom, &Actions.ArtifactStorage, "/data/gitea/actions_artifacts"},
-		{loadPackagesFrom, &Packages.Storage, "/data/gitea/packages"},
-		{loadRepoArchiveFrom, &RepoArchive.Storage, "/data/gitea/the-archives-dir"},
-		{loadActionsFrom, &Actions.LogStorage, "/data/gitea/actions_log"},
-		{loadAvatarsFrom, &Avatar.Storage, "/data/gitea/avatars"},
-		{loadRepoAvatarFrom, &RepoAvatar.Storage, "/data/gitea/repo-avatars"},
-	})
-}
-
-func Test_getStorageInheritStorageTypeLocalPathOverride3(t *testing.T) {
-	testLocalStoragePath(t, "/appdata", `
-[storage.repo-archive]
-STORAGE_TYPE = local
-PATH = /data/gitea/archives
-`, []testLocalStoragePathCase{
-		{loadAttachmentFrom, &Attachment.Storage, "/appdata/attachments"},
-		{loadLFSFrom, &LFS.Storage, "/appdata/lfs"},
-		{loadActionsFrom, &Actions.ArtifactStorage, "/appdata/actions_artifacts"},
-		{loadPackagesFrom, &Packages.Storage, "/appdata/packages"},
-		{loadRepoArchiveFrom, &RepoArchive.Storage, "/data/gitea/archives"},
-		{loadActionsFrom, &Actions.LogStorage, "/appdata/actions_log"},
-		{loadAvatarsFrom, &Avatar.Storage, "/appdata/avatars"},
-		{loadRepoAvatarFrom, &RepoAvatar.Storage, "/appdata/repo-avatars"},
-	})
-}
-
-func Test_getStorageInheritStorageTypeLocalPathOverride3_5(t *testing.T) {
-	testLocalStoragePath(t, "/appdata", `
-[storage.repo-archive]
-STORAGE_TYPE = local
-PATH = a-relative-path
-`, []testLocalStoragePathCase{
-		{loadAttachmentFrom, &Attachment.Storage, "/appdata/attachments"},
-		{loadLFSFrom, &LFS.Storage, "/appdata/lfs"},
-		{loadActionsFrom, &Actions.ArtifactStorage, "/appdata/actions_artifacts"},
-		{loadPackagesFrom, &Packages.Storage, "/appdata/packages"},
-		{loadRepoArchiveFrom, &RepoArchive.Storage, "/appdata/a-relative-path"},
-		{loadActionsFrom, &Actions.LogStorage, "/appdata/actions_log"},
-		{loadAvatarsFrom, &Avatar.Storage, "/appdata/avatars"},
-		{loadRepoAvatarFrom, &RepoAvatar.Storage, "/appdata/repo-avatars"},
-	})
-}
-
-func Test_getStorageInheritStorageTypeLocalPathOverride4(t *testing.T) {
-	testLocalStoragePath(t, "/appdata", `
-[storage.repo-archive]
-STORAGE_TYPE = local
-PATH = /data/gitea/archives
-
-[repo-archive]
-PATH = /tmp/gitea/archives
-`, []testLocalStoragePathCase{
-		{loadAttachmentFrom, &Attachment.Storage, "/appdata/attachments"},
-		{loadLFSFrom, &LFS.Storage, "/appdata/lfs"},
-		{loadActionsFrom, &Actions.ArtifactStorage, "/appdata/actions_artifacts"},
-		{loadPackagesFrom, &Packages.Storage, "/appdata/packages"},
-		{loadRepoArchiveFrom, &RepoArchive.Storage, "/tmp/gitea/archives"},
-		{loadActionsFrom, &Actions.LogStorage, "/appdata/actions_log"},
-		{loadAvatarsFrom, &Avatar.Storage, "/appdata/avatars"},
-		{loadRepoAvatarFrom, &RepoAvatar.Storage, "/appdata/repo-avatars"},
-	})
-}
-
-func Test_getStorageInheritStorageTypeLocalPathOverride5(t *testing.T) {
-	testLocalStoragePath(t, "/appdata", `
-[storage.repo-archive]
-STORAGE_TYPE = local
-PATH = /data/gitea/archives
-
-[repo-archive]
-`, []testLocalStoragePathCase{
-		{loadAttachmentFrom, &Attachment.Storage, "/appdata/attachments"},
-		{loadLFSFrom, &LFS.Storage, "/appdata/lfs"},
-		{loadActionsFrom, &Actions.ArtifactStorage, "/appdata/actions_artifacts"},
-		{loadPackagesFrom, &Packages.Storage, "/appdata/packages"},
-		{loadRepoArchiveFrom, &RepoArchive.Storage, "/data/gitea/archives"},
-		{loadActionsFrom, &Actions.LogStorage, "/appdata/actions_log"},
-		{loadAvatarsFrom, &Avatar.Storage, "/appdata/avatars"},
-		{loadRepoAvatarFrom, &RepoAvatar.Storage, "/appdata/repo-avatars"},
-	})
-}
-
-func Test_getStorageInheritStorageTypeLocalPathOverride72(t *testing.T) {
-	testLocalStoragePath(t, "/appdata", `
-[repo-archive]
-STORAGE_TYPE = local
-PATH = archives
-`, []testLocalStoragePathCase{
-		{loadRepoArchiveFrom, &RepoArchive.Storage, "/appdata/archives"},
-	})
-}
-
-func Test_getStorageConfiguration20(t *testing.T) {
-	cfg, err := NewConfigProviderFromData(`
-[repo-archive]
-STORAGE_TYPE = my_storage
-PATH = archives
-`)
-	assert.NoError(t, err)
-
-	assert.Error(t, loadRepoArchiveFrom(cfg))
-}
-
-func Test_getStorageConfiguration21(t *testing.T) {
-	testLocalStoragePath(t, "/appdata", `
-[storage.repo-archive]
-`, []testLocalStoragePathCase{
-		{loadRepoArchiveFrom, &RepoArchive.Storage, "/appdata/repo-archive"},
-	})
-}
-
-func Test_getStorageConfiguration22(t *testing.T) {
-	testLocalStoragePath(t, "/appdata", `
-[storage.repo-archive]
-PATH = archives
-`, []testLocalStoragePathCase{
-		{loadRepoArchiveFrom, &RepoArchive.Storage, "/appdata/archives"},
-	})
-}
-
-func Test_getStorageConfiguration23(t *testing.T) {
+func Test_getStorageUnnamedSectionIsRejected(t *testing.T) {
 	cfg, err := NewConfigProviderFromData(`
 [repo-archive]
 STORAGE_TYPE = minio
 MINIO_ACCESS_KEY_ID = my_access_key
 MINIO_SECRET_ACCESS_KEY = my_secret_key
 `)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	_, err = getStorage(cfg, "", "", nil)
 	assert.Error(t, err)
-
-	assert.NoError(t, loadRepoArchiveFrom(cfg))
-	cp := RepoArchive.Storage.ToShadowCopy()
-	assert.Equal(t, "******", cp.MinioConfig.AccessKeyID)
-	assert.Equal(t, "******", cp.MinioConfig.SecretAccessKey)
 }
 
-func Test_getStorageConfiguration24(t *testing.T) {
-	cfg, err := NewConfigProviderFromData(`
-[repo-archive]
-STORAGE_TYPE = my_archive
+func Test_getStorageConfigurationErrors(t *testing.T) {
+	defer test.MockVariableValue(&RepoArchive)()
 
-[storage.my_archive]
-; unsupported, storage type should be defined explicitly
-PATH = archives
-`)
-	assert.NoError(t, err)
-	assert.Error(t, loadRepoArchiveFrom(cfg))
+	testConfigLoad(t, []any{loadRepoArchiveFrom}, []configTestCase{
+		{
+			name:    "an unknown named storage",
+			ini:     "[repo-archive]\nSTORAGE_TYPE = my_storage\nPATH = archives",
+			wantErr: assert.Error,
+		},
+		{
+			name:    "a named storage without an explicit type",
+			ini:     "[repo-archive]\nSTORAGE_TYPE = my_archive\n\n[storage.my_archive]\n; unsupported, storage type should be defined explicitly\nPATH = archives",
+			wantErr: assert.Error,
+		},
+		{
+			name:    "a named storage with an unknown type",
+			ini:     "[repo-archive]\nSTORAGE_TYPE = my_archive\n\n[storage.my_archive]\n; unsupported, storage type should be known type\nSTORAGE_TYPE = unknown // should be local or minio\nPATH = archives",
+			wantErr: assert.Error,
+		},
+		{
+			name: "a malformed minio bool",
+			ini:  "[repo-archive]\nSTORAGE_TYPE = minio\nMINIO_ACCESS_KEY_ID = my_access_key\nMINIO_SECRET_ACCESS_KEY = my_secret_key\n; wrong configuration\nMINIO_USE_SSL = abc",
+			// FIXME: this should return error but now ini package's MapTo() doesn't check type
+			wantErr: assert.NoError,
+		},
+		{
+			name: "an azureblob storage in an unnamed section",
+			ini:  "[repo-archive]\nSTORAGE_TYPE = azureblob\nAZURE_BLOB_ACCOUNT_NAME = my_account_name\nAZURE_BLOB_ACCOUNT_KEY = my_account_key",
+			// FIXME: this should return error but now ini package's MapTo() doesn't check type
+			wantErr: assert.NoError,
+		},
+	})
 }
 
-func Test_getStorageConfiguration25(t *testing.T) {
-	cfg, err := NewConfigProviderFromData(`
-[repo-archive]
-STORAGE_TYPE = my_archive
+func Test_getStorageMinioConfiguration(t *testing.T) {
+	defer test.MockVariableValue(&RepoArchive)()
+	defer test.MockVariableValue(&LFS)()
 
-[storage.my_archive]
-; unsupported, storage type should be known type
-STORAGE_TYPE = unknown // should be local or minio
-PATH = archives
-`)
-	assert.NoError(t, err)
-	assert.Error(t, loadRepoArchiveFrom(cfg))
+	archiveMinio := func() MinioStorageConfig { return RepoArchive.Storage.MinioConfig }
+	lfsMinio := func() MinioStorageConfig { return LFS.Storage.MinioConfig }
+
+	testConfigLoad(t, []any{loadRepoArchiveFrom}, []configTestCase{
+		{
+			name: "credentials are shadowed in a copy",
+			ini:  "[repo-archive]\nSTORAGE_TYPE = minio\nMINIO_ACCESS_KEY_ID = my_access_key\nMINIO_SECRET_ACCESS_KEY = my_secret_key",
+			want: []configCheck{guard(&RepoArchive.Storage)},
+			check: func(t *testing.T) {
+				cp := RepoArchive.Storage.ToShadowCopy()
+				assert.Equal(t, "******", cp.MinioConfig.AccessKeyID)
+				assert.Equal(t, "******", cp.MinioConfig.SecretAccessKey)
+			},
+		},
+		{
+			name: "[storage.repo-archive] credentials",
+			ini:  "[storage.repo-archive]\nSTORAGE_TYPE = minio\nMINIO_ACCESS_KEY_ID = my_access_key\nMINIO_SECRET_ACCESS_KEY = my_secret_key\nMINIO_USE_SSL = true",
+			want: []configCheck{
+				guard(&RepoArchive.Storage),
+				fieldOf("MINIO_ACCESS_KEY_ID", func() string { return archiveMinio().AccessKeyID }, "my_access_key"),
+				fieldOf("MINIO_SECRET_ACCESS_KEY", func() string { return archiveMinio().SecretAccessKey }, "my_secret_key"),
+				fieldOf("MINIO_USE_SSL", func() bool { return archiveMinio().UseSSL }, true),
+				fieldOf("MINIO_BASE_PATH", func() string { return archiveMinio().BasePath }, "repo-archive/"),
+			},
+		},
+		{
+			name: "[storage].MINIO_BASE_PATH is a prefix",
+			ini:  "[storage]\nSTORAGE_TYPE = minio\nMINIO_ACCESS_KEY_ID = my_access_key\nMINIO_SECRET_ACCESS_KEY = my_secret_key\nMINIO_USE_SSL = true\nMINIO_BASE_PATH = /prefix",
+			want: []configCheck{
+				guard(&RepoArchive.Storage),
+				fieldOf("MINIO_ACCESS_KEY_ID", func() string { return archiveMinio().AccessKeyID }, "my_access_key"),
+				fieldOf("MINIO_SECRET_ACCESS_KEY", func() string { return archiveMinio().SecretAccessKey }, "my_secret_key"),
+				fieldOf("MINIO_USE_SSL", func() bool { return archiveMinio().UseSSL }, true),
+				fieldOf("MINIO_BASE_PATH", func() string { return archiveMinio().BasePath }, "/prefix/repo-archive/"),
+			},
+		},
+		{
+			name: "an IAM endpoint instead of credentials",
+			ini:  "[storage]\nSTORAGE_TYPE = minio\nMINIO_IAM_ENDPOINT = 127.0.0.1\nMINIO_USE_SSL = true\nMINIO_BASE_PATH = /prefix",
+			want: []configCheck{
+				guard(&RepoArchive.Storage),
+				fieldOf("MINIO_IAM_ENDPOINT", func() string { return archiveMinio().IamEndpoint }, "127.0.0.1"),
+				fieldOf("MINIO_USE_SSL", func() bool { return archiveMinio().UseSSL }, true),
+				fieldOf("MINIO_BASE_PATH", func() string { return archiveMinio().BasePath }, "/prefix/repo-archive/"),
+			},
+		},
+		{
+			name:    "[lfs].MINIO_BASE_PATH replaces the prefix",
+			ini:     "[storage]\nSTORAGE_TYPE = minio\nMINIO_ACCESS_KEY_ID = my_access_key\nMINIO_SECRET_ACCESS_KEY = my_secret_key\nMINIO_USE_SSL = true\nMINIO_BASE_PATH = /prefix\n\n[lfs]\nMINIO_BASE_PATH = /lfs",
+			loaders: []any{loadLFSFrom},
+			want: []configCheck{
+				guard(&LFS.Storage),
+				fieldOf("MINIO_ACCESS_KEY_ID", func() string { return lfsMinio().AccessKeyID }, "my_access_key"),
+				fieldOf("MINIO_SECRET_ACCESS_KEY", func() string { return lfsMinio().SecretAccessKey }, "my_secret_key"),
+				fieldOf("MINIO_USE_SSL", func() bool { return lfsMinio().UseSSL }, true),
+				fieldOf("MINIO_BASE_PATH", func() string { return lfsMinio().BasePath }, "/lfs"),
+			},
+		},
+		{
+			name:    "[storage.lfs].MINIO_BASE_PATH replaces the prefix",
+			ini:     "[storage]\nSTORAGE_TYPE = minio\nMINIO_ACCESS_KEY_ID = my_access_key\nMINIO_SECRET_ACCESS_KEY = my_secret_key\nMINIO_USE_SSL = true\nMINIO_BASE_PATH = /prefix\n\n[storage.lfs]\nMINIO_BASE_PATH = /lfs",
+			loaders: []any{loadLFSFrom},
+			want: []configCheck{
+				guard(&LFS.Storage),
+				fieldOf("MINIO_ACCESS_KEY_ID", func() string { return lfsMinio().AccessKeyID }, "my_access_key"),
+				fieldOf("MINIO_SECRET_ACCESS_KEY", func() string { return lfsMinio().SecretAccessKey }, "my_secret_key"),
+				fieldOf("MINIO_USE_SSL", func() bool { return lfsMinio().UseSSL }, true),
+				fieldOf("MINIO_BASE_PATH", func() string { return lfsMinio().BasePath }, "/lfs"),
+			},
+		},
+	})
 }
 
-func Test_getStorageConfiguration26(t *testing.T) {
-	cfg, err := NewConfigProviderFromData(`
-[repo-archive]
-STORAGE_TYPE = minio
-MINIO_ACCESS_KEY_ID = my_access_key
-MINIO_SECRET_ACCESS_KEY = my_secret_key
-; wrong configuration
-MINIO_USE_SSL = abc
-`)
-	assert.NoError(t, err)
-	// assert.Error(t, loadRepoArchiveFrom(cfg))
-	// FIXME: this should return error but now ini package's MapTo() doesn't check type
-	assert.NoError(t, loadRepoArchiveFrom(cfg))
-}
+func Test_getStorageAzureBlobConfiguration(t *testing.T) {
+	defer test.MockVariableValue(&RepoArchive)()
+	defer test.MockVariableValue(&LFS)()
 
-func Test_getStorageConfiguration27(t *testing.T) {
-	cfg, err := NewConfigProviderFromData(`
-[storage.repo-archive]
-STORAGE_TYPE = minio
-MINIO_ACCESS_KEY_ID = my_access_key
-MINIO_SECRET_ACCESS_KEY = my_secret_key
-MINIO_USE_SSL = true
-`)
-	assert.NoError(t, err)
-	assert.NoError(t, loadRepoArchiveFrom(cfg))
-	assert.Equal(t, "my_access_key", RepoArchive.Storage.MinioConfig.AccessKeyID)
-	assert.Equal(t, "my_secret_key", RepoArchive.Storage.MinioConfig.SecretAccessKey)
-	assert.True(t, RepoArchive.Storage.MinioConfig.UseSSL)
-	assert.Equal(t, "repo-archive/", RepoArchive.Storage.MinioConfig.BasePath)
-}
+	archiveAzure := func() AzureBlobStorageConfig { return RepoArchive.Storage.AzureBlobConfig }
+	lfsAzure := func() AzureBlobStorageConfig { return LFS.Storage.AzureBlobConfig }
 
-func Test_getStorageConfiguration28(t *testing.T) {
-	cfg, err := NewConfigProviderFromData(`
-[storage]
-STORAGE_TYPE = minio
-MINIO_ACCESS_KEY_ID = my_access_key
-MINIO_SECRET_ACCESS_KEY = my_secret_key
-MINIO_USE_SSL = true
-MINIO_BASE_PATH = /prefix
-`)
-	assert.NoError(t, err)
-	assert.NoError(t, loadRepoArchiveFrom(cfg))
-	assert.Equal(t, "my_access_key", RepoArchive.Storage.MinioConfig.AccessKeyID)
-	assert.Equal(t, "my_secret_key", RepoArchive.Storage.MinioConfig.SecretAccessKey)
-	assert.True(t, RepoArchive.Storage.MinioConfig.UseSSL)
-	assert.Equal(t, "/prefix/repo-archive/", RepoArchive.Storage.MinioConfig.BasePath)
-
-	cfg, err = NewConfigProviderFromData(`
-[storage]
-STORAGE_TYPE = minio
-MINIO_IAM_ENDPOINT = 127.0.0.1
-MINIO_USE_SSL = true
-MINIO_BASE_PATH = /prefix
-`)
-	assert.NoError(t, err)
-	assert.NoError(t, loadRepoArchiveFrom(cfg))
-	assert.Equal(t, "127.0.0.1", RepoArchive.Storage.MinioConfig.IamEndpoint)
-	assert.True(t, RepoArchive.Storage.MinioConfig.UseSSL)
-	assert.Equal(t, "/prefix/repo-archive/", RepoArchive.Storage.MinioConfig.BasePath)
-
-	cfg, err = NewConfigProviderFromData(`
-[storage]
-STORAGE_TYPE = minio
-MINIO_ACCESS_KEY_ID = my_access_key
-MINIO_SECRET_ACCESS_KEY = my_secret_key
-MINIO_USE_SSL = true
-MINIO_BASE_PATH = /prefix
-
-[lfs]
-MINIO_BASE_PATH = /lfs
-`)
-	assert.NoError(t, err)
-	assert.NoError(t, loadLFSFrom(cfg))
-	assert.Equal(t, "my_access_key", LFS.Storage.MinioConfig.AccessKeyID)
-	assert.Equal(t, "my_secret_key", LFS.Storage.MinioConfig.SecretAccessKey)
-	assert.True(t, LFS.Storage.MinioConfig.UseSSL)
-	assert.Equal(t, "/lfs", LFS.Storage.MinioConfig.BasePath)
-
-	cfg, err = NewConfigProviderFromData(`
-[storage]
-STORAGE_TYPE = minio
-MINIO_ACCESS_KEY_ID = my_access_key
-MINIO_SECRET_ACCESS_KEY = my_secret_key
-MINIO_USE_SSL = true
-MINIO_BASE_PATH = /prefix
-
-[storage.lfs]
-MINIO_BASE_PATH = /lfs
-`)
-	assert.NoError(t, err)
-	assert.NoError(t, loadLFSFrom(cfg))
-	assert.Equal(t, "my_access_key", LFS.Storage.MinioConfig.AccessKeyID)
-	assert.Equal(t, "my_secret_key", LFS.Storage.MinioConfig.SecretAccessKey)
-	assert.True(t, LFS.Storage.MinioConfig.UseSSL)
-	assert.Equal(t, "/lfs", LFS.Storage.MinioConfig.BasePath)
-}
-
-func Test_getStorageConfiguration29(t *testing.T) {
-	cfg, err := NewConfigProviderFromData(`
-[repo-archive]
-STORAGE_TYPE = azureblob
-AZURE_BLOB_ACCOUNT_NAME = my_account_name
-AZURE_BLOB_ACCOUNT_KEY = my_account_key
-`)
-	assert.NoError(t, err)
-	// assert.Error(t, loadRepoArchiveFrom(cfg))
-	// FIXME: this should return error but now ini package's MapTo() doesn't check type
-	assert.NoError(t, loadRepoArchiveFrom(cfg))
-}
-
-func Test_getStorageConfiguration30(t *testing.T) {
-	cfg, err := NewConfigProviderFromData(`
-[storage.repo-archive]
-STORAGE_TYPE = azureblob
-AZURE_BLOB_ACCOUNT_NAME = my_account_name
-AZURE_BLOB_ACCOUNT_KEY = my_account_key
-`)
-	assert.NoError(t, err)
-	assert.NoError(t, loadRepoArchiveFrom(cfg))
-	assert.Equal(t, "my_account_name", RepoArchive.Storage.AzureBlobConfig.AccountName)
-	assert.Equal(t, "my_account_key", RepoArchive.Storage.AzureBlobConfig.AccountKey)
-	assert.Equal(t, "repo-archive/", RepoArchive.Storage.AzureBlobConfig.BasePath)
-}
-
-func Test_getStorageConfiguration31(t *testing.T) {
-	cfg, err := NewConfigProviderFromData(`
-[storage]
-STORAGE_TYPE = azureblob
-AZURE_BLOB_ACCOUNT_NAME = my_account_name
-AZURE_BLOB_ACCOUNT_KEY = my_account_key
-AZURE_BLOB_BASE_PATH = /prefix
-`)
-	assert.NoError(t, err)
-	assert.NoError(t, loadRepoArchiveFrom(cfg))
-	assert.Equal(t, "my_account_name", RepoArchive.Storage.AzureBlobConfig.AccountName)
-	assert.Equal(t, "my_account_key", RepoArchive.Storage.AzureBlobConfig.AccountKey)
-	assert.Equal(t, "/prefix/repo-archive/", RepoArchive.Storage.AzureBlobConfig.BasePath)
-
-	cfg, err = NewConfigProviderFromData(`
-[storage]
-STORAGE_TYPE = azureblob
-AZURE_BLOB_ACCOUNT_NAME = my_account_name
-AZURE_BLOB_ACCOUNT_KEY = my_account_key
-AZURE_BLOB_BASE_PATH = /prefix
-
-[lfs]
-AZURE_BLOB_BASE_PATH = /lfs
-`)
-	assert.NoError(t, err)
-	assert.NoError(t, loadLFSFrom(cfg))
-	assert.Equal(t, "my_account_name", LFS.Storage.AzureBlobConfig.AccountName)
-	assert.Equal(t, "my_account_key", LFS.Storage.AzureBlobConfig.AccountKey)
-	assert.Equal(t, "/lfs", LFS.Storage.AzureBlobConfig.BasePath)
-
-	cfg, err = NewConfigProviderFromData(`
-[storage]
-STORAGE_TYPE = azureblob
-AZURE_BLOB_ACCOUNT_NAME = my_account_name
-AZURE_BLOB_ACCOUNT_KEY = my_account_key
-AZURE_BLOB_BASE_PATH = /prefix
-
-[storage.lfs]
-AZURE_BLOB_BASE_PATH = /lfs
-`)
-	assert.NoError(t, err)
-	assert.NoError(t, loadLFSFrom(cfg))
-	assert.Equal(t, "my_account_name", LFS.Storage.AzureBlobConfig.AccountName)
-	assert.Equal(t, "my_account_key", LFS.Storage.AzureBlobConfig.AccountKey)
-	assert.Equal(t, "/lfs", LFS.Storage.AzureBlobConfig.BasePath)
+	testConfigLoad(t, []any{loadRepoArchiveFrom}, []configTestCase{
+		{
+			name: "[storage.repo-archive] credentials",
+			ini:  "[storage.repo-archive]\nSTORAGE_TYPE = azureblob\nAZURE_BLOB_ACCOUNT_NAME = my_account_name\nAZURE_BLOB_ACCOUNT_KEY = my_account_key",
+			want: []configCheck{
+				guard(&RepoArchive.Storage),
+				fieldOf("AZURE_BLOB_ACCOUNT_NAME", func() string { return archiveAzure().AccountName }, "my_account_name"),
+				fieldOf("AZURE_BLOB_ACCOUNT_KEY", func() string { return archiveAzure().AccountKey }, "my_account_key"),
+				fieldOf("AZURE_BLOB_BASE_PATH", func() string { return archiveAzure().BasePath }, "repo-archive/"),
+			},
+		},
+		{
+			name: "[storage].AZURE_BLOB_BASE_PATH is a prefix",
+			ini:  "[storage]\nSTORAGE_TYPE = azureblob\nAZURE_BLOB_ACCOUNT_NAME = my_account_name\nAZURE_BLOB_ACCOUNT_KEY = my_account_key\nAZURE_BLOB_BASE_PATH = /prefix",
+			want: []configCheck{
+				guard(&RepoArchive.Storage),
+				fieldOf("AZURE_BLOB_ACCOUNT_NAME", func() string { return archiveAzure().AccountName }, "my_account_name"),
+				fieldOf("AZURE_BLOB_ACCOUNT_KEY", func() string { return archiveAzure().AccountKey }, "my_account_key"),
+				fieldOf("AZURE_BLOB_BASE_PATH", func() string { return archiveAzure().BasePath }, "/prefix/repo-archive/"),
+			},
+		},
+		{
+			name:    "[lfs].AZURE_BLOB_BASE_PATH replaces the prefix",
+			ini:     "[storage]\nSTORAGE_TYPE = azureblob\nAZURE_BLOB_ACCOUNT_NAME = my_account_name\nAZURE_BLOB_ACCOUNT_KEY = my_account_key\nAZURE_BLOB_BASE_PATH = /prefix\n\n[lfs]\nAZURE_BLOB_BASE_PATH = /lfs",
+			loaders: []any{loadLFSFrom},
+			want: []configCheck{
+				guard(&LFS.Storage),
+				fieldOf("AZURE_BLOB_ACCOUNT_NAME", func() string { return lfsAzure().AccountName }, "my_account_name"),
+				fieldOf("AZURE_BLOB_ACCOUNT_KEY", func() string { return lfsAzure().AccountKey }, "my_account_key"),
+				fieldOf("AZURE_BLOB_BASE_PATH", func() string { return lfsAzure().BasePath }, "/lfs"),
+			},
+		},
+		{
+			name:    "[storage.lfs].AZURE_BLOB_BASE_PATH replaces the prefix",
+			ini:     "[storage]\nSTORAGE_TYPE = azureblob\nAZURE_BLOB_ACCOUNT_NAME = my_account_name\nAZURE_BLOB_ACCOUNT_KEY = my_account_key\nAZURE_BLOB_BASE_PATH = /prefix\n\n[storage.lfs]\nAZURE_BLOB_BASE_PATH = /lfs",
+			loaders: []any{loadLFSFrom},
+			want: []configCheck{
+				guard(&LFS.Storage),
+				fieldOf("AZURE_BLOB_ACCOUNT_NAME", func() string { return lfsAzure().AccountName }, "my_account_name"),
+				fieldOf("AZURE_BLOB_ACCOUNT_KEY", func() string { return lfsAzure().AccountKey }, "my_account_key"),
+				fieldOf("AZURE_BLOB_BASE_PATH", func() string { return lfsAzure().BasePath }, "/lfs"),
+			},
+		},
+	})
 }

--- a/modules/setting/testhelper_test.go
+++ b/modules/setting/testhelper_test.go
@@ -1,0 +1,138 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package setting
+
+import (
+	"testing"
+
+	"gitea.dev/modules/test"
+	"gitea.dev/modules/util"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// configCheck is one expectation about the settings globals after a config load.
+type configCheck interface {
+	snapshot() (restore func()) // keeps cases independent of each other
+	check(t *testing.T)
+}
+
+type configFieldCheck[T any] struct {
+	key  string
+	ptr  *T
+	want T
+}
+
+func (c *configFieldCheck[T]) snapshot() func() { return test.MockVariableValue(c.ptr) }
+
+func (c *configFieldCheck[T]) check(t *testing.T) {
+	t.Helper()
+	assert.Equal(t, c.want, *c.ptr, "config key %s", c.key)
+}
+
+// field expects the global at ptr to equal want after loading, key being the ini key it comes from.
+// ptr must address a global directly, use fieldOf for values behind a pointer the loader replaces.
+func field[T any](key string, ptr *T, want T) configCheck {
+	return &configFieldCheck[T]{key: key, ptr: ptr, want: want}
+}
+
+type configValueCheck[T any] struct {
+	key  string
+	get  func() T
+	want T
+}
+
+func (c *configValueCheck[T]) snapshot() func() { return func() {} }
+
+func (c *configValueCheck[T]) check(t *testing.T) {
+	t.Helper()
+	assert.Equal(t, c.want, c.get(), "config key %s", c.key)
+}
+
+// fieldOf is field for values read through a pointer the loader replaces, it restores nothing
+// so the test must guard the whole settings struct with test.MockVariableValue.
+func fieldOf[T any](key string, get func() T, want T) configCheck {
+	return &configValueCheck[T]{key: key, get: get, want: want}
+}
+
+type configGuard[T any] struct{ ptr *T }
+
+func (c *configGuard[T]) snapshot() func() { return test.MockVariableValue(c.ptr) }
+
+func (c *configGuard[T]) check(*testing.T) {}
+
+// guard restores a global the loaders write but the case does not assert, so that loaders keeping
+// the existing value for an absent key (MapTo, MustString(current)) still see the package default.
+func guard[T any](ptr *T) configCheck {
+	return &configGuard[T]{ptr: ptr}
+}
+
+type configTestCase struct {
+	name    string // defaults to ini
+	ini     string
+	loaders []any                     // overrides the table loaders
+	wantErr assert.ErrorAssertionFunc // nil means assert.NoError
+	want    []configCheck
+	check   func(t *testing.T) // for the rare assertion field cannot express
+}
+
+// testConfigLoad runs each case against loaders, which are load*From functions with or without an
+// error return, applied in order to the same config. Use it when the test is "parse this ini, run
+// these loaders, assert settings globals", not when it asserts a local or returned value, mutates
+// files or env between loads, or tests the config provider itself.
+//
+// Cases restore the globals they assert, so they are order independent, but the loaders write more
+// than any one case asserts: guard the whole settings struct with test.MockVariableValue as well.
+func testConfigLoad(t *testing.T, loaders []any, cases []configTestCase) {
+	t.Helper()
+	for _, c := range cases {
+		t.Run(util.IfZero(c.name, c.ini), func(t *testing.T) {
+			for _, w := range c.want {
+				defer w.snapshot()()
+			}
+
+			cfg, err := NewConfigProviderFromData(c.ini)
+			require.NoError(t, err)
+
+			caseLoaders := loaders
+			if c.loaders != nil {
+				caseLoaders = c.loaders // util.IfZero needs comparable, []any is not
+			}
+			var loadErr error
+			for _, loader := range caseLoaders {
+				if loadErr = configLoader(t, loader)(cfg); loadErr != nil {
+					break
+				}
+			}
+
+			wantErr := c.wantErr
+			if wantErr == nil {
+				wantErr = assert.NoError
+			}
+			if !wantErr(t, loadErr) {
+				return
+			}
+
+			for _, w := range c.want {
+				w.check(t)
+			}
+			if c.check != nil {
+				c.check(t)
+			}
+		})
+	}
+}
+
+func configLoader(t *testing.T, loader any) func(ConfigProvider) error {
+	t.Helper()
+	switch f := loader.(type) {
+	case func(ConfigProvider):
+		return func(cfg ConfigProvider) error { f(cfg); return nil }
+	case func(ConfigProvider) error:
+		return f
+	}
+	t.Fatalf("unsupported config loader %T", loader)
+	return nil
+}

--- a/modules/setting/websocket_test.go
+++ b/modules/setting/websocket_test.go
@@ -7,57 +7,51 @@ import (
 	"testing"
 
 	"gitea.dev/modules/test"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestLoadWebsocketConfig(t *testing.T) {
-	cases := []struct {
-		name     string
-		ini      string
-		wantType string
-		wantConn string
-	}{
-		{
-			name:     "defaults to memory",
-			wantType: PubsubTypeMemory,
-		},
-		{
-			name:     "redis with its own conn str",
-			ini:      "[websocket]\nPUBSUB_TYPE = redis\nPUBSUB_CONN_STR = redis://127.0.0.1:6379/0",
-			wantType: PubsubTypeRedis,
-			wantConn: "redis://127.0.0.1:6379/0",
-		},
-		{
-			name:     "redis falls back to the shared [redis] section",
-			ini:      "[redis]\nCONN_STR = redis://127.0.0.1:6379/0\n[websocket]\nPUBSUB_TYPE = redis",
-			wantType: PubsubTypeRedis,
-			wantConn: "redis://127.0.0.1:6379/0",
-		},
-		{
-			name:     "own conn str wins over the shared one",
-			ini:      "[redis]\nCONN_STR = redis://127.0.0.1:6379/0\n[websocket]\nPUBSUB_TYPE = redis\nPUBSUB_CONN_STR = redis://10.0.0.1:6379/1",
-			wantType: PubsubTypeRedis,
-			wantConn: "redis://10.0.0.1:6379/1",
-		},
-		{
-			name:     "memory ignores the shared [redis] section",
-			ini:      "[redis]\nCONN_STR = redis://127.0.0.1:6379/0\n[websocket]\nPUBSUB_TYPE = memory",
-			wantType: PubsubTypeMemory,
-		},
-	}
+	defer test.MockVariableValue(&Websocket)()
+	defer test.MockVariableValue(&Redis)()
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			defer test.MockVariableValue(&Websocket)()
-			defer test.MockVariableValue(&Redis)()
-			cfg, err := NewConfigProviderFromData(tc.ini)
-			assert.NoError(t, err)
-
-			loadRedisFrom(cfg)
-			loadWebsocketFrom(cfg)
-			assert.Equal(t, tc.wantType, Websocket.PubsubType)
-			assert.Equal(t, tc.wantConn, Websocket.PubsubConnStr)
-		})
-	}
+	testConfigLoad(t, []any{loadRedisFrom, loadWebsocketFrom}, []configTestCase{
+		{
+			name: "defaults to memory",
+			want: []configCheck{
+				field("PUBSUB_TYPE", &Websocket.PubsubType, PubsubTypeMemory),
+				field("PUBSUB_CONN_STR", &Websocket.PubsubConnStr, ""),
+			},
+		},
+		{
+			name: "redis with its own conn str",
+			ini:  "[websocket]\nPUBSUB_TYPE = redis\nPUBSUB_CONN_STR = redis://127.0.0.1:6379/0",
+			want: []configCheck{
+				field("PUBSUB_TYPE", &Websocket.PubsubType, PubsubTypeRedis),
+				field("PUBSUB_CONN_STR", &Websocket.PubsubConnStr, "redis://127.0.0.1:6379/0"),
+			},
+		},
+		{
+			name: "redis falls back to the shared [redis] section",
+			ini:  "[redis]\nCONN_STR = redis://127.0.0.1:6379/0\n[websocket]\nPUBSUB_TYPE = redis",
+			want: []configCheck{
+				field("PUBSUB_TYPE", &Websocket.PubsubType, PubsubTypeRedis),
+				field("PUBSUB_CONN_STR", &Websocket.PubsubConnStr, "redis://127.0.0.1:6379/0"),
+			},
+		},
+		{
+			name: "own conn str wins over the shared one",
+			ini:  "[redis]\nCONN_STR = redis://127.0.0.1:6379/0\n[websocket]\nPUBSUB_TYPE = redis\nPUBSUB_CONN_STR = redis://10.0.0.1:6379/1",
+			want: []configCheck{
+				field("PUBSUB_TYPE", &Websocket.PubsubType, PubsubTypeRedis),
+				field("PUBSUB_CONN_STR", &Websocket.PubsubConnStr, "redis://10.0.0.1:6379/1"),
+			},
+		},
+		{
+			name: "memory ignores the shared [redis] section",
+			ini:  "[redis]\nCONN_STR = redis://127.0.0.1:6379/0\n[websocket]\nPUBSUB_TYPE = memory",
+			want: []configCheck{
+				field("PUBSUB_TYPE", &Websocket.PubsubType, PubsubTypeMemory),
+				field("PUBSUB_CONN_STR", &Websocket.PubsubConnStr, ""),
+			},
+		},
+	})
 }


### PR DESCRIPTION
Adding one config option currently costs ~10 lines of test: a provider, an error check, a `MockVariableValue` and a load call. This adds a test-level harness so a new option is one line in an existing table, and migrates the `modules/setting` tests to it.

```go
{name: "sha256 object format", ini: "[repository]\nDEFAULT_OBJECT_FORMAT = sha256",
	want: []configCheck{field("DEFAULT_OBJECT_FORMAT", &Repository.DefaultObjectFormat, "sha256")}},
```

`testConfigLoad` takes the `load*From` functions (both signatures) and a table of ini snippets. `field` names the ini key in failures and snapshots the global, so cases are order-independent — several loaders read the current value as the default for an absent key. `check` covers assertions it cannot express.

Production loaders are unchanged and coverage is identical.
Two latent bugs fixed on the way:
- `git_test.go` deferred `MockVariableValue` without calling the returned reset
- storage helper set `AppDataPath` without restoring it
