### PR TITLE
fix(repo): limit gitignore template selections

### DIFF
--- a/modules/structs/repo.go
+++ b/modules/structs/repo.go
@@ -154,7 +154,7 @@ type CreateRepoOption struct {
 	// Whether the repository is template
 	Template bool `json:"template"`
 	// Gitignores to use
-	Gitignores string `json:"gitignores" binding:"MaxSize(255)"`
+	Gitignores string `json:"gitignores" binding:"MaxSize(1024)"`
 	// License to use
 	License string `json:"license" binding:"MaxSize(100)"`
 	// Readme of the repository to create

--- a/modules/structs/repo.go
+++ b/modules/structs/repo.go
@@ -154,7 +154,7 @@ type CreateRepoOption struct {
 	// Whether the repository is template
 	Template bool `json:"template"`
 	// Gitignores to use
-	Gitignores string `json:"gitignores"`
+	Gitignores string `json:"gitignores" binding:"MaxSize(255)"`
 	// License to use
 	License string `json:"license" binding:"MaxSize(100)"`
 	// Readme of the repository to create

--- a/services/forms/repo_form.go
+++ b/services/forms/repo_form.go
@@ -26,7 +26,7 @@ type CreateRepoForm struct {
 	Description   string `binding:"MaxSize(2048)"`
 	DefaultBranch string `binding:"GitRefName;MaxSize(100)"`
 	AutoInit      bool
-	Gitignores    string `binding:"MaxSize(255)"`
+	Gitignores    string `binding:"MaxSize(1024)"`
 	IssueLabels   string `binding:"MaxSize(255)"`
 	License       string `binding:"MaxSize(100)"`
 	Readme        string `binding:"MaxSize(255)"`

--- a/services/forms/repo_form.go
+++ b/services/forms/repo_form.go
@@ -26,7 +26,7 @@ type CreateRepoForm struct {
 	Description   string `binding:"MaxSize(2048)"`
 	DefaultBranch string `binding:"GitRefName;MaxSize(100)"`
 	AutoInit      bool
-	Gitignores    string
+	Gitignores    string `binding:"MaxSize(255)"`
 	IssueLabels   string `binding:"MaxSize(255)"`
 	License       string `binding:"MaxSize(100)"`
 	Readme        string `binding:"MaxSize(255)"`

--- a/services/forms/repo_form_test.go
+++ b/services/forms/repo_form_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"gitea.dev/modules/json"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/services/forms/repo_form_test.go
+++ b/services/forms/repo_form_test.go
@@ -4,12 +4,9 @@
 package forms
 
 import (
-	"strings"
 	"testing"
 
 	"gitea.dev/modules/json"
-	"gitea.dev/modules/validation"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -86,9 +83,4 @@ func TestMergePullRequestForm(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(input), &m))
 		assert.Equal(t, expected, m)
 	})
-}
-
-func TestCreateRepoFormGitignoresSize(t *testing.T) {
-	form := &CreateRepoForm{RepoName: "repo", Gitignores: strings.Repeat("a", 256)}
-	assert.NotEmpty(t, validation.Binder().Validate(t.Context(), form))
 }

--- a/services/forms/repo_form_test.go
+++ b/services/forms/repo_form_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 The Gitea Authors. All rights reserved.
+// Copyright 2018 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
 package forms
@@ -7,10 +7,86 @@ import (
 	"strings"
 	"testing"
 
+	"gitea.dev/modules/json"
 	"gitea.dev/modules/validation"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestSubmitReviewForm_IsEmpty(t *testing.T) {
+	cases := []struct {
+		form     SubmitReviewForm
+		expected bool
+	}{
+		// Approved PR with a comment shouldn't count as empty
+		{SubmitReviewForm{Type: "approve", Content: "Awesome"}, false},
+
+		// Approved PR without a comment shouldn't count as empty
+		{SubmitReviewForm{Type: "approve", Content: ""}, false},
+
+		// Rejected PR without a comment should count as empty
+		{SubmitReviewForm{Type: "reject", Content: ""}, true},
+
+		// Rejected PR with a comment shouldn't count as empty
+		{SubmitReviewForm{Type: "reject", Content: "Awesome"}, false},
+
+		// Comment review on a PR with a comment shouldn't count as empty
+		{SubmitReviewForm{Type: "comment", Content: "Awesome"}, false},
+
+		// Comment review on a PR without a comment should count as empty
+		{SubmitReviewForm{Type: "comment", Content: ""}, true},
+	}
+
+	for _, v := range cases {
+		assert.Equal(t, v.expected, v.form.HasEmptyContent())
+	}
+}
+
+func TestMergePullRequestForm(t *testing.T) {
+	expected := &MergePullRequestForm{
+		Do:                     "merge",
+		MergeTitleField:        "title",
+		MergeMessageField:      "message",
+		MergeCommitID:          "merge-id",
+		HeadCommitID:           "head-id",
+		ForceMerge:             true,
+		MergeWhenChecksSucceed: true,
+		DeleteBranchAfterMerge: new(true),
+	}
+
+	t.Run("NewFields", func(t *testing.T) {
+		input := `{
+	"do": "merge",
+	"merge_title_field": "title",
+	"merge_message_field": "message",
+	"merge_commit_id": "merge-id",
+	"head_commit_id": "head-id",
+	"force_merge": true,
+	"merge_when_checks_succeed": true,
+	"delete_branch_after_merge": true
+}`
+		var m *MergePullRequestForm
+		require.NoError(t, json.Unmarshal([]byte(input), &m))
+		assert.Equal(t, expected, m)
+	})
+
+	t.Run("OldFields", func(t *testing.T) {
+		input := `{
+	"Do": "merge",
+	"MergeTitleField": "title",
+	"MergeMessageField": "message",
+	"MergeCommitID": "merge-id",
+	"head_commit_id": "head-id",
+	"force_merge": true,
+	"merge_when_checks_succeed": true,
+	"delete_branch_after_merge": true
+}`
+		var m *MergePullRequestForm
+		require.NoError(t, json.Unmarshal([]byte(input), &m))
+		assert.Equal(t, expected, m)
+	})
+}
 
 func TestCreateRepoFormGitignoresSize(t *testing.T) {
 	form := &CreateRepoForm{RepoName: "repo", Gitignores: strings.Repeat("a", 256)}

--- a/services/forms/repo_form_test.go
+++ b/services/forms/repo_form_test.go
@@ -1,87 +1,18 @@
-// Copyright 2018 The Gitea Authors. All rights reserved.
+// Copyright 2026 The Gitea Authors. All rights reserved.
 // SPDX-License-Identifier: MIT
 
 package forms
 
 import (
+	"strings"
 	"testing"
 
-	"gitea.dev/modules/json"
+	"gitea.dev/modules/validation"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestSubmitReviewForm_IsEmpty(t *testing.T) {
-	cases := []struct {
-		form     SubmitReviewForm
-		expected bool
-	}{
-		// Approved PR with a comment shouldn't count as empty
-		{SubmitReviewForm{Type: "approve", Content: "Awesome"}, false},
-
-		// Approved PR without a comment shouldn't count as empty
-		{SubmitReviewForm{Type: "approve", Content: ""}, false},
-
-		// Rejected PR without a comment should count as empty
-		{SubmitReviewForm{Type: "reject", Content: ""}, true},
-
-		// Rejected PR with a comment shouldn't count as empty
-		{SubmitReviewForm{Type: "reject", Content: "Awesome"}, false},
-
-		// Comment review on a PR with a comment shouldn't count as empty
-		{SubmitReviewForm{Type: "comment", Content: "Awesome"}, false},
-
-		// Comment review on a PR without a comment should count as empty
-		{SubmitReviewForm{Type: "comment", Content: ""}, true},
-	}
-
-	for _, v := range cases {
-		assert.Equal(t, v.expected, v.form.HasEmptyContent())
-	}
-}
-
-func TestMergePullRequestForm(t *testing.T) {
-	expected := &MergePullRequestForm{
-		Do:                     "merge",
-		MergeTitleField:        "title",
-		MergeMessageField:      "message",
-		MergeCommitID:          "merge-id",
-		HeadCommitID:           "head-id",
-		ForceMerge:             true,
-		MergeWhenChecksSucceed: true,
-		DeleteBranchAfterMerge: new(true),
-	}
-
-	t.Run("NewFields", func(t *testing.T) {
-		input := `{
-	"do": "merge",
-	"merge_title_field": "title",
-	"merge_message_field": "message",
-	"merge_commit_id": "merge-id",
-	"head_commit_id": "head-id",
-	"force_merge": true,
-	"merge_when_checks_succeed": true,
-	"delete_branch_after_merge": true
-}`
-		var m *MergePullRequestForm
-		require.NoError(t, json.Unmarshal([]byte(input), &m))
-		assert.Equal(t, expected, m)
-	})
-
-	t.Run("OldFields", func(t *testing.T) {
-		input := `{
-	"Do": "merge",
-	"MergeTitleField": "title",
-	"MergeMessageField": "message",
-	"MergeCommitID": "merge-id",
-	"head_commit_id": "head-id",
-	"force_merge": true,
-	"merge_when_checks_succeed": true,
-	"delete_branch_after_merge": true
-}`
-		var m *MergePullRequestForm
-		require.NoError(t, json.Unmarshal([]byte(input), &m))
-		assert.Equal(t, expected, m)
-	})
+func TestCreateRepoFormGitignoresSize(t *testing.T) {
+	form := &CreateRepoForm{RepoName: "repo", Gitignores: strings.Repeat("a", 256)}
+	assert.NotEmpty(t, validation.Binder().Validate(t.Context(), form))
 }


### PR DESCRIPTION
Bound gitignore template selections at both web and API request boundaries before repository initialization.