### PR TITLE
fix(api): deleting a push mirror leaves its credentials in the repository config

### DIFF
--- a/routers/api/v1/repo/mirror.go
+++ b/routers/api/v1/repo/mirror.go
@@ -331,11 +331,26 @@ func DeletePushMirrorByRemoteName(ctx *context.APIContext) {
 		return
 	}
 
-	remoteName := ctx.PathParam("name")
-	// Delete push mirror on repo by name.
-	err := repo_model.DeletePushMirrors(ctx, repo_model.PushMirrorOptions{RepoID: ctx.Repo.Repository.ID, RemoteName: remoteName})
+	m, exist, err := db.Get[repo_model.PushMirror](ctx, repo_model.PushMirrorOptions{
+		RepoID:     ctx.Repo.Repository.ID,
+		RemoteName: ctx.PathParam("name"),
+	}.ToConds())
 	if err != nil {
-		ctx.APIError(http.StatusNotFound, err.Error())
+		ctx.APIErrorInternal(err)
+		return
+	} else if !exist {
+		ctx.APIErrorNotFound()
+		return
+	}
+
+	// the git remote holds the credentials, it has to go with the database row
+	if err := mirror_service.RemovePushMirrorRemote(ctx, m); err != nil {
+		ctx.APIErrorInternal(err)
+		return
+	}
+
+	if err := repo_model.DeletePushMirrors(ctx, repo_model.PushMirrorOptions{ID: m.ID, RepoID: m.RepoID}); err != nil {
+		ctx.APIErrorInternal(err)
 		return
 	}
 	ctx.Status(http.StatusNoContent)

--- a/tests/integration/mirror_push_test.go
+++ b/tests/integration/mirror_push_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	auth_model "gitea.dev/models/auth"
 	"gitea.dev/models/db"
 	repo_model "gitea.dev/models/repo"
 	"gitea.dev/models/unittest"
@@ -25,6 +26,7 @@ import (
 	"gitea.dev/tests"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMirrorPush(t *testing.T) {
@@ -185,4 +187,48 @@ func TestRepoSettingPushMirrorUpdate(t *testing.T) {
 	// delete repo2 push mirror
 	assert.True(t, doRemovePushMirror(t, session, "user2", "repo2", repo2PushMirrorID))
 	unittest.AssertNotExistsBean(t, &repo_model.PushMirror{ID: repo2PushMirrorID})
+}
+
+func TestAPIDeletePushMirrorRemovesRemote(t *testing.T) {
+	onGiteaRun(t, testAPIDeletePushMirrorRemovesRemote)
+}
+
+func testAPIDeletePushMirrorRemovesRemote(t *testing.T, u *url.URL) {
+	defer test.MockVariableValue(&setting.Migrations.AllowLocalNetworks, true)()
+	require.NoError(t, migrations.Init())
+
+	_ = db.TruncateBeans(t.Context(), &repo_model.PushMirror{})
+	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	srcRepo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+
+	mirrorRepo, err := repo_service.CreateRepositoryDirectly(t.Context(), user, user, repo_service.CreateRepoOptions{
+		Name: "test-api-delete-push-mirror",
+	}, true)
+	require.NoError(t, err)
+
+	session := loginUser(t, user.Name)
+	pushMirrorURL := fmt.Sprintf("%s%s/%s", u.String(), url.PathEscape(user.Name), url.PathEscape(mirrorRepo.Name))
+	testCreatePushMirror(t, session, user.Name, srcRepo.Name, pushMirrorURL, user.LowerName, userPassword, "0")
+
+	mirrors, _, err := repo_model.GetPushMirrorsByRepoID(t.Context(), srcRepo.ID, db.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, mirrors, 1)
+	remoteName := mirrors[0].RemoteName
+
+	addr, err := git.GetRemoteAddress(t.Context(), srcRepo, remoteName)
+	require.NoError(t, err)
+	require.NotEmpty(t, addr)
+
+	token := getUserToken(t, user.Name, auth_model.AccessTokenScopeWriteRepository)
+	req := NewRequest(t, "DELETE", fmt.Sprintf("/api/v1/repos/%s/%s/push_mirrors/%s",
+		url.PathEscape(user.Name), url.PathEscape(srcRepo.Name), url.PathEscape(remoteName))).AddTokenAuth(token)
+	MakeRequest(t, req, http.StatusNoContent)
+
+	mirrors, _, err = repo_model.GetPushMirrorsByRepoID(t.Context(), srcRepo.ID, db.ListOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, mirrors)
+
+	// the remote carries the credentials, deleting the mirror must take it along
+	_, err = git.GetRemoteAddress(t.Context(), srcRepo, remoteName)
+	assert.True(t, git.IsRemoteNotExistError(err), "the git remote should be gone, got: %v", err)
 }


### PR DESCRIPTION
Deleting a push mirror through `DELETE /repos/{owner}/{repo}/push_mirrors/{name}` drops the database row but leaves the git remote behind. That remote URL carries the mirror credentials in plain text, so every deletion through the API leaves a working token sitting in the repository config indefinitely.

The web handler already gets this right — it calls `RemovePushMirrorRemote` before deleting the row. This makes the API handler do the same, looking the mirror up the way `GetPushMirrorByName` does.

Side effect: deleting an unknown remote name now returns 404 instead of 204. `DeletePushMirrors` does not treat "not found" as an error, so the old code answered 204 for any name at all, while the swagger comment already documented 404.

Found on a self-hosted instance, where several repositories had accumulated orphaned remotes holding valid tokens. The added integration test fails on current main and passes with this change.

Disclosure: written with AI assistance (Claude Code).
