### PR TITLE
chore: add modelmigration to GO_DIRS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ GO_LICENSE_FILE := assets/go-licenses.json
 
 TAR_EXCLUDES := .git data indexers queues log node_modules $(EXECUTABLE) $(DIST) $(MAKE_EVIDENCE_DIR) $(AIR_TMP_DIR)
 
-GO_DIRS := build cmd models modules routers services tests tools
+GO_DIRS := build cmd modelmigration models modules routers services tests tools
 WEB_DIRS := web_src/js web_src/css
 
 ESLINT_FILES := web_src/js tools *.ts tests/e2e


### PR DESCRIPTION
`modelmigration` was missing here since its creation, leading to those files not being covered by fmt.