### PR TITLE
fix(packages): bound Alpine metadata entries

### DIFF
--- a/modules/packages/alpine/metadata.go
+++ b/modules/packages/alpine/metadata.go
@@ -18,9 +18,10 @@ import (
 )
 
 var (
-	ErrMissingPKGINFOFile = util.NewInvalidArgumentErrorf("PKGINFO file is missing")
-	ErrInvalidName        = util.NewInvalidArgumentErrorf("package name is invalid")
-	ErrInvalidVersion     = util.NewInvalidArgumentErrorf("package version is invalid")
+	ErrMissingPKGINFOFile  = util.NewInvalidArgumentErrorf("PKGINFO file is missing")
+	ErrInvalidName         = util.NewInvalidArgumentErrorf("package name is invalid")
+	ErrInvalidVersion      = util.NewInvalidArgumentErrorf("package version is invalid")
+	ErrPackageInfoTooLarge = util.NewInvalidArgumentErrorf("PKGINFO contains too many entries")
 )
 
 const (
@@ -36,6 +37,8 @@ const (
 	RepositoryVersion = "_repository"
 
 	NoArch = "noarch"
+
+	maxPackageInfoEntries = 1024
 )
 
 // https://wiki.alpinelinux.org/wiki/Apk_spec
@@ -185,10 +188,16 @@ func ParsePackageInfo(r io.Reader) (*Package, error) {
 			p.FileMetadata.InstallIf = value
 		case "provides":
 			if value != "" {
+				if len(p.FileMetadata.Provides)+len(p.FileMetadata.Dependencies) >= maxPackageInfoEntries {
+					return nil, ErrPackageInfoTooLarge
+				}
 				p.FileMetadata.Provides = append(p.FileMetadata.Provides, value)
 			}
 		case "depend":
 			if value != "" {
+				if len(p.FileMetadata.Provides)+len(p.FileMetadata.Dependencies) >= maxPackageInfoEntries {
+					return nil, ErrPackageInfoTooLarge
+				}
 				p.FileMetadata.Dependencies = append(p.FileMetadata.Dependencies, value)
 			}
 		case "provider_priority":

--- a/modules/packages/alpine/metadata_test.go
+++ b/modules/packages/alpine/metadata_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -96,6 +97,15 @@ func TestParsePackage(t *testing.T) {
 		assert.NotNil(t, p)
 
 		assert.Equal(t, "Q1SRYURM5+uQDqfHSwTnNIOIuuDVQ=", p.FileMetadata.Checksum)
+	})
+
+	t.Run("TooManyDependencyEntries", func(t *testing.T) {
+		data := append(createPKGINFOContent(packageName, packageVersion), []byte("\ndepend = item")...)
+		data = append(data, []byte(strings.Repeat("\ndepend = item", maxPackageInfoEntries))...)
+
+		p, err := ParsePackageInfo(bytes.NewReader(data))
+		assert.Nil(t, p)
+		assert.ErrorIs(t, err, ErrPackageInfoTooLarge)
 	})
 }
 


### PR DESCRIPTION
Limit retained dependency and provision metadata while parsing Alpine package information.