### PR TITLE
fix(storage): honor storage path on repo transfer and rename

### DIFF
--- a/modelmigration/migrations.go
+++ b/modelmigration/migrations.go
@@ -422,6 +422,7 @@ func prepareMigrationTasks() []*migration {
 		newMigration(346, "Add license_path column to repo_license and backfill", v28.AddLicensePathToRepoLicense),
 		newMigration(347, "Add watch options", v28.AddWatchOptions),
 		newMigration(348, "Recreate email_hash table for SHA256 avatar hashes", v28.RecreateEmailHashTable),
+		newMigration(349, "Add storage_path column to repository", v28.AddStoragePathToRepository),
 	}
 	return preparedMigrations
 }

--- a/modelmigration/v28/v349.go
+++ b/modelmigration/v28/v349.go
@@ -1,0 +1,25 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v28
+
+import (
+	"context"
+
+	"gitea.dev/modelmigration/base"
+
+	"xorm.io/xorm"
+)
+
+func AddStoragePathToRepository(_ context.Context, x base.EngineMigration) error {
+	// Empty by default: existing repositories keep using the legacy
+	// `lower(owner)/lower(name).git` convention on disk.
+	type Repository struct {
+		StoragePath string `xorm:"VARCHAR(255)"`
+	}
+	_, err := x.SyncWithOptions(xorm.SyncOptions{
+		IgnoreDropIndices: true,
+		IgnoreConstrains:  true,
+	}, new(Repository))
+	return err
+}

