### PR TITLE
fix: resolve system users in merge post-receive hook (#39124)

### DIFF
--- a/routers/private/hook_post_receive.go
+++ b/routers/private/hook_post_receive.go
@@ -245,6 +245,16 @@ func hookPostReceiveRespondWithTrailer(ctx *gitea_context.PrivateContext, opts *
 }
 
 func loadContextCacheUser(ctx context.Context, id int64) (*user_model.User, error) {
+	// System users (e.g. ActionsUserID -2, GhostUserID -1) have no user row
+	// in the user table; GetPossibleUserByID resolves them from the
+	// system-user registry instead of returning ErrUserNotExist.
+	if id < 0 {
+		_, u, err := user_model.GetPossibleUserByID(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		return u, nil
+	}
 	return cache.GetWithContextCache(ctx, cachegroup.User, id, user_model.GetUserByID)
 }
 


### PR DESCRIPTION
Fix: PR merged via Actions token never marked as merged

## Problem
Merging a PR while authenticated with an Actions job token (`secrets.GITEA_TOKEN`, the built-in `gitea-actions` user, ID `-2`) merges the code but never marks the PR as merged. The squash commit lands on the base branch, the API returns `200`, but the PR stays open forever.

## Root cause
Since 1.22.0 (#30805) the merge's DB work lives in the post-receive hook. `hookPostReceiveHandlePullRequestMerging` resolves the pusher via `loadContextCacheUser`, which calls `user_model.GetUserByID`. For system users (`GhostUserID -1`, `ActionsUserID -2`) there is no user row, so it returns `ErrUserNotExist`; only `GetPossibleUserByID` special-cases negative IDs. `SetMerged` is skipped, yet a failing post-receive hook cannot undo an already-applied ref update.

## Fix
In `loadContextCacheUser`, route negative (system) user IDs through `user_model.GetPossibleUserByID`, which resolves them from the system-user registry (`systemUserNewFuncs` maps `ActionsUserID` → `NewActionsUser`, `GhostUserID` → `NewGhostUser`). Positive IDs keep the existing cached `GetUserByID` path.

Fixes #39124
