### PR TITLE
Add Gitea local setup documentation

### DIFF
--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -1,0 +1,19 @@
+# Gitea Local Setup
+
+## Environment
+
+Gitea was cloned and configured to run locally on Windows without Docker.
+
+## Local Run
+
+The Gitea application was successfully started and accessed through:
+
+http://localhost:3000
+
+## Verification
+
+The Gitea web application loaded successfully in the browser at localhost:3000.
+
+## What I Learned
+
+I learned the basic structure of the Gitea project, how to prepare the local development environment, and how to run Gitea locally without Docker.


### PR DESCRIPTION
## Summary

- Added documentation for running Gitea locally on Windows without Docker.
- Documented the local setup and verification steps.
- Verified that Gitea runs successfully at localhost:3000.

## Testing

- Started Gitea locally without Docker.
- Verified the application in a browser at http://localhost:3000.