### PR TITLE
fix(automerge): recover pull requests whose queued evaluation was lost

### DIFF
--- a/models/pull/automerge.go
+++ b/models/pull/automerge.go
@@ -80,6 +80,14 @@ func GetScheduledMergeByPullID(ctx context.Context, pullID int64) (bool, *AutoMe
 	return true, scheduledPRM, err
 }
 
+// IterateScheduledAutoMerges calls f for every pull request currently scheduled
+// to auto merge. The table holds one row per armed pull request, so it stays
+// small; it is the durable record of intent behind the auto merge queue, which
+// is why it can be used to rebuild queue state that was lost.
+func IterateScheduledAutoMerges(ctx context.Context, f func(ctx context.Context, am *AutoMerge) error) error {
+	return db.Iterate(ctx, nil, f)
+}
+
 // DeleteScheduledAutoMerge delete a scheduled pull request
 func DeleteScheduledAutoMerge(ctx context.Context, pullID int64) error {
 	exist, scheduledPRM, err := GetScheduledMergeByPullID(ctx, pullID)

--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -2987,6 +2987,7 @@
   "admin.dashboard.check_repo_stats": "Check all repository statistics",
   "admin.dashboard.archive_cleanup": "Delete old repository archives",
   "admin.dashboard.deleted_branches_cleanup": "Clean up deleted branches",
+  "admin.dashboard.reconcile_scheduled_auto_merges": "Re-queue pull requests scheduled to auto merge",
   "admin.dashboard.update_migration_poster_id": "Update migration poster IDs",
   "admin.dashboard.git_gc_repos": "Garbage-collect all repositories",
   "admin.dashboard.resync_all_sshkeys": "Update the '.ssh/authorized_keys' file with Gitea SSH keys",

--- a/services/automerge/automerge.go
+++ b/services/automerge/automerge.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 
 	"gitea.dev/models/db"
 	git_model "gitea.dev/models/git"
@@ -40,8 +41,44 @@ func Init() error {
 	return nil
 }
 
-// handle passed PR IDs and test the PRs
+// maxTransientRetries bounds how many times a queue item is requeued after a
+// transient failure (e.g. a temporary database or filesystem error), so a
+// persistently failing item cannot keep a queue worker spinning forever.
+// When the bound is reached the scheduled merge stays recorded in the
+// database, but it is only evaluated again when a new event arrives for the
+// pull request.
+const maxTransientRetries = 30
+
+var (
+	transientRetryMu     sync.Mutex
+	transientRetryCounts = map[string]int{}
+)
+
+// countTransientFailure records a transient failure for the given queue item
+// and reports whether the item should be requeued for another attempt.
+func countTransientFailure(item string) (requeue bool) {
+	transientRetryMu.Lock()
+	defer transientRetryMu.Unlock()
+	transientRetryCounts[item]++
+	if transientRetryCounts[item] >= maxTransientRetries {
+		delete(transientRetryCounts, item)
+		return false
+	}
+	return true
+}
+
+func clearTransientFailures(item string) {
+	transientRetryMu.Lock()
+	defer transientRetryMu.Unlock()
+	delete(transientRetryCounts, item)
+}
+
+// handle passed PR IDs and test the PRs. Items that fail transiently are
+// returned to the queue so its retry mechanism can requeue them; before this,
+// any transient failure permanently dropped the scheduled merge, leaving the
+// pull request green and armed but never merged.
 func handler(items ...string) []string {
+	var unhandled []string
 	for _, s := range items {
 		var id int64
 		var sha string
@@ -49,9 +86,18 @@ func handler(items ...string) []string {
 			log.Error("could not parse data from pr_auto_merge queue (%v): %v", s, err)
 			continue
 		}
-		handlePullRequestAutoMerge(id, sha)
+		if err := handlePullRequestAutoMerge(id, sha); err != nil {
+			if countTransientFailure(s) {
+				log.Warn("PullRequest[%d] automerge evaluation failed, it will be retried: %v", id, err)
+				unhandled = append(unhandled, s)
+			} else {
+				log.Error("PullRequest[%d] automerge evaluation failed %d times, giving up until a new event for it arrives: %v", id, maxTransientRetries, err)
+			}
+			continue
+		}
+		clearTransientFailures(s)
 	}
-	return nil
+	return unhandled
 }
 
 // ScheduleAutoMerge if schedule is false and no error, pull can be merged directly
@@ -152,57 +198,89 @@ func getPullRequestsByHeadSHA(ctx context.Context, sha string, repo *repo_model.
 	return pulls, nil
 }
 
-// handlePullRequestAutoMerge merge the pull request if all checks are successful
-func handlePullRequestAutoMerge(pullID int64, sha string) {
+// isTerminalMergeCheckError reports whether a CheckPullMergeable failure is a
+// definite refusal that retrying cannot cure, as opposed to a transient
+// infrastructure error.
+func isTerminalMergeCheckError(err error) bool {
+	for _, terminal := range []error{
+		pull_service.ErrHasMerged,
+		pull_service.ErrIsClosed,
+		pull_service.ErrNoPermissionToMerge,
+		pull_service.ErrNotReadyToMerge,
+		pull_service.ErrIsWorkInProgress,
+		pull_service.ErrIsChecking,
+		pull_service.ErrNotMergeableState,
+		pull_service.ErrDependenciesLeft,
+		pull_service.ErrHeadCommitsNotAllVerified,
+	} {
+		if errors.Is(err, terminal) {
+			return true
+		}
+	}
+	return false
+}
+
+// handlePullRequestAutoMerge is a function variable so tests can intercept it.
+var handlePullRequestAutoMerge = realHandlePullRequestAutoMerge
+
+// realHandlePullRequestAutoMerge merges the pull request if all checks are
+// successful. It returns nil when the queue item is fully handled — the pull
+// request was merged, or was refused for a reason retrying cannot cure — and
+// an error for transient infrastructure failures (database reads, git
+// repository access), so the caller can requeue the item instead of silently
+// dropping the scheduled merge.
+func realHandlePullRequestAutoMerge(pullID int64, sha string) error {
 	ctx, _, finished := process.GetManager().AddContext(graceful.GetManager().HammerContext(),
 		fmt.Sprintf("Handle AutoMerge of PR[%d] with sha[%s]", pullID, sha))
 	defer finished()
 
 	pr, err := issues_model.GetPullRequestByID(ctx, pullID)
 	if err != nil {
-		log.Error("GetPullRequestByID[%d]: %v", pullID, err)
-		return
+		if issues_model.IsErrPullRequestNotExist(err) {
+			log.Warn("GetPullRequestByID[%d]: pull request does not exist", pullID)
+			return nil
+		}
+		return fmt.Errorf("GetPullRequestByID[%d]: %w", pullID, err)
 	}
 
 	// Check if there is a scheduled pr in the db
 	exists, scheduledPRM, err := pull_model.GetScheduledMergeByPullID(ctx, pr.ID)
 	if err != nil {
-		log.Error("%-v GetScheduledMergeByPullID: %v", pr, err)
-		return
+		return fmt.Errorf("GetScheduledMergeByPullID[%d]: %w", pr.ID, err)
 	}
 	if !exists {
-		return
+		return nil
 	}
 
 	if err = pr.LoadBaseRepo(ctx); err != nil {
-		log.Error("%-v LoadBaseRepo: %v", pr, err)
-		return
+		return fmt.Errorf("LoadBaseRepo[%d]: %w", pr.ID, err)
 	}
 
 	// check the sha is the same as pull request head commit id
 	baseGitRepo, err := git.OpenRepository(ctx, pr.BaseRepo)
 	if err != nil {
-		log.Error("OpenRepository: %v", err)
-		return
+		return fmt.Errorf("OpenRepository[%d]: %w", pr.BaseRepoID, err)
 	}
 	defer baseGitRepo.Close()
 
 	headCommitID, err := baseGitRepo.GetRefCommitID(ctx, pr.GetGitHeadRefName())
 	if err != nil {
-		log.Error("GetRefCommitID: %v", err)
-		return
+		if git.IsErrNotExist(err) {
+			log.Warn("Head ref of auto merge %-v does not exist: %v", pr, err)
+			return nil
+		}
+		return fmt.Errorf("GetRefCommitID[%d]: %w", pr.ID, err)
 	}
 	if headCommitID != sha {
 		log.Warn("Head commit id of auto merge %-v does not match sha [%s], it may means the head branch has been updated. Just ignore this request because a new request expected in the queue", pr, sha)
-		return
+		return nil
 	}
 
 	// Get all checks for this pr
 	// We get the latest sha commit hash again to handle the case where the check of a previous push
 	// did not succeed or was not finished yet.
 	if err = pr.LoadHeadRepo(ctx); err != nil {
-		log.Error("%-v LoadHeadRepo: %v", pr, err)
-		return
+		return fmt.Errorf("LoadHeadRepo[%d]: %w", pr.ID, err)
 	}
 
 	switch pr.Flow {
@@ -213,50 +291,54 @@ func handlePullRequestAutoMerge(pullID int64, sha string) {
 		}
 		if !headBranchExist {
 			log.Warn("Head branch of auto merge %-v does not exist [HeadRepoID: %d, Branch: %s]", pr, pr.HeadRepoID, pr.HeadBranch)
-			return
+			return nil
 		}
 	case issues_model.PullRequestFlowAGit:
 		headBranchExist := git.IsReferenceExist(ctx, pr.BaseRepo, pr.GetGitHeadRefName())
 		if !headBranchExist {
 			log.Warn("Head branch of auto merge %-v does not exist [HeadRepoID: %d, Branch(Agit): %s]", pr, pr.HeadRepoID, pr.HeadBranch)
-			return
+			return nil
 		}
 	default:
 		log.Error("wrong flow type %d", pr.Flow)
-		return
+		return nil
 	}
 
 	// Check if all checks succeeded
 	pass, err := pull_service.IsPullCommitStatusPass(ctx, pr)
 	if err != nil {
-		log.Error("%-v IsPullCommitStatusPass: %v", pr, err)
-		return
+		return fmt.Errorf("IsPullCommitStatusPass[%d]: %w", pr.ID, err)
 	}
 	if !pass {
 		log.Info("Scheduled auto merge %-v has unsuccessful status checks", pr)
-		return
+		return nil
 	}
 
 	// Merge if all checks succeeded
 	doer, err := user_model.GetUserByID(ctx, scheduledPRM.DoerID)
 	if err != nil {
-		log.Error("Unable to get scheduled User[%d]: %v", scheduledPRM.DoerID, err)
-		return
+		if user_model.IsErrUserNotExist(err) {
+			log.Warn("Scheduled auto merge %-v: scheduling User[%d] no longer exists", pr, scheduledPRM.DoerID)
+			return nil
+		}
+		return fmt.Errorf("GetUserByID[%d]: %w", scheduledPRM.DoerID, err)
 	}
 
 	perm, err := access_model.GetDoerRepoPermission(ctx, pr.BaseRepo, doer)
 	if err != nil {
-		log.Error("GetDoerRepoPermission %-v: %v", pr.BaseRepo, err)
-		return
+		return fmt.Errorf("GetDoerRepoPermission[%d]: %w", pr.BaseRepoID, err)
 	}
 
 	if err := pull_service.CheckPullMergeable(ctx, doer, &perm, pr, pull_service.MergeCheckTypeGeneral, scheduledPRM.MergeStyle, false); err != nil {
-		if errors.Is(err, pull_service.ErrNotReadyToMerge) {
-			log.Info("%-v was scheduled to automerge by an unauthorized user", pr)
-			return
+		if isTerminalMergeCheckError(err) {
+			// the error carries the precise reason (e.g. for ErrNotReadyToMerge:
+			// status checks, approvals, requested changes, official review
+			// requests, behind base branch, protected files), so log it instead
+			// of discarding it.
+			log.Info("%-v is not ready for scheduled auto merge: %v", pr, err)
+			return nil
 		}
-		log.Error("%-v CheckPullMergeable: %v", pr, err)
-		return
+		return fmt.Errorf("CheckPullMergeable[%d]: %w", pr.ID, err)
 	}
 
 	if err := pull_service.Merge(ctx, pr, doer, scheduledPRM.MergeStyle, "", scheduledPRM.Message, true); err != nil {
@@ -264,7 +346,7 @@ func handlePullRequestAutoMerge(pullID int64, sha string) {
 		// FIXME: if merge failed, we should display some error message to the pull request page.
 		// The resolution is add a new column on automerge table named `error_message` to store the error message and displayed
 		// on the pull request page. But this should not be finished in a bug fix PR which will be backport to release branch.
-		return
+		return nil
 	}
 
 	deleteBranchAfterMerge, err := pull_service.ShouldDeleteBranchAfterMerge(ctx, &scheduledPRM.DeleteBranchAfterMerge, pr.BaseRepo, pr)
@@ -275,4 +357,5 @@ func handlePullRequestAutoMerge(pullID int64, sha string) {
 			log.Error("DeleteBranchAfterMerge: %v", err)
 		}
 	}
+	return nil
 }

--- a/services/automerge/automerge.go
+++ b/services/automerge/automerge.go
@@ -120,6 +120,41 @@ func ScheduleAutoMerge(ctx context.Context, doer *user_model.User, pull *issues_
 	return scheduled, err
 }
 
+// ReconcileScheduledAutoMerges re-queues an evaluation for every pull request
+// that is still scheduled to auto merge.
+//
+// The queue is the only thing that drives a scheduled merge forward, and an
+// evaluation can be lost: handlePullRequestAutoMerge returns on any error with
+// nothing but a log line, and the handler reports every item as handled, so
+// the queue never retries it. Once the head commit's checks have settled there
+// is no further status event to enqueue a replacement, and the pull request
+// stays green, scheduled and unmerged indefinitely.
+//
+// pull_auto_merge is the durable record of intent, so walking it rebuilds
+// whatever queue state was lost — whichever way it was lost, including a
+// restart discarding an in-memory queue. This is deliberately a sweep rather
+// than a retry of the specific failure: it needs no attempt accounting and
+// cannot spin, because the queue is unique-keyed and an evaluation for a pull
+// request that is not ready returns immediately.
+func ReconcileScheduledAutoMerges(ctx context.Context) error {
+	return pull_model.IterateScheduledAutoMerges(ctx, func(ctx context.Context, am *pull_model.AutoMerge) error {
+		pr, err := issues_model.GetPullRequestByID(ctx, am.PullID)
+		if err != nil {
+			// A scheduled row for a pull request that no longer exists is
+			// stale, not a reason to abort the sweep.
+			log.Error("ReconcileScheduledAutoMerges GetPullRequestByID[%d]: %v", am.PullID, err)
+			return nil
+		}
+		if pr.HasMerged || !pr.IsStatusMergeable() {
+			return nil
+		}
+		// StartPRCheckAndAutoMerge resolves the current head sha itself, so a
+		// pull request whose head moved on is re-queued under its new key.
+		automergequeue.StartPRCheckAndAutoMerge(ctx, pr)
+		return nil
+	})
+}
+
 // RemoveScheduledAutoMerge cancels a previously scheduled pull request
 func RemoveScheduledAutoMerge(ctx context.Context, doer *user_model.User, pull *issues_model.PullRequest) error {
 	return db.WithTx(ctx, func(ctx context.Context) error {

--- a/services/automerge/automerge_test.go
+++ b/services/automerge/automerge_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package automerge
+
+import (
+	"errors"
+	"testing"
+
+	"gitea.dev/models/unittest"
+	"gitea.dev/modules/test"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestHandlerRequeuesTransientFailures asserts that a transient failure while
+// evaluating a scheduled auto merge is reported back to the queue as
+// unhandled — so the queue's retry mechanism requeues it — instead of being
+// dropped, which permanently lost the scheduled merge.
+func TestHandlerRequeuesTransientFailures(t *testing.T) {
+	defer test.MockVariableValue(&handlePullRequestAutoMerge, func(pullID int64, sha string) error {
+		if pullID == 1 {
+			return errors.New("transient database failure")
+		}
+		return nil
+	})()
+	defer clearTransientFailures("1_sha1")
+
+	assert.Equal(t, []string{"1_sha1"}, handler("1_sha1", "2_sha2"))
+}
+
+func TestHandlerDoesNotRequeueHandledItems(t *testing.T) {
+	calls := 0
+	defer test.MockVariableValue(&handlePullRequestAutoMerge, func(pullID int64, sha string) error {
+		calls++
+		return nil
+	})()
+
+	// a handled item and an unparsable item are both terminal: nothing to requeue
+	assert.Empty(t, handler("1_sha1", "not-parsable"))
+	assert.Equal(t, 1, calls)
+}
+
+func TestHandlerGivesUpAfterMaxTransientRetries(t *testing.T) {
+	defer test.MockVariableValue(&handlePullRequestAutoMerge, func(pullID int64, sha string) error {
+		return errors.New("transient database failure")
+	})()
+	defer clearTransientFailures("1_sha1")
+
+	for range maxTransientRetries - 1 {
+		assert.Equal(t, []string{"1_sha1"}, handler("1_sha1"))
+	}
+	// the attempt that reaches the bound is dropped instead of requeued,
+	// so a persistently failing item cannot spin in the queue forever
+	assert.Empty(t, handler("1_sha1"))
+	// and a later event for the same item starts counting afresh
+	assert.Equal(t, []string{"1_sha1"}, handler("1_sha1"))
+}
+
+func TestHandleAutoMergeMissingPullRequestIsTerminal(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	// a deleted pull request cannot be cured by retrying: the item must be
+	// reported as handled so it is not requeued
+	assert.NoError(t, realHandlePullRequestAutoMerge(123456789, "0123456789012345678901234567890123456789"))
+}

--- a/services/automerge/automerge_test.go
+++ b/services/automerge/automerge_test.go
@@ -5,9 +5,15 @@ package automerge
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
+	issues_model "gitea.dev/models/issues"
+	pull_model "gitea.dev/models/pull"
+	repo_model "gitea.dev/models/repo"
 	"gitea.dev/models/unittest"
+	user_model "gitea.dev/models/user"
+	"gitea.dev/modules/setting"
 	"gitea.dev/modules/test"
 
 	"github.com/stretchr/testify/assert"
@@ -55,6 +61,31 @@ func TestHandlerGivesUpAfterMaxTransientRetries(t *testing.T) {
 	assert.Empty(t, handler("1_sha1"))
 	// and a later event for the same item starts counting afresh
 	assert.Equal(t, []string{"1_sha1"}, handler("1_sha1"))
+}
+
+// TestHandlerRequeuesOnRepositoryAccessFailure exercises the full evaluation
+// with nothing mocked but the storage location: a scheduled auto merge whose
+// git repository is momentarily inaccessible must be reported back to the
+// queue for requeueing. It fails against the previous handler, which reported
+// every item as handled and so permanently lost the scheduled merge.
+func TestHandlerRequeuesOnRepositoryAccessFailure(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	pr := unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{ID: 2})
+	doer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	assert.NoError(t, pull_model.ScheduleAutoMerge(t.Context(), doer, pr.ID, repo_model.MergeStyleMerge, "", false))
+	defer func() {
+		assert.NoError(t, pull_model.DeleteScheduledAutoMerge(t.Context(), pr.ID))
+	}()
+
+	// point the repository root at an empty directory so opening the base
+	// repository fails the way it would during a storage hiccup
+	defer test.MockVariableValue(&setting.RepoRootPath, t.TempDir())()
+
+	item := fmt.Sprintf("%d_%s", pr.ID, "0123456789012345678901234567890123456789")
+	defer clearTransientFailures(item)
+
+	assert.Equal(t, []string{item}, handler(item))
 }
 
 func TestHandleAutoMergeMissingPullRequestIsTerminal(t *testing.T) {

--- a/services/automerge/main_test.go
+++ b/services/automerge/main_test.go
@@ -1,0 +1,14 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package automerge
+
+import (
+	"testing"
+
+	"gitea.dev/models/unittest"
+)
+
+func TestMain(m *testing.M) {
+	unittest.MainTest(m)
+}

--- a/services/cron/tasks_basic.go
+++ b/services/cron/tasks_basic.go
@@ -14,6 +14,7 @@ import (
 	"gitea.dev/modules/git/gitcmd"
 	"gitea.dev/modules/setting"
 	"gitea.dev/services/auth"
+	automerge_service "gitea.dev/services/automerge"
 	"gitea.dev/services/migrations"
 	mirror_service "gitea.dev/services/mirror"
 	packages_cleanup_service "gitea.dev/services/packages/cleanup"
@@ -159,10 +160,21 @@ func registerSyncRepoLicenses() {
 	})
 }
 
+func registerReconcileScheduledAutoMerges() {
+	RegisterTaskFatal("reconcile_scheduled_auto_merges", &BaseConfig{
+		Enabled:    true,
+		RunAtStart: true,
+		Schedule:   "@every 5m",
+	}, func(ctx context.Context, _ *user_model.User, _ *BaseConfig) error {
+		return automerge_service.ReconcileScheduledAutoMerges(ctx)
+	})
+}
+
 func initBasicTasks() {
 	if setting.Mirror.Enabled {
 		registerUpdateMirrorTask()
 	}
+	registerReconcileScheduledAutoMerges()
 	registerRepoHealthCheck()
 	registerCheckRepoStats()
 	registerArchiveCleanup()

--- a/tests/integration/api_admin_test.go
+++ b/tests/integration/api_admin_test.go
@@ -289,10 +289,10 @@ func TestAPICron(t *testing.T) {
 			AddTokenAuth(token)
 		resp := MakeRequest(t, req, http.StatusOK)
 
-		assert.Equal(t, "29", resp.Header().Get("X-Total-Count"))
+		assert.Equal(t, "30", resp.Header().Get("X-Total-Count"))
 
 		crons := DecodeJSON(t, resp, []api.Cron{})
-		assert.Len(t, crons, 29)
+		assert.Len(t, crons, 30)
 	})
 
 	t.Run("Execute", func(t *testing.T) {

--- a/tests/integration/pull_merge_test.go
+++ b/tests/integration/pull_merge_test.go
@@ -861,6 +861,91 @@ func TestPullAutoMergeAfterCommitStatusSucceed(t *testing.T) {
 	})
 }
 
+// TestPullAutoMergeRecoversFromALostQueueItem pins the behaviour that makes a
+// scheduled auto merge survivable.
+//
+// The queue is the only thing that drives a scheduled merge forward, and an
+// evaluation can be lost: handlePullRequestAutoMerge returns on any error with
+// nothing but a log line, and the handler reports every item as handled, so the
+// queue never retries. Once the head commit's checks have settled there is no
+// further status event to enqueue a replacement, and the pull request stays
+// green, scheduled and unmerged indefinitely.
+//
+// The lost enqueue is simulated by stubbing AddToQueue — the same seam
+// TestPullAutoMergeAfterCommitStatusSucceed already uses — because the outcome
+// is identical however the item was lost: nothing is in the queue, and the row
+// in pull_auto_merge is the only remaining record that a merge was ever wanted.
+func TestPullAutoMergeRecoversFromALostQueueItem(t *testing.T) {
+	onGiteaRun(t, func(t *testing.T, giteaURL *url.URL) {
+		session := loginUser(t, "user1")
+		user1 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 1})
+		forkedName := "repo1-lost-queue-item"
+		testRepoFork(t, session, "user2", "repo1", "user1", forkedName, "")
+		testEditFile(t, session, "user1", forkedName, "master", "README.md", "Hello, World (Edited)\n")
+		testPullCreate(t, session, "user1", forkedName, false, "master", "master", "lost queue item test pull")
+
+		baseRepo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{OwnerName: "user2", Name: "repo1"})
+		forkedRepo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{OwnerName: "user1", Name: forkedName})
+		pr := unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{
+			BaseRepoID: baseRepo.ID,
+			BaseBranch: "master",
+			HeadRepoID: forkedRepo.ID,
+			HeadBranch: "master",
+		})
+
+		req := NewRequestWithValues(t, "POST", "/user2/repo1/settings/branches/edit", map[string]string{
+			"rule_name":             "master",
+			"enable_push":           "true",
+			"enable_status_check":   "true",
+			"status_check_contexts": "gitea/actions",
+		})
+		session.MakeRequest(t, req, http.StatusSeeOther)
+
+		// Drop every enqueue for the rest of the arming and status window, so
+		// the scheduled merge exists in the database with nothing in the queue
+		// to act on it.
+		oldAutoMergeAddToQueue := automergequeue.AddToQueue
+		automergequeue.AddToQueue = func(pr *issues_model.PullRequest, sha string) {}
+
+		scheduled, err := automerge.ScheduleAutoMerge(t.Context(), user1, pr, repo_model.MergeStyleMerge, "auto merge test", false)
+		assert.NoError(t, err)
+		assert.True(t, scheduled)
+
+		baseGitRepo, err := git.OpenRepository(t.Context(), baseRepo)
+		assert.NoError(t, err)
+		sha, err := baseGitRepo.GetRefCommitID(t.Context(), pr.GetGitHeadRefName())
+		assert.NoError(t, err)
+		baseGitRepo.Close()
+
+		err = commitstatus_service.CreateCommitStatus(t.Context(), baseRepo, user1, sha, &git_model.CommitStatus{
+			State:     commitstatus.CommitStatusSuccess,
+			TargetURL: "https://gitea.com",
+			Context:   "gitea/actions",
+		})
+		assert.NoError(t, err)
+
+		// Everything a maintainer can see now says the pull request is ready:
+		// checks are green and auto merge is scheduled. It will never merge,
+		// because no further status event is coming for this head commit.
+		assert.Never(t, func() bool {
+			pr = unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{ID: pr.ID})
+			return pr.HasMerged
+		}, time.Second, 100*time.Millisecond)
+		unittest.AssertExistsAndLoadBean(t, &pull_model.AutoMerge{PullID: pr.ID})
+
+		// The scheduled row is enough to rebuild what the queue lost.
+		automergequeue.AddToQueue = oldAutoMergeAddToQueue
+		assert.NoError(t, automerge.ReconcileScheduledAutoMerges(t.Context()))
+
+		assert.Eventually(t, func() bool {
+			pr = unittest.AssertExistsAndLoadBean(t, &issues_model.PullRequest{ID: pr.ID})
+			return pr.HasMerged
+		}, 5*time.Second, 100*time.Millisecond)
+		assert.NotEmpty(t, pr.MergedCommitID)
+		unittest.AssertNotExistsBean(t, &pull_model.AutoMerge{PullID: pr.ID})
+	})
+}
+
 func TestPullAutoMergeAfterCommitStatusSucceedAndApproval(t *testing.T) {
 	onGiteaRun(t, func(t *testing.T, giteaURL *url.URL) {
 		// create a pull request


### PR DESCRIPTION
Follow-up to <https://github.com/go-gitea/gitea/pull/38970> for <https://github.com/go-gitea/gitea/issues/38969>. Stacked on that PR; only the last commit is new here.

A handler-side retry cannot recover an evaluation that never reached the queue (a lost enqueue, or queue state lost across a restart). `pull_auto_merge` is the durable record of intent, so a periodic task re-enqueues an evaluation for every still-open scheduled merge. The sweep is idempotent and cannot spin: the queue is unique-keyed, and an evaluation for a pull request that is not ready returns immediately.

The new integration test reproduces the lost-enqueue stall end-to-end and shows the sweep recovering it.

Assisted-by: Claude Code:claude-fable-5
