### PR TITLE
fix: enforce repository limits atomically

### DIFF
--- a/models/user/user_update.go
+++ b/models/user/user_update.go
@@ -9,7 +9,14 @@ import (
 	"gitea.dev/models/db"
 )
 
-func IncrUserRepoNum(ctx context.Context, userID int64) error {
-	_, err := db.GetEngine(ctx).Incr("num_repos").ID(userID).Update(new(User))
-	return err
+// IncrUserRepoNum increments a user's repository count if it is below limit.
+// A negative limit means no limit.
+func IncrUserRepoNum(ctx context.Context, userID int64, limit int) (bool, error) {
+	sess := db.GetEngine(ctx).Incr("num_repos").ID(userID)
+	if limit >= 0 {
+		sess.Where("num_repos < ?", limit)
+	}
+
+	updated, err := sess.Update(new(User))
+	return updated > 0, err
 }

--- a/services/repository/create.go
+++ b/services/repository/create.go
@@ -349,6 +349,10 @@ func createRepositoryInDB(ctx context.Context, doer, u *user_model.User, repo *r
 		}
 	}
 
+	if err := checkAndIncrUserRepoNum(ctx, doer, u); err != nil {
+		return err
+	}
+
 	if err = db.Insert(ctx, repo); err != nil {
 		return err
 	}
@@ -405,11 +409,6 @@ func createRepositoryInDB(ctx context.Context, doer, u *user_model.User, repo *r
 		return fmt.Errorf("UpdateUserCols: %w", err)
 	}
 
-	if err = user_model.IncrUserRepoNum(ctx, u.ID); err != nil {
-		return fmt.Errorf("IncrUserRepoNum: %w", err)
-	}
-	u.NumRepos++
-
 	// Give access to all members in teams with access to all repositories.
 	if u.IsOrganization() {
 		teams, err := organization.FindOrgTeams(ctx, u.ID)
@@ -447,6 +446,22 @@ func createRepositoryInDB(ctx context.Context, doer, u *user_model.User, repo *r
 		return fmt.Errorf("CopyDefaultWebhooksToRepo: %w", err)
 	}
 
+	return nil
+}
+
+func checkAndIncrUserRepoNum(ctx context.Context, doer, owner *user_model.User) error {
+	limit := -1
+	if !doer.IsAdmin {
+		limit = owner.MaxCreationLimit()
+	}
+	updated, err := user_model.IncrUserRepoNum(ctx, owner.ID, limit)
+	if err != nil {
+		return fmt.Errorf("IncrUserRepoNum: %w", err)
+	}
+	if !updated {
+		return repo_model.ErrReachLimitOfRepo{Limit: limit}
+	}
+	owner.NumRepos++
 	return nil
 }
 

--- a/services/repository/create_test.go
+++ b/services/repository/create_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"gitea.dev/models/db"
 	repo_model "gitea.dev/models/repo"
 	"gitea.dev/models/unittest"
 	user_model "gitea.dev/models/user"
@@ -60,4 +61,21 @@ func TestCreateRepositoryDirectly(t *testing.T) {
 		assert.NoError(t, err)
 		assert.False(t, exist)
 	})
+}
+
+func TestCreateRepositoryDirectlyRespectsCurrentRepositoryLimit(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	limit := user.NumRepos + 1
+	user.MaxRepoCreation = limit
+
+	_, err := db.GetEngine(t.Context()).Incr("num_repos").ID(user.ID).Update(new(user_model.User))
+	assert.NoError(t, err)
+
+	repo, err := CreateRepositoryDirectly(t.Context(), user, user, CreateRepoOptions{Name: "limit-race"}, true)
+	assert.Nil(t, repo)
+	assert.Error(t, err)
+	assert.True(t, repo_model.IsErrReachLimitOfRepo(err))
+	unittest.AssertNotExistsBean(t, &repo_model.Repository{OwnerID: user.ID, Name: "limit-race"})
 }

--- a/services/repository/transfer.go
+++ b/services/repository/transfer.go
@@ -64,6 +64,9 @@ func AcceptTransferOwnership(ctx context.Context, repo *repo_model.Repository, d
 		if !doer.CanCreateRepoIn(repoTransfer.Recipient) {
 			return LimitReachedError{Limit: repoTransfer.Recipient.MaxCreationLimit()}
 		}
+		if err := checkAndIncrUserRepoNum(ctx, doer, repoTransfer.Recipient); err != nil {
+			return LimitReachedError{Limit: repoTransfer.Recipient.MaxCreationLimit()}
+		}
 
 		if !repoTransfer.CanUserAcceptOrRejectTransfer(ctx, doer) {
 			return util.ErrPermissionDenied
@@ -261,9 +264,7 @@ func transferOwnership(ctx context.Context, doer *user_model.User, newOwnerName 
 	}
 
 	// Update repository count.
-	if _, err := sess.Exec("UPDATE `user` SET num_repos=num_repos+1 WHERE id=?", newOwner.ID); err != nil {
-		return fmt.Errorf("increase new owner repository count: %w", err)
-	} else if _, err := sess.Exec("UPDATE `user` SET num_repos=num_repos-1 WHERE id=?", oldOwner.ID); err != nil {
+	if _, err := sess.Exec("UPDATE `user` SET num_repos=num_repos-1 WHERE id=?", oldOwner.ID); err != nil {
 		return fmt.Errorf("decrease old owner repository count: %w", err)
 	}
 
@@ -447,6 +448,9 @@ func StartRepositoryTransfer(ctx context.Context, doer, newOwner *user_model.Use
 		// then it will transfer directly without acceptance.
 		if doer.IsAdmin || doer.ID == newOwner.ID {
 			isDirectTransfer = true
+			if err := checkAndIncrUserRepoNum(ctx, doer, newOwner); err != nil {
+				return LimitReachedError{Limit: newOwner.MaxCreationLimit()}
+			}
 			return transferOwnership(ctx, doer, newOwner.Name, repo, teams)
 		}
 
@@ -462,6 +466,9 @@ func StartRepositoryTransfer(ctx context.Context, doer, newOwner *user_model.Use
 			}
 			if allowed {
 				isDirectTransfer = true
+				if err := checkAndIncrUserRepoNum(ctx, doer, newOwner); err != nil {
+					return LimitReachedError{Limit: newOwner.MaxCreationLimit()}
+				}
 				return transferOwnership(ctx, doer, newOwner.Name, repo, teams)
 			}
 		}


### PR DESCRIPTION
Enforce repository creation limits with an atomic counter update.

Concurrent repository creation and transfer requests could otherwise exceed configured limits.
