### PR TITLE
fix(api): allow read-only pull request access for fork PR Actions token #38444

### DIFF
--- a/models/actions/token_permissions.go
+++ b/models/actions/token_permissions.go
@@ -53,7 +53,7 @@ func ComputeTaskTokenPermissions(ctx context.Context, task *ActionTask, targetRe
 	isSameRepo := task.Job.RepoID == targetRepo.ID
 	restrictCrossRepoAccess := task.IsForkPullRequest || !isSameRepo
 	if restrictCrossRepoAccess {
-		effectivePerms = repo_model.ClampActionsTokenPermissions(effectivePerms, repo_model.MakeRestrictedPermissions())
+		effectivePerms = repo_model.ClampActionsTokenPermissions(effectivePerms, repo_model.MakeCrossRepoAccessPermissions())
 	}
 
 	return effectivePerms, nil

--- a/models/perm/access/actions_repo_permission_test.go
+++ b/models/perm/access/actions_repo_permission_test.go
@@ -129,6 +129,27 @@ func TestGetActionsUserRepoPermission(t *testing.T) {
 		require.NoError(t, repo_model.UpdateRepoUnitConfig(ctx, repo15ActionsUnit))
 	})
 
+	t.Run("ForkPR_SameRepo_CanReadPullRequests", func(t *testing.T) {
+		// task.RepoID == repo.ID here: the workflow still runs against its own base repo.
+		task53 := unittest.AssertExistsAndLoadBean(t, &actions_model.ActionTask{ID: 53})
+		require.Equal(t, repo2.ID, task53.RepoID)
+
+		task53.IsForkPullRequest = true
+		require.NoError(t, actions_model.UpdateTask(ctx, task53, "is_fork_pull_request"))
+
+		perm, err := GetActionsUserRepoPermission(ctx, repo2, actionsUser, task53.ID)
+		require.NoError(t, err)
+
+		assert.True(t, perm.CanRead(unit.TypePullRequests))
+		assert.True(t, perm.CanRead(unit.TypeIssues))
+		assert.False(t, perm.CanWrite(unit.TypePullRequests))
+		assert.False(t, perm.CanWrite(unit.TypeIssues))
+
+		// Restore state for subsequent subtests.
+		task53.IsForkPullRequest = false
+		require.NoError(t, actions_model.UpdateTask(ctx, task53, "is_fork_pull_request"))
+	})
+
 	t.Run("Inheritance_And_Clamping", func(t *testing.T) {
 		task53 := unittest.AssertExistsAndLoadBean(t, &actions_model.ActionTask{ID: 53})
 		task53.IsForkPullRequest = false

--- a/models/perm/access/actions_repo_permission_test.go
+++ b/models/perm/access/actions_repo_permission_test.go
@@ -136,6 +136,10 @@ func TestGetActionsUserRepoPermission(t *testing.T) {
 
 		task53.IsForkPullRequest = true
 		require.NoError(t, actions_model.UpdateTask(ctx, task53, "is_fork_pull_request"))
+		t.Cleanup(func() {
+			task53.IsForkPullRequest = false
+			require.NoError(t, actions_model.UpdateTask(ctx, task53, "is_fork_pull_request"))
+		})
 
 		perm, err := GetActionsUserRepoPermission(ctx, repo2, actionsUser, task53.ID)
 		require.NoError(t, err)
@@ -144,10 +148,6 @@ func TestGetActionsUserRepoPermission(t *testing.T) {
 		assert.True(t, perm.CanRead(unit.TypeIssues))
 		assert.False(t, perm.CanWrite(unit.TypePullRequests))
 		assert.False(t, perm.CanWrite(unit.TypeIssues))
-
-		// Restore state for subsequent subtests.
-		task53.IsForkPullRequest = false
-		require.NoError(t, actions_model.UpdateTask(ctx, task53, "is_fork_pull_request"))
 	})
 
 	t.Run("Inheritance_And_Clamping", func(t *testing.T) {

--- a/models/repo/repo_unit_actions.go
+++ b/models/repo/repo_unit_actions.go
@@ -68,6 +68,13 @@ func MakeRestrictedPermissions() ActionsTokenPermissions {
 	return ret
 }
 
+// MakeCrossRepoAccessPermissions returns the permission ceiling applied to Actions tokens for
+// fork pull requests and cross-repository access: read-only across every unit, since these tokens
+// must never be allowed to write, but plain reads (e.g. listing PR reviews) are safe (go-gitea/gitea#38444).
+func MakeCrossRepoAccessPermissions() ActionsTokenPermissions {
+	return MakeActionsTokenPermissions(perm.AccessModeRead)
+}
+
 type ActionsConfig struct {
 	DisabledWorkflows []string
 	// DisabledScopedWorkflows maps a scoped workflow's source repository ID to the entry names opted out of in this repository.

--- a/models/repo/repo_unit_actions.go
+++ b/models/repo/repo_unit_actions.go
@@ -69,8 +69,7 @@ func MakeRestrictedPermissions() ActionsTokenPermissions {
 }
 
 // MakeCrossRepoAccessPermissions returns the permission ceiling applied to Actions tokens for
-// fork pull requests and cross-repository access: read-only across every unit, since these tokens
-// must never be allowed to write, but plain reads (e.g. listing PR reviews) are safe (go-gitea/gitea#38444).
+// fork pull requests and cross-repository access: read-only across every unit.
 func MakeCrossRepoAccessPermissions() ActionsTokenPermissions {
 	return MakeActionsTokenPermissions(perm.AccessModeRead)
 }

--- a/tests/integration/actions_job_token_test.go
+++ b/tests/integration/actions_job_token_test.go
@@ -182,13 +182,18 @@ func TestActionsJobTokenPermissiveAccess(t *testing.T) {
 					assertRespCodeForSuccess(t, resp, false)
 				})
 
-				// Restricted-mode tokens deny pull request access by design (contents/packages/releases
-				// read only), so this only applies when the declared mode isn't Restricted.
-				if tt.isFork && tt.repoPermMode != repo_model.ActionsTokenPermissionModeRestricted {
+				if tt.isFork {
 					t.Run("ReadPullRequests", func(t *testing.T) {
+						// Restricted-mode tokens deny pull request access by design (contents/packages/releases
+						// read only); every other mode grants fork PR tokens read-only PR access.
+						effectiveMode := tt.repoPermMode
+						if effectiveMode == "" {
+							effectiveMode = tt.ownerPermMode
+						}
+
 						req := NewRequest(t, "GET", "/api/v1/repos/"+repo.FullName()+"/pulls").AddTokenAuth(task.Token)
 						resp := MakeRequest(t, req, NoExpectedStatus)
-						assertRespCodeForSuccess(t, resp, true)
+						assertRespCodeForSuccess(t, resp, effectiveMode != repo_model.ActionsTokenPermissionModeRestricted)
 					})
 				}
 			})

--- a/tests/integration/actions_job_token_test.go
+++ b/tests/integration/actions_job_token_test.go
@@ -181,6 +181,16 @@ func TestActionsJobTokenPermissiveAccess(t *testing.T) {
 					resp := MakeRequest(t, req, NoExpectedStatus)
 					assertRespCodeForSuccess(t, resp, false)
 				})
+
+				// Restricted-mode tokens deny pull request access by design (contents/packages/releases
+				// read only), so this only applies when the declared mode isn't Restricted.
+				if tt.isFork && tt.repoPermMode != repo_model.ActionsTokenPermissionModeRestricted {
+					t.Run("ReadPullRequests", func(t *testing.T) {
+						req := NewRequest(t, "GET", "/api/v1/repos/"+repo.FullName()+"/pulls").AddTokenAuth(task.Token)
+						resp := MakeRequest(t, req, NoExpectedStatus)
+						assertRespCodeForSuccess(t, resp, true)
+					})
+				}
 			})
 		}
 	})


### PR DESCRIPTION
Actions tokens for workflows triggered by a fork pull request were
clamped to a permission set with no access to Issues/PullRequests at
all, even when the workflow runs against its own base repo. This made
`mustAllowPulls` reject any PR API call (e.g. listing PR reviews) for
fork-triggered CI jobs with a 404, while identical calls from non-fork
PRs succeeded.

Fork PR tokens are documented as being restricted to read-only access,
not no access. This adds a dedicated read-only permission ceiling for
the fork-PR/cross-repo clamp instead of reusing the admin-configured
"Restricted" mode preset (which intentionally excludes Issues/PRs and
must stay unchanged).

Fixes #38444
