### PR TITLE
fix: scope LFS diff detection to repository

### DIFF
--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -1590,7 +1590,7 @@ func GetPullRequestFiles(ctx *context.APIContext) {
 			MaxLineCharacters:  setting.Git.MaxGitDiffLineCharacters,
 			MaxFiles:           -1, // GetDiff() will return all files
 			WhitespaceBehavior: gitdiff.GetWhitespaceFlag(ctx.FormString("whitespace")),
-			LFSRepositoryID:    pr.BaseRepoID,
+			LFSRepositoryID:    pr.HeadRepoID,
 		})
 	if err != nil {
 		ctx.APIErrorInternal(err)

--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -1590,6 +1590,7 @@ func GetPullRequestFiles(ctx *context.APIContext) {
 			MaxLineCharacters:  setting.Git.MaxGitDiffLineCharacters,
 			MaxFiles:           -1, // GetDiff() will return all files
 			WhitespaceBehavior: gitdiff.GetWhitespaceFlag(ctx.FormString("whitespace")),
+			LFSRepositoryID:    pr.BaseRepoID,
 		})
 	if err != nil {
 		ctx.APIErrorInternal(err)

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -779,7 +779,7 @@ func viewPullFiles(ctx *context.Context, beforeCommitID, afterCommitID string) {
 		MaxLineCharacters:  setting.Git.MaxGitDiffLineCharacters,
 		MaxFiles:           maxFiles,
 		WhitespaceBehavior: gitdiff.GetWhitespaceFlag(GetWhitespaceBehavior(ctx)),
-		LFSRepositoryID:    ctx.Repo.Repository.ID,
+		LFSRepositoryID:    pull.HeadRepoID,
 	}
 
 	diff, err := gitdiff.GetDiffForRender(ctx, ctx.Repo.RepoLink, gitRepo, diffOptions, files...)

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -779,6 +779,7 @@ func viewPullFiles(ctx *context.Context, beforeCommitID, afterCommitID string) {
 		MaxLineCharacters:  setting.Git.MaxGitDiffLineCharacters,
 		MaxFiles:           maxFiles,
 		WhitespaceBehavior: gitdiff.GetWhitespaceFlag(GetWhitespaceBehavior(ctx)),
+		LFSRepositoryID:    ctx.Repo.Repository.ID,
 	}
 
 	diff, err := gitdiff.GetDiffForRender(ctx, ctx.Repo.RepoLink, gitRepo, diffOptions, files...)

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -687,6 +687,10 @@ const cmdDiffHead = "diff --git "
 
 // ParsePatch builds a Diff object from a io.Reader and some parameters.
 func ParsePatch(ctx context.Context, maxLines, maxLineCharacters, maxFiles int, reader io.Reader, skipToFile string) (*Diff, error) {
+	return parsePatch(ctx, maxLines, maxLineCharacters, maxFiles, reader, skipToFile, 0)
+}
+
+func parsePatch(ctx context.Context, maxLines, maxLineCharacters, maxFiles int, reader io.Reader, skipToFile string, lfsRepositoryID int64) (*Diff, error) {
 	log.Debug("ParsePatch(%d, %d, %d, ..., %s)", maxLines, maxLineCharacters, maxFiles, skipToFile)
 	var curFile *DiffFile
 
@@ -892,7 +896,7 @@ parsingLoop:
 					curFile.isAmbiguous = false
 				}
 				// Otherwise do nothing with this line, but now switch to parsing hunks
-				lineBytes, isFragment, err := parseHunks(ctx, curFile, maxLines, maxLineCharacters, input)
+				lineBytes, isFragment, err := parseHunks(ctx, curFile, maxLines, maxLineCharacters, input, lfsRepositoryID)
 				if err != nil {
 					if err != io.EOF {
 						return diff, err
@@ -1007,7 +1011,7 @@ func newDiffSectionForDiffFile(curFile *DiffFile) *DiffSection {
 	}
 }
 
-func parseHunks(ctx context.Context, curFile *DiffFile, maxLines, maxLineCharacters int, input *bufio.Reader) (lineBytes []byte, isFragment bool, err error) {
+func parseHunks(ctx context.Context, curFile *DiffFile, maxLines, maxLineCharacters int, input *bufio.Reader, lfsRepositoryID int64) (lineBytes []byte, isFragment bool, err error) {
 	sb := strings.Builder{}
 
 	var curSection *DiffSection
@@ -1198,10 +1202,18 @@ func parseHunks(ctx context.Context, curFile *DiffFile, maxLines, maxLineCharact
 		} else if curFileLFSPrefix && strings.HasPrefix(line[1:], lfs.MetaFileOidPrefix) {
 			oid := strings.TrimPrefix(line[1:], lfs.MetaFileOidPrefix)
 			if len(oid) == 64 {
-				m := &git_model.LFSMetaObject{Pointer: lfs.Pointer{Oid: oid}}
-				count, err := db.CountByBean(ctx, m)
+				var isLFSFile bool
 
-				if err == nil && count > 0 {
+				if lfsRepositoryID > 0 {
+					_, err := git_model.GetLFSMetaObjectByOid(ctx, lfsRepositoryID, oid)
+					isLFSFile = err == nil
+				} else {
+					m := &git_model.LFSMetaObject{Pointer: lfs.Pointer{Oid: oid}}
+					count, err := db.CountByBean(ctx, m)
+					isLFSFile = err == nil && count > 0
+				}
+
+				if isLFSFile {
 					curFile.IsBin = true
 					curFile.IsLFSFile = true
 					curSection.Lines = nil
@@ -1304,6 +1316,7 @@ type DiffOptions struct {
 	MaxFiles           int
 	WhitespaceBehavior gitcmd.TrustedCmdArgs
 	DirectComparison   bool
+	LFSRepositoryID    int64
 }
 
 func guessBeforeCommitForDiff(ctx context.Context, gitRepo *git.Repository, beforeCommitID string, afterCommit *git.Commit) (actualBeforeCommit *git.Commit, actualBeforeCommitID git.ObjectID, err error) {
@@ -1373,7 +1386,7 @@ func getDiffBasic(ctx context.Context, gitRepo *git.Repository, opts *DiffOption
 		}
 	}()
 
-	diff, err := ParsePatch(cmdCtx, opts.MaxLines, opts.MaxLineCharacters, opts.MaxFiles, reader, parsePatchSkipToFile)
+	diff, err := parsePatch(cmdCtx, opts.MaxLines, opts.MaxLineCharacters, opts.MaxFiles, reader, parsePatchSkipToFile, opts.LFSRepositoryID)
 	// Ensure the git process is killed if it didn't exit already
 	cmdCancel()
 	if err != nil {

--- a/services/gitdiff/gitdiff_test.go
+++ b/services/gitdiff/gitdiff_test.go
@@ -192,6 +192,7 @@ diff --git "\\a/README.md" "\\b/README.md"
 		})
 	}
 }
+
 func TestParsePatch_LFSRepositoryScope(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
 

--- a/services/gitdiff/gitdiff_test.go
+++ b/services/gitdiff/gitdiff_test.go
@@ -10,13 +10,16 @@ import (
 	"strings"
 	"testing"
 
+	git_model "gitea.dev/models/git"
 	issues_model "gitea.dev/models/issues"
 	pull_model "gitea.dev/models/pull"
+	repo_model "gitea.dev/models/repo"
 	"gitea.dev/models/unittest"
 	user_model "gitea.dev/models/user"
 	"gitea.dev/modules/git"
 	"gitea.dev/modules/git/gitcmd"
 	"gitea.dev/modules/json"
+	"gitea.dev/modules/lfs"
 	"gitea.dev/modules/setting"
 	"gitea.dev/modules/translation"
 	"gitea.dev/modules/util"
@@ -188,6 +191,60 @@ diff --git "\\a/README.md" "\\b/README.md"
 			}
 		})
 	}
+}
+func TestParsePatch_LFSRepositoryScope(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	repoA := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+	repoB := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 54})
+
+	pointer, err := lfs.GeneratePointer(strings.NewReader("lfs test content"))
+	require.NoError(t, err)
+
+	_, err = git_model.NewLFSMetaObject(t.Context(), repoA.ID, pointer)
+	require.NoError(t, err)
+
+	diff := `diff --git a/test.bin b/test.bin
+--- a/test.bin
++++ b/test.bin
+@@ -1,3 +1,3 @@
+ version https://git-lfs.github.com/spec/v1
+ oid sha256:` + pointer.Oid + `
+ size 15
+`
+
+	t.Run("OID belonging to another repository is not LFS", func(t *testing.T) {
+		got, err := parsePatch(
+			t.Context(),
+			setting.Git.MaxGitDiffLines,
+			setting.Git.MaxGitDiffLineCharacters,
+			setting.Git.MaxGitDiffFiles,
+			strings.NewReader(diff),
+			"",
+			repoB.ID,
+		)
+		require.NoError(t, err)
+		require.Len(t, got.Files, 1)
+		assert.False(t, got.Files[0].IsLFSFile)
+	})
+
+	t.Run("OID belonging to repository is LFS", func(t *testing.T) {
+		_, err := git_model.NewLFSMetaObject(t.Context(), repoB.ID, pointer)
+		require.NoError(t, err)
+
+		got, err := parsePatch(
+			t.Context(),
+			setting.Git.MaxGitDiffLines,
+			setting.Git.MaxGitDiffLineCharacters,
+			setting.Git.MaxGitDiffFiles,
+			strings.NewReader(diff),
+			"",
+			repoB.ID,
+		)
+		require.NoError(t, err)
+		require.Len(t, got.Files, 1)
+		assert.True(t, got.Files[0].IsLFSFile)
+	})
 }
 
 func TestParsePatch_singlefile(t *testing.T) {


### PR DESCRIPTION
Fixes #39020.

Git LFS pointers were previously detected by OID without considering the repository they belonged to. This could cause an LFS file in a pull request to be displayed as plaintext when the same OID existed in another repository.

This change passes the repository ID through the pull request diff path and scopes the LFS metadata lookup to that repository.

Added a regression test covering:
- an LFS OID belonging to another repository
- an LFS OID belonging to the current repository

Tests:
- `go test ./services/gitdiff`
- `go test ./routers/web/repo ./routers/api/v1/repo ./services/gitdiff ./services/repository/files`
- `git diff --check`