### PR TITLE
chore: anchor golangci exclusion paths to directories

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -165,10 +165,10 @@ linters:
           - gocritic
         text: '(?i)exitAfterDefer:'
     paths:
-      - node_modules
-      - .venv
-      - public
-      - web_src
+      - ^node_modules/
+      - ^\.venv/
+      - ^public/
+      - ^web_src/
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
@@ -190,10 +190,10 @@ formatters:
   exclusions:
     generated: lax
     paths:
-      - node_modules
-      - .venv
-      - public
-      - web_src
+      - ^node_modules/
+      - ^\.venv/
+      - ^public/
+      - ^web_src/
 
 run:
   timeout: 10m

--- a/modules/public/public.go
+++ b/modules/public/public.go
@@ -43,7 +43,7 @@ func AssetsCors() func(next http.Handler) http.Handler {
 func FileHandlerFunc() http.HandlerFunc {
 	assetFS := AssetFS()
 	return func(resp http.ResponseWriter, req *http.Request) {
-		if req.Method != "GET" && req.Method != "HEAD" {
+		if req.Method != http.MethodGet && req.Method != http.MethodHead {
 			resp.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}

--- a/modules/public/public_bindata.go
+++ b/modules/public/public_bindata.go
@@ -10,9 +10,9 @@ package public
 import (
 	"sync"
 
-	_ "embed"
-
 	"gitea.dev/modules/assetfs"
+
+	_ "embed"
 )
 
 //go:embed bindata.dat

--- a/modules/public/public_test.go
+++ b/modules/public/public_test.go
@@ -28,7 +28,7 @@ func TestParseAcceptEncoding(t *testing.T) {
 
 	for _, kase := range kases {
 		t.Run(kase.Header, func(t *testing.T) {
-			assert.EqualValues(t, kase.Expected, parseAcceptEncoding(kase.Header))
+			assert.Equal(t, kase.Expected, parseAcceptEncoding(kase.Header))
 		})
 	}
 }

--- a/modules/public/vitedev.go
+++ b/modules/public/vitedev.go
@@ -115,7 +115,7 @@ func IsViteDevMode() bool {
 
 	now := time.Now()
 	lastCheck := viteDevModeCheck.Load()
-	if lastCheck != nil && time.Now().Sub(lastCheck.time) < time.Second {
+	if lastCheck != nil && now.Sub(lastCheck.time) < time.Second {
 		return lastCheck.isDev
 	}
 


### PR DESCRIPTION
`exclusions.paths` are unanchored regexes in golangci-lint which resulted in some files not getting linted, they now are.