### PR TITLE
fix: skip GPG signing key fallback when SIGNING_FORMAT is ssh (Fixes #37452)

### DIFF
--- a/services/asymkey/commit.go
+++ b/services/asymkey/commit.go
@@ -143,7 +143,7 @@ func parseCommitWithGPGSignature(ctx context.Context, c *git.Commit, committer *
 		}
 	}
 
-	if setting.Repository.Signing.SigningKey != "" && setting.Repository.Signing.SigningKey != "default" && setting.Repository.Signing.SigningKey != "none" {
+	if setting.Repository.Signing.SigningFormat != git.SigningKeyFormatSSH && setting.Repository.Signing.SigningKey != "" && setting.Repository.Signing.SigningKey != "default" && setting.Repository.Signing.SigningKey != "none" {
 		// OK we should try the default key
 		gpgSettings := git.GPGSettings{
 			Sign:  true,


### PR DESCRIPTION
## Description

When `SIGNING_FORMAT = ssh` is configured, `parseCommitWithGPGSignature` still tries to use the instance-wide signing key as a GPG key. This causes a `gpg --export` call on the SSH `.pub` file path, which always fails and logs `Error getting default signing key`.

In container environments where GnuPG locks persist across restarts, each failed `gpg` call blocks ~10s waiting for the stale lock, adding significant latency to every page load of repos with GPG-signed commits whose keys aren't registered in Gitea.

## Fix

Add a `SigningFormat != ssh` guard to the GPG default-key condition at `services/asymkey/commit.go:146`, matching the existing SSH path at line 408 which already checks `SigningFormat == git.SigningKeyFormatSSH`.

Fixes #37452