### PR TITLE
refactor: wiki edit form

### DIFF
--- a/routers/web/repo/wiki.go
+++ b/routers/web/repo/wiki.go
@@ -27,7 +27,6 @@ import (
 	"gitea.dev/modules/templates"
 	"gitea.dev/modules/timeutil"
 	"gitea.dev/modules/util"
-	"gitea.dev/modules/web"
 	"gitea.dev/routers/common"
 	"gitea.dev/services/context"
 	"gitea.dev/services/forms"
@@ -639,6 +638,16 @@ func WikiRaw(ctx *context.Context) {
 	ctx.NotFound(nil)
 }
 
+func wikiHandleEditError(ctx *context.Context, wikiName wiki_service.WebPath, err error) {
+	if repo_model.IsErrWikiReservedName(err) {
+		ctx.JSONErrorWithField(ctx.Tr("repo.wiki.reserved_page", wikiName), "title")
+	} else if repo_model.IsErrWikiAlreadyExist(err) {
+		ctx.JSONErrorWithField(ctx.Tr("repo.wiki.page_already_exists"), "title")
+	} else {
+		ctx.ServerError("EditWiki", err)
+	}
+}
+
 // NewWiki render wiki create page
 func NewWiki(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("repo.wiki.new_page")
@@ -655,41 +664,25 @@ func NewWiki(ctx *context.Context) {
 
 // NewWikiPost response for wiki create request
 func NewWikiPost(ctx *context.Context) {
-	form := web.GetForm[*forms.NewWikiForm](ctx)
-	ctx.Data["Title"] = ctx.Tr("repo.wiki.new_page")
-
-	if ctx.HasError() {
-		ctx.HTML(http.StatusOK, tplWikiNew)
-		return
-	}
-
-	if util.IsEmptyString(form.Title) {
-		ctx.RenderWithErrDeprecated(ctx.Tr("repo.issues.new.title_empty"), tplWikiNew, form)
+	form := context.GetFetchActionForm[*forms.WikiEditForm](ctx)
+	if form == nil {
 		return
 	}
 
 	wikiName := wiki_service.UserTitleToWebPath("", form.Title)
-
-	if len(form.Message) == 0 {
+	if form.Message == "" {
 		form.Message = ctx.Locale.TrString("repo.editor.add", form.Title)
 	}
 
-	if err := wiki_service.AddWikiPage(ctx, ctx.Doer, ctx.Repo.Repository, wikiName, form.Content, form.Message); err != nil {
-		if repo_model.IsErrWikiReservedName(err) {
-			ctx.Data["Err_Title"] = true
-			ctx.RenderWithErrDeprecated(ctx.Tr("repo.wiki.reserved_page", wikiName), tplWikiNew, &form)
-		} else if repo_model.IsErrWikiAlreadyExist(err) {
-			ctx.Data["Err_Title"] = true
-			ctx.RenderWithErrDeprecated(ctx.Tr("repo.wiki.page_already_exists"), tplWikiNew, &form)
-		} else {
-			ctx.ServerError("AddWikiPage", err)
-		}
+	err := wiki_service.AddWikiPage(ctx, ctx.Doer, ctx.Repo.Repository, wikiName, form.Content, form.Message)
+	if err != nil {
+		wikiHandleEditError(ctx, wikiName, err)
 		return
 	}
 
 	notify_service.NewWikiPage(ctx, ctx.Doer, ctx.Repo.Repository, string(wikiName), form.Message)
 
-	ctx.Redirect(ctx.Repo.RepoLink + "/wiki/" + wiki_service.WebPathToURLPath(wikiName))
+	ctx.JSONRedirect(ctx.Repo.RepoLink + "/wiki/" + wiki_service.WebPathToURLPath(wikiName))
 }
 
 // EditWiki render wiki modify page
@@ -711,38 +704,31 @@ func EditWiki(ctx *context.Context) {
 
 // EditWikiPost response for wiki modify request
 func EditWikiPost(ctx *context.Context) {
-	form := web.GetForm[*forms.NewWikiForm](ctx)
-	ctx.Data["Title"] = ctx.Tr("repo.wiki.new_page")
-
-	if ctx.HasError() {
-		ctx.HTML(http.StatusOK, tplWikiNew)
+	form := context.GetFetchActionForm[*forms.WikiEditForm](ctx)
+	if form == nil {
 		return
 	}
 
 	oldWikiName := wiki_service.WebPathFromRequest(ctx.PathParamRaw("*"))
 	newWikiName := wiki_service.UserTitleToWebPath("", form.Title)
-
-	if len(form.Message) == 0 {
+	if form.Message == "" {
 		form.Message = ctx.Locale.TrString("repo.editor.update", form.Title)
 	}
 
 	if err := wiki_service.EditWikiPage(ctx, ctx.Doer, ctx.Repo.Repository, oldWikiName, newWikiName, form.Content, form.Message); err != nil {
-		ctx.ServerError("EditWikiPage", err)
+		wikiHandleEditError(ctx, newWikiName, err)
 		return
 	}
 
 	notify_service.EditWikiPage(ctx, ctx.Doer, ctx.Repo.Repository, string(newWikiName), form.Message)
 
-	ctx.Redirect(ctx.Repo.RepoLink + "/wiki/" + wiki_service.WebPathToURLPath(newWikiName))
+	ctx.JSONRedirect(ctx.Repo.RepoLink + "/wiki/" + wiki_service.WebPathToURLPath(newWikiName))
 }
 
 // DeleteWikiPagePost delete wiki page
 func DeleteWikiPagePost(ctx *context.Context) {
 	wikiName := wiki_service.WebPathFromRequest(ctx.PathParamRaw("*"))
-	if len(wikiName) == 0 {
-		wikiName = "Home"
-	}
-
+	wikiName = util.IfZero(wikiName, "Home")
 	if err := wiki_service.DeleteWikiPage(ctx, ctx.Doer, ctx.Repo.Repository, wikiName); err != nil {
 		ctx.ServerError("DeleteWikiPage", err)
 		return

--- a/routers/web/repo/wiki_test.go
+++ b/routers/web/repo/wiki_test.go
@@ -4,6 +4,7 @@
 package repo
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -12,9 +13,8 @@ import (
 	repo_model "gitea.dev/models/repo"
 	"gitea.dev/models/unittest"
 	"gitea.dev/modules/git"
-	"gitea.dev/modules/web"
+	"gitea.dev/modules/test"
 	"gitea.dev/services/contexttest"
-	"gitea.dev/services/forms"
 	repo_service "gitea.dev/services/repository"
 	wiki_service "gitea.dev/services/wiki"
 
@@ -23,16 +23,15 @@ import (
 )
 
 const (
-	content = "Wiki contents for unit tests"
-	message = "Wiki commit message for unit tests"
+	testWikiContent = "Wiki contents for unit tests"
+	testWikiMessage = "Wiki commit message for unit tests"
 )
 
 func wikiEntry(t *testing.T, repo *repo_model.Repository, wikiName wiki_service.WebPath) (*git.Repository, *git.TreeEntry) {
 	wikiRepo, err := git.OpenRepository(t.Context(), repo.WikiStorageRepo())
-	assert.NoError(t, err)
-	t.Cleanup(func() {
-		defer wikiRepo.Close()
-	})
+	require.NoError(t, err)
+	defer wikiRepo.Close()
+
 	commit, err := wikiRepo.GetBranchCommit(t.Context(), "master")
 	assert.NoError(t, err)
 	entries, err := commit.Tree().ListEntries(t.Context(), wikiRepo)
@@ -81,25 +80,35 @@ func assertPagesMetas(t *testing.T, expectedNames []string, metas any) {
 func TestWiki(t *testing.T) {
 	unittest.PrepareTestEnv(t)
 
-	ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki")
-	ctx.SetPathParam("*", "Home")
-	contexttest.LoadRepo(t, ctx, 1)
-	Wiki(ctx)
-	assert.Equal(t, http.StatusOK, ctx.Resp.WrittenStatus())
-	assert.EqualValues(t, "Home", ctx.Data["Title"])
-	assertPagesMetas(t, []string{"Home", "Page With Image", "Page With Spaced Name", "Unescaped File"}, ctx.Data["Pages"])
-
-	ctx, _ = contexttest.MockContext(t, "user2/repo1/jpeg.jpg")
-	ctx.SetPathParam("*", "jpeg.jpg")
-	contexttest.LoadRepo(t, ctx, 1)
-	Wiki(ctx)
-	assert.Equal(t, http.StatusSeeOther, ctx.Resp.WrittenStatus())
-	assert.Equal(t, "/user2/repo1/wiki/raw/jpeg.jpg", ctx.Resp.Header().Get("Location"))
+	t.Run("Home", func(t *testing.T) {
+		ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki")
+		ctx.SetPathParam("*", "Home")
+		contexttest.LoadRepo(t, ctx, 1)
+		Wiki(ctx)
+		assert.Equal(t, http.StatusOK, ctx.Resp.WrittenStatus())
+		assert.EqualValues(t, "Home", ctx.Data["Title"])
+		assertPagesMetas(t, []string{"Home", "Page With Image", "Page With Spaced Name", "Unescaped File"}, ctx.Data["Pages"])
+	})
+	t.Run("Image", func(t *testing.T) {
+		ctx, _ := contexttest.MockContext(t, "user2/repo1/jpeg.jpg")
+		ctx.SetPathParam("*", "jpeg.jpg")
+		contexttest.LoadRepo(t, ctx, 1)
+		Wiki(ctx)
+		assert.Equal(t, http.StatusSeeOther, ctx.Resp.WrittenStatus())
+		assert.Equal(t, "/user2/repo1/wiki/raw/jpeg.jpg", ctx.Resp.Header().Get("Location"))
+	})
+	t.Run("Pages", testWikiPages)
+	t.Run("NewWiki", testNewWiki)
+	t.Run("NewWikiPost", testNewWikiPost)
+	t.Run("NewWikiPostReservedName", testNewWikiPostReservedName)
+	t.Run("EditWiki", testEditWiki)
+	t.Run("EditWikiPost", testEditWikiPost)
+	t.Run("DeletePost", testDeleteWikiPagePost)
+	t.Run("Raw", testWikiRaw)
+	t.Run("DefaultWikiBranch", testDefaultWikiBranch)
 }
 
-func TestWikiPages(t *testing.T) {
-	unittest.PrepareTestEnv(t)
-
+func testWikiPages(t *testing.T) {
 	ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki/?action=_pages")
 	contexttest.LoadRepo(t, ctx, 1)
 	WikiPages(ctx)
@@ -107,9 +116,7 @@ func TestWikiPages(t *testing.T) {
 	assertPagesMetas(t, []string{"Home", "Page With Image", "Page With Spaced Name", "Unescaped File"}, ctx.Data["Pages"])
 }
 
-func TestNewWiki(t *testing.T) {
-	unittest.PrepareTestEnv(t)
-
+func testNewWiki(t *testing.T) {
 	ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki/?action=_new")
 	contexttest.LoadUser(t, ctx, 2)
 	contexttest.LoadRepo(t, ctx, 1)
@@ -118,48 +125,42 @@ func TestNewWiki(t *testing.T) {
 	assert.EqualValues(t, ctx.Tr("repo.wiki.new_page"), ctx.Data["Title"])
 }
 
-func TestNewWikiPost(t *testing.T) {
+func testNewWikiPost(t *testing.T) {
 	for _, title := range []string{
 		"New page",
 		"&&&&",
 	} {
-		unittest.PrepareTestEnv(t)
-
 		ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki/?action=_new")
 		contexttest.LoadUser(t, ctx, 2)
 		contexttest.LoadRepo(t, ctx, 1)
-		web.SetForm(ctx, &forms.NewWikiForm{
-			Title:   title,
-			Content: content,
-			Message: message,
+		contexttest.MockRequestPostForm(ctx.Req, url.Values{
+			"title":   []string{title},
+			"content": []string{testWikiContent},
+			"message": []string{testWikiMessage},
 		})
 		NewWikiPost(ctx)
-		assert.Equal(t, http.StatusSeeOther, ctx.Resp.WrittenStatus())
+		assert.Equal(t, http.StatusOK, ctx.Resp.WrittenStatus())
 		assertWikiExists(t, ctx.Repo.Repository, wiki_service.UserTitleToWebPath("", title))
-		assert.Equal(t, content, wikiContent(t, ctx.Repo.Repository, wiki_service.UserTitleToWebPath("", title)))
+		assert.Equal(t, testWikiContent, wikiContent(t, ctx.Repo.Repository, wiki_service.UserTitleToWebPath("", title)))
 	}
 }
 
-func TestNewWikiPost_ReservedName(t *testing.T) {
-	unittest.PrepareTestEnv(t)
-
-	ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki/?action=_new")
+func testNewWikiPostReservedName(t *testing.T) {
+	ctx, resp := contexttest.MockContext(t, "user2/repo1/wiki/?action=_new")
 	contexttest.LoadUser(t, ctx, 2)
 	contexttest.LoadRepo(t, ctx, 1)
-	web.SetForm(ctx, &forms.NewWikiForm{
-		Title:   "_edit",
-		Content: content,
-		Message: message,
+	contexttest.MockRequestPostForm(ctx.Req, url.Values{
+		"title":   []string{"_edit"},
+		"content": []string{testWikiContent},
+		"message": []string{testWikiMessage},
 	})
 	NewWikiPost(ctx)
-	assert.Equal(t, http.StatusOK, ctx.Resp.WrittenStatus())
-	assert.EqualValues(t, ctx.Tr("repo.wiki.reserved_page", "_edit"), ctx.Flash.ErrorMsg)
+	assert.Equal(t, http.StatusBadRequest, ctx.Resp.WrittenStatus())
+	assert.EqualValues(t, ctx.Tr("repo.wiki.reserved_page", "_edit"), test.ParseJSONError(resp.Body.Bytes()).ErrorMessage)
 	assertWikiNotExists(t, ctx.Repo.Repository, "_edit")
 }
 
-func TestEditWiki(t *testing.T) {
-	unittest.PrepareTestEnv(t)
-
+func testEditWiki(t *testing.T) {
 	ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki/Home?action=_edit")
 	ctx.SetPathParam("*", "Home")
 	contexttest.LoadUser(t, ctx, 2)
@@ -177,34 +178,31 @@ func TestEditWiki(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, ctx.Resp.WrittenStatus())
 }
 
-func TestEditWikiPost(t *testing.T) {
-	for _, title := range []string{
-		"Home",
-		"New/<page>",
-	} {
+func testEditWikiPost(t *testing.T) {
+	const existingPageTitle = "Page With Image"
+	for _, title := range []string{existingPageTitle, "New/<page>"} {
 		unittest.PrepareTestEnv(t)
-		ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki/Home?action=_new")
-		ctx.SetPathParam("*", "Home")
+		ctx, _ := contexttest.MockContext(t, fmt.Sprintf("/user2/repo1/wiki/%s?action=_new", url.PathEscape(existingPageTitle)))
+		ctx.SetPathParam("*", existingPageTitle)
 		contexttest.LoadUser(t, ctx, 2)
 		contexttest.LoadRepo(t, ctx, 1)
-		web.SetForm(ctx, &forms.NewWikiForm{
-			Title:   title,
-			Content: content,
-			Message: message,
+		contexttest.MockRequestPostForm(ctx.Req, url.Values{
+			"title":   []string{title},
+			"content": []string{testWikiContent},
+			"message": []string{testWikiMessage},
 		})
+		assertWikiExists(t, ctx.Repo.Repository, wiki_service.UserTitleToWebPath("", existingPageTitle))
 		EditWikiPost(ctx)
-		assert.Equal(t, http.StatusSeeOther, ctx.Resp.WrittenStatus())
+		assert.Equal(t, http.StatusOK, ctx.Resp.WrittenStatus())
 		assertWikiExists(t, ctx.Repo.Repository, wiki_service.UserTitleToWebPath("", title))
-		assert.Equal(t, content, wikiContent(t, ctx.Repo.Repository, wiki_service.UserTitleToWebPath("", title)))
-		if title != "Home" {
-			assertWikiNotExists(t, ctx.Repo.Repository, "Home")
+		assert.Equal(t, testWikiContent, wikiContent(t, ctx.Repo.Repository, wiki_service.UserTitleToWebPath("", title)))
+		if title != existingPageTitle {
+			assertWikiNotExists(t, ctx.Repo.Repository, wiki_service.UserTitleToWebPath("", existingPageTitle))
 		}
 	}
 }
 
-func TestDeleteWikiPagePost(t *testing.T) {
-	unittest.PrepareTestEnv(t)
-
+func testDeleteWikiPagePost(t *testing.T) {
 	ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki/Home?action=_delete")
 	contexttest.LoadUser(t, ctx, 2)
 	contexttest.LoadRepo(t, ctx, 1)
@@ -213,7 +211,7 @@ func TestDeleteWikiPagePost(t *testing.T) {
 	assertWikiNotExists(t, ctx.Repo.Repository, "Home")
 }
 
-func TestWikiRaw(t *testing.T) {
+func testWikiRaw(t *testing.T) {
 	for filepath, filetype := range map[string]string{
 		"jpeg.jpg":                      "image/jpeg",
 		"images/jpeg.jpg":               "image/jpeg",
@@ -223,8 +221,6 @@ func TestWikiRaw(t *testing.T) {
 		"Page With Spaced Name.md":      "", // there is no "Page With Spaced Name.md" in repo
 		"Page-With-Spaced-Name.md":      "text/plain; charset=utf-8",
 	} {
-		unittest.PrepareTestEnv(t)
-
 		ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki/raw/"+url.PathEscape(filepath))
 		ctx.SetPathParam("*", filepath)
 		contexttest.LoadUser(t, ctx, 2)
@@ -239,9 +235,7 @@ func TestWikiRaw(t *testing.T) {
 	}
 }
 
-func TestDefaultWikiBranch(t *testing.T) {
-	unittest.PrepareTestEnv(t)
-
+func testDefaultWikiBranch(t *testing.T) {
 	// repo with no wiki
 	repoWithNoWiki := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 2})
 	assert.False(t, repo_service.HasWiki(t.Context(), repoWithNoWiki))

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1583,10 +1583,10 @@ func registerWebRoutes(m *web.Router, webAuth *AuthMiddleware) {
 	m.Group("/{username}/{reponame}/wiki", func() {
 		m.Combo("").
 			Get(repo.Wiki).
-			Post(context.RepoMustNotBeArchived(), reqSignIn, reqUnitWikiWriter, web.Bind[*forms.NewWikiForm](), repo.WikiPost)
+			Post(context.RepoMustNotBeArchived(), reqSignIn, reqUnitWikiWriter, repo.WikiPost)
 		m.Combo("/*").
 			Get(repo.Wiki).
-			Post(context.RepoMustNotBeArchived(), reqSignIn, reqUnitWikiWriter, web.Bind[*forms.NewWikiForm](), repo.WikiPost)
+			Post(context.RepoMustNotBeArchived(), reqSignIn, reqUnitWikiWriter, repo.WikiPost)
 		m.Get("/blob_excerpt/{sha}", repo.SetEditorconfigIfExists, repo.SetDiffViewStyle, repo.ExcerptBlob)
 		m.Get("/commit/{sha:[a-f0-9]{7,64}}", repo.SetEditorconfigIfExists, repo.SetDiffViewStyle, repo.SetWhitespaceBehavior, repo.Diff)
 		m.Get("/commit/{sha:[a-f0-9]{7,64}}.{ext:patch|diff}", repo.RawDiff)

--- a/services/context/context.go
+++ b/services/context/context.go
@@ -298,6 +298,7 @@ func GetFetchActionForm[T interface {
 	}
 	form := T(new(E))
 	errs := binding.Bind(ctx.Req, form)
+	errs = form.Validate(GetValidateContext(ctx.Req), errs)
 	errorMessage, fieldName, _ := middleware.BuildValidationErrorForUser(form, ctx.Locale, errs)
 	if errorMessage != "" {
 		ctx.Resp.Header().Set("Content-Type", "application/json")

--- a/services/forms/repo_form.go
+++ b/services/forms/repo_form.go
@@ -558,27 +558,20 @@ type EditReleaseForm struct {
 	Files      []string
 }
 
-//  __      __.__ __   .__
-// /  \    /  \__|  | _|__|
-// \   \/\/   /  |  |/ /  |
-//  \        /|  |    <|  |
-//   \__/\  / |__|__|_ \__|
-//        \/          \/
-
-// NewWikiForm form for creating wiki
-type NewWikiForm struct {
-	middleware.FormDefaultValidator
-	Title   string `binding:"Required"`
-	Content string `binding:"Required"`
+type WikiEditForm struct {
+	Title   string
+	Content string
 	Message string
 }
 
-// ___________.__                 ___________                     __
-// \__    ___/|__| _____   ____   \__    ___/___________    ____ |  | __ ___________
-// |    |   |  |/     \_/ __ \    |    |  \_  __ \__  \ _/ ___\|  |/ // __ \_  __ \
-// |    |   |  |  Y Y  \  ___/    |    |   |  | \// __ \\  \___|    <\  ___/|  | \/
-// |____|   |__|__|_|  /\___  >   |____|   |__|  (____  /\___  >__|_ \\___  >__|
-// \/     \/                        \/     \/     \/    \/
+func (f *WikiEditForm) Validate(ctx *middleware.ValidateContext, errs binding.Errors) binding.Errors {
+	f.Title = strings.TrimSpace(f.Title)
+	if f.Title == "" {
+		errs = middleware.AddValidationError(errs, "title", ctx.Locale.TrString("repo.issues.new.title_empty"))
+	}
+	f.Message = strings.TrimSpace(f.Message)
+	return errs
+}
 
 // AddTimeManuallyForm form that adds spent time manually.
 type AddTimeManuallyForm struct {

--- a/templates/repo/wiki/new.tmpl
+++ b/templates/repo/wiki/new.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div role="main" aria-label="{{.Title}}" class="page-content repository wiki new">
+<div role="main" aria-label="{{.Title}}" class="page-content repository wiki">
 	{{template "repo/header" .}}
 	<div class="ui container">
 		{{template "base/alert" .}}
@@ -9,8 +9,8 @@
 				<a class="ui tiny primary button" href="{{.RepoLink}}/wiki?action=_new">{{ctx.Locale.Tr "repo.wiki.new_page_button"}}</a>
 			{{end}}
 		</div>
-		<form class="ui form" action="?action={{if .PageIsWikiEdit}}_edit{{else}}_new{{end}}" method="post">
-			<div class="field {{if .Err_Title}}error{{end}}">
+		<form class="ui form form-fetch-action" action="?action={{Iif .PageIsWikiEdit "_edit" "_new"}}" method="post" data-global-init="initRepoWikiForm">
+			<div class="field">
 				<input name="title" value="{{.title}}" aria-label="{{ctx.Locale.Tr "repo.wiki.page_title"}}" placeholder="{{ctx.Locale.Tr "repo.wiki.page_title"}}" autofocus required>
 			</div>
 			<div class="help">

--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -1,5 +1,5 @@
 {{template "base/head" .}}
-<div role="main" aria-label="{{.Title}}" class="page-content repository wiki view">
+<div role="main" aria-label="{{.Title}}" class="page-content repository wiki">
 	{{template "repo/header" .}}
 	{{$title := .title}}
 	<div class="ui container">
@@ -63,7 +63,7 @@
 
 		<div class="wiki-content-parts">
 			{{if .WikiSidebarTocHTML}}
-			<div class="render-content markup wiki-content-sidebar wiki-content-toc">
+			<div class="render-content markup wiki-content-sidebar wiki-content-toc" data-global-init="initRepoWikiSidebarToc">
 				{{.WikiSidebarTocHTML}}
 			</div>
 			{{end}}

--- a/templates/shared/combomarkdowneditor.tmpl
+++ b/templates/shared/combomarkdowneditor.tmpl
@@ -54,7 +54,7 @@
 				<md-unordered-list class="markdown-toolbar-button" data-tooltip-content="{{ctx.Locale.Tr "editor.buttons.list.unordered.tooltip"}}">{{svg "octicon-list-unordered"}}</md-unordered-list>
 				<md-ordered-list class="markdown-toolbar-button" data-tooltip-content="{{ctx.Locale.Tr "editor.buttons.list.ordered.tooltip"}}">{{svg "octicon-list-ordered"}}</md-ordered-list>
 				<md-task-list class="markdown-toolbar-button" data-tooltip-content="{{ctx.Locale.Tr "editor.buttons.list.task.tooltip"}}">{{svg "octicon-tasklist"}}</md-task-list>
-				<button class="markdown-toolbar-button markdown-button-table-add" data-tooltip-content="{{ctx.Locale.Tr "editor.buttons.table.add.tooltip"}}">{{svg "octicon-table"}}</button>
+				<button class="markdown-toolbar-button markdown-button-table-add" type="button" data-tooltip-content="{{ctx.Locale.Tr "editor.buttons.table.add.tooltip"}}">{{svg "octicon-table"}}</button>
 			</div>
 			{{if $mentionsLink}}
 			<div class="markdown-toolbar-group">
@@ -63,9 +63,9 @@
 			</div>
 			{{end}}
 			<div class="markdown-toolbar-group">
-				<button class="markdown-toolbar-button markdown-switch-monospace" role="switch" data-enable-text="{{ctx.Locale.Tr "editor.buttons.enable_monospace_font"}}" data-disable-text="{{ctx.Locale.Tr "editor.buttons.disable_monospace_font"}}">{{svg "octicon-typography"}}</button>
+				<button class="markdown-toolbar-button markdown-switch-monospace" type="button" role="switch" data-enable-text="{{ctx.Locale.Tr "editor.buttons.enable_monospace_font"}}" data-disable-text="{{ctx.Locale.Tr "editor.buttons.disable_monospace_font"}}">{{svg "octicon-typography"}}</button>
 				{{if $supportEasyMDE}}
-				<button class="markdown-toolbar-button markdown-switch-easymde" data-tooltip-content="{{ctx.Locale.Tr "editor.buttons.switch_to_legacy.tooltip"}}">{{svg "octicon-arrow-switch"}}</button>
+				<button class="markdown-toolbar-button markdown-switch-easymde" type="button" data-tooltip-content="{{ctx.Locale.Tr "editor.buttons.switch_to_legacy.tooltip"}}">{{svg "octicon-arrow-switch"}}</button>
 				{{end}}
 			</div>
 		</markdown-toolbar>

--- a/web_src/js/features/repo-wiki.ts
+++ b/web_src/js/features/repo-wiki.ts
@@ -3,13 +3,11 @@ import {fomanticMobileScreen} from '../modules/fomantic.ts';
 import {POST} from '../modules/fetch.ts';
 import type {ComboMarkdownEditor} from './comp/ComboMarkdownEditor.ts';
 import {html, htmlRaw} from '../utils/html.ts';
+import {registerGlobalInitFunc} from '../modules/observer.ts';
 
-async function initRepoWikiFormEditor() {
-  const editArea = document.querySelector<HTMLTextAreaElement>('.repository.wiki .combo-markdown-editor textarea');
-  if (!editArea) return;
-
-  const form = document.querySelector('.repository.wiki.new .ui.form')!;
+async function initRepoWikiForm(form: HTMLFormElement) {
   const editorContainer = form.querySelector<HTMLElement>('.combo-markdown-editor')!;
+  const editArea = editorContainer.querySelector<HTMLTextAreaElement>('textarea')!;
   let editor: ComboMarkdownEditor;
 
   let renderRequesting = false;
@@ -69,17 +67,13 @@ async function initRepoWikiFormEditor() {
   });
 }
 
-function collapseWikiTocForMobile(collapse: boolean) {
-  if (collapse) {
-    document.querySelector('.wiki-content-toc details')?.removeAttribute('open');
-  }
-}
-
-export function initRepoWikiForm() {
-  if (!document.querySelector('.page-content.repository.wiki')) return;
-
-  fomanticMobileScreen.addEventListener('change', (e) => collapseWikiTocForMobile(e.matches));
-  collapseWikiTocForMobile(fomanticMobileScreen.matches);
-
-  initRepoWikiFormEditor();
+export function initRepoWiki() {
+  registerGlobalInitFunc('initRepoWikiSidebarToc', (el) => {
+    const collapseWikiTocForMobile = (collapse: boolean) => {
+      if (collapse) el.querySelector('details')?.removeAttribute('open');
+    };
+    fomanticMobileScreen.addEventListener('change', (e) => collapseWikiTocForMobile(e.matches));
+    collapseWikiTocForMobile(fomanticMobileScreen.matches);
+  });
+  registerGlobalInitFunc('initRepoWikiForm', initRepoWikiForm);
 }

--- a/web_src/js/index.ts
+++ b/web_src/js/index.ts
@@ -38,7 +38,7 @@ import {initInstall} from './features/install.ts';
 import {initCompWebHookEditor} from './features/comp/WebHookEditor.ts';
 import {initRepoBranchButton} from './features/repo-branch.ts';
 import {initCommonOrganization} from './features/common-organization.ts';
-import {initRepoWikiForm} from './features/repo-wiki.ts';
+import {initRepoWiki} from './features/repo-wiki.ts';
 import {initRepository, initBranchSelectorTabs} from './features/repo-legacy.ts';
 import {initCaptcha} from './features/captcha.ts';
 import {initRepositoryActions} from './features/repo-actions.ts';
@@ -135,7 +135,7 @@ const initPerformanceTracer = callInitFunctions([
   initRepoReleaseNew,
   initRepoTopicBar,
   initRepoViewFileTree,
-  initRepoWikiForm,
+  initRepoWiki,
   initRepository,
   initRepositoryActions,
   initRepositorySearch,


### PR DESCRIPTION
1. the fragile `document.querySelector('.repository.wiki.new .ui.form')!` is broken (again), rewrite to "data-global-init"
    * regression from #37571 because a new form was added
3. use "form-fetch-action" and JSON response instead of "RenderWithErrDeprecated"