### PR TITLE
fix(packages): limit Swift package manifests

### DIFF
--- a/modules/packages/swift/metadata.go
+++ b/modules/packages/swift/metadata.go
@@ -21,6 +21,7 @@ import (
 var (
 	ErrMissingManifestFile    = util.NewInvalidArgumentErrorf("Package.swift file is missing")
 	ErrManifestFileTooLarge   = util.NewInvalidArgumentErrorf("Package.swift file is too large")
+	ErrManifestFilesTooLarge  = util.NewInvalidArgumentErrorf("Package.swift files are too large")
 	ErrInvalidManifestVersion = util.NewInvalidArgumentErrorf("manifest version is invalid")
 
 	manifestPattern     = regexp.MustCompile(`\APackage(?:@swift-(\d+(?:\.\d+)?(?:\.\d+)?))?\.swift\z`)
@@ -29,6 +30,8 @@ var (
 
 const (
 	maxManifestFileSize = 128 * 1024
+	maxManifestFiles    = 64
+	maxManifestSize     = maxManifestFiles * maxManifestFileSize
 
 	PropertyScope         = "swift.scope"
 	PropertyName          = "swift.name"
@@ -139,6 +142,16 @@ func ParsePackage(sr io.ReaderAt, size int64, mr io.Reader) (*Package, error) {
 		case dir == manifestDir:
 			manifestFiles = append(manifestFiles, file)
 		}
+	}
+	if len(manifestFiles) > maxManifestFiles {
+		return nil, ErrManifestFilesTooLarge
+	}
+	var manifestSize uint64
+	for _, file := range manifestFiles {
+		manifestSize += file.UncompressedSize64
+	}
+	if manifestSize > maxManifestSize {
+		return nil, ErrManifestFilesTooLarge
 	}
 
 	for _, file := range manifestFiles {

--- a/modules/packages/swift/metadata_test.go
+++ b/modules/packages/swift/metadata_test.go
@@ -58,7 +58,7 @@ func TestParsePackage(t *testing.T) {
 	t.Run("TooManyManifestFiles", func(t *testing.T) {
 		entries := make([][2]string, 0, maxManifestFiles+1)
 		entries = append(entries, [2]string{"Package.swift", "// swift-tools-version:5.7"})
-		for i := 0; i < maxManifestFiles; i++ {
+		for i := range maxManifestFiles {
 			entries = append(entries, [2]string{fmt.Sprintf("Package@swift-5.%d.swift", i), "// swift-tools-version:5.7"})
 		}
 

--- a/modules/packages/swift/metadata_test.go
+++ b/modules/packages/swift/metadata_test.go
@@ -6,6 +6,7 @@ package swift
 import (
 	"archive/zip"
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -52,6 +53,19 @@ func TestParsePackage(t *testing.T) {
 		p, err := ParsePackage(bytes.NewReader(data.Bytes()), int64(data.Len()), nil)
 		assert.Nil(t, p)
 		assert.ErrorIs(t, err, ErrManifestFileTooLarge)
+	})
+
+	t.Run("TooManyManifestFiles", func(t *testing.T) {
+		entries := make([][2]string, 0, maxManifestFiles+1)
+		entries = append(entries, [2]string{"Package.swift", "// swift-tools-version:5.7"})
+		for i := 0; i < maxManifestFiles; i++ {
+			entries = append(entries, [2]string{fmt.Sprintf("Package@swift-5.%d.swift", i), "// swift-tools-version:5.7"})
+		}
+
+		data := writeOrderedZipArchive(entries)
+		p, err := ParsePackage(bytes.NewReader(data.Bytes()), int64(data.Len()), nil)
+		assert.Nil(t, p)
+		assert.ErrorIs(t, err, ErrManifestFilesTooLarge)
 	})
 
 	t.Run("WithoutMetadata", func(t *testing.T) {


### PR DESCRIPTION
Bound the number and aggregate size of Swift manifests retained from an uploaded archive.