### PR TITLE
fix(migrations): drop SQLite columns natively instead of by schema text

### DIFF
--- a/modelmigration/base/db.go
+++ b/modelmigration/base/db.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"regexp"
+	"slices"
 	"strings"
 
 	"gitea.dev/models/db" //nolint:depguard // allow to access db in migration
@@ -318,85 +318,54 @@ func DropTableColumns(sess Session, tableName string, columnNames ...string) (er
 
 	switch {
 	case setting.Database.Type.IsSQLite3():
-		// First drop the indexes on the columns
-		res, errIndex := sess.Query(fmt.Sprintf("PRAGMA index_list(`%s`)", tableName))
-		if errIndex != nil {
-			return errIndex
-		}
-		for _, row := range res {
-			indexName := row["name"]
-			indexRes, err := sess.Query(fmt.Sprintf("PRAGMA index_info(`%s`)", indexName))
-			if err != nil {
-				return err
-			}
-			if len(indexRes) != 1 {
-				continue
-			}
-			indexColumn := string(indexRes[0]["name"])
-			for _, name := range columnNames {
-				if name == indexColumn {
-					_, err := sess.Exec(fmt.Sprintf("DROP INDEX `%s`", indexName))
-					if err != nil {
-						return err
-					}
-				}
-			}
-		}
-
-		// Here we need to get the columns from the original table
-		sql := fmt.Sprintf("SELECT sql FROM sqlite_master WHERE tbl_name='%s' and type='table'", tableName)
-		res, err := sess.Query(sql)
+		existing, err := sess.Query(fmt.Sprintf("PRAGMA table_info(`%s`)", tableName))
 		if err != nil {
 			return err
 		}
-		tableSQL := string(res[0]["sql"])
-
-		// Get the string offset for column definitions: `CREATE TABLE ( column-definitions... )`
-		columnDefinitionsIndex := strings.Index(tableSQL, "(")
-		if columnDefinitionsIndex < 0 {
-			return errors.New("couldn't find column definitions")
-		}
-
-		// Separate out the column definitions
-		tableSQL = tableSQL[columnDefinitionsIndex:]
-
-		// Remove the required columnNames
+		dropColumns := make([]string, 0, len(columnNames))
 		for _, name := range columnNames {
-			tableSQL = regexp.MustCompile(regexp.QuoteMeta("`"+name+"`")+"[^`,)]*?[,)]").ReplaceAllString(tableSQL, "")
-		}
-
-		// Ensure the query is ended properly
-		tableSQL = strings.TrimSpace(tableSQL)
-		if tableSQL[len(tableSQL)-1] != ')' {
-			if tableSQL[len(tableSQL)-1] == ',' {
-				tableSQL = tableSQL[:len(tableSQL)-1]
+			if slices.ContainsFunc(existing, func(row map[string][]byte) bool {
+				return strings.EqualFold(string(row["name"]), name)
+			}) {
+				dropColumns = append(dropColumns, name)
 			}
-			tableSQL += ")"
+		}
+		if len(dropColumns) == 0 {
+			return nil
 		}
 
-		// Find all the columns in the table
-		columns := regexp.MustCompile("`([^`]*)`").FindAllString(tableSQL, -1)
-
-		tableSQL = fmt.Sprintf("CREATE TABLE `new_%s_new` ", tableName) + tableSQL
-		if _, err := sess.Exec(tableSQL); err != nil {
+		// SQLite refuses to drop a column while any index still covers it, so remove those indexes first
+		indexes, err := sess.Query(fmt.Sprintf("PRAGMA index_list(`%s`)", tableName))
+		if err != nil {
 			return err
 		}
-
-		// Now restore the data
-		columnsSeparated := strings.Join(columns, ",")
-		insertSQL := fmt.Sprintf("INSERT INTO `new_%s_new` (%s) SELECT %s FROM %s", tableName, columnsSeparated, columnsSeparated, tableName)
-		if _, err := sess.Exec(insertSQL); err != nil {
-			return err
+		for _, index := range indexes {
+			indexName := string(index["name"])
+			// an auto-index backs a PRIMARY KEY or UNIQUE constraint and cannot be dropped on its own
+			if strings.HasPrefix(indexName, "sqlite_autoindex_") {
+				continue
+			}
+			indexCols, err := sess.Query(fmt.Sprintf("PRAGMA index_info(`%s`)", indexName))
+			if err != nil {
+				return err
+			}
+			covered := slices.ContainsFunc(indexCols, func(indexCol map[string][]byte) bool {
+				return slices.ContainsFunc(dropColumns, func(name string) bool {
+					return strings.EqualFold(string(indexCol["name"]), name)
+				})
+			})
+			if !covered {
+				continue
+			}
+			if _, err := sess.Exec(fmt.Sprintf("DROP INDEX `%s`", indexName)); err != nil {
+				return err
+			}
 		}
 
-		// Now drop the old table
-		if _, err := sess.Exec(fmt.Sprintf("DROP TABLE `%s`", tableName)); err != nil {
-			return err
-		}
-
-		// Rename the table
-		if _, err := sess.Exec(fmt.Sprintf("ALTER TABLE `new_%s_new` RENAME TO `%s`", tableName, tableName)); err != nil {
-			return err
+		for _, name := range dropColumns {
+			if _, err := sess.Exec(fmt.Sprintf("ALTER TABLE `%s` DROP COLUMN `%s`", tableName, name)); err != nil {
+				return fmt.Errorf("drop table `%s` column `%s`: %w", tableName, name, err)
+			}
 		}
 
 	case setting.Database.Type.IsPostgreSQL():

--- a/modelmigration/base/db_test.go
+++ b/modelmigration/base/db_test.go
@@ -8,13 +8,54 @@ import (
 
 	"gitea.dev/modelmigration/base"
 	"gitea.dev/modelmigration/migrationtest"
+	"gitea.dev/modules/setting"
 	"gitea.dev/modules/timeutil"
 
+	"github.com/stretchr/testify/require"
 	"xorm.io/xorm/names"
 )
 
 func TestMain(m *testing.M) {
 	migrationtest.MainTest(m)
+}
+
+func Test_DropTableColumnsWithForeignSchemaText(t *testing.T) {
+	if !setting.Database.Type.IsSQLite3() {
+		t.Skip("only SQLite drops columns based on the stored schema of the table")
+	}
+
+	x, deferable := migrationtest.PrepareTestEnv(t, 0)
+	defer deferable()
+	if x == nil || t.Failed() {
+		t.Skip("PrepareTestEnv did not yield a usable engine")
+	}
+
+	// identifiers quoted the standard SQL way instead of with backticks, as written by external tools that rebuild the database
+	_, err := x.Exec(`CREATE TABLE "drop_test" ("id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, "repo_id" INTEGER NULL, "to_drop_column" TEXT NOT NULL)`)
+	require.NoError(t, err)
+	// a later xorm sync appends its own columns, leaving the stored schema with mixed quoting
+	_, err = x.Exec("ALTER TABLE `drop_test` ADD COLUMN `keep_column` TEXT NULL")
+	require.NoError(t, err)
+	// a composite index over the dropped column: SQLite refuses to drop a column any index still covers
+	_, err = x.Exec("CREATE INDEX `IDX_drop_test_repo_to_drop` ON `drop_test` (`repo_id`,`to_drop_column`)")
+	require.NoError(t, err)
+	_, err = x.Exec(`INSERT INTO "drop_test" ("repo_id", "keep_column", "to_drop_column") VALUES (1, 'keep', 'drop')`)
+	require.NoError(t, err)
+
+	sess := x.NewSession()
+	defer sess.Close()
+	require.NoError(t, sess.Begin())
+	require.NoError(t, base.DropTableColumns(sess, "drop_test", "to_drop_column"))
+	require.NoError(t, sess.Commit())
+
+	exist, err := x.Dialect().IsColumnExist(x.DB(), t.Context(), "drop_test", "to_drop_column")
+	require.NoError(t, err)
+	require.False(t, exist, "to_drop_column must be gone")
+
+	rows, err := x.Query(`SELECT "keep_column" FROM "drop_test"`)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "keep", string(rows[0]["keep_column"]))
 }
 
 func Test_DropTableColumns(t *testing.T) {

--- a/modelmigration/migrations.go
+++ b/modelmigration/migrations.go
@@ -422,6 +422,7 @@ func prepareMigrationTasks() []*migration {
 		newMigration(346, "Add license_path column to repo_license and backfill", v28.AddLicensePathToRepoLicense),
 		newMigration(347, "Add watch options", v28.AddWatchOptions),
 		newMigration(348, "Recreate email_hash table for SHA256 avatar hashes", v28.RecreateEmailHashTable),
+		newMigration(349, "Drop leftover legacy concurrency columns from action_run", v28.DropLeftoverActionRunConcurrencyColumns),
 	}
 	return preparedMigrations
 }

--- a/modelmigration/v1_27/v331.go
+++ b/modelmigration/v1_27/v331.go
@@ -152,7 +152,6 @@ func AddActionRunAttemptModel(ctx context.Context, x base.EngineMigration) error
 	if err := base.DropTableColumns(sess, "action_run", concurrencyColumns...); err != nil {
 		return err
 	}
-	// DropTableColumns rebuilds the table on SQLite, which drops all existing indexes.
-	// Re-sync to restore the indexes defined on actionRun.
+	// DropTableColumns removes the indexes covering the dropped columns, so re-sync to restore the ones defined on actionRun.
 	return x.Sync(new(actionRun))
 }

--- a/modelmigration/v28/v349.go
+++ b/modelmigration/v28/v349.go
@@ -1,0 +1,39 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v28
+
+import (
+	"context"
+
+	"gitea.dev/modelmigration/base"
+)
+
+// DropLeftoverActionRunConcurrencyColumns re-runs the "action_run" column drop of migration 331.
+// On SQLite that drop used to be a no-op whenever the stored schema text did not quote identifiers
+// with backticks, leaving a NOT NULL column that no model writes, so every run insert failed.
+func DropLeftoverActionRunConcurrencyColumns(ctx context.Context, x base.EngineMigration) error {
+	leftover := make([]string, 0, 2)
+	for _, col := range []string{"concurrency_group", "concurrency_cancel"} {
+		exist, err := x.Dialect().IsColumnExist(x.DB(), ctx, "action_run", col)
+		if err != nil {
+			return err
+		}
+		if exist {
+			leftover = append(leftover, col)
+		}
+	}
+	if len(leftover) == 0 {
+		return nil
+	}
+
+	sess := x.NewSession()
+	defer sess.Close()
+	if err := sess.Begin(); err != nil {
+		return err
+	}
+	if err := base.DropTableColumns(sess, "action_run", leftover...); err != nil {
+		return err
+	}
+	return sess.Commit()
+}

--- a/modelmigration/v28/v349_test.go
+++ b/modelmigration/v28/v349_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v28
+
+import (
+	"testing"
+
+	"gitea.dev/modelmigration/migrationtest"
+
+	"github.com/stretchr/testify/require"
+)
+
+type actionRunBeforeV349 struct {
+	ID                int64  `xorm:"pk autoincr"`
+	RepoID            int64  `xorm:"index(repo_concurrency)"`
+	ConcurrencyGroup  string `xorm:"index(repo_concurrency) NOT NULL DEFAULT ''"`
+	ConcurrencyCancel bool   `xorm:"NOT NULL DEFAULT FALSE"`
+}
+
+func (actionRunBeforeV349) TableName() string {
+	return "action_run"
+}
+
+func TestDropLeftoverActionRunConcurrencyColumns(t *testing.T) {
+	x, deferable := migrationtest.PrepareTestEnv(t, 0, new(actionRunBeforeV349))
+	defer deferable()
+	if x == nil || t.Failed() {
+		return
+	}
+
+	_, err := x.Insert(&actionRunBeforeV349{RepoID: 1, ConcurrencyGroup: "group"})
+	require.NoError(t, err)
+
+	require.NoError(t, DropLeftoverActionRunConcurrencyColumns(t.Context(), x))
+
+	for _, col := range []string{"concurrency_group", "concurrency_cancel"} {
+		exist, err := x.Dialect().IsColumnExist(x.DB(), t.Context(), "action_run", col)
+		require.NoError(t, err)
+		require.False(t, exist, "%s must be gone", col)
+	}
+
+	count, err := x.Table("action_run").Count()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, count, "existing runs must survive")
+
+	require.NoError(t, DropLeftoverActionRunConcurrencyColumns(t.Context(), x), "re-running must be a no-op")
+}


### PR DESCRIPTION
The SQLite path of `DropTableColumns` rebuilt the table from the `CREATE TABLE` text in `sqlite_master` and stripped the target columns with a regex that only matched backtick-quoted identifiers. On a database whose schema text was written by another tool, the strip matched nothing, the rebuild copied the column straight across, and the migration still returned success.

Migration 331 drops `action_run.concurrency_group` that way. Where the drop silently did nothing, the leftover `NOT NULL` column is one no model writes any more, so every run insert fails and no workflow can start:

```
[E] repo owner/repo.git: PrepareRunAndInsert: InsertRun: constraint failed: NOT NULL constraint failed: action_run.concurrency_group (1299)
```

`ALTER TABLE ... DROP COLUMN` is quoting agnostic and available since SQLite 3.35, well below what either bundled driver ships. Using it also means the index cleanup has to cover composite indexes, not just single-column ones — SQLite refuses to drop a column any index still references, and `IDX_action_run_repo_concurrency` is exactly such an index.

Migration 349 re-runs the `action_run` drop, since instances already past 331 do not get another chance at it.

Not backportable to 1.27: 1.27.0 ends at migration ID 342 and 343 is taken by 1.28, so a new migration cannot be added to the release branch. Affected 1.27 instances can drop the two columns by hand in the meantime.

Fixes https://github.com/go-gitea/gitea/issues/38916