### PR TITLE
fix: recognize linguist language aliases

### DIFF
--- a/modules/git/languagestats/language_stats_get.go
+++ b/modules/git/languagestats/language_stats_get.go
@@ -114,6 +114,10 @@ func GetLanguageStats(ctx context.Context, repo *git.Repository, commitID string
 			if hasLanguage := attrs.GetLanguage(); hasLanguage.Value() != "" {
 				language := hasLanguage.Value()
 
+				if canonicalLanguage, ok := enry.GetLanguageByAlias(language); ok {
+					language = canonicalLanguage
+				}
+
 				// group languages, such as Pug -> HTML; SCSS -> CSS
 				group := enry.GetLanguageGroup(language)
 				if len(group) != 0 {

--- a/tests/integration/linguist_test.go
+++ b/tests/integration/linguist_test.go
@@ -225,6 +225,17 @@ func TestLinguist(t *testing.T) {
 				},
 				ExpectedLanguageOrder: []string{"YAML"},
 			},
+			// case 15: linguist-language alias should resolve to its canonical language
+			{
+				GitAttributesContent: "*.cpp linguist-language=golang",
+				FilesToAdd: []*files_service.ChangeRepoFile{
+					{
+						TreePath:      "cplusplus.cpp",
+						ContentReader: strings.NewReader(cppContent),
+					},
+				},
+				ExpectedLanguageOrder: []string{"Go"},
+			},
 		}
 
 		for i, c := range cases {


### PR DESCRIPTION
<!--
Before submitting:
- Target the `main` branch; release branches are for backports only.
- Use a Conventional Commits title, e.g. `fix(repo): handle empty branch names`.
- Read the contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
- Documentation changes go to https://gitea.com/gitea/docs

Describe your change below and link any issue it fixes.
-->
### Summary

- Normalize recognized `linguist-language` aliases before language grouping.
- Preserve the existing behavior for unrecognized language values.
- Add regression coverage for resolving `golang` to `Go`.

### Testing

- `make 'test-integration#TestLinguist'`

### AI assistance

ChatGPT was used to help investigate the issue and draft the change. I reviewed the code and verified the regression test locally.

Fixes #35968