### PR TITLE
feat(wiki): support nested wiki pages

### DIFF
--- a/models/renderhelper/repo_wiki.go
+++ b/models/renderhelper/repo_wiki.go
@@ -36,9 +36,9 @@ func (r *RepoWiki) ResolveLink(link, preferLinkType string) (finalLink string) {
 	case markup.LinkTypeRoot:
 		finalLink = r.ctx.ResolveLinkRoot(link)
 	case markup.LinkTypeMedia, markup.LinkTypeRaw:
-		finalLink = r.ctx.ResolveLinkRelative(path.Join(r.repoLink, "wiki/raw", r.opts.currentRefSubURL), util.PathEscapeSegments(r.opts.currentTreePath), link)
+		finalLink = r.ctx.ResolveLinkRelative(path.Join(r.repoLink, "wiki/raw", r.opts.CurrentRefSubURL), util.PathEscapeSegments(r.opts.CurrentTreePath), link)
 	default:
-		finalLink = r.ctx.ResolveLinkRelative(path.Join(r.repoLink, "wiki", r.opts.currentRefSubURL), util.PathEscapeSegments(r.opts.currentTreePath), link)
+		finalLink = r.ctx.ResolveLinkRelative(path.Join(r.repoLink, "wiki", r.opts.CurrentRefSubURL), util.PathEscapeSegments(r.opts.CurrentTreePath), link)
 	}
 	return finalLink
 }
