### PR TITLE
chore: bump `declaration-strict-value` and reconfigure it

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "stylelint": "17.14.1",
     "stylelint-config-recommended": "18.0.0",
     "stylelint-declaration-block-no-ignored-properties": "3.0.0",
-    "stylelint-declaration-strict-value": "1.11.1",
+    "stylelint-declaration-strict-value": "1.12.0",
     "stylelint-value-no-unknown-custom-properties": "6.1.1",
     "svgo": "4.0.2",
     "typescript": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "stylelint": "17.14.1",
     "stylelint-config-recommended": "18.0.0",
     "stylelint-declaration-block-no-ignored-properties": "3.0.0",
-    "stylelint-declaration-strict-value": "1.12.0",
+    "stylelint-declaration-strict-value": "1.12.1",
     "stylelint-value-no-unknown-custom-properties": "6.1.1",
     "svgo": "4.0.2",
     "typescript": "6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,8 +295,8 @@ importers:
         specifier: 3.0.0
         version: 3.0.0(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))
       stylelint-declaration-strict-value:
-        specifier: 1.12.0
-        version: 1.12.0(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))
+        specifier: 1.12.1
+        version: 1.12.1(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))
       stylelint-value-no-unknown-custom-properties:
         specifier: 6.1.1
         version: 6.1.1(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))
@@ -3990,8 +3990,8 @@ packages:
     peerDependencies:
       stylelint: ^17.0.0
 
-  stylelint-declaration-strict-value@1.12.0:
-    resolution: {integrity: sha512-0OpPTvuvU0PlRn8X83DBogoQDfVlCG0klyPSVVLVGZPUD7aG3xKAFX8zFpRLSH817zj1VxBdNIGzfYo6CaPm6g==}
+  stylelint-declaration-strict-value@1.12.1:
+    resolution: {integrity: sha512-KSQTXfWboeebH0tw3bZq5ZPLnkUBHvz9PtzAmIaqU7egLvjN7wU/F0tukFBVyGDKQEfDlLNGDNvhI/O1+6KipQ==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       stylelint: '>=16 <=17'
@@ -8586,7 +8586,7 @@ snapshots:
     dependencies:
       stylelint: 17.14.1(supports-color@10.2.2)(typescript@6.0.3)
 
-  stylelint-declaration-strict-value@1.12.0(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3)):
+  stylelint-declaration-strict-value@1.12.1(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3)):
     dependencies:
       regexp.escape: 2.0.1
       stylelint: 17.14.1(supports-color@10.2.2)(typescript@6.0.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,8 +295,8 @@ importers:
         specifier: 3.0.0
         version: 3.0.0(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))
       stylelint-declaration-strict-value:
-        specifier: 1.11.1
-        version: 1.11.1(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))
+        specifier: 1.12.0
+        version: 1.12.0(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))
       stylelint-value-no-unknown-custom-properties:
         specifier: 6.1.1
         version: 6.1.1(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))
