### PR TITLE
fix(migrations): cancel GitLab version probes

### DIFF
--- a/services/migrations/gitlab.go
+++ b/services/migrations/gitlab.go
@@ -105,7 +105,7 @@ func NewGitlabDownloader(ctx context.Context, baseURL, repoPath, token string) (
 	var resp *gitlab.Response
 	u, _ := url.Parse(baseURL)
 	for len(pathParts) >= 2 {
-		_, resp, err = gitlabClient.Version.GetVersion()
+		_, resp, err = gitlabClient.Version.GetVersion(gitlab.WithContext(ctx))
 		if err == nil || resp != nil && resp.StatusCode == http.StatusUnauthorized {
 			err = nil // if no authentication given, this still should work
 			break

--- a/services/migrations/gitlab_test.go
+++ b/services/migrations/gitlab_test.go
@@ -4,6 +4,7 @@
 package migrations
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -357,6 +358,28 @@ func TestGitlabDownloadRepo(t *testing.T) {
 			State:        "APPROVED",
 		},
 	}, rvs)
+}
+
+func TestGitlabVersionProbeUsesMigrationContext(t *testing.T) {
+	started := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := NewGitlabDownloader(ctx, server.URL, "owner/repo", "")
+		result <- err
+	}()
+
+	<-started
+	cancel()
+	assert.Error(t, <-result)
 }
 
 func gitlabClientMockSetup(t *testing.T) (*http.ServeMux, *httptest.Server, *gitlab.Client) {


### PR DESCRIPTION
Bind the GitLab version probe to the migration context so a cancelled migration does not remain blocked on a remote response.