### PR TITLE
feat(api): expose issue sorting in project column listings

### DIFF
--- a/models/project/issue.go
+++ b/models/project/issue.go
@@ -52,13 +52,21 @@ func IsIssueInColumn(ctx context.Context, issueID int64, column *Column) (bool, 
 		Exist(new(ProjectIssue))
 }
 
-// GetColumnIssueIDs returns the IDs of the issues placed in a column.
-func GetColumnIssueIDs(ctx context.Context, column *Column) ([]int64, error) {
-	issueIDs := make([]int64, 0, 10)
-	return issueIDs, db.GetEngine(ctx).Table("project_issue").
+// GetColumnIssueSortings returns the sorting value of every issue placed in a column,
+// keyed by issue ID.
+func GetColumnIssueSortings(ctx context.Context, column *Column) (map[int64]int64, error) {
+	placements := make([]*ProjectIssue, 0, 10)
+	if err := db.GetEngine(ctx).Table("project_issue").
 		Where("project_id=?", column.ProjectID).
 		In("project_board_id", columnIssueIDs(column)).
-		Cols("issue_id").Find(&issueIDs)
+		Cols("issue_id", "sorting").Find(&placements); err != nil {
+		return nil, err
+	}
+	sortings := make(map[int64]int64, len(placements))
+	for _, placement := range placements {
+		sortings[placement.IssueID] = placement.Sorting
+	}
+	return sortings, nil
 }
 
 // GetColumnIssueNextSorting returns the sorting value to append an issue at the end of the column.

--- a/modules/structs/project.go
+++ b/modules/structs/project.go
@@ -119,3 +119,11 @@ type MoveProjectIssueOption struct {
 	// the rest, equal values are ordered newest first.
 	Sorting *int64 `json:"sorting,omitempty"`
 }
+
+// ProjectColumnIssue represents an issue placed in a project column
+// swagger:model
+type ProjectColumnIssue struct {
+	Issue *Issue `json:"issue"`
+	// Position of the issue within the column, ascending, as accepted by the move endpoint
+	Sorting int64 `json:"sorting"`
+}

--- a/modules/structs/project.go
+++ b/modules/structs/project.go
@@ -123,7 +123,8 @@ type MoveProjectIssueOption struct {
 // ProjectColumnIssue represents an issue placed in a project column
 // swagger:model
 type ProjectColumnIssue struct {
-	Issue *Issue `json:"issue"`
+	// the issue fields stay inlined, so clients reading plain issues keep working
+	*Issue
 	// Position of the issue within the column, ascending, as accepted by the move endpoint
 	Sorting int64 `json:"sorting"`
 }

--- a/routers/api/v1/shared/project.go
+++ b/routers/api/v1/shared/project.go
@@ -4,8 +4,10 @@
 package shared
 
 import (
+	"maps"
 	"math"
 	"net/http"
+	"slices"
 
 	"gitea.dev/models/db"
 	issues_model "gitea.dev/models/issues"
@@ -1548,6 +1550,7 @@ func ListProjectColumnIssues(ctx *context.APIContext) {
 	// swagger:operation GET /repos/{owner}/{repo}/projects/{id}/columns/{column_id}/issues repository repoListProjectColumnIssues
 	// ---
 	// summary: List the issues in a project column
+	// description: Issues are returned in board order, each with its sorting value.
 	// produces:
 	// - application/json
 	// parameters:
@@ -1583,13 +1586,14 @@ func ListProjectColumnIssues(ctx *context.APIContext) {
 	//   type: integer
 	// responses:
 	//   "200":
-	//     "$ref": "#/responses/IssueList"
+	//     "$ref": "#/responses/ProjectColumnIssueList"
 	//   "404":
 	//     "$ref": "#/responses/notFound"
 
 	// swagger:operation GET /orgs/{org}/projects/{id}/columns/{column_id}/issues organization orgListProjectColumnIssues
 	// ---
 	// summary: List the issues in a project column
+	// description: Issues are returned in board order, each with its sorting value.
 	// produces:
 	// - application/json
 	// parameters:
@@ -1620,13 +1624,14 @@ func ListProjectColumnIssues(ctx *context.APIContext) {
 	//   type: integer
 	// responses:
 	//   "200":
-	//     "$ref": "#/responses/IssueList"
+	//     "$ref": "#/responses/ProjectColumnIssueList"
 	//   "404":
 	//     "$ref": "#/responses/notFound"
 
 	// swagger:operation GET /user/projects/{id}/columns/{column_id}/issues user userCurrentListProjectColumnIssues
 	// ---
 	// summary: List the issues in a project column
+	// description: Issues are returned in board order, each with its sorting value.
 	// produces:
 	// - application/json
 	// parameters:
@@ -1652,7 +1657,7 @@ func ListProjectColumnIssues(ctx *context.APIContext) {
 	//   type: integer
 	// responses:
 	//   "200":
-	//     "$ref": "#/responses/IssueList"
+	//     "$ref": "#/responses/ProjectColumnIssueList"
 	//   "404":
 	//     "$ref": "#/responses/notFound"
 
@@ -1662,21 +1667,21 @@ func ListProjectColumnIssues(ctx *context.APIContext) {
 		return
 	}
 
-	issueIDs, err := project_model.GetColumnIssueIDs(ctx, column)
+	sortings, err := project_model.GetColumnIssueSortings(ctx, column)
 	if err != nil {
 		ctx.APIErrorInternal(err)
 		return
 	}
-	if len(issueIDs) == 0 {
+	if len(sortings) == 0 {
 		ctx.SetTotalCountHeader(0)
-		ctx.JSON(http.StatusOK, []*api.Issue{})
+		ctx.JSON(http.StatusOK, []*api.ProjectColumnIssue{})
 		return
 	}
 
 	listOptions := utils.GetListOptions(ctx)
 	issuesOpts := &issues_model.IssuesOptions{
 		Paginator:  &listOptions,
-		IssueIDs:   issueIDs,
+		IssueIDs:   slices.Collect(maps.Keys(sortings)),
 		ProjectIDs: []int64{project.ID}, // joins project_issue so the column sorting applies
 		SortType:   "project-column-sorting",
 	}
@@ -1707,7 +1712,7 @@ func ListProjectColumnIssues(ctx *context.APIContext) {
 
 	ctx.SetLinkHeader(count, listOptions.PageSize)
 	ctx.SetTotalCountHeader(count)
-	ctx.JSON(http.StatusOK, convert.ToAPIIssueList(ctx, ctx.Doer, issues))
+	ctx.JSON(http.StatusOK, convert.ToProjectColumnIssueList(ctx, ctx.Doer, issues, sortings))
 }
 
 func AddIssueToProjectColumn(ctx *context.APIContext) {

--- a/routers/api/v1/swagger/project.go
+++ b/routers/api/v1/swagger/project.go
@@ -34,3 +34,10 @@ type swaggerResponseProjectColumnList struct {
 	// in:body
 	Body []api.ProjectColumn `json:"body"`
 }
+
+// ProjectColumnIssueList
+// swagger:response ProjectColumnIssueList
+type swaggerResponseProjectColumnIssueList struct {
+	// in:body
+	Body []api.ProjectColumnIssue `json:"body"`
+}

--- a/services/convert/project.go
+++ b/services/convert/project.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	issues_model "gitea.dev/models/issues"
 	project_model "gitea.dev/models/project"
 	user_model "gitea.dev/models/user"
 	"gitea.dev/modules/container"
@@ -192,6 +193,16 @@ func ToProjectColumnList(ctx context.Context, columns []*project_model.Column, d
 	result := make([]*api.ProjectColumn, len(columns))
 	for i, column := range columns {
 		result[i] = toProjectColumn(ctx, column, doer, creators)
+	}
+	return result
+}
+
+// ToProjectColumnIssueList pairs each issue with its position in the column it is placed in.
+func ToProjectColumnIssueList(ctx context.Context, doer *user_model.User, issues issues_model.IssueList, sortings map[int64]int64) []*api.ProjectColumnIssue {
+	apiIssues := ToAPIIssueList(ctx, doer, issues)
+	result := make([]*api.ProjectColumnIssue, len(apiIssues))
+	for i, apiIssue := range apiIssues {
+		result[i] = &api.ProjectColumnIssue{Issue: apiIssue, Sorting: sortings[apiIssue.ID]}
 	}
 	return result
 }

--- a/templates/swagger/v1-openapi3.generated.json
+++ b/templates/swagger/v1-openapi3.generated.json
@@ -990,6 +990,19 @@
         },
         "description": "ProjectColumn"
       },
+      "ProjectColumnIssueList": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/ProjectColumnIssue"
+              },
+              "type": "array"
+            }
+          }
+        },
+        "description": "ProjectColumnIssueList"
+      },
       "ProjectColumnList": {
         "content": {
           "application/json": {
@@ -8682,6 +8695,22 @@
         "type": "object",
         "x-go-package": "gitea.dev/modules/structs"
       },
+      "ProjectColumnIssue": {
+        "description": "ProjectColumnIssue represents an issue placed in a project column",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/Issue"
+          },
+          "sorting": {
+            "description": "Position of the issue within the column, ascending, as accepted by the move endpoint",
+            "format": "int64",
+            "type": "integer",
+            "x-go-name": "Sorting"
+          }
+        },
+        "type": "object",
+        "x-go-package": "gitea.dev/modules/structs"
+      },
       "PublicKey": {
         "description": "PublicKey publickey is a user key to push code to repository",
         "properties": {
@@ -15203,6 +15232,7 @@
     },
     "/orgs/{org}/projects/{id}/columns/{column_id}/issues": {
       "get": {
+        "description": "Issues are returned in board order, each with its sorting value.",
         "operationId": "orgListProjectColumnIssues",
         "parameters": [
           {
@@ -15253,7 +15283,7 @@
         ],
         "responses": {
           "200": {
-            "$ref": "#/components/responses/IssueList"
+            "$ref": "#/components/responses/ProjectColumnIssueList"
           },
           "404": {
             "$ref": "#/components/responses/notFound"
@@ -28394,6 +28424,7 @@
     },
     "/repos/{owner}/{repo}/projects/{id}/columns/{column_id}/issues": {
       "get": {
+        "description": "Issues are returned in board order, each with its sorting value.",
         "operationId": "repoListProjectColumnIssues",
         "parameters": [
           {
@@ -28453,7 +28484,7 @@
         ],
         "responses": {
           "200": {
-            "$ref": "#/components/responses/IssueList"
+            "$ref": "#/components/responses/ProjectColumnIssueList"
           },
           "404": {
             "$ref": "#/components/responses/notFound"
@@ -36137,6 +36168,7 @@
     },
     "/user/projects/{id}/columns/{column_id}/issues": {
       "get": {
+        "description": "Issues are returned in board order, each with its sorting value.",
         "operationId": "userCurrentListProjectColumnIssues",
         "parameters": [
           {
@@ -36178,7 +36210,7 @@
         ],
         "responses": {
           "200": {
-            "$ref": "#/components/responses/IssueList"
+            "$ref": "#/components/responses/ProjectColumnIssueList"
           },
           "404": {
             "$ref": "#/components/responses/notFound"

--- a/templates/swagger/v1-openapi3.generated.json
+++ b/templates/swagger/v1-openapi3.generated.json
@@ -8698,14 +8698,143 @@
       "ProjectColumnIssue": {
         "description": "ProjectColumnIssue represents an issue placed in a project column",
         "properties": {
-          "issue": {
-            "$ref": "#/components/schemas/Issue"
+          "assets": {
+            "items": {
+              "$ref": "#/components/schemas/Attachment"
+            },
+            "type": "array",
+            "x-go-name": "Attachments"
+          },
+          "assignee": {
+            "$ref": "#/components/schemas/User"
+          },
+          "assignees": {
+            "items": {
+              "$ref": "#/components/schemas/User"
+            },
+            "type": "array",
+            "x-go-name": "Assignees"
+          },
+          "body": {
+            "type": "string",
+            "x-go-name": "Body"
+          },
+          "closed_at": {
+            "format": "date-time",
+            "type": "string",
+            "x-go-name": "Closed"
+          },
+          "comments": {
+            "format": "int64",
+            "type": "integer",
+            "x-go-name": "Comments"
+          },
+          "content_version": {
+            "description": "The version of the issue content for optimistic locking",
+            "format": "int64",
+            "type": "integer",
+            "x-go-name": "ContentVersion"
+          },
+          "created_at": {
+            "format": "date-time",
+            "type": "string",
+            "x-go-name": "Created"
+          },
+          "due_date": {
+            "format": "date-time",
+            "type": "string",
+            "x-go-name": "Deadline"
+          },
+          "html_url": {
+            "format": "uri",
+            "type": "string",
+            "x-go-name": "HTMLURL"
+          },
+          "id": {
+            "format": "int64",
+            "type": "integer",
+            "x-go-name": "ID"
+          },
+          "is_locked": {
+            "type": "boolean",
+            "x-go-name": "IsLocked"
+          },
+          "labels": {
+            "items": {
+              "$ref": "#/components/schemas/Label"
+            },
+            "type": "array",
+            "x-go-name": "Labels"
+          },
+          "milestone": {
+            "$ref": "#/components/schemas/Milestone"
+          },
+          "number": {
+            "format": "int64",
+            "type": "integer",
+            "x-go-name": "Index"
+          },
+          "original_author": {
+            "type": "string",
+            "x-go-name": "OriginalAuthor"
+          },
+          "original_author_id": {
+            "format": "int64",
+            "type": "integer",
+            "x-go-name": "OriginalAuthorID"
+          },
+          "pin_order": {
+            "format": "int64",
+            "type": "integer",
+            "x-go-name": "PinOrder"
+          },
+          "projects": {
+            "items": {
+              "$ref": "#/components/schemas/Project"
+            },
+            "type": "array",
+            "x-go-name": "Projects"
+          },
+          "pull_request": {
+            "$ref": "#/components/schemas/PullRequestMeta"
+          },
+          "ref": {
+            "type": "string",
+            "x-go-name": "Ref"
+          },
+          "repository": {
+            "$ref": "#/components/schemas/RepositoryMeta"
           },
           "sorting": {
             "description": "Position of the issue within the column, ascending, as accepted by the move endpoint",
             "format": "int64",
             "type": "integer",
             "x-go-name": "Sorting"
+          },
+          "state": {
+            "$ref": "#/components/schemas/StateType"
+          },
+          "time_estimate": {
+            "format": "int64",
+            "type": "integer",
+            "x-go-name": "TimeEstimate"
+          },
+          "title": {
+            "type": "string",
+            "x-go-name": "Title"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": "string",
+            "x-go-name": "Updated"
+          },
+          "url": {
+            "format": "uri",
+            "type": "string",
+            "x-go-name": "URL"
+          },
+          "user": {
+            "$ref": "#/components/schemas/User"
           }
         },
         "type": "object",

--- a/templates/swagger/v1-swagger.generated.json
+++ b/templates/swagger/v1-swagger.generated.json
@@ -4008,6 +4008,7 @@
     },
     "/orgs/{org}/projects/{id}/columns/{column_id}/issues": {
       "get": {
+        "description": "Issues are returned in board order, each with its sorting value.",
         "produces": [
           "application/json"
         ],
@@ -4055,7 +4056,7 @@
         ],
         "responses": {
           "200": {
-            "$ref": "#/responses/IssueList"
+            "$ref": "#/responses/ProjectColumnIssueList"
           },
           "404": {
             "$ref": "#/responses/notFound"
@@ -16131,6 +16132,7 @@
     },
     "/repos/{owner}/{repo}/projects/{id}/columns/{column_id}/issues": {
       "get": {
+        "description": "Issues are returned in board order, each with its sorting value.",
         "produces": [
           "application/json"
         ],
@@ -16185,7 +16187,7 @@
         ],
         "responses": {
           "200": {
-            "$ref": "#/responses/IssueList"
+            "$ref": "#/responses/ProjectColumnIssueList"
           },
           "404": {
             "$ref": "#/responses/notFound"
@@ -23439,6 +23441,7 @@
     },
     "/user/projects/{id}/columns/{column_id}/issues": {
       "get": {
+        "description": "Issues are returned in board order, each with its sorting value.",
         "produces": [
           "application/json"
         ],
@@ -23479,7 +23482,7 @@
         ],
         "responses": {
           "200": {
-            "$ref": "#/responses/IssueList"
+            "$ref": "#/responses/ProjectColumnIssueList"
           },
           "404": {
             "$ref": "#/responses/notFound"
@@ -31721,6 +31724,22 @@
       },
       "x-go-package": "gitea.dev/modules/structs"
     },
+    "ProjectColumnIssue": {
+      "description": "ProjectColumnIssue represents an issue placed in a project column",
+      "type": "object",
+      "properties": {
+        "issue": {
+          "$ref": "#/definitions/Issue"
+        },
+        "sorting": {
+          "description": "Position of the issue within the column, ascending, as accepted by the move endpoint",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Sorting"
+        }
+      },
+      "x-go-package": "gitea.dev/modules/structs"
+    },
     "PublicKey": {
       "description": "PublicKey publickey is a user key to push code to repository",
       "type": "object",
@@ -34681,6 +34700,15 @@
       "description": "ProjectColumn",
       "schema": {
         "$ref": "#/definitions/ProjectColumn"
+      }
+    },
+    "ProjectColumnIssueList": {
+      "description": "ProjectColumnIssueList",
+      "schema": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/ProjectColumnIssue"
+        }
       }
     },
     "ProjectColumnList": {

--- a/templates/swagger/v1-swagger.generated.json
+++ b/templates/swagger/v1-swagger.generated.json
@@ -31728,14 +31728,147 @@
       "description": "ProjectColumnIssue represents an issue placed in a project column",
       "type": "object",
       "properties": {
-        "issue": {
-          "$ref": "#/definitions/Issue"
+        "assets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Attachment"
+          },
+          "x-go-name": "Attachments"
+        },
+        "assignee": {
+          "$ref": "#/definitions/User"
+        },
+        "assignees": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/User"
+          },
+          "x-go-name": "Assignees"
+        },
+        "body": {
+          "type": "string",
+          "x-go-name": "Body"
+        },
+        "closed_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "Closed"
+        },
+        "comments": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Comments"
+        },
+        "content_version": {
+          "description": "The version of the issue content for optimistic locking",
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "ContentVersion"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "Created"
+        },
+        "due_date": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "Deadline"
+        },
+        "html_url": {
+          "type": "string",
+          "x-go-name": "HTMLURL"
+        },
+        "id": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "ID"
+        },
+        "is_locked": {
+          "type": "boolean",
+          "x-go-name": "IsLocked"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Label"
+          },
+          "x-go-name": "Labels"
+        },
+        "milestone": {
+          "$ref": "#/definitions/Milestone"
+        },
+        "number": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Index"
+        },
+        "original_author": {
+          "type": "string",
+          "x-go-name": "OriginalAuthor"
+        },
+        "original_author_id": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "OriginalAuthorID"
+        },
+        "pin_order": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "PinOrder"
+        },
+        "projects": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Project"
+          },
+          "x-go-name": "Projects"
+        },
+        "pull_request": {
+          "$ref": "#/definitions/PullRequestMeta"
+        },
+        "ref": {
+          "type": "string",
+          "x-go-name": "Ref"
+        },
+        "repository": {
+          "$ref": "#/definitions/RepositoryMeta"
         },
         "sorting": {
           "description": "Position of the issue within the column, ascending, as accepted by the move endpoint",
           "type": "integer",
           "format": "int64",
           "x-go-name": "Sorting"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "open",
+            "closed"
+          ],
+          "x-go-enum-desc": "open StateOpen pr is opened\nclosed StateClosed pr is closed",
+          "x-go-name": "State"
+        },
+        "time_estimate": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "TimeEstimate"
+        },
+        "title": {
+          "type": "string",
+          "x-go-name": "Title"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time",
+          "x-go-name": "Updated"
+        },
+        "url": {
+          "type": "string",
+          "x-go-name": "URL"
+        },
+        "user": {
+          "$ref": "#/definitions/User"
         }
       },
       "x-go-package": "gitea.dev/modules/structs"

--- a/tests/integration/api_project_test.go
+++ b/tests/integration/api_project_test.go
@@ -215,6 +215,10 @@ func testProjectLifecycle(t *testing.T, scope projectScope, token string) {
 	issues := *DecodeJSON(t, MakeRequest(t, req, http.StatusOK), &[]api.ProjectColumnIssue{})
 	require.Len(t, issues, 1)
 	assert.Equal(t, scope.issueID, issues[0].Issue.ID)
+	// the issue fields stay inlined, so a client reading plain issues is unaffected
+	plain := *DecodeJSON(t, MakeRequest(t, req, http.StatusOK), &[]api.Issue{})
+	require.Len(t, plain, 1)
+	assert.Equal(t, scope.issueID, plain[0].ID)
 
 	// the sibling column must not report the same issue
 	req = NewRequest(t, "GET", fmt.Sprintf("%s/columns/%d/issues", projectURL, columnIDs[0])).AddTokenAuth(token)

--- a/tests/integration/api_project_test.go
+++ b/tests/integration/api_project_test.go
@@ -71,8 +71,8 @@ func TestAPIProjects(t *testing.T) {
 		defaultColumn := unittest.AssertExistsAndLoadBean(t, &project_model.Column{ProjectID: 1, Default: true})
 		req := NewRequestf(t, "GET", "/api/v1/repos/user2/repo1/projects/1/columns/%d/issues", defaultColumn.ID).AddTokenAuth(token)
 		issueIDs := make([]int64, 0)
-		for _, issue := range *DecodeJSON(t, MakeRequest(t, req, http.StatusOK), &[]api.Issue{}) {
-			issueIDs = append(issueIDs, issue.ID)
+		for _, columnIssue := range *DecodeJSON(t, MakeRequest(t, req, http.StatusOK), &[]api.ProjectColumnIssue{}) {
+			issueIDs = append(issueIDs, columnIssue.Issue.ID)
 		}
 		assert.Contains(t, issueIDs, int64(2))
 
@@ -212,13 +212,13 @@ func testProjectLifecycle(t *testing.T, scope projectScope, token string) {
 	})
 
 	req = NewRequest(t, "GET", fmt.Sprintf("%s/columns/%d/issues", projectURL, columnIDs[1])).AddTokenAuth(token)
-	issues := *DecodeJSON(t, MakeRequest(t, req, http.StatusOK), &[]api.Issue{})
+	issues := *DecodeJSON(t, MakeRequest(t, req, http.StatusOK), &[]api.ProjectColumnIssue{})
 	require.Len(t, issues, 1)
-	assert.Equal(t, scope.issueID, issues[0].ID)
+	assert.Equal(t, scope.issueID, issues[0].Issue.ID)
 
 	// the sibling column must not report the same issue
 	req = NewRequest(t, "GET", fmt.Sprintf("%s/columns/%d/issues", projectURL, columnIDs[0])).AddTokenAuth(token)
-	assert.Empty(t, *DecodeJSON(t, MakeRequest(t, req, http.StatusOK), &[]api.Issue{}))
+	assert.Empty(t, *DecodeJSON(t, MakeRequest(t, req, http.StatusOK), &[]api.ProjectColumnIssue{}))
 
 	// an issue that is not in the project cannot be moved within it
 	req = NewRequestWithJSON(t, "POST", fmt.Sprintf("%s/issues/%d/move", projectURL, scope.foreignIssueID),
@@ -232,6 +232,12 @@ func testProjectLifecycle(t *testing.T, scope projectScope, token string) {
 	moved := unittest.AssertExistsAndLoadBean(t, &project_model.ProjectIssue{ProjectID: project.ID, IssueID: scope.issueID})
 	assert.Equal(t, columnIDs[0], moved.ProjectColumnID)
 	assert.Equal(t, sortPos, moved.Sorting)
+
+	// the position written by the move must be readable back, so clients can reorder deterministically
+	req = NewRequest(t, "GET", fmt.Sprintf("%s/columns/%d/issues", projectURL, columnIDs[0])).AddTokenAuth(token)
+	listed := *DecodeJSON(t, MakeRequest(t, req, http.StatusOK), &[]api.ProjectColumnIssue{})
+	require.Len(t, listed, 1)
+	assert.Equal(t, sortPos, listed[0].Sorting)
 
 	// removing through a column the issue no longer occupies must not detach it
 	req = NewRequest(t, "DELETE", fmt.Sprintf("%s/columns/%d/issues/%d", projectURL, columnIDs[1], scope.issueID)).AddTokenAuth(token)


### PR DESCRIPTION
The project column issue listing returned plain issues, so the kanban order was only implicit in the response order and clients had no value to feed back into the move endpoint.

Each item now carries an extra `sorting` key next to the inlined issue fields, which makes the board order readable and repositioning deterministic for external tooling. The wire format stays a superset of the previous one, so clients decoding plain issues are unaffected.

Fixes: https://github.com/go-gitea/gitea/issues/37151

Assisted-by: Codet:claude-sonnet-4.5