### PR TITLE
fix(util): avoid non-nil sanitized error for nil input

### DIFF
--- a/modules/util/sanitize.go
+++ b/modules/util/sanitize.go
@@ -23,6 +23,9 @@ func (err sanitizedError) Unwrap() error {
 
 // SanitizeErrorCredentialURLs wraps the error and make sure the returned error message doesn't contain sensitive credentials in URLs
 func SanitizeErrorCredentialURLs(err error) error {
+	if err == nil {
+		return nil
+	}
 	return sanitizedError{err: err}
 }
 

--- a/modules/util/sanitize_test.go
+++ b/modules/util/sanitize_test.go
@@ -11,9 +11,32 @@ import (
 )
 
 func TestSanitizeErrorCredentialURLs(t *testing.T) {
-	err := errors.New("error with https://a@b.com")
-	se := SanitizeErrorCredentialURLs(err)
-	assert.Equal(t, "error with https://"+userInfoPlaceholder+"@b.com", se.Error())
+	tests := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{
+			name:     "sanitizes credentials",
+			err:      errors.New("error with https://a@b.com"),
+			expected: "error with https://" + userInfoPlaceholder + "@b.com",
+		},
+		{
+			name: "nil error",
+			err:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			se := SanitizeErrorCredentialURLs(tt.err)
+			if tt.err == nil {
+				assert.Nil(t, se)
+				return
+			}
+			assert.Equal(t, tt.expected, se.Error())
+		})
+	}
 }
 
 func TestSanitizeCredentialURLs(t *testing.T) {


### PR DESCRIPTION
### Problem
`SanitizeErrorCredentialURLs(nil)` returns a non-nil wrapper whose `Error()` method would panic when formatted. Callers expect error-wrapping helpers to preserve nil, especially on success paths that sanitize an error before returning it.

### Reproducer
```go
err := SanitizeErrorCredentialURLs(nil)
// before: err is util.sanitizedError{err:nil}
// after:  err == nil
```

### Fix
Return nil immediately when the input error is nil; otherwise keep the existing credential-sanitizing wrapper unchanged.

### Testing
Added a table-driven nil-input case to `TestSanitizeErrorCredentialURLs`.

```text
go test ./modules/util -run TestSanitizeErrorCredentialURLs -count=1
# before: FAIL, expected nil but got util.sanitizedError{err:error(nil)}
# after:  ok   gitea.dev/modules/util
```

Additional validation: `go vet ./modules/util`, `go test ./modules/validation ./modules/timeutil ./modules/base`, and `go build ./...`.

Disclosure: This PR was prepared with GitHub Copilot CLI assistance and manually validated.