### PR TITLE
fix(packages): limit Maven checksum uploads

### DIFF
--- a/routers/api/packages/maven/maven.go
+++ b/routers/api/packages/maven/maven.go
@@ -30,6 +30,8 @@ import (
 	packages_service "gitea.dev/services/packages"
 )
 
+const maxChecksumSize = sha512.Size*2 + 1
+
 const (
 	mavenMetadataFile = "maven-metadata.xml"
 	extensionMD5      = ".md5"
@@ -260,12 +262,21 @@ func UploadPackageFile(ctx *context.Context) {
 	}
 	defer releaser()
 
-	buf, err := packages_module.CreateHashedBufferFromReader(ctx.Req.Body)
+	ext := path.Ext(params.Filename)
+	reader := io.Reader(ctx.Req.Body)
+	if isChecksumExtension(ext) {
+		reader = io.LimitReader(reader, maxChecksumSize+1)
+	}
+	buf, err := packages_module.CreateHashedBufferFromReader(reader)
 	if err != nil {
 		apiError(ctx, http.StatusInternalServerError, err)
 		return
 	}
 	defer buf.Close()
+	if isChecksumExtension(ext) && !isChecksumSizeAllowed(buf.Size()) {
+		apiError(ctx, http.StatusRequestEntityTooLarge, "checksum is too large")
+		return
+	}
 
 	pvci := &packages_service.PackageCreationInfo{
 		PackageInfo: packages_service.PackageInfo{
@@ -290,8 +301,6 @@ func UploadPackageFile(ctx *context.Context) {
 			return
 		}
 	}
-
-	ext := path.Ext(params.Filename)
 
 	// Do not upload checksum files but compare the hashes.
 	if isChecksumExtension(ext) {
@@ -402,6 +411,10 @@ func UploadPackageFile(ctx *context.Context) {
 	}
 
 	ctx.Status(http.StatusCreated)
+}
+
+func isChecksumSizeAllowed(size int64) bool {
+	return size <= maxChecksumSize
 }
 
 func isChecksumExtension(ext string) bool {

--- a/routers/api/packages/maven/maven_test.go
+++ b/routers/api/packages/maven/maven_test.go
@@ -1,0 +1,15 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package maven
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChecksumSizeAllowed(t *testing.T) {
+	assert.True(t, isChecksumSizeAllowed(maxChecksumSize))
+	assert.False(t, isChecksumSizeAllowed(maxChecksumSize+1))
+}


### PR DESCRIPTION
Bound checksum uploads to the maximum usable digest length before buffering their content.