### PR TITLE
fix(repo): prevent MarkAsBrokenEmpty when repository is being migrated (#39091)

### DIFF
--- a/services/context/repo.go
+++ b/services/context/repo.go
@@ -707,6 +707,9 @@ func repoAssignmentPrepareGitRepo(ctx *Context, data *repoAssignmentPrepareDataS
 	ctx.Repo.GitRepo, err = gitrepo.RepositoryFromRequestContextOrOpen(ctx, repo)
 	if err != nil {
 		if strings.Contains(err.Error(), "repository does not exist") || strings.Contains(err.Error(), "no such file or directory") {
+			if ctx.Repo.Repository.IsBeingCreated() {
+				return
+			}
 			log.Error("Repository %-v has a broken repository on the file system: %s Error: %v", ctx.Repo.Repository, ctx.Repo.Repository.RelativePath(), err)
 			ctx.Repo.Repository.MarkAsBrokenEmpty()
 			// Only allow access to base of repo or settings


### PR DESCRIPTION
backport #39091