### PR TITLE
enhance(repo): allow multiple forks of the same repo per owner, distinguished by name #38967

### DIFF
--- a/models/repo/fork.go
+++ b/models/repo/fork.go
@@ -5,6 +5,7 @@ package repo
 
 import (
 	"context"
+	"strings"
 
 	"gitea.dev/models/db"
 	user_model "gitea.dev/models/user"
@@ -20,7 +21,8 @@ func GetRepositoriesByForkID(ctx context.Context, forkID int64) ([]*Repository, 
 		Find(&repos)
 }
 
-// GetForkedRepo checks if given user has already forked a repository with given ID.
+// GetForkedRepo returns one of the owner's forks of the given repository, if any, otherwise nil.
+// An owner may have multiple forks of the same repository under different names.
 func GetForkedRepo(ctx context.Context, ownerID, repoID int64) *Repository {
 	repo := new(Repository)
 	has, _ := db.GetEngine(ctx).
@@ -41,10 +43,28 @@ func HasForkedRepo(ctx context.Context, ownerID, repoID int64) bool {
 	return has
 }
 
-// GetUserFork return user forked repository from this repository, if not forked return nil
+// GetUserFork returns one of the user's forked repositories from this repository, if not forked return nil.
+// An owner may have multiple forks of the same repository under different names.
 func GetUserFork(ctx context.Context, repoID, userID int64) (*Repository, error) {
 	var forkedRepo Repository
 	has, err := db.GetEngine(ctx).Where("fork_id = ?", repoID).And("owner_id = ?", userID).Get(&forkedRepo)
+	if err != nil {
+		return nil, err
+	}
+	if !has {
+		return nil, nil //nolint:nilnil // return nil to indicate that the object does not exist
+	}
+	return &forkedRepo, nil
+}
+
+// GetUserForkByName returns the user's forked repository of this repository with the given name, if not forked return nil.
+func GetUserForkByName(ctx context.Context, repoID, userID int64, name string) (*Repository, error) {
+	var forkedRepo Repository
+	has, err := db.GetEngine(ctx).
+		Where("fork_id = ?", repoID).
+		And("owner_id = ?", userID).
+		And("lower_name = ?", strings.ToLower(name)).
+		Get(&forkedRepo)
 	if err != nil {
 		return nil, err
 	}

--- a/models/repo/fork_test.go
+++ b/models/repo/fork_test.go
@@ -30,3 +30,20 @@ func TestGetUserFork(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Nil(t, repo)
 }
+
+func TestGetUserForkByName(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	// User13 has repo 11 ("repo11") forked from repo10
+	repo, err := repo_model.GetRepositoryByID(t.Context(), 10)
+	assert.NoError(t, err)
+	assert.NotNil(t, repo)
+
+	fork, err := repo_model.GetUserForkByName(t.Context(), repo.ID, 13, "repo11")
+	assert.NoError(t, err)
+	assert.NotNil(t, fork)
+
+	fork, err = repo_model.GetUserForkByName(t.Context(), repo.ID, 13, "does-not-exist")
+	assert.NoError(t, err)
+	assert.Nil(t, fork)
+}

--- a/modules/repository/fork.go
+++ b/modules/repository/fork.go
@@ -23,11 +23,13 @@ func CanUserForkBetweenOwners(id1, id2 int64) bool {
 }
 
 // CanUserForkRepo returns true if specified user can fork repository.
+// An owner may already have one or more forks of the repository; that doesn't prevent forking
+// again under a different name, so existing forks are not considered here.
 func CanUserForkRepo(ctx context.Context, user *user_model.User, repo *repo_model.Repository) (bool, error) {
 	if user == nil {
 		return false, nil
 	}
-	if CanUserForkBetweenOwners(repo.OwnerID, user.ID) && !repo_model.HasForkedRepo(ctx, user.ID, repo.ID) {
+	if CanUserForkBetweenOwners(repo.OwnerID, user.ID) {
 		return true, nil
 	}
 	ownedOrgs, err := organization.GetOrgsCanCreateRepoByUserID(ctx, user.ID)
@@ -35,7 +37,7 @@ func CanUserForkRepo(ctx context.Context, user *user_model.User, repo *repo_mode
 		return false, err
 	}
 	for _, org := range ownedOrgs {
-		if repo.OwnerID != org.ID && !repo_model.HasForkedRepo(ctx, org.ID, repo.ID) {
+		if repo.OwnerID != org.ID {
 			return true, nil
 		}
 	}

--- a/routers/web/repo/fork.go
+++ b/routers/web/repo/fork.go
@@ -49,7 +49,7 @@ func getForkRepository(ctx *context.Context) *repo_model.Repository {
 	ctx.Data["repo_name"] = forkRepo.Name
 	ctx.Data["description"] = forkRepo.Description
 	ctx.Data["IsPrivate"] = forkRepo.IsPrivate || forkRepo.Owner.Visibility == structs.VisibleTypePrivate
-	canForkToUser := repository.CanUserForkBetweenOwners(forkRepo.OwnerID, ctx.Doer.ID) && !repo_model.HasForkedRepo(ctx, ctx.Doer.ID, forkRepo.ID)
+	canForkToUser := repository.CanUserForkBetweenOwners(forkRepo.OwnerID, ctx.Doer.ID)
 
 	ctx.Data["ForkRepo"] = forkRepo
 
@@ -60,7 +60,7 @@ func getForkRepository(ctx *context.Context) *repo_model.Repository {
 	}
 	var orgs []*organization.Organization
 	for _, org := range ownedOrgs {
-		if forkRepo.OwnerID != org.ID && !repo_model.HasForkedRepo(ctx, org.ID, forkRepo.ID) {
+		if forkRepo.OwnerID != org.ID {
 			orgs = append(orgs, org)
 		}
 	}
@@ -155,14 +155,17 @@ func ForkPost(ctx *context.Context) {
 		return
 	}
 
-	var err error
 	traverseParentRepo := forkRepo
 	for {
 		if !repository.CanUserForkBetweenOwners(ctxUser.ID, traverseParentRepo.OwnerID) {
 			ctx.JSONError(ctx.Tr("repo.settings.new_owner_has_same_repo"))
 			return
 		}
-		repo := repo_model.GetForkedRepo(ctx, ctxUser.ID, traverseParentRepo.ID)
+		repo, err := repo_model.GetUserForkByName(ctx, traverseParentRepo.ID, ctxUser.ID, form.RepoName)
+		if err != nil {
+			ctx.ServerError("GetUserForkByName", err)
+			return
+		}
 		if repo != nil {
 			ctx.JSONRedirect(ctxUser.HomeLink() + "/" + url.PathEscape(repo.Name))
 			return
@@ -212,7 +215,7 @@ func ForkRepoTo(ctx *context.Context, owner *user_model.User, forkOpts repo_serv
 			maxCreationLimit := owner.MaxCreationLimit()
 			msg := ctx.TrN(maxCreationLimit, "repo.form.reach_limit_of_creation_1", "repo.form.reach_limit_of_creation_n", maxCreationLimit)
 			ctx.JSONError(msg)
-		case repo_model.IsErrRepoAlreadyExist(err):
+		case repo_model.IsErrRepoAlreadyExist(err), repo_service.IsErrForkAlreadyExist(err):
 			ctx.JSONError(ctx.Tr("repo.settings.new_owner_has_same_repo"))
 		case repo_model.IsErrRepoFilesAlreadyExist(err):
 			switch {

--- a/services/repository/fork.go
+++ b/services/repository/fork.go
@@ -70,7 +70,7 @@ func ForkRepository(ctx context.Context, doer, owner *user_model.User, opts Fork
 		}
 	}
 
-	forkedRepo, err := repo_model.GetUserFork(ctx, opts.BaseRepo.ID, owner.ID)
+	forkedRepo, err := repo_model.GetUserForkByName(ctx, opts.BaseRepo.ID, owner.ID, opts.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/services/repository/fork_test.go
+++ b/services/repository/fork_test.go
@@ -21,13 +21,13 @@ import (
 func TestForkRepository(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
 
-	// user 13 has already forked repo10
+	// user 13 has already forked repo10 as "repo11"
 	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 13})
 	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 10})
 
 	fork, err := ForkRepository(t.Context(), user, user, ForkRepoOptions{
 		BaseRepo:    repo,
-		Name:        "test",
+		Name:        "repo11",
 		Description: "test",
 	})
 	assert.Nil(t, fork)
@@ -48,6 +48,25 @@ func TestForkRepository(t *testing.T) {
 	})
 	assert.Nil(t, fork2)
 	assert.True(t, repo_model.IsErrReachLimitOfRepo(err))
+}
+
+func TestForkRepositoryMultipleForksUnderDifferentNames(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	// user 13 has already forked repo10 as "repo11", forking again under a different name should succeed
+	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 13})
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 10})
+
+	fork, err := ForkRepository(t.Context(), user, user, ForkRepoOptions{
+		BaseRepo:    repo,
+		Name:        "repo10-variant",
+		Description: "test",
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, fork)
+
+	err = DeleteRepositoryDirectly(t.Context(), fork.ID)
+	assert.NoError(t, err)
 }
 
 func TestForkRepositoryCleanup(t *testing.T) {

--- a/tests/integration/repo_fork_test.go
+++ b/tests/integration/repo_fork_test.go
@@ -80,6 +80,37 @@ func TestRepoForkToOrg(t *testing.T) {
 	assert.False(t, exists, "Forking should not be allowed anymore")
 }
 
+func TestRepoForkMultipleUnderDifferentNames(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+	session := loginUser(t, "user1")
+	testRepoFork(t, session, "user2", "repo1", "user1", "repo1", "")
+
+	// forking the same repo again under a different name should still be offered (via the fork modal) and succeed
+	req := NewRequest(t, "GET", "/user2/repo1")
+	resp := session.MakeRequest(t, req, http.StatusOK)
+	htmlDoc := NewHTMLParser(t, resp.Body)
+	link, exists := htmlDoc.doc.Find(`a[href$="/fork"]`).Attr("href")
+	assert.True(t, exists, "The template has changed")
+
+	req = NewRequest(t, "GET", link)
+	resp = session.MakeRequest(t, req, http.StatusOK)
+	htmlDoc = NewHTMLParser(t, resp.Body)
+	formAction, exists := htmlDoc.doc.Find(`form.ui.form[action*="/fork"]`).Attr("action")
+	assert.True(t, exists, "The template has changed")
+
+	forkOwner := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user1"})
+	req = NewRequestWithValues(t, "POST", formAction, map[string]string{
+		"uid":                strconv.FormatInt(forkOwner.ID, 10),
+		"repo_name":          "repo1-variant",
+		"fork_single_branch": "",
+	})
+	resp = session.MakeRequest(t, req, http.StatusOK)
+	assert.Equal(t, "/user1/repo1-variant", test.RedirectURL(resp))
+
+	req = NewRequest(t, "GET", "/user1/repo1-variant")
+	session.MakeRequest(t, req, http.StatusOK)
+}
+
 func TestForkListLimitedAndPrivateRepos(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
 	forkItemSelector := ".fork-list .item"


### PR DESCRIPTION
An owner (user or org) could only ever have one fork of a given source repository,
regardless of the name given to it. `GetUserFork` matched on `(fork_id, owner_id)`
only, so `ForkRepository` rejected any second fork attempt with `ErrForkAlreadyExist`
even when the destination name didn't collide with anything.

Scopes the check to `(fork_id, owner_id, name)` instead: an owner can't fork the same
source twice under the same name, but can under different names. Added
`GetUserForkByName` for the name-aware lookup and updated `ForkRepository`'s duplicate
check to use it.

The web fork page and modal (`routers/web/repo/fork.go`, `modules/repository/fork.go`)
no longer treat "already has a fork" as disqualifying an owner from forking again —
they now only block on a name collision, consistent with the API. Permission checks
that only care whether an owner has *any* fork (branch write access, PR eligibility)
are unaffected.

Fixes: #38967