--- a/modelmigration/v28/v349_test.go
+++ b/modelmigration/v28/v349_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v28
+
+import (
+	"testing"
+
+	"gitea.dev/modelmigration/migrationtest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// repositoryBeforeV349 mirrors the pre-migration repository table: no
+// storage_path column.
+type repositoryBeforeV349 struct {
+	ID        int64 `xorm:"pk autoincr"`
+	OwnerID   int64
+	OwnerName string
+	LowerName string
+	Name      string
+}
+
+func (repositoryBeforeV349) TableName() string { return "repository" }
+
+func Test_AddStoragePathToRepository(t *testing.T) {
+	x, deferable := migrationtest.PrepareTestEnv(t, 0, new(repositoryBeforeV349))
+	defer deferable()
+
+	_, err := x.Insert(&repositoryBeforeV349{OwnerID: 1, OwnerName: "user2", LowerName: "repo1", Name: "repo1"})
+	require.NoError(t, err)
+
+	require.NoError(t, AddStoragePathToRepository(t.Context(), x))
+	require.NoError(t, AddStoragePathToRepository(t.Context(), x)) // idempotent
+
+	type row struct {
+		StoragePath string
+	}
+	var rows []row
+	require.NoError(t, x.SQL("SELECT storage_path FROM repository").Find(&rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "", rows[0].StoragePath, "existing rows keep the legacy convention")
+}

--- a/models/repo/repo.go
+++ b/models/repo/repo.go
@@ -211,6 +211,11 @@ type Repository struct {
 	Topics                          []string           `xorm:"TEXT JSON"`
 	ObjectFormatName                string             `xorm:"VARCHAR(6) NOT NULL DEFAULT 'sha1'"`
 
+	// StoragePath is the relative path of the repository on disk. Empty means
+	// the legacy convention `lower(owner)/lower(name).git`, e.g.: sub-groups
+	// will store repositories at a different location.
+	StoragePath string `xorm:"VARCHAR(255)"`
+
 	TrustModel TrustModelType
 
 	// Avatar: ID(10-20)-md5(32) - must fit into 64 symbols

--- a/models/repo/repo_location.go
+++ b/models/repo/repo_location.go
@@ -7,21 +7,32 @@ import (
 	"strconv"
 
 	"gitea.dev/modules/git/gitrepo"
+	"gitea.dev/modules/util"
 )
 
 func repoCodeGitRepoManagedID(repoID int64) string {
 	return "repo-" + strconv.FormatInt(repoID, 10)
 }
 
+// repoCodeGitRepoRelativePath returns the relative path of the code
+// repository on disk. The StoragePath column overrides the legacy
+// `lower(owner)/lower(name).git` convention, e.g.: for sub-group support.
+func (repo *Repository) repoCodeGitRepoRelativePath() string {
+	if repo.StoragePath != "" {
+		return util.PathJoinRelX(repo.StoragePath)
+	}
+	return gitrepo.RepoCodeGitRepoRelativePath(repo.OwnerName, repo.Name)
+}
+
 func (repo *Repository) CodeStorageRepo() gitrepo.RepositoryFacade {
 	id := repoCodeGitRepoManagedID(repo.ID)
-	relPath := gitrepo.RepoCodeGitRepoRelativePath(repo.OwnerName, repo.Name)
+	relPath := repo.repoCodeGitRepoRelativePath()
 	return gitrepo.RepositoryManaged(id, relPath)
 }
 
 func (repo *Repository) GitRepoLocation() string {
 	// TODO: use CodeGitRepo instead of this one
-	return gitrepo.RepoCodeGitRepoRelativePath(repo.OwnerName, repo.Name)
+	return repo.repoCodeGitRepoRelativePath()
 }
 
 func (repo *Repository) GitRepoManagedID() string {

--- a/models/repo/repo_location_test.go
+++ b/models/repo/repo_location_test.go
@@ -4,6 +4,7 @@
 package repo_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	repo_model "gitea.dev/models/repo"
@@ -24,4 +25,17 @@ func TestRepository_GitRepo(t *testing.T) {
 	assert.Equal(t, "user2/repo1.wiki.git", gitrepo.WikiRepoByName(repo.OwnerName, repo.Name).GitRepoLocation())
 	assert.Equal(t, "user2/repo1.wiki.git", repo.WikiStorageRepo().GitRepoLocation())
 	assert.Equal(t, "repo-wiki-1", repo.WikiStorageRepo().GitRepoManagedID())
+}
+
+func TestRepository_GitRepo_WithStoragePath(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+
+	// a custom storage path overrides the legacy owner/name convention;
+	// the managed id stays unchanged
+	repo.StoragePath = "user2/group/repo1.git"
+
+	assert.Equal(t, filepath.FromSlash("user2/group/repo1.git"), repo.CodeStorageRepo().GitRepoLocation())
+	assert.Equal(t, "user2/group/repo1.git", repo.GitRepoLocation())
+	assert.Equal(t, "repo-1", repo.CodeStorageRepo().GitRepoManagedID())
 }

--- a/services/repository/transfer.go
+++ b/services/repository/transfer.go
@@ -165,6 +165,8 @@ func transferOwnership(ctx context.Context, doer *user_model.User, newOwnerName 
 
 	oldOwner := repo.Owner
 	oldOwnerName = oldOwner.Name
+	// GitRepoLocation() depends on OwnerName, remember it before switching owners.
+	oldCodeRepoLoc := repo.GitRepoLocation()
 
 	// Note: we have to set value here to make sure recalculate accesses is based on
 	// new owner.
@@ -304,12 +306,18 @@ func transferOwnership(ctx context.Context, doer *user_model.User, newOwnerName 
 	}
 
 	// Rename remote repository to new path and delete local copy.
-	oldCodeRepo := gitrepo.CodeRepoByName(oldOwner.Name, repo.Name)
+	oldCodeRepo := gitrepo.RepositoryUnmanaged(oldCodeRepoLoc)
 	newCodeRepo := gitrepo.CodeRepoByName(newOwner.Name, repo.Name)
-	if err := git.RenameRepository(ctx, oldCodeRepo, newCodeRepo); err != nil {
-		return fmt.Errorf("rename repository directory: %w", err)
+	if repo.StoragePath != "" {
+		// a custom storage location is stable across owner changes
+		newCodeRepo = oldCodeRepo
 	}
-	repoRenamed = true
+	if oldCodeRepo.GitRepoLocation() != newCodeRepo.GitRepoLocation() {
+		if err := git.RenameRepository(ctx, oldCodeRepo, newCodeRepo); err != nil {
+			return fmt.Errorf("rename repository directory: %w", err)
+		}
+		repoRenamed = true
+	}
 
 	// Rename remote wiki repository to new path and delete local copy.
 	oldWikiRepo := gitrepo.WikiRepoByName(oldOwner.Name, repo.Name)
@@ -377,9 +385,16 @@ func changeRepositoryName(ctx context.Context, repo *repo_model.Repository, newR
 		}
 	}
 
+	oldCodeRepo := repo.CodeStorageRepo()
 	newCodeRepo := gitrepo.CodeRepoByName(repo.OwnerName, newRepoName)
-	if err = git.RenameRepository(ctx, repo, newCodeRepo); err != nil {
-		return fmt.Errorf("rename repository directory: %w", err)
+	if repo.StoragePath != "" {
+		// a custom storage location is stable across renames
+		newCodeRepo = oldCodeRepo
+	}
+	if oldCodeRepo.GitRepoLocation() != newCodeRepo.GitRepoLocation() {
+		if err = git.RenameRepository(ctx, oldCodeRepo, newCodeRepo); err != nil {
+			return fmt.Errorf("rename repository directory: %w", err)
+		}
 	}
 
 	if HasWiki(ctx, repo) {

--- a/services/repository/transfer_test.go
+++ b/services/repository/transfer_test.go
@@ -4,6 +4,7 @@
 package repository
 
 import (
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -60,6 +61,42 @@ func TestTransferOwnership(t *testing.T) {
 		RepoID:    3,
 		Content:   "org3/repo3",
 	})
+
+	unittest.CheckConsistencyFor(t, &repo_model.Repository{}, &user_model.User{}, &organization.Team{})
+}
+
+func TestTransferOwnershipWithStoragePath(t *testing.T) {
+	registerNotifier()
+
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	doer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 1})
+	sourceRepo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 3})
+	assert.NoError(t, sourceRepo.LoadOwner(t.Context()))
+
+	// simulate a repository stored at a custom location (e.g.: a sub-group)
+	sourceRepo.StoragePath = "org3/custom/repo3.git"
+	require.NoError(t, repo_model.UpdateRepositoryColsNoAutoTime(t.Context(), sourceRepo, "storage_path"))
+
+	// cancel the fixture transfer and start a new one to a user whose
+	// directory is untouched by other tests
+	transfer, err := repo_model.GetPendingRepositoryTransfer(t.Context(), sourceRepo)
+	require.NoError(t, err)
+	require.NoError(t, CancelRepositoryTransfer(t.Context(), transfer, doer))
+	recipient := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	require.NoError(t, repo_model.CreatePendingRepositoryTransfer(t.Context(), doer, recipient, sourceRepo.ID, nil))
+
+	// the recipient accepts the transfer
+	require.NoError(t, AcceptTransferOwnership(t.Context(), sourceRepo, recipient))
+
+	transferredRepo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 3})
+	assert.EqualValues(t, 2, transferredRepo.OwnerID)
+	assert.Equal(t, "org3/custom/repo3.git", transferredRepo.StoragePath)
+	// the custom storage location is kept as-is, it is not renamed to the new owner path
+	assert.Equal(t, filepath.FromSlash("org3/custom/repo3.git"), transferredRepo.CodeStorageRepo().GitRepoLocation())
+
+	_, err = repo_model.GetPendingRepositoryTransfer(t.Context(), transferredRepo)
+	assert.Error(t, err)
 
 	unittest.CheckConsistencyFor(t, &repo_model.Repository{}, &user_model.User{}, &organization.Team{})
 }


### PR DESCRIPTION
Repositories with a custom storage_path were still renamed on disk to the new owner/name location during owner transfer and rename. This keeps the custom location stable in both flows; repositories without one keep the previous behavior.

Builds on https://github.com/go-gitea/gitea/pull/38960 (the storage_path column).
Depends on https://github.com/go-gitea/gitea/issues/1872

Assisted-by: opencode:deepseek-v4-flash-free