@@ -3707,6 +3707,10 @@ packages:
     resolution: {integrity: sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
+  regexp.escape@2.0.1:
+    resolution: {integrity: sha512-JItRb4rmyTzmERBkAf6J87LjDPy/RscIwmaJQ3gsFlAzrmZbZU8LwBw5IydFZXW9hqpgbPlGbMhtpqtuAhMgtg==}
+    engines: {node: '>= 0.4'}
+
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
@@ -3986,8 +3990,8 @@ packages:
     peerDependencies:
       stylelint: ^17.0.0
 
-  stylelint-declaration-strict-value@1.11.1:
-    resolution: {integrity: sha512-DYihiMuKGk9AeCYp+c3PMy6Z+Qu6yb6wRLeXQJZVMdXV+QOqs7P+Xj6jt8RVTgFJfII+cEQaFI5uWu08WwlkOA==}
+  stylelint-declaration-strict-value@1.12.0:
+    resolution: {integrity: sha512-0OpPTvuvU0PlRn8X83DBogoQDfVlCG0klyPSVVLVGZPUD7aG3xKAFX8zFpRLSH817zj1VxBdNIGzfYo6CaPm6g==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       stylelint: '>=16 <=17'
@@ -5966,7 +5970,6 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       is-array-buffer: 3.0.5
-    optional: true
 
   array-includes@3.1.9:
     dependencies:
@@ -6016,7 +6019,6 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
-    optional: true
 
   asciinema-player@3.17.0:
     dependencies:
@@ -6028,15 +6030,13 @@ snapshots:
 
   astral-regex@2.0.0: {}
 
-  async-function@1.0.0:
-    optional: true
+  async-function@1.0.0: {}
 
   asynckit@0.4.0: {}
 
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
-    optional: true
 
   balanced-match@1.0.2:
     optional: true
@@ -6104,13 +6104,11 @@ snapshots:
       es-define-property: 1.0.1
       get-intrinsic: 1.3.0
       set-function-length: 1.2.2
-    optional: true
 
   call-bound@1.0.4:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
-    optional: true
 
   callsites@3.1.0: {}
 
@@ -6475,21 +6473,18 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
-    optional: true
 
   data-view-byte-length@1.0.2:
     dependencies:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
-    optional: true
 
   data-view-byte-offset@1.0.1:
     dependencies:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
-    optional: true
 
   dayjs@1.11.23: {}
 
@@ -6521,14 +6516,12 @@ snapshots:
       es-define-property: 1.0.1
       es-errors: 1.3.0
       gopd: 1.2.0
-    optional: true
 
   define-properties@1.2.1:
     dependencies:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-    optional: true
 
   delaunator@5.1.0:
     dependencies:
@@ -6671,7 +6664,6 @@ snapshots:
       typed-array-length: 1.0.8
       unbox-primitive: 1.1.0
       which-typed-array: 1.1.21
-    optional: true
 
   es-define-property@1.0.1: {}
 
@@ -6700,7 +6692,6 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
-    optional: true
 
   es-toolkit@1.47.0: {}
 
@@ -7066,7 +7057,6 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
-    optional: true
 
   form-data@4.0.5:
     dependencies:
@@ -7094,13 +7084,10 @@ snapshots:
       functions-have-names: 1.2.3
       hasown: 2.0.4
       is-callable: 1.2.7
-    optional: true
 
-  functions-have-names@1.2.3:
-    optional: true
+  functions-have-names@1.2.3: {}
 
-  generator-function@2.0.1:
-    optional: true
+  generator-function@2.0.1: {}
 
   get-east-asian-width@1.6.0: {}
 
@@ -7127,7 +7114,6 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
-    optional: true
 
   get-tsconfig@4.14.0:
     dependencies:
@@ -7157,7 +7143,6 @@ snapshots:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
-    optional: true
 
   globby@16.2.2:
     dependencies:
@@ -7192,8 +7177,7 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  has-bigints@1.1.0:
-    optional: true
+  has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
 
@@ -7202,12 +7186,10 @@ snapshots:
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
-    optional: true
 
   has-proto@1.2.0:
     dependencies:
       dunder-proto: 1.0.1
-    optional: true
 
   has-symbols@1.1.0: {}
 
@@ -7291,7 +7273,6 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.4
       side-channel: 1.1.0
-    optional: true
 
   internmap@1.0.1: {}
 
@@ -7309,7 +7290,6 @@ snapshots:
       call-bind: 1.0.9
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
-    optional: true
 
   is-arrayish@0.2.1: {}
 
@@ -7320,12 +7300,10 @@ snapshots:
       get-proto: 1.0.1
       has-tostringtag: 1.0.2
       safe-regex-test: 1.1.0
-    optional: true
 
   is-bigint@1.1.0:
     dependencies:
       has-bigints: 1.1.0
-    optional: true
 
   is-binary-path@2.1.0:
     dependencies:
@@ -7335,7 +7313,6 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
-    optional: true
 
   is-builtin-module@5.0.0:
     dependencies:
@@ -7345,8 +7322,7 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  is-callable@1.2.7:
-    optional: true
+  is-callable@1.2.7: {}
 
   is-core-module@2.16.2:
     dependencies:
@@ -7357,13 +7333,11 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
       is-typed-array: 1.1.15
-    optional: true
 
   is-date-object@1.1.0:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
-    optional: true
 
   is-decimal@2.0.1: {}
 
@@ -7372,7 +7346,6 @@ snapshots:
   is-finalizationregistry@1.1.1:
     dependencies:
       call-bound: 1.0.4
-    optional: true
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -7383,7 +7356,6 @@ snapshots:
       get-proto: 1.0.1
       has-tostringtag: 1.0.2
       safe-regex-test: 1.1.0
-    optional: true
 
   is-glob@4.0.3:
     dependencies:
@@ -7396,11 +7368,9 @@ snapshots:
       identifier-regex: 1.1.0
       super-regex: 1.1.0
 
-  is-map@2.0.3:
-    optional: true
+  is-map@2.0.3: {}
 
-  is-negative-zero@2.0.3:
-    optional: true
+  is-negative-zero@2.0.3: {}
 
   is-network-error@1.3.2: {}
 
@@ -7408,7 +7378,6 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
-    optional: true
 
   is-number@7.0.0: {}
 
@@ -7422,54 +7391,44 @@ snapshots:
       gopd: 1.2.0
       has-tostringtag: 1.0.2
       hasown: 2.0.4
-    optional: true
 
-  is-set@2.0.3:
-    optional: true
+  is-set@2.0.3: {}
 
   is-shared-array-buffer@1.0.4:
     dependencies:
       call-bound: 1.0.4
-    optional: true
 
   is-string@1.1.1:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
-    optional: true
 
   is-symbol@1.1.1:
     dependencies:
       call-bound: 1.0.4
       has-symbols: 1.1.0
       safe-regex-test: 1.1.0
-    optional: true
 
   is-typed-array@1.1.15:
     dependencies:
       which-typed-array: 1.1.21
-    optional: true
 
   is-valid-element-name@1.0.0:
     dependencies:
       is-potential-custom-element-name: 1.0.1
 
-  is-weakmap@2.0.2:
-    optional: true
+  is-weakmap@2.0.2: {}
 
   is-weakref@1.1.1:
     dependencies:
       call-bound: 1.0.4
-    optional: true
 
   is-weakset@2.0.4:
     dependencies:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
-    optional: true
 
-  isarray@2.0.5:
-    optional: true
+  isarray@2.0.5: {}
 
   isexe@2.0.0: {}
 
@@ -8044,11 +8003,9 @@ snapshots:
 
   object-hash@3.0.0: {}
 
-  object-inspect@1.13.4:
-    optional: true
+  object-inspect@1.13.4: {}
 
-  object-keys@1.1.1:
-    optional: true
+  object-keys@1.1.1: {}
 
   object.assign@4.1.7:
     dependencies:
@@ -8058,7 +8015,6 @@ snapshots:
       es-object-atoms: 1.1.2
       has-symbols: 1.1.0
       object-keys: 1.1.1
-    optional: true
 
   object.entries@1.1.9:
     dependencies:
@@ -8113,7 +8069,6 @@ snapshots:
       get-intrinsic: 1.3.0
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
-    optional: true
 
   p-event@6.0.1:
     dependencies:
@@ -8199,8 +8154,7 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  possible-typed-array-names@1.1.0:
-    optional: true
+  possible-typed-array-names@1.1.0: {}
 
   postcss-html@2.0.0(postcss@8.5.26):
     dependencies:
@@ -8306,12 +8260,20 @@ snapshots:
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
-    optional: true
 
   regexp-ast-analysis@0.7.1:
     dependencies:
       '@eslint-community/regexpp': 4.12.2
       refa: 0.12.1
+
+  regexp.escape@2.0.1:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      for-each: 0.3.5
+      safe-regex-test: 1.1.0
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -8321,7 +8283,6 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
-    optional: true
 
   regjsparser@0.13.2:
     dependencies:
@@ -8409,20 +8370,17 @@ snapshots:
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
       isarray: 2.0.5
-    optional: true
 
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
       isarray: 2.0.5
-    optional: true
 
   safe-regex-test@1.1.0:
     dependencies:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
-    optional: true
 
   safer-buffer@2.1.2: {}
 
@@ -8457,7 +8415,6 @@ snapshots:
       get-intrinsic: 1.3.0
       gopd: 1.2.0
       has-property-descriptors: 1.0.2
-    optional: true
 
   set-function-name@2.0.2:
     dependencies:
@@ -8465,14 +8422,12 @@ snapshots:
       es-errors: 1.3.0
       functions-have-names: 1.2.3
       has-property-descriptors: 1.0.2
-    optional: true
 
   set-proto@1.0.0:
     dependencies:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.2
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -8484,7 +8439,6 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-    optional: true
 
   side-channel-map@1.0.1:
     dependencies:
@@ -8492,7 +8446,6 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       object-inspect: 1.13.4
-    optional: true
 
   side-channel-weakmap@1.0.2:
     dependencies:
@@ -8501,7 +8454,6 @@ snapshots:
       get-intrinsic: 1.3.0
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
-    optional: true
 
   side-channel@1.1.0:
     dependencies:
@@ -8510,7 +8462,6 @@ snapshots:
       side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
-    optional: true
 
   siginfo@2.0.0: {}
 
@@ -8571,7 +8522,6 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
-    optional: true
 
   strictdom@1.0.1: {}
 
@@ -8595,7 +8545,6 @@ snapshots:
       es-abstract: 1.24.2
       es-object-atoms: 1.1.2
       has-property-descriptors: 1.0.2
-    optional: true
 
   string.prototype.trimend@1.0.9:
     dependencies:
@@ -8603,14 +8552,12 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
-    optional: true
 
   string.prototype.trimstart@1.0.8:
     dependencies:
       call-bind: 1.0.9
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
-    optional: true
 
   strip-ansi@6.0.1:
     dependencies:
@@ -8639,8 +8586,9 @@ snapshots:
     dependencies:
       stylelint: 17.14.1(supports-color@10.2.2)(typescript@6.0.3)
 
-  stylelint-declaration-strict-value@1.11.1(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3)):
+  stylelint-declaration-strict-value@1.12.0(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3)):
     dependencies:
+      regexp.escape: 2.0.1
       stylelint: 17.14.1(supports-color@10.2.2)(typescript@6.0.3)
 
   stylelint-value-no-unknown-custom-properties@6.1.1(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3)):
@@ -8865,7 +8813,6 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-typed-array: 1.1.15
-    optional: true
 
   typed-array-byte-length@1.0.3:
     dependencies:
@@ -8874,7 +8821,6 @@ snapshots:
       gopd: 1.2.0
       has-proto: 1.2.0
       is-typed-array: 1.1.15
-    optional: true
 
   typed-array-byte-offset@1.0.4:
     dependencies:
@@ -8885,7 +8831,6 @@ snapshots:
       has-proto: 1.2.0
       is-typed-array: 1.1.15
       reflect.getprototypeof: 1.0.10
-    optional: true
 
   typed-array-length@1.0.8:
     dependencies:
@@ -8895,7 +8840,6 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
-    optional: true
 
   typescript-eslint@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3):
     dependencies:
@@ -8920,7 +8864,6 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
-    optional: true
 
   undici-types@8.3.0: {}
 
@@ -9089,7 +9032,6 @@ snapshots:
       is-number-object: 1.1.1
       is-string: 1.1.1
       is-symbol: 1.1.1
-    optional: true
 
   which-builtin-type@1.2.1:
     dependencies:
@@ -9106,7 +9048,6 @@ snapshots:
       which-boxed-primitive: 1.1.1
       which-collection: 1.0.2
       which-typed-array: 1.1.21
-    optional: true
 
   which-collection@1.0.2:
     dependencies:
@@ -9114,7 +9055,6 @@ snapshots:
       is-set: 2.0.3
       is-weakmap: 2.0.2
       is-weakset: 2.0.4
-    optional: true
 
   which-typed-array@1.1.21:
     dependencies:
@@ -9125,7 +9065,6 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-    optional: true
 
   which@1.3.1:
     dependencies:

--- a/stylelint.config.ts
+++ b/stylelint.config.ts
@@ -132,7 +132,7 @@ export default {
     'no-unknown-custom-properties': null,  // disabled until stylelint supports multi-file linting
     'plugin/declaration-block-no-ignored-properties': true,
     'property-no-vendor-prefix': true,
-    'scale-unlimited/declaration-strict-value': [['/color$/', 'fill', 'stroke', 'font-weight'], {ignoreValues: '/^(inherit|transparent|unset|initial|currentcolor|none)$/', ignoreFunctions: true, disableFix: true, expandShorthand: true}],
+    'scale-unlimited/declaration-strict-value': [['/color$/', 'fill', 'stroke', 'font-weight'], {ignoreValues: '/^(inherit|transparent|unset|initial|currentcolor|none)$/', ignoreAtRules: {'@font-face': 'font-weight', '@page': true}, ignoreFunctions: true, disableFix: true, expandShorthand: true}],
     'selector-attribute-quotes': 'always',
     'selector-no-vendor-prefix': true,
     'selector-pseudo-element-colon-notation': 'double',

--- a/stylelint.config.ts
+++ b/stylelint.config.ts
@@ -132,7 +132,7 @@ export default {
     'no-unknown-custom-properties': null,  // disabled until stylelint supports multi-file linting
     'plugin/declaration-block-no-ignored-properties': true,
     'property-no-vendor-prefix': true,
-    'scale-unlimited/declaration-strict-value': [['/color$/', 'fill', 'stroke', 'font-weight'], {ignoreValues: '/^(inherit|transparent|unset|initial|currentcolor|none)$/', ignoreAtRules: {'@font-face': 'font-weight', '@page': true}, ignoreFunctions: true, disableFix: true, expandShorthand: true}],
+    'scale-unlimited/declaration-strict-value': [['/color$/', 'fill', 'stroke', 'font-weight'], {ignoreValues: '/^(inherit|transparent|unset|initial|currentcolor|none)$/', ignoreAtRules: ['@font-face', '@page'], ignoreFunctions: true, disableFix: true, expandShorthand: true}],
     'selector-attribute-quotes': 'always',
     'selector-no-vendor-prefix': true,
     'selector-pseudo-element-colon-notation': 'double',

--- a/web_src/css/font_i18n.css
+++ b/web_src/css/font_i18n.css
@@ -51,7 +51,7 @@
     local("SourceHanSans-Light"), local("Yu Gothic Regular"),
     local("YuGothic Regular"), local("Droid Sans Japanese"), local("Meiryo"),
     local("MS PGothic");
-  font-weight: 300; /* stylelint-disable-line scale-unlimited/declaration-strict-value -- @font-face descriptors do not accept var() */
+  font-weight: 300;
   unicode-range: U+11??, U+2E80-4DBF, U+4E00-9FFF, U+A960-A97F, U+AC00-D7FF,
     U+F900-FAFF, U+FE00-FE6F, U+FF00-FFEF, U+1F2??, U+2????;
 }
@@ -66,7 +66,7 @@
     local("SourceHanSans-Regular"), local("Yu Gothic Medium"),
     local("YuGothic Medium"), local("Droid Sans Japanese"), local("Meiryo"),
     local("MS PGothic");
-  font-weight: 400; /* stylelint-disable-line scale-unlimited/declaration-strict-value -- @font-face descriptors do not accept var() */
+  font-weight: 400;
   unicode-range: U+11??, U+2E80-4DBF, U+4E00-9FFF, U+A960-A97F, U+AC00-D7FF,
     U+F900-FAFF, U+FE00-FE6F, U+FF00-FFEF, U+1F2??, U+2????;
 }