@@ -49,9 +49,8 @@ type RepoWikiOptions struct {
 	DeprecatedRepoName  string // it is only a patch for the non-standard "markup" api
 	DeprecatedOwnerName string // it is only a patch for the non-standard "markup" api
 
-	// these options are not used at the moment because Wiki doesn't support sub-path, nor branch
-	currentRefSubURL string // eg: "branch/main"
-	currentTreePath  string // eg: "path/to/file" in the repo
+	CurrentRefSubURL string // eg: "branch/main"
+	CurrentTreePath  string // eg: "path/to/file" in the repo
 }
 
 func NewRenderContextRepoWiki(ctx context.Context, repo *repo_model.Repository, opts ...RepoWikiOptions) *markup.RenderContext {

--- a/models/renderhelper/repo_wiki_test.go
+++ b/models/renderhelper/repo_wiki_test.go
@@ -51,7 +51,7 @@ func TestRepoWiki(t *testing.T) {
 
 	t.Run("PathInTag", func(t *testing.T) {
 		rctx := NewRenderContextRepoWiki(t.Context(), repo1, RepoWikiOptions{
-			currentTreePath: "my dir",
+			CurrentTreePath: "my dir",
 		}).WithMarkupType(markdown.MarkupName)
 		rendered, err := testRenderString(rctx, `
 <img src="LINK">
@@ -61,5 +61,18 @@ func TestRepoWiki(t *testing.T) {
 		assert.Equal(t, `<a href="/user2/repo1/wiki/my%20dir/LINK" target="_blank" rel="nofollow noopener"><img src="/user2/repo1/wiki/raw/my%20dir/LINK"/></a>
 <video src="/user2/repo1/wiki/raw/my%20dir/LINK">
 </video>`, rendered)
+	})
+
+	t.Run("RelativePath", func(t *testing.T) {
+		rctx := NewRenderContextRepoWiki(t.Context(), repo1, RepoWikiOptions{
+			CurrentTreePath: "Guides/Configuration",
+		}).WithMarkupType(markdown.MarkupName)
+		rendered, err := testRenderString(rctx, `[Setup](Setup)
+![diagram](assets/diagram.png)
+`)
+		assert.NoError(t, err)
+		assert.Equal(t, `<p><a href="/user2/repo1/wiki/Guides/Configuration/Setup" rel="nofollow">Setup</a>
+<a href="/user2/repo1/wiki/Guides/Configuration/assets/diagram.png" target="_blank" rel="nofollow noopener"><img src="/user2/repo1/wiki/raw/Guides/Configuration/assets/diagram.png" alt="diagram"/></a></p>
+`, rendered)
 	})
 }

--- a/routers/api/v1/repo/wiki.go
+++ b/routers/api/v1/repo/wiki.go
@@ -135,7 +135,11 @@ func EditWikiPage(ctx *context.APIContext) {
 
 	form := web.GetForm[*api.CreateWikiPageOptions](ctx)
 
-	oldWikiName := wiki_service.WebPathFromRequest(ctx.PathParamRaw("pageName"))
+	oldWikiName, err := wiki_service.WebPathFromRequest(ctx.PathParamRaw("pageName"))
+	if err != nil {
+		ctx.APIError(http.StatusBadRequest, err.Error())
+		return
+	}
 	newWikiName := wiki_service.UserTitleToWebPath("", form.Title)
 
 	if len(newWikiName) == 0 {
@@ -241,7 +245,11 @@ func DeleteWikiPage(ctx *context.APIContext) {
 	//   "423":
 	//     "$ref": "#/responses/repoArchivedError"
 
-	wikiName := wiki_service.WebPathFromRequest(ctx.PathParamRaw("pageName"))
+	wikiName, err := wiki_service.WebPathFromRequest(ctx.PathParamRaw("pageName"))
+	if err != nil {
+		ctx.APIError(http.StatusBadRequest, err.Error())
+		return
+	}
 
 	if err := wiki_service.DeleteWikiPage(ctx, ctx.Doer, ctx.Repo.Repository, wikiName); err != nil {
 		ctx.APIErrorAuto(err)
@@ -363,7 +371,11 @@ func GetWikiPage(ctx *context.APIContext) {
 	//     "$ref": "#/responses/notFound"
 
 	// get requested pagename
-	pageName := wiki_service.WebPathFromRequest(ctx.PathParamRaw("pageName"))
+	pageName, err := wiki_service.WebPathFromRequest(ctx.PathParamRaw("pageName"))
+	if err != nil {
+		ctx.APIError(http.StatusBadRequest, err.Error())
+		return
+	}
 
 	wikiPage := getWikiPage(ctx, pageName)
 	if !ctx.Written() {
@@ -413,7 +425,11 @@ func ListPageRevisions(ctx *context.APIContext) {
 	}
 
 	// get requested pagename
-	pageName := wiki_service.WebPathFromRequest(ctx.PathParamRaw("pageName"))
+	pageName, err := wiki_service.WebPathFromRequest(ctx.PathParamRaw("pageName"))
+	if err != nil {
+		ctx.APIError(http.StatusBadRequest, err.Error())
+		return
+	}
 	if len(pageName) == 0 {
 		pageName = "Home"
 	}

--- a/routers/web/repo/wiki.go
+++ b/routers/web/repo/wiki.go
@@ -71,9 +71,30 @@ func MustEnableWiki(ctx *context.Context) {
 // PageMeta wiki page meta information
 type PageMeta struct {
 	Name         string
+	IsDir        bool
 	SubURL       string
 	GitEntryName string
 	UpdatedUnix  timeutil.TimeStamp
+}
+
+func treeHasWikiPage(ctx gocontext.Context, wikiRepo *git.Repository, tree *git.Tree) bool {
+	if tree == nil {
+		return false
+	}
+	entries, err := tree.ListEntries(ctx, wikiRepo)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if entry.IsRegular() {
+			if _, err := wiki_service.GitPathToWebPath(entry.Name()); err == nil {
+				return true
+			}
+		} else if entry.IsDir() && treeHasWikiPage(ctx, wikiRepo, entry.Tree(ctx, wikiRepo)) {
+			return true
+		}
+	}
+	return false
 }
 
 // findEntryForFile finds the tree entry for a target filepath.
@@ -194,10 +215,15 @@ func renderViewPage(ctx *context.Context) (*git.Repository, *git.TreeEntry) {
 	}
 	pages := make([]PageMeta, 0, len(entries))
 	for _, entry := range entries {
-		if !entry.IsRegular() {
+		if !entry.IsRegular() && (!entry.IsDir() || !treeHasWikiPage(ctx, wikiGitRepo, entry.Tree(ctx, wikiGitRepo))) {
 			continue
 		}
-		wikiName, err := wiki_service.GitPathToWebPath(entry.Name())
+		var wikiName wiki_service.WebPath
+		if entry.IsDir() {
+			wikiName, err = wiki_service.GitDirPathToWebPath(entry.Name())
+		} else {
+			wikiName, err = wiki_service.GitPathToWebPath(entry.Name())
+		}
 		if err != nil {
 			if repo_model.IsErrWikiInvalidFileName(err) {
 				continue
@@ -210,6 +236,7 @@ func renderViewPage(ctx *context.Context) (*git.Repository, *git.TreeEntry) {
 		_, displayName := wiki_service.WebPathToUserTitle(wikiName)
 		pages = append(pages, PageMeta{
 			Name:         displayName,
+			IsDir:        entry.IsDir(),
 			SubURL:       wiki_service.WebPathToURLPath(wikiName),
 			GitEntryName: entry.Name(),
 		})
@@ -217,13 +244,20 @@ func renderViewPage(ctx *context.Context) (*git.Repository, *git.TreeEntry) {
 	ctx.Data["Pages"] = pages
 
 	// get requested page name
-	pageName := wiki_service.WebPathFromRequest(ctx.PathParamRaw("*"))
+	pageName, err := wiki_service.WebPathFromRequest(ctx.PathParamRaw("*"))
+	if err != nil {
+		ctx.NotFound(err)
+		return nil, nil
+	}
 	if len(pageName) == 0 {
 		pageName = "Home"
 	}
 
 	_, displayName := wiki_service.WebPathToUserTitle(pageName)
 	ctx.Data["PageURL"] = wiki_service.WebPathToURLPath(pageName)
+	if pageDir := path.Dir(string(pageName)); pageDir != "." {
+		ctx.Data["PageDir"] = wiki_service.WebPathToURLPath(wiki_service.WebPath(pageDir))
+	}
 	ctx.Data["old_title"] = displayName
 	ctx.Data["Title"] = displayName
 	ctx.Data["title"] = displayName
@@ -234,6 +268,11 @@ func renderViewPage(ctx *context.Context) (*git.Repository, *git.TreeEntry) {
 	// lookup filename in wiki - get gitTree entry , real filename
 	entry, pageFilename, noEntry, isRaw := wikiEntryByName(ctx, wikiGitRepo, commit, pageName)
 	if noEntry {
+		dirEntry, err := commit.GetTreeEntryByPath(ctx, wikiGitRepo, wiki_service.WebDirPathToGitPath(pageName))
+		if err == nil && dirEntry.IsDir() {
+			ctx.Redirect(ctx.Repo.RepoLink + "/wiki/" + wiki_service.WebPathToURLPath(pageName) + "?action=_pages")
+			return nil, nil
+		}
 		ctx.Redirect(ctx.Repo.RepoLink + "/wiki/?action=_pages")
 	}
 	if isRaw {
@@ -249,9 +288,13 @@ func renderViewPage(ctx *context.Context) (*git.Repository, *git.TreeEntry) {
 		return nil, nil
 	}
 
-	rctx := renderhelper.NewRenderContextRepoWiki(ctx, ctx.Repo.Repository)
+	pageDir := path.Dir(pageFilename)
+	if pageDir == "." {
+		pageDir = ""
+	}
+	rctx := renderhelper.NewRenderContextRepoWiki(ctx, ctx.Repo.Repository, renderhelper.RepoWikiOptions{CurrentTreePath: pageDir})
 
-	renderFn := func(data []byte) (escaped *charset.EscapeStatus, output template.HTML, err error) {
+	renderFn := func(rctx *markup.RenderContext, data []byte) (escaped *charset.EscapeStatus, output template.HTML, err error) {
 		buf := &strings.Builder{}
 		markupRd, markupWr := io.Pipe()
 		defer markupWr.Close()
@@ -269,7 +312,7 @@ func renderViewPage(ctx *context.Context) (*git.Repository, *git.TreeEntry) {
 		return escaped, output, err
 	}
 
-	ctx.Data["EscapeStatus"], ctx.Data["WikiContentHTML"], err = renderFn(data)
+	ctx.Data["EscapeStatus"], ctx.Data["WikiContentHTML"], err = renderFn(rctx, data)
 	if err != nil {
 		ctx.ServerError("Render", err)
 		return nil, nil
@@ -286,7 +329,7 @@ func renderViewPage(ctx *context.Context) (*git.Repository, *git.TreeEntry) {
 		if ctx.Written() {
 			return nil, nil
 		}
-		ctx.Data["WikiSidebarEscapeStatus"], ctx.Data["WikiSidebarHTML"], err = renderFn(sidebarContent)
+		ctx.Data["WikiSidebarEscapeStatus"], ctx.Data["WikiSidebarHTML"], err = renderFn(renderhelper.NewRenderContextRepoWiki(ctx, ctx.Repo.Repository), sidebarContent)
 		if err != nil {
 			ctx.ServerError("Render", err)
 			return nil, nil
@@ -298,7 +341,7 @@ func renderViewPage(ctx *context.Context) (*git.Repository, *git.TreeEntry) {
 		if ctx.Written() {
 			return nil, nil
 		}
-		ctx.Data["WikiFooterEscapeStatus"], ctx.Data["WikiFooterHTML"], err = renderFn(footerContent)
+		ctx.Data["WikiFooterEscapeStatus"], ctx.Data["WikiFooterHTML"], err = renderFn(renderhelper.NewRenderContextRepoWiki(ctx, ctx.Repo.Repository), footerContent)
 		if err != nil {
 			ctx.ServerError("Render", err)
 			return nil, nil
@@ -322,13 +365,20 @@ func renderRevisionPage(ctx *context.Context) (*git.Repository, *git.TreeEntry) 
 	}
 
 	// get requested page name
-	pageName := wiki_service.WebPathFromRequest(ctx.PathParamRaw("*"))
+	pageName, err := wiki_service.WebPathFromRequest(ctx.PathParamRaw("*"))
+	if err != nil {
+		ctx.NotFound(err)
+		return nil, nil
+	}
 	if len(pageName) == 0 {
 		pageName = "Home"
 	}
 
 	_, displayName := wiki_service.WebPathToUserTitle(pageName)
 	ctx.Data["PageURL"] = wiki_service.WebPathToURLPath(pageName)
+	if pageDir := path.Dir(string(pageName)); pageDir != "." {
+		ctx.Data["PageDir"] = wiki_service.WebPathToURLPath(wiki_service.WebPath(pageDir))
+	}
 	ctx.Data["old_title"] = displayName
 	ctx.Data["Title"] = displayName
 	ctx.Data["title"] = displayName
@@ -383,13 +433,20 @@ func renderEditPage(ctx *context.Context) {
 	}
 
 	// get requested page name
-	pageName := wiki_service.WebPathFromRequest(ctx.PathParamRaw("*"))
+	pageName, err := wiki_service.WebPathFromRequest(ctx.PathParamRaw("*"))
+	if err != nil {
+		ctx.NotFound(err)
+		return
+	}
 	if len(pageName) == 0 {
 		pageName = "Home"
 	}
 
 	_, displayName := wiki_service.WebPathToUserTitle(pageName)
 	ctx.Data["PageURL"] = wiki_service.WebPathToURLPath(pageName)
+	if pageDir := path.Dir(string(pageName)); pageDir != "." {
+		ctx.Data["PageDir"] = wiki_service.WebPathToURLPath(wiki_service.WebPath(pageDir))
+	}
 	ctx.Data["old_title"] = displayName
 	ctx.Data["Title"] = displayName
 	ctx.Data["title"] = displayName
@@ -484,7 +541,13 @@ func Wiki(ctx *context.Context) {
 		return
 	}
 
-	wikiPath := entry.Name()
+	wikiName, err := wiki_service.WebPathFromRequest(ctx.PathParamRaw("*"))
+	if err != nil {
+		ctx.NotFound(err)
+		return
+	}
+	wikiName = util.IfZero(wikiName, "Home")
+	wikiPath := wiki_service.WebPathToGitPath(wikiName)
 	detectedRender := markup.DetectRendererTypeByFilename(wikiPath)
 	if detectedRender == nil || detectedRender.Name() != markdown.MarkupName {
 		ctx.Data["FormatWarning"] = "File extension " + path.Ext(wikiPath) + " is not supported at the moment. Rendered as Markdown."
@@ -521,7 +584,13 @@ func WikiRevision(ctx *context.Context) {
 	}
 
 	// Get last change information.
-	wikiPath := entry.Name()
+	wikiName, err := wiki_service.WebPathFromRequest(ctx.PathParamRaw("*"))
+	if err != nil {
+		ctx.NotFound(err)
+		return
+	}
+	wikiName = util.IfZero(wikiName, "Home")
+	wikiPath := wiki_service.WebPathToGitPath(wikiName)
 	lastCommit, err := wikiGitRepo.GetCommitByPath(ctx, wikiPath)
 	if err != nil {
 		ctx.ServerError("GetCommitByPath", err)
@@ -548,7 +617,12 @@ func WikiPages(ctx *context.Context) {
 		return
 	}
 
-	treePath := "" // To support list sub folders' pages in the future
+	dirPath, err := wiki_service.WebPathFromRequest(ctx.PathParamRaw("*"))
+	if err != nil {
+		ctx.NotFound(err)
+		return
+	}
+	treePath := wiki_service.WebDirPathToGitPath(dirPath)
 	tree, err := commit.SubTree(ctx, wikiGitRepo, treePath)
 	if err != nil {
 		ctx.ServerError("SubTree", err)
@@ -570,10 +644,15 @@ func WikiPages(ctx *context.Context) {
 
 	pages := make([]PageMeta, 0, len(entries))
 	for _, entry := range entries {
-		if !entry.Entry.IsRegular() {
+		if !entry.Entry.IsRegular() && (!entry.Entry.IsDir() || !treeHasWikiPage(ctx, wikiGitRepo, entry.Entry.Tree(ctx, wikiGitRepo))) {
 			continue
 		}
-		wikiName, err := wiki_service.GitPathToWebPath(entry.Entry.Name())
+		var wikiName wiki_service.WebPath
+		if entry.Entry.IsDir() {
+			wikiName, err = wiki_service.GitDirPathToWebPath(entry.Entry.Name())
+		} else {
+			wikiName, err = wiki_service.GitPathToWebPath(entry.Entry.Name())
+		}
 		if err != nil {
 			if repo_model.IsErrWikiInvalidFileName(err) {
 				continue
@@ -584,12 +663,17 @@ func WikiPages(ctx *context.Context) {
 		_, displayName := wiki_service.WebPathToUserTitle(wikiName)
 		pages = append(pages, PageMeta{
 			Name:         displayName,
-			SubURL:       wiki_service.WebPathToURLPath(wikiName),
-			GitEntryName: entry.Entry.Name(),
+			IsDir:        entry.Entry.IsDir(),
+			SubURL:       wiki_service.WebPathToURLPath(wiki_service.WebPath(path.Join(string(dirPath), string(wikiName)))),
+			GitEntryName: path.Join(treePath, entry.Entry.Name()),
 			UpdatedUnix:  timeutil.TimeStamp(entry.Commit.Committer.When.Unix()),
 		})
 	}
 	ctx.Data["Pages"] = pages
+	ctx.Data["PageDir"] = wiki_service.WebPathToURLPath(dirPath)
+	if parentDir := path.Dir(string(dirPath)); parentDir != "." {
+		ctx.Data["ParentPageDir"] = wiki_service.WebPathToURLPath(wiki_service.WebPath(parentDir))
+	}
 
 	ctx.HTML(http.StatusOK, tplWikiPages)
 }
@@ -606,7 +690,11 @@ func WikiRaw(ctx *context.Context) {
 		return
 	}
 
-	providedWebPath := wiki_service.WebPathFromRequest(ctx.PathParamRaw("*"))
+	providedWebPath, err := wiki_service.WebPathFromRequest(ctx.PathParamRaw("*"))
+	if err != nil {
+		ctx.NotFound(err)
+		return
+	}
 	providedGitPath := wiki_service.WebPathToGitPath(providedWebPath)
 	var entry *git.TreeEntry
 	if commit != nil {
@@ -651,6 +739,12 @@ func wikiHandleEditError(ctx *context.Context, wikiName wiki_service.WebPath, er
 // NewWiki render wiki create page
 func NewWiki(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("repo.wiki.new_page")
+	dirPath, err := wiki_service.WebPathFromRequest(ctx.PathParamRaw("*"))
+	if err != nil {
+		ctx.NotFound(err)
+		return
+	}
+	ctx.Data["PageDir"] = wiki_service.WebPathToURLPath(dirPath)
 
 	if !repo_service.HasWiki(ctx, ctx.Repo.Repository) {
 		ctx.Data["title"] = "Home"
@@ -669,12 +763,17 @@ func NewWikiPost(ctx *context.Context) {
 		return
 	}
 
-	wikiName := wiki_service.UserTitleToWebPath("", form.Title)
+	dirPath, err := wiki_service.WebPathFromRequest(ctx.PathParamRaw("*"))
+	if err != nil {
+		ctx.NotFound(err)
+		return
+	}
+	wikiName := wiki_service.UserTitleToWebPath(string(dirPath), form.Title)
 	if form.Message == "" {
 		form.Message = ctx.Locale.TrString("repo.editor.add", form.Title)
 	}
 
-	err := wiki_service.AddWikiPage(ctx, ctx.Doer, ctx.Repo.Repository, wikiName, form.Content, form.Message)
+	err = wiki_service.AddWikiPage(ctx, ctx.Doer, ctx.Repo.Repository, wikiName, form.Content, form.Message)
 	if err != nil {
 		wikiHandleEditError(ctx, wikiName, err)
 		return
@@ -709,8 +808,16 @@ func EditWikiPost(ctx *context.Context) {
 		return
 	}
 
-	oldWikiName := wiki_service.WebPathFromRequest(ctx.PathParamRaw("*"))
-	newWikiName := wiki_service.UserTitleToWebPath("", form.Title)
+	oldWikiName, err := wiki_service.WebPathFromRequest(ctx.PathParamRaw("*"))
+	if err != nil {
+		ctx.NotFound(err)
+		return
+	}
+	dirPath := path.Dir(string(oldWikiName))
+	if dirPath == "." {
+		dirPath = ""
+	}
+	newWikiName := wiki_service.UserTitleToWebPath(dirPath, form.Title)
 	if form.Message == "" {
 		form.Message = ctx.Locale.TrString("repo.editor.update", form.Title)
 	}
@@ -727,7 +834,11 @@ func EditWikiPost(ctx *context.Context) {
 
 // DeleteWikiPagePost delete wiki page
 func DeleteWikiPagePost(ctx *context.Context) {
-	wikiName := wiki_service.WebPathFromRequest(ctx.PathParamRaw("*"))
+	wikiName, err := wiki_service.WebPathFromRequest(ctx.PathParamRaw("*"))
+	if err != nil {
+		ctx.NotFound(err)
+		return
+	}
 	wikiName = util.IfZero(wikiName, "Home")
 	if err := wiki_service.DeleteWikiPage(ctx, ctx.Doer, ctx.Repo.Repository, wikiName); err != nil {
 		ctx.ServerError("DeleteWikiPage", err)

--- a/routers/web/repo/wiki.go
+++ b/routers/web/repo/wiki.go
@@ -385,6 +385,7 @@ func renderViewPage(ctx *context.Context) (*git.Repository, *git.TreeEntry) {
 	if entry == nil || ctx.Written() {
 		return nil, nil
 	}
+	ctx.Data["WikiGitPath"] = pageFilename
 
 	// get page content
 	data := wikiContentsByEntry(ctx, wikiGitRepo, entry)
@@ -495,6 +496,7 @@ func renderRevisionPage(ctx *context.Context) (*git.Repository, *git.TreeEntry) 
 	if entry == nil || ctx.Written() {
 		return nil, nil
 	}
+	ctx.Data["WikiGitPath"] = pageFilename
 
 	// get commit count - wiki revisions
 	commitsCount, _ := git.FileCommitsCount(ctx, ctx.Repo.Repository.WikiStorageRepo(), ctx.Repo.Repository.DefaultWikiBranch, pageFilename)
@@ -651,7 +653,10 @@ func Wiki(ctx *context.Context) {
 		return
 	}
 	wikiName = util.IfZero(wikiName, "Home")
-	wikiPath := wiki_service.WebPathToGitPath(wikiName)
+	wikiPath, ok := ctx.Data["WikiGitPath"].(string)
+	if !ok {
+		wikiPath = wiki_service.WebPathToGitPath(wikiName)
+	}
 	detectedRender := markup.DetectRendererTypeByFilename(wikiPath)
 	if detectedRender == nil || detectedRender.Name() != markdown.MarkupName {
 		ctx.Data["FormatWarning"] = "File extension " + path.Ext(wikiPath) + " is not supported at the moment. Rendered as Markdown."
@@ -694,7 +699,10 @@ func WikiRevision(ctx *context.Context) {
 		return
 	}
 	wikiName = util.IfZero(wikiName, "Home")
-	wikiPath := wiki_service.WebPathToGitPath(wikiName)
+	wikiPath, ok := ctx.Data["WikiGitPath"].(string)
+	if !ok {
+		wikiPath = wiki_service.WebPathToGitPath(wikiName)
+	}
 	lastCommit, err := wikiGitRepo.GetCommitByPath(ctx, wikiPath)
 	if err != nil {
 		ctx.ServerError("GetCommitByPath", err)

--- a/routers/web/repo/wiki.go
+++ b/routers/web/repo/wiki.go
@@ -244,19 +244,33 @@ func wikiContentsByEntry(ctx *context.Context, wikiRepo *git.Repository, entry *
 // The last return value indicates whether the file should be returned as a raw file
 func wikiEntryByName(ctx *context.Context, wikiRepo *git.Repository, commit *git.Commit, wikiName wiki_service.WebPath) (*git.TreeEntry, string, bool, bool) {
 	isRaw := false
-	gitFilename := wiki_service.WebPathToGitPath(wikiName)
-	entry, err := findEntryForFile(ctx, wikiRepo, commit, gitFilename)
-	if err != nil && !git.IsErrNotExist(err) {
-		ctx.ServerError("findEntryForFile", err)
-		return nil, "", false, false
-	}
-	if entry == nil {
-		// check if the file without ".md" suffix exists
-		gitFilename := strings.TrimSuffix(gitFilename, ".md")
-		entry, err = findEntryForFile(ctx, wikiRepo, commit, gitFilename)
+	gitFilenames := wiki_service.WebPathToGitPathCandidates(wikiName)
+	var entry *git.TreeEntry
+	var err error
+	gitFilename := gitFilenames[0]
+	for _, candidate := range gitFilenames {
+		entry, err = findEntryForFile(ctx, wikiRepo, commit, candidate)
 		if err != nil && !git.IsErrNotExist(err) {
 			ctx.ServerError("findEntryForFile", err)
 			return nil, "", false, false
+		}
+		if entry != nil {
+			gitFilename = candidate
+			break
+		}
+	}
+	if entry == nil {
+		// check if the file without ".md" suffix exists
+		for _, candidate := range gitFilenames {
+			gitFilename = strings.TrimSuffix(candidate, ".md")
+			entry, err = findEntryForFile(ctx, wikiRepo, commit, gitFilename)
+			if err != nil && !git.IsErrNotExist(err) {
+				ctx.ServerError("findEntryForFile", err)
+				return nil, "", false, false
+			}
+			if entry != nil {
+				break
+			}
 		}
 		isRaw = true
 	}
@@ -352,10 +366,16 @@ func renderViewPage(ctx *context.Context) (*git.Repository, *git.TreeEntry) {
 	// lookup filename in wiki - get gitTree entry , real filename
 	entry, pageFilename, noEntry, isRaw := wikiEntryByName(ctx, wikiGitRepo, commit, pageName)
 	if noEntry {
-		dirEntry, err := commit.GetTreeEntryByPath(ctx, wikiGitRepo, wiki_service.WebDirPathToGitPath(pageName))
-		if err == nil && dirEntry.IsDir() {
-			ctx.Redirect(ctx.Repo.RepoLink + "/wiki/" + wiki_service.WebPathToURLPath(pageName) + "?action=_pages")
-			return nil, nil
+		for _, dirPath := range wiki_service.WebDirPathToGitPathCandidates(pageName) {
+			dirEntry, err := commit.GetTreeEntryByPath(ctx, wikiGitRepo, dirPath)
+			if err == nil && dirEntry.IsDir() {
+				ctx.Redirect(ctx.Repo.RepoLink + "/wiki/" + wiki_service.WebPathToURLPath(pageName) + "?action=_pages")
+				return nil, nil
+			}
+			if err != nil && !git.IsErrNotExist(err) {
+				ctx.ServerError("GetTreeEntryByPath", err)
+				return nil, nil
+			}
 		}
 		ctx.Redirect(ctx.Repo.RepoLink + "/wiki/?action=_pages")
 	}
@@ -706,10 +726,21 @@ func WikiPages(ctx *context.Context) {
 		ctx.NotFound(err)
 		return
 	}
-	treePath := wiki_service.WebDirPathToGitPath(dirPath)
-	tree, err := commit.SubTree(ctx, wikiGitRepo, treePath)
-	if err != nil {
-		ctx.ServerError("SubTree", err)
+	var tree *git.Tree
+	treePath := ""
+	for _, candidate := range wiki_service.WebDirPathToGitPathCandidates(dirPath) {
+		tree, err = commit.SubTree(ctx, wikiGitRepo, candidate)
+		if err == nil {
+			treePath = candidate
+			break
+		}
+		if !git.IsErrNotExist(err) {
+			ctx.ServerError("SubTree", err)
+			return
+		}
+	}
+	if tree == nil {
+		ctx.NotFound(err)
 		return
 	}
 

--- a/routers/web/repo/wiki.go
+++ b/routers/web/repo/wiki.go
@@ -77,6 +77,84 @@ type PageMeta struct {
 	UpdatedUnix  timeutil.TimeStamp
 }
 
+type WikiTreeNode struct {
+	Name     string
+	IsDir    bool
+	Open     bool
+	SubURL   string
+	Children []*WikiTreeNode
+}
+
+func buildWikiTree(ctx gocontext.Context, wikiRepo *git.Repository, tree *git.Tree, basePath string) ([]*WikiTreeNode, error) {
+	entries, err := tree.ListEntries(ctx, wikiRepo)
+	if err != nil {
+		return nil, err
+	}
+	entries.CustomSort(base.NaturalSortCompare)
+
+	nodes := make([]*WikiTreeNode, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsRegular() && !entry.IsDir() {
+			continue
+		}
+
+		if entry.IsDir() {
+			wikiName, err := wiki_service.GitDirPathToWebPath(entry.Name())
+			if err != nil {
+				return nil, err
+			}
+			children, err := buildWikiTree(ctx, wikiRepo, entry.Tree(ctx, wikiRepo), path.Join(basePath, string(wikiName)))
+			if err != nil {
+				return nil, err
+			}
+			if len(children) == 0 {
+				continue
+			}
+			_, displayName := wiki_service.WebPathToUserTitle(wikiName)
+			nodes = append(nodes, &WikiTreeNode{
+				Name:     displayName,
+				IsDir:    true,
+				SubURL:   wiki_service.WebPathToURLPath(wiki_service.WebPath(path.Join(basePath, string(wikiName)))),
+				Children: children,
+			})
+			continue
+		}
+
+		wikiName, err := wiki_service.GitPathToWebPath(entry.Name())
+		if err != nil {
+			if repo_model.IsErrWikiInvalidFileName(err) {
+				continue
+			}
+			return nil, err
+		}
+		if basePath == "" && (wikiName == "_Sidebar" || wikiName == "_Footer") {
+			continue
+		}
+		_, displayName := wiki_service.WebPathToUserTitle(wikiName)
+		nodes = append(nodes, &WikiTreeNode{
+			Name:   displayName,
+			SubURL: wiki_service.WebPathToURLPath(wiki_service.WebPath(path.Join(basePath, string(wikiName)))),
+		})
+	}
+	return nodes, nil
+}
+
+func openWikiTreePath(nodes []*WikiTreeNode, pagePath string) bool {
+	for _, node := range nodes {
+		if node.IsDir {
+			node.Open = openWikiTreePath(node.Children, pagePath)
+			if node.Open {
+				return true
+			}
+			continue
+		}
+		if node.SubURL == pagePath {
+			return true
+		}
+	}
+	return false
+}
+
 func treeHasWikiPage(ctx gocontext.Context, wikiRepo *git.Repository, tree *git.Tree) bool {
 	if tree == nil {
 		return false
@@ -206,7 +284,6 @@ func renderViewPage(ctx *context.Context) (*git.Repository, *git.TreeEntry) {
 		}
 		return nil, nil
 	}
-
 	// get the wiki pages list.
 	entries, err := commit.Tree().ListEntries(ctx, wikiGitRepo)
 	if err != nil {
@@ -252,6 +329,13 @@ func renderViewPage(ctx *context.Context) (*git.Repository, *git.TreeEntry) {
 	if len(pageName) == 0 {
 		pageName = "Home"
 	}
+	wikiTree, err := buildWikiTree(ctx, wikiGitRepo, commit.Tree(), "")
+	if err != nil {
+		ctx.ServerError("buildWikiTree", err)
+		return nil, nil
+	}
+	openWikiTreePath(wikiTree, wiki_service.WebPathToURLPath(pageName))
+	ctx.Data["WikiTree"] = wikiTree
 
 	_, displayName := wiki_service.WebPathToUserTitle(pageName)
 	ctx.Data["PageURL"] = wiki_service.WebPathToURLPath(pageName)

--- a/routers/web/repo/wiki_test.go
+++ b/routers/web/repo/wiki_test.go
@@ -76,6 +76,28 @@ func assertPagesMetas(t *testing.T, expectedNames []string, metas any) {
 	}
 }
 
+func assertWikiTree(t *testing.T, expectedNames []string, tree any) {
+	nodes, ok := tree.([]*WikiTreeNode)
+	require.True(t, ok)
+	require.Len(t, nodes, len(expectedNames))
+
+	for i, node := range nodes {
+		assert.Equal(t, expectedNames[i], node.Name)
+	}
+}
+
+func findWikiTreeNode(t *testing.T, tree any, name string) *WikiTreeNode {
+	nodes, ok := tree.([]*WikiTreeNode)
+	require.True(t, ok)
+	for _, node := range nodes {
+		if node.Name == name {
+			return node
+		}
+	}
+	require.Failf(t, "wiki tree node not found", "%q", name)
+	return nil
+}
+
 func TestWiki(t *testing.T) {
 	unittest.PrepareTestEnv(t)
 
@@ -87,6 +109,7 @@ func TestWiki(t *testing.T) {
 		assert.Equal(t, http.StatusOK, ctx.Resp.WrittenStatus())
 		assert.EqualValues(t, "Home", ctx.Data["Title"])
 		assertPagesMetas(t, []string{"Home", "Page With Image", "Page With Spaced Name", "Unescaped File"}, ctx.Data["Pages"])
+		assertWikiTree(t, []string{"Home", "Page With Image", "Page With Spaced Name", "Unescaped File"}, ctx.Data["WikiTree"])
 	})
 	t.Run("Image", func(t *testing.T) {
 		ctx, _ := contexttest.MockContext(t, "user2/repo1/jpeg.jpg")
@@ -124,6 +147,13 @@ func testNestedWiki(t *testing.T) {
 		assert.Equal(t, http.StatusOK, ctx.Resp.WrittenStatus())
 		assert.EqualValues(t, "Setup", ctx.Data["Title"])
 		assert.EqualValues(t, "Guides", ctx.Data["PageDir"])
+		guides := findWikiTreeNode(t, ctx.Data["WikiTree"], "Guides")
+		require.True(t, guides.IsDir)
+		assert.True(t, guides.Open)
+		require.Equal(t, "Guides", guides.SubURL)
+		require.Len(t, guides.Children, 1)
+		assert.Equal(t, "Setup", guides.Children[0].Name)
+		assert.Equal(t, "Guides/Setup", guides.Children[0].SubURL)
 	})
 
 	t.Run("folder", func(t *testing.T) {

--- a/routers/web/repo/wiki_test.go
+++ b/routers/web/repo/wiki_test.go
@@ -12,6 +12,7 @@ import (
 
 	repo_model "gitea.dev/models/repo"
 	"gitea.dev/models/unittest"
+	user_model "gitea.dev/models/user"
 	"gitea.dev/modules/git"
 	"gitea.dev/modules/test"
 	"gitea.dev/services/contexttest"
@@ -34,14 +35,12 @@ func wikiEntry(t *testing.T, repo *repo_model.Repository, wikiName wiki_service.
 
 	commit, err := wikiRepo.GetBranchCommit(t.Context(), "master")
 	assert.NoError(t, err)
-	entries, err := commit.Tree().ListEntries(t.Context(), wikiRepo)
-	assert.NoError(t, err)
-	for _, entry := range entries {
-		if entry.Name() == wiki_service.WebPathToGitPath(wikiName) {
-			return wikiRepo, entry
-		}
+	entry, err := commit.GetTreeEntryByPath(t.Context(), wikiRepo, wiki_service.WebPathToGitPath(wikiName))
+	if git.IsErrNotExist(err) {
+		return wikiRepo, nil
 	}
-	return wikiRepo, nil
+	assert.NoError(t, err)
+	return wikiRepo, entry
 }
 
 func wikiContent(t *testing.T, repo *repo_model.Repository, wikiName wiki_service.WebPath) string {
@@ -105,7 +104,60 @@ func TestWiki(t *testing.T) {
 	t.Run("EditWikiPost", testEditWikiPost)
 	t.Run("DeletePost", testDeleteWikiPagePost)
 	t.Run("Raw", testWikiRaw)
+	t.Run("Nested", testNestedWiki)
 	t.Run("DefaultWikiBranch", testDefaultWikiBranch)
+}
+
+func testNestedWiki(t *testing.T) {
+	unittest.PrepareTestEnv(t)
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+	doer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	require.NoError(t, wiki_service.AddWikiPage(t.Context(), doer, repo, "Guides", testWikiContent, testWikiMessage))
+	require.NoError(t, wiki_service.AddWikiPage(t.Context(), doer, repo, "Guides/Setup", testWikiContent, testWikiMessage))
+	assertWikiExists(t, repo, "Guides/Setup")
+
+	t.Run("page", func(t *testing.T) {
+		ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki/Guides/Setup")
+		ctx.SetPathParamRaw("*", "Guides/Setup")
+		contexttest.LoadRepo(t, ctx, 1)
+		Wiki(ctx)
+		assert.Equal(t, http.StatusOK, ctx.Resp.WrittenStatus())
+		assert.EqualValues(t, "Setup", ctx.Data["Title"])
+		assert.EqualValues(t, "Guides", ctx.Data["PageDir"])
+	})
+
+	t.Run("folder", func(t *testing.T) {
+		ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki/Guides?action=_pages")
+		ctx.SetPathParamRaw("*", "Guides")
+		contexttest.LoadRepo(t, ctx, 1)
+		WikiPages(ctx)
+		assert.Equal(t, http.StatusOK, ctx.Resp.WrittenStatus())
+		assertPagesMetas(t, []string{"Setup"}, ctx.Data["Pages"])
+	})
+
+	t.Run("page and folder coexist", func(t *testing.T) {
+		ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki/Guides")
+		ctx.SetPathParamRaw("*", "Guides")
+		contexttest.LoadRepo(t, ctx, 1)
+		Wiki(ctx)
+		assert.Equal(t, http.StatusOK, ctx.Resp.WrittenStatus())
+		assert.Equal(t, "Guides", ctx.Data["Title"])
+	})
+
+	t.Run("new page", func(t *testing.T) {
+		ctx, _ := contexttest.MockContext(t, "user2/repo1/wiki/Guides?action=_new")
+		ctx.SetPathParamRaw("*", "Guides")
+		contexttest.LoadUser(t, ctx, 2)
+		contexttest.LoadRepo(t, ctx, 1)
+		contexttest.MockRequestPostForm(ctx.Req, url.Values{
+			"title":   []string{"New page"},
+			"content": []string{testWikiContent},
+			"message": []string{testWikiMessage},
+		})
+		NewWikiPost(ctx)
+		assert.Equal(t, http.StatusOK, ctx.Resp.WrittenStatus())
+		assertWikiExists(t, ctx.Repo.Repository, "Guides/New-page")
+	})
 }
 
 func testWikiPages(t *testing.T) {

--- a/services/wiki/wiki.go
+++ b/services/wiki/wiki.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"slices"
 
 	"gitea.dev/models/db"
 	repo_model "gitea.dev/models/repo"
@@ -67,10 +68,8 @@ func prepareGitPath(ctx context.Context, gitRepo *git.Repository, defaultWikiBra
 	}
 
 	for _, candidate := range gitPaths {
-		for _, filename := range filesInIndex {
-			if filename == candidate {
-				return true, candidate, nil
-			}
+		if slices.Contains(filesInIndex, candidate) {
+			return true, candidate, nil
 		}
 	}
 
@@ -78,14 +77,14 @@ func prepareGitPath(ctx context.Context, gitRepo *git.Repository, defaultWikiBra
 	// second directory whose normalized web path is identical.
 	commit, err := gitRepo.GetBranchCommit(ctx, defaultWikiBranch)
 	if err == nil {
-		for i := len(gitPaths) - 1; i >= 0; i-- {
-			parentPath := path.Dir(gitPaths[i])
+		for _, candidate := range slices.Backward(gitPaths) {
+			parentPath := path.Dir(candidate)
 			if parentPath == "." {
 				continue
 			}
 			entry, err := commit.GetTreeEntryByPath(ctx, gitRepo, parentPath)
 			if err == nil && entry.IsDir() {
-				return false, gitPaths[i], nil
+				return false, candidate, nil
 			}
 			if err != nil && !git.IsErrNotExist(err) {
 				return false, gitPath, err

--- a/services/wiki/wiki.go
+++ b/services/wiki/wiki.go
@@ -7,6 +7,7 @@ package wiki
 import (
 	"context"
 	"fmt"
+	"path"
 
 	"gitea.dev/models/db"
 	repo_model "gitea.dev/models/repo"
@@ -52,11 +53,11 @@ func InitWiki(ctx context.Context, repo *repo_model.Repository) error {
 // prepareGitPath try to find a suitable file path with file name by the given raw wiki name.
 // return: existence, prepared file path with name, error
 func prepareGitPath(ctx context.Context, gitRepo *git.Repository, defaultWikiBranch string, wikiPath WebPath) (bool, string, error) {
-	unescaped := string(wikiPath) + ".md"
-	gitPath := WebPathToGitPath(wikiPath)
+	gitPaths := WebPathToGitPathCandidates(wikiPath)
+	gitPath := gitPaths[0]
 
-	// Look for both files
-	filesInIndex, err := gitRepo.LsTree(ctx, defaultWikiBranch, unescaped, gitPath)
+	// Look for files using both the generated and literal Git path forms.
+	filesInIndex, err := gitRepo.LsTree(ctx, defaultWikiBranch, gitPaths...)
 	if err != nil {
 		if gitcmd.IsStderr(err, gitcmd.StderrNotValidObjectName) {
 			return false, gitPath, nil // branch doesn't exist
@@ -65,19 +66,34 @@ func prepareGitPath(ctx context.Context, gitRepo *git.Repository, defaultWikiBra
 		return false, gitPath, err
 	}
 
-	foundEscaped := false
-	for _, filename := range filesInIndex {
-		switch filename {
-		case unescaped:
-			// if we find the unescaped file return it
-			return true, unescaped, nil
-		case gitPath:
-			foundEscaped = true
+	for _, candidate := range gitPaths {
+		for _, filename := range filesInIndex {
+			if filename == candidate {
+				return true, candidate, nil
+			}
 		}
 	}
 
-	// If not return whether the escaped file exists, and the escaped filename to keep backwards compatibility.
-	return foundEscaped, gitPath, nil
+	// New pages must reuse the existing parent directory instead of creating a
+	// second directory whose normalized web path is identical.
+	commit, err := gitRepo.GetBranchCommit(ctx, defaultWikiBranch)
+	if err == nil {
+		for i := len(gitPaths) - 1; i >= 0; i-- {
+			parentPath := path.Dir(gitPaths[i])
+			if parentPath == "." {
+				continue
+			}
+			entry, err := commit.GetTreeEntryByPath(ctx, gitRepo, parentPath)
+			if err == nil && entry.IsDir() {
+				return false, gitPaths[i], nil
+			}
+			if err != nil && !git.IsErrNotExist(err) {
+				return false, gitPath, err
+			}
+		}
+	}
+
+	return false, gitPath, nil
 }
 
 // updateWikiPage adds a new page or edits an existing page in repository wiki.

--- a/services/wiki/wiki_path.go
+++ b/services/wiki/wiki_path.go
@@ -97,6 +97,23 @@ func WebPathToGitPath(s WebPath) string {
 	return WebDirPathToGitPath(s) + ".md"
 }
 
+// WebPathToGitPathCandidates returns the Gitea-generated path first, followed
+// by the literal Git path used when a wiki is populated outside the web editor.
+func WebPathToGitPathCandidates(s WebPath) []string {
+	paths := []string{WebPathToGitPath(s)}
+	if strings.HasSuffix(string(s), ".md") {
+		return paths
+	}
+
+	for _, dirPath := range WebDirPathToGitPathCandidates(s) {
+		literalPath := dirPath + ".md"
+		if literalPath != paths[0] {
+			paths = append(paths, literalPath)
+		}
+	}
+	return paths
+}
+
 func WebDirPathToGitPath(s WebPath) string {
 	a := strings.Split(string(s), "/")
 	for i := range a {
@@ -107,6 +124,19 @@ func WebDirPathToGitPath(s WebPath) string {
 		a[i] = strings.ReplaceAll(a[i], "+", " ")
 	}
 	return strings.Join(a, "/")
+}
+
+func WebDirPathToGitPathCandidates(s WebPath) []string {
+	paths := []string{WebDirPathToGitPath(s)}
+	segments := strings.Split(string(s), "/")
+	for i := range segments {
+		segments[i], _ = unescapeSegment(segments[i])
+	}
+	literalPath := util.PathJoinRelX(strings.Join(segments, "/"))
+	if literalPath != paths[0] {
+		paths = append(paths, literalPath)
+	}
+	return paths
 }
 
 func GitPathToWebPath(s string) (wp WebPath, err error) {

--- a/services/wiki/wiki_path.go
+++ b/services/wiki/wiki_path.go
@@ -183,8 +183,7 @@ func WebPathToURLPath(s WebPath) string {
 }
 
 func WebPathFromRequest(s string) (WebPath, error) {
-	segments := strings.Split(s, "/")
-	for _, segment := range segments {
+	for segment := range strings.SplitSeq(s, "/") {
 		unescaped, err := url.PathUnescape(segment)
 		if err != nil || unescaped == "." || unescaped == ".." {
 			return "", repo_model.ErrWikiInvalidFileName{FileName: s}

--- a/services/wiki/wiki_path.go
+++ b/services/wiki/wiki_path.go
@@ -30,12 +30,8 @@ import (
 //   - "/.wiki.git/Home-Page.md"
 //   - "/.wiki.git/100%25 Free.md"
 //   - "/.wiki.git/2000-01-02 meeting.-.md"
-// TODO: support subdirectory in the future
-//
-// Although this package now has the ability to support subdirectory, but the route package doesn't:
-// * Double-escaping problem: the URL "/wiki/abc%2Fdef" becomes "/wiki/abc/def" by ctx.PathParam, which is incorrect
-//   * This problem should have been 99% fixed, but it needs more tests.
-// * The old wiki code's behavior is always using %2F, instead of subdirectory, so there are a lot of legacy "%2F" files in user wikis.
+// A slash in a raw route parameter separates wiki path segments. An encoded slash
+// remains part of a segment so legacy "%2F" wiki page names keep working.
 
 type WebPath string
 
@@ -98,7 +94,10 @@ func WebPathToGitPath(s WebPath) string {
 		ret, _ := url.PathUnescape(string(s))
 		return util.PathJoinRelX(ret)
 	}
+	return WebDirPathToGitPath(s) + ".md"
+}
 
+func WebDirPathToGitPath(s WebPath) string {
 	a := strings.Split(string(s), "/")
 	for i := range a {
 		shouldAddDashMarker := hasDashMarker(a[i])
@@ -107,7 +106,7 @@ func WebPathToGitPath(s WebPath) string {
 		a[i] = strings.ReplaceAll(a[i], "%20", " ") // space is safe to be kept in git path
 		a[i] = strings.ReplaceAll(a[i], "+", " ")
 	}
-	return strings.Join(a, "/") + ".md"
+	return strings.Join(a, "/")
 }
 
 func GitPathToWebPath(s string) (wp WebPath, err error) {
@@ -115,6 +114,18 @@ func GitPathToWebPath(s string) (wp WebPath, err error) {
 		return "", repo_model.ErrWikiInvalidFileName{FileName: s}
 	}
 	s = strings.TrimSuffix(s, ".md")
+	a := strings.Split(s, "/")
+	for i := range a {
+		shouldAddDashMarker := hasDashMarker(a[i])
+		if a[i], err = unescapeSegment(a[i]); err != nil {
+			return "", err
+		}
+		a[i] = escapeSegToWeb(a[i], shouldAddDashMarker)
+	}
+	return WebPath(strings.Join(a, "/")), nil
+}
+
+func GitDirPathToWebPath(s string) (wp WebPath, err error) {
 	a := strings.Split(s, "/")
 	for i := range a {
 		shouldAddDashMarker := hasDashMarker(a[i])
@@ -141,11 +152,15 @@ func WebPathToURLPath(s WebPath) string {
 	return string(s)
 }
 
-func WebPathFromRequest(s string) WebPath {
-	s = util.PathJoinRelX(s)
-	// The old wiki code's behavior is always using %2F, instead of subdirectory.
-	s = strings.ReplaceAll(s, "/", "%2F")
-	return WebPath(s)
+func WebPathFromRequest(s string) (WebPath, error) {
+	segments := strings.Split(s, "/")
+	for _, segment := range segments {
+		unescaped, err := url.PathUnescape(segment)
+		if err != nil || unescaped == "." || unescaped == ".." {
+			return "", repo_model.ErrWikiInvalidFileName{FileName: s}
+		}
+	}
+	return WebPath(util.PathJoinRelX(s)), nil
 }
 
 func UserTitleToWebPath(base, title string) WebPath {

--- a/services/wiki/wiki_test.go
+++ b/services/wiki/wiki_test.go
@@ -322,7 +322,24 @@ func TestWebPathConversion(t *testing.T) {
 }
 
 func TestWebPathFromRequest(t *testing.T) {
-	assert.Equal(t, WebPath("a%2Fb"), WebPathFromRequest("a/b"))
-	assert.Equal(t, WebPath("a"), WebPathFromRequest("a"))
-	assert.Equal(t, WebPath("b"), WebPathFromRequest("a/../b"))
+	for _, test := range []struct {
+		request string
+		want    WebPath
+		gitPath string
+		wantErr bool
+	}{
+		{request: "a/b", want: "a/b", gitPath: "a/b.md"},
+		{request: "a%2Fb", want: "a%2Fb", gitPath: "a%2Fb.md"},
+		{request: "a%252Fb", want: "a%252Fb", gitPath: "a%252Fb.md"},
+		{request: "a", want: "a", gitPath: "a.md"},
+		{request: "a/%2e%2e/b", wantErr: true},
+		{request: "a/%", wantErr: true},
+	} {
+		got, err := WebPathFromRequest(test.request)
+		assert.Equal(t, test.wantErr, err != nil, "request: %q", test.request)
+		assert.Equal(t, test.want, got, "request: %q", test.request)
+		if !test.wantErr {
+			assert.Equal(t, test.gitPath, WebPathToGitPath(got), "request: %q", test.request)
+		}
+	}
 }

--- a/services/wiki/wiki_test.go
+++ b/services/wiki/wiki_test.go
@@ -84,6 +84,13 @@ func TestWebPathToGitPath(t *testing.T) {
 	}
 }
 
+func TestWebPathToGitPathCandidates(t *testing.T) {
+	assert.Equal(t, []string{"AI-Systems.md", "AI Systems.md"}, WebPathToGitPathCandidates("AI-Systems"))
+	assert.Equal(t, []string{"nested/AI-Systems.md", "nested/AI Systems.md"}, WebPathToGitPathCandidates("nested/AI-Systems"))
+	assert.Equal(t, []string{"AI-Systems.-.md", "AI-Systems.md"}, WebPathToGitPathCandidates("AI-Systems.-"))
+	assert.Equal(t, []string{"Misc-Ideas", "Misc Ideas"}, WebDirPathToGitPathCandidates("Misc-Ideas"))
+}
+
 func TestGitPathToWebPath(t *testing.T) {
 	type test struct {
 		Expected string

--- a/services/wiki/wiki_test.go
+++ b/services/wiki/wiki_test.go
@@ -322,6 +322,29 @@ func TestPrepareWikiFileName_FirstPage(t *testing.T) {
 	assert.Equal(t, "Home.md", newWikiPath)
 }
 
+func TestPrepareWikiFileName_ReusesExistingLiteralParent(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, git.InitRepositoryLocal(t.Context(), tmpDir, true, git.Sha1ObjectFormat.Name()))
+
+	gitRepo, err := git.OpenRepositoryLocal(t.Context(), tmpDir)
+	require.NoError(t, err)
+	defer gitRepo.Close()
+
+	objectHash, err := gitRepo.HashObjectBytes(t.Context(), []byte("existing"))
+	require.NoError(t, err)
+	require.NoError(t, gitRepo.AddObjectToIndex(t.Context(), "100644", objectHash, "SOAH GDD/Development/existing.md"))
+	tree, err := gitRepo.WriteTree(t.Context())
+	require.NoError(t, err)
+	commit, err := gitRepo.CommitTree(t.Context(), &git.Signature{Name: "Test", Email: "test@example.com"}, &git.Signature{Name: "Test", Email: "test@example.com"}, tree, git.CommitTreeOpts{Message: "seed", NoGPGSign: true})
+	require.NoError(t, err)
+	require.NoError(t, git.UpdateRef(t.Context(), gitRepo, git.BranchPrefix+"master", commit.String()))
+
+	exists, path, err := prepareGitPath(t.Context(), gitRepo, "master", "SOAH-GDD/Development/test")
+	assert.NoError(t, err)
+	assert.False(t, exists)
+	assert.Equal(t, "SOAH GDD/Development/test.md", path)
+}
+
 func TestWebPathConversion(t *testing.T) {
 	assert.Equal(t, "path/wiki", WebPathToURLPath(WebPath("path/wiki")))
 	assert.Equal(t, "wiki", WebPathToURLPath(WebPath("wiki")))

--- a/templates/repo/wiki/new.tmpl
+++ b/templates/repo/wiki/new.tmpl
@@ -6,7 +6,7 @@
 		<div class="ui header flex-left-right">
 			{{ctx.Locale.Tr "repo.wiki.new_page"}}
 			{{if .PageIsWikiEdit}}
-				<a class="ui tiny primary button" href="{{.RepoLink}}/wiki?action=_new">{{ctx.Locale.Tr "repo.wiki.new_page_button"}}</a>
+				<a class="ui tiny primary button" href="{{.RepoLink}}/wiki/{{.PageDir}}?action=_new">{{ctx.Locale.Tr "repo.wiki.new_page_button"}}</a>
 			{{end}}
 		</div>
 		<form class="ui form form-fetch-action" action="?action={{Iif .PageIsWikiEdit "_edit" "_new"}}" method="post" data-global-init="initRepoWikiForm">

--- a/templates/repo/wiki/pages.tmpl
+++ b/templates/repo/wiki/pages.tmpl
@@ -6,19 +6,28 @@
 			<span>{{ctx.Locale.Tr "repo.wiki.pages"}}</span>
 			<span>
 				{{if and .CanWriteWiki (not .Repository.IsMirror)}}
-					<a class="ui small primary button" href="{{.RepoLink}}/wiki?action=_new">{{ctx.Locale.Tr "repo.wiki.new_page_button"}}</a>
+					<a class="ui small primary button" href="{{.RepoLink}}/wiki/{{.PageDir}}?action=_new">{{ctx.Locale.Tr "repo.wiki.new_page_button"}}</a>
 				{{end}}
 			</span>
 		</h2>
 		{{if $.Permission.IsAdmin}}<div>{{ctx.Locale.Tr "repo.default_branch"}}: {{.Repository.DefaultWikiBranch}}</div>{{end}}
 		<table class="ui table selectable wiki-pages-list">
 			<tbody>
+				{{if .PageDir}}
+					<tr>
+						<td>
+							{{svg "octicon-file-directory-fill"}}
+							<a href="{{$.RepoLink}}/wiki/{{.ParentPageDir}}?action=_pages">..</a>
+						</td>
+						<td></td>
+					</tr>
+				{{end}}
 				{{range .Pages}}
 					<tr>
 						<td>
-							{{svg "octicon-file"}}
-							<a href="{{$.RepoLink}}/wiki/{{.SubURL}}">{{.Name}}</a>
-							<a class="wiki-git-entry" href="{{$.RepoLink}}/wiki/{{.GitEntryName | PathEscape}}" data-tooltip-content="{{ctx.Locale.Tr "repo.wiki.original_git_entry_tooltip"}}">{{svg "octicon-chevron-right"}}</a>
+							{{if .IsDir}}{{svg "octicon-file-directory-fill"}}{{else}}{{svg "octicon-file"}}{{end}}
+							<a href="{{$.RepoLink}}/wiki/{{.SubURL}}{{if .IsDir}}?action=_pages{{end}}">{{.Name}}</a>
+							<a class="wiki-git-entry" href="{{$.RepoLink}}/wiki/{{.SubURL}}{{if .IsDir}}?action=_pages{{end}}" data-tooltip-content="{{ctx.Locale.Tr "repo.wiki.original_git_entry_tooltip"}}">{{svg "octicon-chevron-right"}}</a>
 						</td>
 						{{$timeSince := DateUtils.TimeSince .UpdatedUnix}}
 						<td class="tw-text-right">{{ctx.Locale.Tr "repo.wiki.last_updated" $timeSince}}</td>

--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -21,7 +21,9 @@
 						<div class="scrolling menu">
 							<a class="item muted" href="{{.RepoLink}}/wiki/?action=_pages">{{ctx.Locale.Tr "repo.wiki.pages"}}</a>
 							<div class="divider"></div>
-							{{template "repo/wiki/tree" .}}
+							{{range .Pages}}
+								<a class="item {{if eq $.PageURL .SubURL}}selected{{end}}" href="{{$.RepoLink}}/wiki/{{.SubURL}}{{if .IsDir}}?action=_pages{{end}}">{{.Name}}</a>
+							{{end}}
 						</div>
 					</div>
 				</div>
@@ -60,9 +62,16 @@
 		{{end}}
 
 		<div class="wiki-content-parts">
-			{{if .WikiSidebarTocHTML}}
+			{{if or .WikiSidebarTocHTML .WikiTree}}
 			<div class="render-content markup wiki-content-sidebar wiki-content-toc" data-global-init="initRepoWikiSidebarToc">
-				{{.WikiSidebarTocHTML}}
+				{{if .WikiSidebarTocHTML}}{{.WikiSidebarTocHTML}}{{end}}
+				{{if .WikiTree}}
+					{{if .WikiSidebarTocHTML}}<hr>{{end}}
+					<details open>
+						<summary>{{ctx.Locale.Tr "repo.wiki.pages"}}</summary>
+						{{template "repo/wiki/tree" .}}
+					</details>
+				{{end}}
 			</div>
 			{{end}}
 
@@ -103,7 +112,7 @@
 {{template "base/footer" .}}
 
 {{define "repo/wiki/tree"}}
-	<ul class="tw-m-0 tw-pl-4">
+	<ul class="tw-m-0 tw-list-none tw-pl-4">
 		{{range .WikiTree}}
 			<li>
 				{{if .IsDir}}
@@ -120,7 +129,7 @@
 {{end}}
 
 {{define "repo/wiki/tree-nodes"}}
-	<ul class="tw-m-0 tw-pl-4">
+	<ul class="tw-m-0 tw-list-none tw-pl-4">
 		{{range .Nodes}}
 			<li>
 				{{if .IsDir}}

--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -75,7 +75,7 @@
 			</div>
 			{{end}}
 
-			<div class="render-content markup wiki-content-main {{if or .WikiSidebarTocHTML .WikiSidebarHTML}}with-sidebar{{end}}">
+			<div class="render-content markup wiki-content-main {{if or .WikiSidebarTocHTML .WikiSidebarHTML .WikiTree}}with-sidebar{{end}}">
 				{{template "repo/unicode_escape_prompt" dict "EscapeStatus" .EscapeStatus}}
 				{{.WikiContentHTML}}
 			</div>

--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -21,9 +21,7 @@
 						<div class="scrolling menu">
 							<a class="item muted" href="{{.RepoLink}}/wiki/?action=_pages">{{ctx.Locale.Tr "repo.wiki.pages"}}</a>
 							<div class="divider"></div>
-							{{range .Pages}}
-								<a class="item {{if eq $.Title .Name}}selected{{end}}" href="{{$.RepoLink}}/wiki/{{.SubURL}}{{if .IsDir}}?action=_pages{{end}}">{{.Name}}</a>
-							{{end}}
+							{{template "repo/wiki/tree" .}}
 						</div>
 					</div>
 				</div>
@@ -103,3 +101,37 @@
 </div>
 
 {{template "base/footer" .}}
+
+{{define "repo/wiki/tree"}}
+	<ul class="tw-m-0 tw-pl-4">
+		{{range .WikiTree}}
+			<li>
+				{{if .IsDir}}
+					<details{{if .Open}} open{{end}}>
+						<summary>{{svg "octicon-file-directory-fill"}} <a href="{{$.RepoLink}}/wiki/{{.SubURL}}?action=_pages">{{.Name}}</a></summary>
+						{{template "repo/wiki/tree-nodes" dict "Nodes" .Children "Root" $}}
+					</details>
+				{{else}}
+					<a class="{{if eq $.PageURL .SubURL}}selected{{end}}" href="{{$.RepoLink}}/wiki/{{.SubURL}}">{{svg "octicon-file"}} {{.Name}}</a>
+				{{end}}
+			</li>
+		{{end}}
+	</ul>
+{{end}}
+
+{{define "repo/wiki/tree-nodes"}}
+	<ul class="tw-m-0 tw-pl-4">
+		{{range .Nodes}}
+			<li>
+				{{if .IsDir}}
+					<details{{if .Open}} open{{end}}>
+						<summary>{{svg "octicon-file-directory-fill"}} <a href="{{$.Root.RepoLink}}/wiki/{{.SubURL}}?action=_pages">{{.Name}}</a></summary>
+						{{template "repo/wiki/tree-nodes" dict "Nodes" .Children "Root" $.Root}}
+					</details>
+				{{else}}
+					<a class="{{if eq $.Root.PageURL .SubURL}}selected{{end}}" href="{{$.Root.RepoLink}}/wiki/{{.SubURL}}">{{svg "octicon-file"}} {{.Name}}</a>
+				{{end}}
+			</li>
+		{{end}}
+	</ul>
+{{end}}

--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -22,7 +22,7 @@
 							<a class="item muted" href="{{.RepoLink}}/wiki/?action=_pages">{{ctx.Locale.Tr "repo.wiki.pages"}}</a>
 							<div class="divider"></div>
 							{{range .Pages}}
-								<a class="item {{if eq $.Title .Name}}selected{{end}}" href="{{$.RepoLink}}/wiki/{{.SubURL}}">{{.Name}}</a>
+								<a class="item {{if eq $.Title .Name}}selected{{end}}" href="{{$.RepoLink}}/wiki/{{.SubURL}}{{if .IsDir}}?action=_pages{{end}}">{{.Name}}</a>
 							{{end}}
 						</div>
 					</div>
@@ -49,7 +49,7 @@
 					{{end}}
 					{{if and .CanWriteWiki (not .Repository.IsMirror)}}
 						<a class="ui small button" href="{{.RepoLink}}/wiki/{{.PageURL}}?action=_edit">{{ctx.Locale.Tr "repo.wiki.edit_page_button"}}</a>
-						<a class="ui small primary button" href="{{.RepoLink}}/wiki?action=_new">{{ctx.Locale.Tr "repo.wiki.new_page_button"}}</a>
+						<a class="ui small primary button" href="{{.RepoLink}}/wiki/{{.PageDir}}?action=_new">{{ctx.Locale.Tr "repo.wiki.new_page_button"}}</a>
 						<a class="ui small red button link-action" href data-modal-confirm="#repo-wiki-delete-page-modal" data-url="{{.RepoLink}}/wiki/{{.PageURL}}?action=_delete">{{ctx.Locale.Tr "repo.wiki.delete_page_button"}}</a>
 					{{end}}
 				</div>


### PR DESCRIPTION
Adds native support for wiki pages stored in subdirectories.

Users can browse nested folders from the pages view and sidebar tree, open nested pages, keep relative links relative to their page, and create new pages in the current folder. Existing flat wikis and legacy encoded-slash page names remain supported.

Tested with a Git-backed wiki containing nested pages, folders, literal spaces, and ampersands; verified in a self-hosted deployment. Focused wiki path, rendering, and router tests pass.

Reference: https://github.com/go-gitea/gitea/issues/823

Assisted by: Codex, supervised by Pachinko0.