### PR TITLE
chore: document that the file APIs expect the git blob SHA, also for LFS files

### DIFF
--- a/modules/structs/repo_file.go
+++ b/modules/structs/repo_file.go
@@ -47,7 +47,9 @@ type CreateFileOptions struct {
 // Note: `author` and `committer` are optional (if only one is given, it will be used for the other, otherwise the authenticated user will be used)
 type DeleteFileOptions struct {
 	FileOptions
-	// the blob ID (SHA) for the file to delete
+	// the blob ID (SHA) for the file to delete, as returned in `sha` by the "Get contents" API.
+	// For a file tracked by Git LFS this is the ID of the pointer blob committed to the repository,
+	// not the `lfs_oid` of the LFS object and not a checksum of the file content.
 	// required: true
 	SHA string `json:"sha" binding:"Required"`
 }
@@ -56,7 +58,10 @@ type DeleteFileOptions struct {
 // Note: `author` and `committer` are optional (if only one is given, it will be used for the other, otherwise the authenticated user will be used)
 type UpdateFileOptions struct {
 	FileOptions
-	// the blob ID (SHA) for the file that already exists to update, or leave it empty to create a new file
+	// the blob ID (SHA) for the file that already exists to update, or leave it empty to create a new file.
+	// It is the `sha` returned by the "Get contents" API; for a file tracked by Git LFS this is the ID of
+	// the pointer blob committed to the repository, not the `lfs_oid` of the LFS object and not a checksum
+	// of the file content.
 	SHA string `json:"sha"`
 	// content must be base64 encoded
 	// required: true
@@ -79,7 +84,10 @@ type ChangeFileOperation struct {
 	Path string `json:"path" binding:"Required;MaxSize(500)"`
 	// new or updated file content, it must be base64 encoded
 	ContentBase64 string `json:"content"`
-	// the blob ID (SHA) for the file that already exists, required for changing existing files
+	// the blob ID (SHA) for the file that already exists, required for changing existing files.
+	// It is the `sha` returned by the "Get contents" API; for a file tracked by Git LFS this is the ID of
+	// the pointer blob committed to the repository, not the `lfs_oid` of the LFS object and not a checksum
+	// of the file content.
 	SHA string `json:"sha"`
 	// old path of the file to move
 	FromPath string `json:"from_path"`
@@ -125,7 +133,8 @@ type ContentsResponse struct {
 	Name string `json:"name"`
 	// Path is the full path to the file or directory
 	Path string `json:"path"`
-	// SHA is the Git blob or tree SHA
+	// SHA is the Git blob or tree SHA. It is the value the file APIs expect in `sha`, also for a file
+	// tracked by Git LFS, where it is the ID of the pointer blob rather than of the LFS object.
 	SHA string `json:"sha"`
 
 	// LastCommitSHA is the SHA of the last commit that affected this file

--- a/templates/swagger/v1-openapi3.generated.json
+++ b/templates/swagger/v1-openapi3.generated.json
@@ -3067,7 +3067,7 @@
             "x-go-name": "Path"
           },
           "sha": {
-            "description": "the blob ID (SHA) for the file that already exists, required for changing existing files",
+            "description": "the blob ID (SHA) for the file that already exists, required for changing existing files.\nIt is the `sha` returned by the \"Get contents\" API; for a file tracked by Git LFS this is the ID of\nthe pointer blob committed to the repository, not the `lfs_oid` of the LFS object and not a checksum\nof the file content.",
             "type": "string",
             "x-go-name": "SHA"
           }
@@ -3656,7 +3656,7 @@
             "x-go-name": "Path"
           },
           "sha": {
-            "description": "SHA is the Git blob or tree SHA",
+            "description": "SHA is the Git blob or tree SHA. It is the value the file APIs expect in `sha`, also for a file\ntracked by Git LFS, where it is the ID of the pointer blob rather than of the LFS object.",
             "type": "string",
             "x-go-name": "SHA"
           },
@@ -5159,7 +5159,7 @@
             "x-go-name": "NewBranchName"
           },
           "sha": {
-            "description": "the blob ID (SHA) for the file to delete",
+            "description": "the blob ID (SHA) for the file to delete, as returned in `sha` by the \"Get contents\" API.\nFor a file tracked by Git LFS this is the ID of the pointer blob committed to the repository,\nnot the `lfs_oid` of the LFS object and not a checksum of the file content.",
             "type": "string",
             "x-go-name": "SHA"
           },
@@ -10495,7 +10495,7 @@
             "x-go-name": "NewBranchName"
           },
           "sha": {
-            "description": "the blob ID (SHA) for the file that already exists to update, or leave it empty to create a new file",
+            "description": "the blob ID (SHA) for the file that already exists to update, or leave it empty to create a new file.\nIt is the `sha` returned by the \"Get contents\" API; for a file tracked by Git LFS this is the ID of\nthe pointer blob committed to the repository, not the `lfs_oid` of the LFS object and not a checksum\nof the file content.",
             "type": "string",
             "x-go-name": "SHA"
           },

--- a/templates/swagger/v1-swagger.generated.json
+++ b/templates/swagger/v1-swagger.generated.json
@@ -25938,7 +25938,7 @@
           "x-go-name": "Path"
         },
         "sha": {
-          "description": "the blob ID (SHA) for the file that already exists, required for changing existing files",
+          "description": "the blob ID (SHA) for the file that already exists, required for changing existing files.\nIt is the `sha` returned by the \"Get contents\" API; for a file tracked by Git LFS this is the ID of\nthe pointer blob committed to the repository, not the `lfs_oid` of the LFS object and not a checksum\nof the file content.",
           "type": "string",
           "x-go-name": "SHA"
         }
