### PR TITLE
fix(ui): respect FEED_PAGING_NUM on the dashboard feed

### DIFF
--- a/routers/web/user/home.go
+++ b/routers/web/user/home.go
@@ -111,7 +111,7 @@ func Dashboard(ctx *context.Context) {
 
 	prepareHeatmapURL(ctx)
 
-	pageSize := setting.UI.User.RepoPagingNum
+	pageSize := setting.UI.FeedPagingNum
 	feeds, count, err := feed_service.GetFeedsForDashboard(ctx, activities_model.GetFeedsOptions{
 		RequestedUser:   ctxUser,
 		RequestedTeam:   ctx.Org.Team,


### PR DESCRIPTION

The dashboard activity feed was paginated with `[ui.user] REPO_PAGING_NUM`
instead of `[ui] FEED_PAGING_NUM`.

The wrong setting was picked up when the page size was hoisted into a local
variable in https://github.com/go-gitea/gitea/pull/34994, most likely copied
from the `dashboardRepoList` block a few lines above. `REPO_PAGING_NUM` should
only control repository lists.

Fixes https://github.com/go-gitea/gitea/issues/38925