@@ -81,7 +81,7 @@
     local("SourceHanSans-Medium"), local("Yu Gothic Medium"),
     local("YuGothic Medium"), local("Droid Sans Japanese"), local("Meiryo"),
     local("MS PGothic");
-  font-weight: 500; /* stylelint-disable-line scale-unlimited/declaration-strict-value -- @font-face descriptors do not accept var() */
+  font-weight: 500;
   unicode-range: U+11??, U+2E80-4DBF, U+4E00-9FFF, U+A960-A97F, U+AC00-D7FF,
     U+F900-FAFF, U+FE00-FE6F, U+FF00-FFEF, U+1F2??, U+2????;
 }
@@ -95,7 +95,7 @@
     local("NotoSansCJKJP-Bold"), local("Source Han Sans Bold"),
     local("SourceHanSans-Bold"), local("Yu Gothic Bold"), local("YuGothic Bold"),
     local("Droid Sans Japanese"), local("Meiryo Bold"), local("MS PGothic");
-  font-weight: 600; /* stylelint-disable-line scale-unlimited/declaration-strict-value -- @font-face descriptors do not accept var() */
+  font-weight: 600;
   unicode-range: U+11??, U+2E80-4DBF, U+4E00-9FFF, U+A960-A97F, U+AC00-D7FF,
     U+F900-FAFF, U+FE00-FE6F, U+FF00-FFEF, U+1F2??, U+2????;
 }