@@ -26508,7 +26508,7 @@
           "x-go-name": "Path"
         },
         "sha": {
-          "description": "SHA is the Git blob or tree SHA",
+          "description": "SHA is the Git blob or tree SHA. It is the value the file APIs expect in `sha`, also for a file\ntracked by Git LFS, where it is the ID of the pointer blob rather than of the LFS object.",
           "type": "string",
           "x-go-name": "SHA"
         },
@@ -28043,7 +28043,7 @@
           "x-go-name": "NewBranchName"
         },
         "sha": {
-          "description": "the blob ID (SHA) for the file to delete",
+          "description": "the blob ID (SHA) for the file to delete, as returned in `sha` by the \"Get contents\" API.\nFor a file tracked by Git LFS this is the ID of the pointer blob committed to the repository,\nnot the `lfs_oid` of the LFS object and not a checksum of the file content.",
           "type": "string",
           "x-go-name": "SHA"
         },
@@ -33352,7 +33352,7 @@
           "x-go-name": "NewBranchName"
         },
         "sha": {
-          "description": "the blob ID (SHA) for the file that already exists to update, or leave it empty to create a new file",
+          "description": "the blob ID (SHA) for the file that already exists to update, or leave it empty to create a new file.\nIt is the `sha` returned by the \"Get contents\" API; for a file tracked by Git LFS this is the ID of\nthe pointer blob committed to the repository, not the `lfs_oid` of the LFS object and not a checksum\nof the file content.",
           "type": "string",
           "x-go-name": "SHA"
         },


### PR DESCRIPTION
The `sha` accepted by the file APIs (`PUT /repos/{owner}/{repo}/contents/{filepath}`, `DELETE /repos/{owner}/{repo}/contents/{filepath}` and `POST /repos/{owner}/{repo}/contents`) is compared against the ID of the blob the tree entry points at:

https://github.com/go-gitea/gitea/blob/main/services/repository/files/update.go#L381-L389

For a file tracked by Git LFS the committed blob is the pointer file, so the value to send is the ID of that pointer blob (the `sha` the "Get contents" API returns), not the `lfs_oid` of the LFS object and not a checksum of the file content. Sending the LFS object ID fails with `sha does not match`, which is hard to figure out from the current descriptions, they only say "the blob ID (SHA) for the file".

This adds that to the swagger comments of `sha` in `DeleteFileOptions`, `UpdateFileOptions` and `ChangeFileOperation`, and points `ContentsResponse.sha` at the file APIs, so the two ends of the workflow reference each other. No behaviour change, only comments and the regenerated specs.

Reported at https://gitea.com/gitea/docs/issues/243
