### PR TITLE
docs: add Gitea local setup notes

### DIFF
--- a/docs/gitea-local-setup.md
+++ b/docs/gitea-local-setup.md
@@ -1,0 +1,70 @@
+# Gitea Local Setup and Project Understanding
+
+## 1. Project Overview
+
+Gitea is an open-source, self-hosted Git service that provides Git
+repository hosting and collaboration features.
+
+It provides functionality such as:
+
+- Git repository management
+- User authentication
+- Issues
+- Pull requests
+- Repository management
+- User and organization management
+- Git LFS support
+
+Gitea is primarily written in Go. Its frontend uses JavaScript,
+TypeScript, Vite, and pnpm.
+
+## 2. Repository Structure
+
+During the setup, I reviewed the main project directories and files.
+
+Important components include:
+
+- `cmd/` - Command-line commands and application entry points.
+- `models/` - Data models and database-related code.
+- `modules/` - Reusable application modules.
+- `routers/` - HTTP routing and request handling.
+- `services/` - Application services and business logic.
+- `templates/` - Server-side HTML templates.
+- `web_src/` - Frontend source code.
+- `assets/` - Static and frontend assets.
+- `docs/` - Project documentation.
+- `tests/` - Test-related code.
+- `custom/` - Custom configuration and application data.
+- `go.mod` - Go module definition and backend dependencies.
+- `go.sum` - Checksums for Go dependencies.
+- `package.json` - Node.js and frontend project configuration.
+- `pnpm-lock.yaml` - Locked frontend dependency versions.
+- `Makefile` - Build, dependency, development, and testing commands.
+- `main.go` - Main Go application entry point.
+
+## 3. Development Environment
+
+I set up Gitea locally using Ubuntu through WSL instead of Docker.
+
+The environment used during the setup was:
+
+- Ubuntu 24.04
+- Go 1.27.0
+- Node.js 24.19.0
+- npm 11.17.0
+- pnpm 11.24.0
+- GNU Make 4.3
+- GCC 13.3.0
+- Python 3.12.3
+- uv
+
+The required Go version was checked from `go.mod`.
+
+The Node.js and pnpm requirements were checked from `package.json`.
+
+The repository required:
+
+```text
+Go >= the version specified in go.mod
+Node.js >= 22.18.0
+pnpm >= 11.0.0


### PR DESCRIPTION
## Gitea Local Setup – Task 1

### What I understood

Gitea is an open-source, self-hosted Git service. It allows users to create and manage Git repositories, issues, pull requests, users, and code.

### Repository structure

I explored the main folders and files:

- `cmd/` – application commands
- `routers/` – web routes
- `services/` – application services
- `models/` – database models
- `modules/` – common modules
- `templates/` – web templates
- `web_src/` – frontend code
- `docs/` – documentation
- `tests/` – tests
- `go.mod` – Go dependencies
- `package.json` – frontend dependencies
- `Makefile` – build commands

### Local setup

I cloned the repository and installed the required tools:

- Go 1.27
- Node.js 24
- pnpm 11
- Make
- GCC
- uv

I installed the project dependencies using:

```bash
make deps
I also downloaded Go dependencies using:

go mod download
Build and Run

I built Gitea using:

make build

Then I ran it without Docker using:

./gitea web

Gitea successfully started on:

http://localhost:3000
Issues I faced

I initially faced issues with:

Go not being installed
Node.js version being too old
pnpm not being available
uv not being installed
Database configuration during the first Gitea setup

I fixed the environment and dependency issues and successfully built and started Gitea locally.

What I learned

I learned how a large Go project is structured, how its dependencies are managed, how to build it from source, and how to run Gitea locally without Docker.