@@ -124,7 +124,7 @@
     local("NotoSansCJKSC-Light"), local("HiraginoSansGB-W3"),
     local("Hiragino Sans GB W3"), local("Microsoft YaHei Light"),
     local("Heiti SC Light"), local("SimHei");
-  font-weight: 300; /* stylelint-disable-line scale-unlimited/declaration-strict-value -- @font-face descriptors do not accept var() */
+  font-weight: 300;
   unicode-range: U+11??, U+2E80-4DBF, U+4E00-9FFF, U+A960-A97F, U+AC00-D7FF,
     U+F900-FAFF, U+FE00-FE6F, U+FF00-FFEF, U+1F2??, U+2????;
 }
@@ -137,7 +137,7 @@
     local("NotoSansCJKSC-Regular"), local("HiraginoSansGB-W3"),
     local("Hiragino Sans GB W3"), local("Microsoft YaHei"),
     local("Heiti SC Light"), local("SimHei");
-  font-weight: 400; /* stylelint-disable-line scale-unlimited/declaration-strict-value -- @font-face descriptors do not accept var() */
+  font-weight: 400;
   unicode-range: U+11??, U+2E80-4DBF, U+4E00-9FFF, U+A960-A97F, U+AC00-D7FF,
     U+F900-FAFF, U+FE00-FE6F, U+FF00-FFEF, U+1F2??, U+2????;
 }
@@ -150,7 +150,7 @@
     local("NotoSansCJKSC-Medium"), local("HiraginoSansGB-W3"),
     local("Hiragino Sans GB W3"), local("Microsoft YaHei"),
     local("Heiti SC Light"), local("SimHei");
-  font-weight: 500; /* stylelint-disable-line scale-unlimited/declaration-strict-value -- @font-face descriptors do not accept var() */
+  font-weight: 500;
   unicode-range: U+11??, U+2E80-4DBF, U+4E00-9FFF, U+A960-A97F, U+AC00-D7FF,
     U+F900-FAFF, U+FE00-FE6F, U+FF00-FFEF, U+1F2??, U+2????;
 }
@@ -163,7 +163,7 @@
     local("NotoSansCJKSC-Bold"), local("HiraginoSansGB-W6"),
     local("Hiragino Sans GB W6"), local("Microsoft YaHei Bold"),
     local("Heiti SC Medium"), local("SimHei");
-  font-weight: 600; /* stylelint-disable-line scale-unlimited/declaration-strict-value -- @font-face descriptors do not accept var() */
+  font-weight: 600;
   unicode-range: U+11??, U+2E80-4DBF, U+4E00-9FFF, U+A960-A97F, U+AC00-D7FF,
     U+F900-FAFF, U+FE00-FE6F, U+FF00-FFEF, U+1F2??, U+2????;
 }
@@ -192,7 +192,7 @@
     local("NotoSansCJKTC-Light"), local("HiraginoSansTC-W3"),
     local("Hiragino Sans TC W3"), local("Microsoft JhengHei Light"),
     local("Heiti TC Light"), local("PMingLiU");
-  font-weight: 300; /* stylelint-disable-line scale-unlimited/declaration-strict-value -- @font-face descriptors do not accept var() */
+  font-weight: 300;
   unicode-range: U+11??, U+2E80-4DBF, U+4E00-9FFF, U+A960-A97F, U+AC00-D7FF,
     U+F900-FAFF, U+FE00-FE6F, U+FF00-FFEF, U+1F2??, U+2????;
 }
