### PR TITLE
chore: repo compare link

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -1128,7 +1128,6 @@ LEVEL = Info
 ;ALLOW_FORK_WITHOUT_MAXIMUM_LIMIT = true
 
 ;; Allow to fork repositories into the same owner (user or organization)
-;; This feature is experimental, not fully tested, and may be changed in the future
 ;ALLOW_FORK_INTO_SAME_OWNER = false
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -1299,18 +1299,19 @@ func stopTimerIfAvailable(ctx *context.Context, user *user_model.User, issue *is
 }
 
 func PullsNewRedirect(ctx *context.Context) {
-	branch := ctx.PathParam("*")
-	redirectRepo := ctx.Repo.Repository
-	repo := ctx.Repo.Repository
-	if repo.IsFork {
-		if err := repo.GetBaseRepo(ctx); err != nil {
+	branchName := ctx.PathParam("*")
+	baseRepo, headRepo := ctx.Repo.Repository, ctx.Repo.Repository
+	if headRepo.IsFork {
+		if err := headRepo.GetBaseRepo(ctx); err != nil {
 			ctx.ServerError("GetBaseRepo", err)
 			return
 		}
-		redirectRepo = repo.BaseRepo
-		branch = context.CompareHeadRef(repo, branch)
+		baseRepo = headRepo.BaseRepo
 	}
-	ctx.Redirect(fmt.Sprintf("%s/compare/%s...%s?expand=1", redirectRepo.Link(), util.PathEscapeSegments(redirectRepo.DefaultBranch), util.PathEscapeSegments(branch)))
+	ctx.Redirect(fmt.Sprintf("%s/compare/%s...%s?expand=1", baseRepo.Link(),
+		util.PathEscapeSegments(baseRepo.DefaultBranch),
+		util.PathEscapeSegments(context.CompareHeadRef(baseRepo, headRepo, branchName)),
+	))
 }
 
 // CompareAndPullRequestPost response for creating pull request

--- a/services/context/repo.go
+++ b/services/context/repo.go
@@ -71,6 +71,11 @@ func CompareHeadRef(baseRepo, headRepo *repo_model.Repository, headBranch string
 	} else if baseRepo.OwnerID == headRepo.OwnerID /* same owner */ {
 		return headRepo.FullName() + ":" + headBranch
 	}
+	// not the same owner: if there can be multiple forks in one owner, we still need the full name
+	if setting.Repository.AllowForkIntoSameOwner {
+		return headRepo.FullName() + ":" + headBranch
+	}
+	// if there is only one fork in the different owner, we only need the owner's name for the head ref
 	return headRepo.OwnerName + ":" + headBranch
 }
 

--- a/services/context/repo.go
+++ b/services/context/repo.go
@@ -65,14 +65,19 @@ func (prc *PullRequestContext) CanCreateNewPull() bool {
 }
 
 // CompareHeadRef formats the head side of a compare link, "owner/repo:branch" is only needed when a fork can share its base repo's owner
-func CompareHeadRef(headRepo *repo_model.Repository, headBranch string) string {
-	return util.Iif(setting.Repository.AllowForkIntoSameOwner, headRepo.FullName(), headRepo.OwnerName) + ":" + headBranch
+func CompareHeadRef(baseRepo, headRepo *repo_model.Repository, headBranch string) string {
+	if baseRepo.ID == headRepo.ID /*same repo*/ {
+		return headBranch
+	} else if baseRepo.OwnerID == headRepo.OwnerID /* same owner */ {
+		return headRepo.FullName() + ":" + headBranch
+	}
+	return headRepo.OwnerName + ":" + headBranch
 }
 
 func (prc *PullRequestContext) MakeDefaultCompareLink(headBranch string) string {
 	return prc.baseRepo.Link() + "/compare/" +
 		util.PathEscapeSegments(prc.DefaultTargetBranch()) + "..." +
-		util.PathEscapeSegments(util.Iif(prc.SameRepo(), headBranch, CompareHeadRef(prc.headRepo, headBranch)))
+		util.PathEscapeSegments(CompareHeadRef(prc.baseRepo, prc.headRepo, headBranch))
 }
 
 func (prc *PullRequestContext) DefaultTargetBranch() string {

--- a/services/context/repo.go
+++ b/services/context/repo.go
@@ -66,7 +66,7 @@ func (prc *PullRequestContext) CanCreateNewPull() bool {
 
 // CompareHeadRef formats the head side of a compare link, "owner/repo:branch" is only needed when a fork can share its base repo's owner
 func CompareHeadRef(baseRepo, headRepo *repo_model.Repository, headBranch string) string {
-	if baseRepo.ID == headRepo.ID /*same repo */ {
+	if baseRepo.ID == headRepo.ID /* same repo */ {
 		return headBranch
 	} else if baseRepo.OwnerID == headRepo.OwnerID /* same owner */ {
 		return headRepo.FullName() + ":" + headBranch

--- a/services/context/repo.go
+++ b/services/context/repo.go
@@ -66,7 +66,7 @@ func (prc *PullRequestContext) CanCreateNewPull() bool {
 
 // CompareHeadRef formats the head side of a compare link, "owner/repo:branch" is only needed when a fork can share its base repo's owner
 func CompareHeadRef(baseRepo, headRepo *repo_model.Repository, headBranch string) string {
-	if baseRepo.ID == headRepo.ID /*same repo*/ {
+	if baseRepo.ID == headRepo.ID /*same repo */ {
 		return headBranch
 	} else if baseRepo.OwnerID == headRepo.OwnerID /* same owner */ {
 		return headRepo.FullName() + ":" + headBranch

--- a/services/context/repo_test.go
+++ b/services/context/repo_test.go
@@ -7,19 +7,13 @@ import (
 	"testing"
 
 	repo_model "gitea.dev/models/repo"
-	"gitea.dev/modules/setting"
-	"gitea.dev/modules/test"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCompareHeadRef(t *testing.T) {
-	defer test.MockVariableValue(&setting.Repository.AllowForkIntoSameOwner)()
-	headRepo := &repo_model.Repository{OwnerName: "user", Name: "fork"}
-
-	setting.Repository.AllowForkIntoSameOwner = false
-	assert.Equal(t, "user:my-branch", CompareHeadRef(headRepo, "my-branch"))
-
-	setting.Repository.AllowForkIntoSameOwner = true
-	assert.Equal(t, "user/fork:my-branch", CompareHeadRef(headRepo, "my-branch"))
+	baseRepo := &repo_model.Repository{ID: 1, OwnerID: 100, OwnerName: "base-owner", Name: "base-repo"}
+	assert.Equal(t, "my-branch", CompareHeadRef(baseRepo, baseRepo, "my-branch"))
+	assert.Equal(t, "head-owner/head-repo:my-branch", CompareHeadRef(baseRepo, &repo_model.Repository{ID: 2, OwnerID: 100, OwnerName: "head-owner", Name: "head-repo"}, "my-branch"))
+	assert.Equal(t, "head-owner:my-branch", CompareHeadRef(baseRepo, &repo_model.Repository{ID: 2, OwnerID: 101, OwnerName: "head-owner", Name: "head-repo"}, "my-branch"))
 }

--- a/services/context/repo_test.go
+++ b/services/context/repo_test.go
@@ -7,13 +7,22 @@ import (
 	"testing"
 
 	repo_model "gitea.dev/models/repo"
+	"gitea.dev/modules/setting"
+	"gitea.dev/modules/test"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCompareHeadRef(t *testing.T) {
+	defer test.MockVariableValue(&setting.Repository.AllowForkIntoSameOwner, false)()
 	baseRepo := &repo_model.Repository{ID: 1, OwnerID: 100, OwnerName: "base-owner", Name: "base-repo"}
-	assert.Equal(t, "my-branch", CompareHeadRef(baseRepo, baseRepo, "my-branch"))
-	assert.Equal(t, "head-owner/head-repo:my-branch", CompareHeadRef(baseRepo, &repo_model.Repository{ID: 2, OwnerID: 100, OwnerName: "head-owner", Name: "head-repo"}, "my-branch"))
-	assert.Equal(t, "head-owner:my-branch", CompareHeadRef(baseRepo, &repo_model.Repository{ID: 2, OwnerID: 101, OwnerName: "head-owner", Name: "head-repo"}, "my-branch"))
+	sameRepo := baseRepo
+	sameOwner := &repo_model.Repository{ID: 2, OwnerID: 100, OwnerName: "head-owner", Name: "head-repo"}
+	diffOwner := &repo_model.Repository{ID: 2, OwnerID: 101, OwnerName: "head-owner", Name: "head-repo"}
+
+	assert.Equal(t, "my-branch", CompareHeadRef(baseRepo, sameRepo, "my-branch"))
+	assert.Equal(t, "head-owner/head-repo:my-branch", CompareHeadRef(baseRepo, sameOwner, "my-branch"))
+	assert.Equal(t, "head-owner:my-branch", CompareHeadRef(baseRepo, diffOwner, "my-branch"))
+	setting.Repository.AllowForkIntoSameOwner = true
+	assert.Equal(t, "head-owner/head-repo:my-branch", CompareHeadRef(baseRepo, diffOwner, "my-branch"))
 }


### PR DESCRIPTION
improve #39075

The compare link should be controlled by the "repo ID" and "owner ID"

This feature seems stable enough now and there are real users: https://gitea.com/gitea/docs/pulls/530