### PR TITLE
docs: remove dead localization docs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Translations are done through [Crowdin](https://translate.gitea.com). If you wan
 
 You can also just create an issue for adding a language or ask on Discord on the #translation channel. If you need context or find some translation issues, you can leave a comment on the string or ask on Discord. For general translation questions there is a section in the docs. Currently a bit empty, but we hope to fill it as questions pop up.
 
-Get more information from [documentation](https://docs.gitea.com/contributing/localization).
+Get more information from [documentation](https://docs.gitea.com/1.26/contributing/localization/).
 
 ## Official and Third-Party Projects
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,6 @@ Translations are done through [Crowdin](https://translate.gitea.com). If you wan
 
 You can also just create an issue for adding a language or ask on Discord on the #translation channel. If you need context or find some translation issues, you can leave a comment on the string or ask on Discord. For general translation questions there is a section in the docs. Currently a bit empty, but we hope to fill it as questions pop up.
 
-Get more information from [documentation](https://docs.gitea.com/1.26/contributing/localization/).
-
 ## Official and Third-Party Projects
 
 We provide an official [go-sdk](https://gitea.com/gitea/go-sdk), a CLI tool called [tea](https://gitea.com/gitea/tea) and an [action runner](https://gitea.com/gitea/runner) for Gitea Action.


### PR DESCRIPTION
The translating link in the README is dead:

- `https://docs.gitea.com/contributing/localization` → **HTTP 404**

The English localization page now exists only under versioned paths on docs.gitea.com (checked the sitemap — no unversioned or `/next` English variant). Point it at the current stable version:

- `https://docs.gitea.com/1.26/contributing/localization/` → **HTTP 200**