@@ -205,7 +205,7 @@
     local("NotoSansCJKTC-Regular"), local("HiraginoSansTC-W3"),
     local("Hiragino Sans TC W3"), local("Microsoft JhengHei"),
     local("Heiti TC Light"), local("PMingLiU");
-  font-weight: 400; /* stylelint-disable-line scale-unlimited/declaration-strict-value -- @font-face descriptors do not accept var() */
+  font-weight: 400;
   unicode-range: U+11??, U+2E80-4DBF, U+4E00-9FFF, U+A960-A97F, U+AC00-D7FF,
     U+F900-FAFF, U+FE00-FE6F, U+FF00-FFEF, U+1F2??, U+2????;
 }
@@ -218,7 +218,7 @@
     local("NotoSansCJKTC-Medium"), local("HiraginoSansTC-W3"),
     local("Hiragino Sans TC W3"), local("Microsoft JhengHei"),
     local("Heiti TC Light"), local("PMingLiU");
-  font-weight: 500; /* stylelint-disable-line scale-unlimited/declaration-strict-value -- @font-face descriptors do not accept var() */
+  font-weight: 500;
   unicode-range: U+11??, U+2E80-4DBF, U+4E00-9FFF, U+A960-A97F, U+AC00-D7FF,
     U+F900-FAFF, U+FE00-FE6F, U+FF00-FFEF, U+1F2??, U+2????;
 }
@@ -231,7 +231,7 @@
     local("NotoSansCJKTC-Bold"), local("HiraginoSansTC-W6"),
     local("Hiragino Sans TC W6"), local("Microsoft JhengHei Bold"),
     local("Heiti TC Medium"), local("PMingLiU");
-  font-weight: 600; /* stylelint-disable-line scale-unlimited/declaration-strict-value -- @font-face descriptors do not accept var() */
+  font-weight: 600;
   unicode-range: U+11??, U+2E80-4DBF, U+4E00-9FFF, U+A960-A97F, U+AC00-D7FF,
     U+F900-FAFF, U+FE00-FE6F, U+FF00-FFEF, U+1F2??, U+2????;
 }
@@ -262,7 +262,7 @@
     local("NotoSansCJKTC-Light"), local("HiraginoSansTC-W3"),
     local("Hiragino Sans TC W3"), local("Microsoft JhengHei Light"),
     local("Heiti TC Light"), local("PMingLiU_HKSCS"), local("PMingLiU");
-  font-weight: 300; /* stylelint-disable-line scale-unlimited/declaration-strict-value -- @font-face descriptors do not accept var() */
+  font-weight: 300;
   unicode-range: U+11??, U+2E80-4DBF, U+4E00-9FFF, U+A960-A97F, U+AC00-D7FF,
     U+F900-FAFF, U+FE00-FE6F, U+FF00-FFEF, U+1F2??, U+2????;
 }
@@ -277,7 +277,7 @@
     local("NotoSansCJKTC-Regular"), local("HiraginoSansTC-W3"),
     local("Hiragino Sans TC W3"), local("Microsoft JhengHei"),
     local("Heiti TC Light"), local("PMingLiU_HKSCS"), local("PMingLiU");
-  font-weight: 400; /* stylelint-disable-line scale-unlimited/declaration-strict-value -- @font-face descriptors do not accept var() */
+  font-weight: 400;
   unicode-range: U+11??, U+2E80-4DBF, U+4E00-9FFF, U+A960-A97F, U+AC00-D7FF,
     U+F900-FAFF, U+FE00-FE6F, U+FF00-FFEF, U+1F2??, U+2????;
 }
@@ -292,7 +292,7 @@
     local("NotoSansCJKTC-Medium"), local("HiraginoSansTC-W3"),
     local("Hiragino Sans TC W3"), local("Microsoft JhengHei"),
     local("Heiti TC Light"), local("PMingLiU_HKSCS"), local("PMingLiU");
