### PR TITLE
fix(repo): prevent MarkAsBrokenEmpty when repository is being migrated

### DIFF
--- a/services/context/repo.go
+++ b/services/context/repo.go
@@ -695,6 +695,12 @@ func repoAssignmentPrepareGitRepo(ctx *Context, data *repoAssignmentPrepareDataS
 	ctx.Repo.GitRepo, err = git.RepositoryFromRequestContextOrOpen(ctx, repo)
 	if err != nil {
 		if strings.Contains(err.Error(), "repository does not exist") || strings.Contains(err.Error(), "no such file or directory") {
+			// A repository that is still being created (migrated or forked) does not have its
+			// git data on disk yet, so opening it fails. This is expected and must not be
+			// treated as a permanently broken repository.
+			if ctx.Repo.Repository.IsBeingCreated() {
+				return
+			}
 			log.Error("Repository %-v has a broken repository on the file system: %s Error: %v", ctx.Repo.Repository, ctx.Repo.Repository.FullName(), err)
 			ctx.Repo.Repository.MarkAsBrokenEmpty()
 			// Only allow access to base of repo or settings


### PR DESCRIPTION
### Description

Since v1.27.0, a race condition causes newly migrated repositories to immediately display a "broken" error because the frontend redirects faster than the background worker initializes the `.git` directory. This causes `repoAssignmentPrepareGitRepo` to prematurely trigger `MarkAsBrokenEmpty()` in `services/context/repo.go`.

### Solution

Insert `if ctx.Repo.Repository.IsBeingCreated() { return }` in the error handler. This safely skips `MarkAsBrokenEmpty()` during the brief, critical window when the repository is still initializing on disk.

### How to test?

1. Initiate migration of any repository.
2. The error appears on the initial, immediate redirect (See attached GIF [1]).
3. A page refresh resolves the issue.

### Screenshots / GIFs

<img width="1652" height="860" alt="2026-08-25_16-42-08" src="https://github.com/user-attachments/assets/889c91ea-08df-4f4b-a4dc-4f5c90f08485" />
