### PR TITLE
ci: install `node` for renovate post-upgrade tasks

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -21,6 +21,7 @@
     "commands": ["make tidy", "make svg", "make generate-codemirror-languages"],
     "installTools": {
       "golang": {},
+      "node": {},
       "pnpm": {},
     },
     "fileFilters": [


### PR DESCRIPTION
Containerbase declares `node` as the parent of `pnpm`, so `install-tool pnpm` aborts with `MissingParent` (exit 16) when node was never installed as a containerbase tool. Renovate's npm manager installs node itself, so this only breaks on branches without an npm update, where the failed install blocks every post-upgrade command including `make tidy`, leaving an untidy `go.sum` behind.

Seen on https://github.com/go-gitea/gitea/pull/38914.

Verified in `ghcr.io/renovatebot/renovate:latest`:

```
install-tool pnpm 11.22.0                    exit=16
  FATAL: parent tool not installed  tool: "pnpm"  parent: "node"
install-tool node 22.18.0 && install-tool pnpm 11.22.0   exit=0
```

Assisted-by: Claude Code:claude-opus-5