-  font-weight: 500; /* stylelint-disable-line scale-unlimited/declaration-strict-value -- @font-face descriptors do not accept var() */
+  font-weight: 500;
   unicode-range: U+11??, U+2E80-4DBF, U+4E00-9FFF, U+A960-A97F, U+AC00-D7FF,
     U+F900-FAFF, U+FE00-FE6F, U+FF00-FFEF, U+1F2??, U+2????;
 }
@@ -307,7 +307,7 @@
     local("NotoSansCJKTC-Bold"), local("HiraginoSansTC-W6"),
     local("Hiragino Sans TC W6"), local("Microsoft JhengHei Bold"),
     local("Heiti TC Medium"), local("PMingLiU_HKSCS"), local("PMingLiU");
-  font-weight: 600; /* stylelint-disable-line scale-unlimited/declaration-strict-value -- @font-face descriptors do not accept var() */
+  font-weight: 600;
   unicode-range: U+11??, U+2E80-4DBF, U+4E00-9FFF, U+A960-A97F, U+AC00-D7FF,
     U+F900-FAFF, U+FE00-FE6F, U+FF00-FFEF, U+1F2??, U+2????;
 }
@@ -335,7 +335,7 @@
     local("SourceHanSansK-Light"), local("Noto Sans CJK KR Light"),
     local("NotoSansCJKKR-Light"), local("NanumBarunGothic Light"),
     local("Malgun Gothic Semilight"), local("Nanum Gothic"), local("Dotum");
-  font-weight: 300; /* stylelint-disable-line scale-unlimited/declaration-strict-value -- @font-face descriptors do not accept var() */
+  font-weight: 300;
   unicode-range: U+11??, U+2E80-4DBF, U+4E00-9FFF, U+A960-A97F, U+AC00-D7FF,
     U+F900-FAFF, U+FE00-FE6F, U+FF00-FFEF, U+1F2??, U+2????;
 }
@@ -347,7 +347,7 @@
     local("SourceHanSansK-Regular"), local("Noto Sans CJK KR Regular"),
     local("NotoSansCJKKR-Regular"), local("NanumBarunGothic"),
     local("Malgun Gothic"), local("Nanum Gothic"), local("Dotum");
-  font-weight: 400; /* stylelint-disable-line scale-unlimited/declaration-strict-value -- @font-face descriptors do not accept var() */
+  font-weight: 400;
   unicode-range: U+11??, U+2E80-4DBF, U+4E00-9FFF, U+A960-A97F, U+AC00-D7FF,
     U+F900-FAFF, U+FE00-FE6F, U+FF00-FFEF, U+1F2??, U+2????;
 }
@@ -359,7 +359,7 @@
     local("SourceHanSansK-Medium"), local("Noto Sans CJK KR Medium"),
     local("NotoSansCJKKR-Medium"), local("NanumBarunGothic"),
     local("Malgun Gothic"), local("Nanum Gothic"), local("Dotum");
-  font-weight: 500; /* stylelint-disable-line scale-unlimited/declaration-strict-value -- @font-face descriptors do not accept var() */
+  font-weight: 500;
   unicode-range: U+11??, U+2E80-4DBF, U+4E00-9FFF, U+A960-A97F, U+AC00-D7FF,
     U+F900-FAFF, U+FE00-FE6F, U+FF00-FFEF, U+1F2??, U+2????;
 }
@@ -371,7 +371,7 @@
     local("SourceHanSansK-Bold"), local("Noto Sans CJK KR Bold"),
     local("NotoSansCJKKR-Bold"), local("NanumBarunGothic Bold"),
     local("Malgun Gothic Bold"), local("Nanum Gothic Bold"), local("Dotum");
-  font-weight: 600; /* stylelint-disable-line scale-unlimited/declaration-strict-value -- @font-face descriptors do not accept var() */
+  font-weight: 600;
   unicode-range: U+11??, U+2E80-4DBF, U+4E00-9FFF, U+A960-A97F, U+AC00-D7FF,
     U+F900-FAFF, U+FE00-FE6F, U+FF00-FFEF, U+1F2??, U+2????;
 }


### PR DESCRIPTION
Bump https://github.com/AndyOGo/stylelint-declaration-strict-value and configure it to avoid needing these lint exclusions.

Related: https://github.com/AndyOGo/stylelint-declaration-strict-value/issues/201
