### PR TITLE
fix: always use FullName() in CompareHeadRef to avoid 404 when fork owner matches base owner

### DIFF
--- a/services/context/repo.go
+++ b/services/context/repo.go
@@ -66,7 +66,7 @@ func (prc *PullRequestContext) CanCreateNewPull() bool {
 
 // CompareHeadRef formats the head side of a compare link, "owner/repo:branch" is only needed when a fork can share its base repo's owner
 func CompareHeadRef(headRepo *repo_model.Repository, headBranch string) string {
-	return util.Iif(setting.Repository.AllowForkIntoSameOwner, headRepo.FullName(), headRepo.OwnerName) + ":" + headBranch
+	return headRepo.FullName() + ":" + headBranch
 }
 
 func (prc *PullRequestContext) MakeDefaultCompareLink(headBranch string) string {

--- a/services/context/repo_test.go
+++ b/services/context/repo_test.go
@@ -7,19 +7,10 @@ import (
 	"testing"
 
 	repo_model "gitea.dev/models/repo"
-	"gitea.dev/modules/setting"
-	"gitea.dev/modules/test"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCompareHeadRef(t *testing.T) {
-	defer test.MockVariableValue(&setting.Repository.AllowForkIntoSameOwner)()
-	headRepo := &repo_model.Repository{OwnerName: "user", Name: "fork"}
-
-	setting.Repository.AllowForkIntoSameOwner = false
-	assert.Equal(t, "user:my-branch", CompareHeadRef(headRepo, "my-branch"))
-
-	setting.Repository.AllowForkIntoSameOwner = true
+	headRepo := \&repo_model.Repository{OwnerName: "user", Name: "fork"}
 	assert.Equal(t, "user/fork:my-branch", CompareHeadRef(headRepo, "my-branch"))
 }

--- a/services/context/repo_test.go
+++ b/services/context/repo_test.go
@@ -11,6 +11,6 @@ import (
 )
 
 func TestCompareHeadRef(t *testing.T) {
-	headRepo := \&repo_model.Repository{OwnerName: "user", Name: "fork"}
+	headRepo := &repo_model.Repository{OwnerName: "user", Name: "fork"}
 	assert.Equal(t, "user/fork:my-branch", CompareHeadRef(headRepo, "my-branch"))
 }


### PR DESCRIPTION
Fixes #39074

## Problem
When the head repository is a fork owned by the same owner as the base repository (e.g., `AllowForkIntoSameOwner=true` or fork transferred to same owner), `CompareHeadRef` returned only `{owner}:{branch}` (without repo name). The compare router then resolved the head ref to the base repository, looking for the branch there instead of in the fork, resulting in a 404.

## Root Cause
`CompareHeadRef` conditionally included the repo name based on `setting.Repository.AllowForkIntoSameOwner`. When the setting was false (default), it returned `owner:branch` format. When the fork had the same owner as the base repo, the router matched `owner` to the base repo instead of the fork.

## Fix
Always use `headRepo.FullName()` (i.e., `{owner}/{repo}:{branch}`) in `CompareHeadRef`. This format is unambiguous: the `{owner}/{repo}` prefix always identifies the correct repository, regardless of whether the owner matches the base repo's owner.

This is consistent with `ComposeBranchCompareURL` which already uses `{owner}/{repo}:{branch}` when the repos differ.

## Changes
- `services/context/repo.go`: Simplify `CompareHeadRef` to always return `FullName():branch`
- `services/context/repo_test.go`: Update test to expect the new behavior

## Testing
- Existing test `TestCompareHeadRef` updated to expect `user/fork:my-branch`
- The `parseHead`/`GetHeadOwnerAndRepo` functions already handle `{owner}/{repo}:{branch}` format correctly