### PR TITLE
feat(storage): add storage_path column to repository

### DIFF
--- a/modelmigration/migrations.go
+++ b/modelmigration/migrations.go
@@ -422,6 +422,7 @@ func prepareMigrationTasks() []*migration {
 		newMigration(346, "Add license_path column to repo_license and backfill", v28.AddLicensePathToRepoLicense),
 		newMigration(347, "Add watch options", v28.AddWatchOptions),
 		newMigration(348, "Recreate email_hash table for SHA256 avatar hashes", v28.RecreateEmailHashTable),
+		newMigration(349, "Add storage_path column to repository", v28.AddStoragePathToRepository),
 	}
 	return preparedMigrations
 }

--- a/modelmigration/v28/v349.go
+++ b/modelmigration/v28/v349.go
@@ -1,0 +1,25 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v28
+
+import (
+	"context"
+
+	"gitea.dev/modelmigration/base"
+
+	"xorm.io/xorm"
+)
+
+func AddStoragePathToRepository(_ context.Context, x base.EngineMigration) error {
+	// Empty by default: existing repositories keep using the legacy
+	// `lower(owner)/lower(name).git` convention on disk.
+	type Repository struct {
+		StoragePath string `xorm:"VARCHAR(255)"`
+	}
+	_, err := x.SyncWithOptions(xorm.SyncOptions{
+		IgnoreDropIndices: true,
+		IgnoreConstrains:  true,
+	}, new(Repository))
+	return err
+}

--- a/modelmigration/v28/v349_test.go
+++ b/modelmigration/v28/v349_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v28
+
+import (
+	"testing"
+
+	"gitea.dev/modelmigration/migrationtest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// repositoryBeforeV349 mirrors the pre-migration repository table: no
+// storage_path column.
+type repositoryBeforeV349 struct {
+	ID        int64 `xorm:"pk autoincr"`
+	OwnerID   int64
+	OwnerName string
+	LowerName string
+	Name      string
+}
+
+func (repositoryBeforeV349) TableName() string { return "repository" }
+
+func Test_AddStoragePathToRepository(t *testing.T) {
+	x, deferable := migrationtest.PrepareTestEnv(t, 0, new(repositoryBeforeV349))
+	defer deferable()
+
+	_, err := x.Insert(&repositoryBeforeV349{OwnerID: 1, OwnerName: "user2", LowerName: "repo1", Name: "repo1"})
+	require.NoError(t, err)
+
+	require.NoError(t, AddStoragePathToRepository(t.Context(), x))
+	require.NoError(t, AddStoragePathToRepository(t.Context(), x)) // idempotent
+
+	type row struct {
+		StoragePath string
+	}
+	var rows []row
+	require.NoError(t, x.SQL("SELECT storage_path FROM repository").Find(&rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "", rows[0].StoragePath, "existing rows keep the legacy convention")
+}

--- a/models/repo/repo.go
+++ b/models/repo/repo.go
@@ -211,6 +211,11 @@ type Repository struct {
 	Topics                          []string           `xorm:"TEXT JSON"`
 	ObjectFormatName                string             `xorm:"VARCHAR(6) NOT NULL DEFAULT 'sha1'"`
 
+	// StoragePath is the relative path of the repository on disk. Empty means
+	// the legacy convention `lower(owner)/lower(name).git`, e.g.: sub-groups
+	// will store repositories at a different location.
+	StoragePath string `xorm:"VARCHAR(255)"`
+
 	TrustModel TrustModelType
 
 	// Avatar: ID(10-20)-md5(32) - must fit into 64 symbols

--- a/models/repo/repo_location.go
+++ b/models/repo/repo_location.go
@@ -7,21 +7,32 @@ import (
 	"strconv"
 
 	"gitea.dev/modules/git/gitrepo"
+	"gitea.dev/modules/util"
 )
 
 func repoCodeGitRepoManagedID(repoID int64) string {
 	return "repo-" + strconv.FormatInt(repoID, 10)
 }
 
+// repoCodeGitRepoRelativePath returns the relative path of the code
+// repository on disk. The StoragePath column overrides the legacy
+// `lower(owner)/lower(name).git` convention, e.g.: for sub-group support.
+func (repo *Repository) repoCodeGitRepoRelativePath() string {
+	if repo.StoragePath != "" {
+		return util.PathJoinRelX(repo.StoragePath)
+	}
+	return gitrepo.RepoCodeGitRepoRelativePath(repo.OwnerName, repo.Name)
+}
+
 func (repo *Repository) CodeStorageRepo() gitrepo.RepositoryFacade {
 	id := repoCodeGitRepoManagedID(repo.ID)
-	relPath := gitrepo.RepoCodeGitRepoRelativePath(repo.OwnerName, repo.Name)
+	relPath := repo.repoCodeGitRepoRelativePath()
 	return gitrepo.RepositoryManaged(id, relPath)
 }
 
 func (repo *Repository) GitRepoLocation() string {
 	// TODO: use CodeGitRepo instead of this one
-	return gitrepo.RepoCodeGitRepoRelativePath(repo.OwnerName, repo.Name)
+	return repo.repoCodeGitRepoRelativePath()
 }
 
 func (repo *Repository) GitRepoManagedID() string {

--- a/models/repo/repo_location_test.go
+++ b/models/repo/repo_location_test.go
@@ -4,6 +4,7 @@
 package repo_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	repo_model "gitea.dev/models/repo"
@@ -24,4 +25,17 @@ func TestRepository_GitRepo(t *testing.T) {
 	assert.Equal(t, "user2/repo1.wiki.git", gitrepo.WikiRepoByName(repo.OwnerName, repo.Name).GitRepoLocation())
 	assert.Equal(t, "user2/repo1.wiki.git", repo.WikiStorageRepo().GitRepoLocation())
 	assert.Equal(t, "repo-wiki-1", repo.WikiStorageRepo().GitRepoManagedID())
+}
+
+func TestRepository_GitRepo_WithStoragePath(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+
+	// a custom storage path overrides the legacy owner/name convention;
+	// the managed id stays unchanged
+	repo.StoragePath = "user2/group/repo1.git"
+
+	assert.Equal(t, filepath.FromSlash("user2/group/repo1.git"), repo.CodeStorageRepo().GitRepoLocation())
+	assert.Equal(t, "user2/group/repo1.git", repo.GitRepoLocation())
+	assert.Equal(t, "repo-1", repo.CodeStorageRepo().GitRepoManagedID())
 }


### PR DESCRIPTION
Add a `storage_path` column to the `repository` table storing the relative path of the repository on disk - the foundation for sub-group support (https://github.com/go-gitea/gitea/issues/1872).

An empty value keeps the legacy `lower(owner)/lower(name).git` convention, so existing repositories and all current behavior are unaffected. Only code repositories with a set value resolve to the custom location.

Covered by unit tests: migration idempotency and path resolution.