### PR TITLE
chore(frontend): avoid loading CSS twice in vite dev mode

### DIFF
--- a/modules/public/manifest.go
+++ b/modules/public/manifest.go
@@ -142,17 +142,19 @@ func AssetURI(srcPath string) string {
 // AssetCSSLinks renders the <link> tags for a JS entry's stylesheets: the entry's CSS plus the CSS
 // of every statically-imported chunk. Dev links devStylesheetSrc and lets the JS module inject the rest.
 func AssetCSSLinks(jsEntrySrc, devStylesheetSrc string) template.HTML {
+	if IsViteDevMode() {
+		// data-vite-dev-id makes Vite's HMR client skip injecting a duplicate <style> for this module
+		return template.HTML(`<link rel="stylesheet" href="` + html.EscapeString(devAssetURL(devStylesheetSrc)) +
+			`" data-vite-dev-id="` + html.EscapeString(viteDevModuleID(devStylesheetSrc)) + `">`)
+	}
 	var b strings.Builder
-	for _, href := range entryStyleURLs(jsEntrySrc, devStylesheetSrc) {
+	for _, href := range entryStyleURLs(jsEntrySrc) {
 		b.WriteString(`<link rel="stylesheet" href="` + html.EscapeString(href) + `">`)
 	}
 	return template.HTML(b.String())
 }
 
-func entryStyleURLs(jsEntrySrc, devStylesheetSrc string) []string {
-	if IsViteDevMode() {
-		return []string{devAssetURL(devStylesheetSrc)}
-	}
+func entryStyleURLs(jsEntrySrc string) []string {
 	entries := getManifestData().entries
 	var urls []string
 	seen := make(map[string]bool)

--- a/modules/public/manifest_test.go
+++ b/modules/public/manifest_test.go
@@ -43,7 +43,7 @@ func TestViteManifest(t *testing.T) {
 		storeManifestFromBytes([]byte(``), 0, time.Now())
 		// not in manifest -> custom theme fallback
 		assert.Equal(t, "/assets/css/theme-gitea-dark.css", AssetURI("web_src/css/themes/theme-gitea-dark.css"))
-		assert.Empty(t, entryStyleURLs("web_src/js/index.ts", "web_src/css/index.css"))
+		assert.Empty(t, entryStyleURLs("web_src/js/index.ts"))
 		assert.Empty(t, AssetNameFromHashedPath("css/no-such-file.css"))
 	})
 
@@ -62,7 +62,7 @@ func TestViteManifest(t *testing.T) {
 			"/assets/css/index.B3zrQPqD.css",
 			"/assets/css/index-extra.CcCcCcCc.css",
 			"/assets/css/shared.BbBbBbBb.css",
-		}, entryStyleURLs("web_src/js/index.ts", "web_src/css/index.css"))
+		}, entryStyleURLs("web_src/js/index.ts"))
 		assert.Equal(t, template.HTML(
 			`<link rel="stylesheet" href="/assets/css/index.B3zrQPqD.css">`+
 				`<link rel="stylesheet" href="/assets/css/index-extra.CcCcCcCc.css">`+

--- a/modules/public/vitedev.go
+++ b/modules/public/vitedev.go
@@ -142,11 +142,14 @@ func IsViteDevMode() bool {
 
 // viteDevSourceURL returns the dev server URL for a source file, or "" if it doesn't exist.
 func viteDevSourceURL(srcPath string) string {
-	localPath := util.FilePathJoinAbs(setting.StaticRootPath, srcPath)
-	if _, err := os.Stat(localPath); err != nil {
+	if _, err := os.Stat(viteDevModuleID(srcPath)); err != nil {
 		return ""
 	}
 	return setting.AppSubURL + "/" + srcPath
+}
+
+func viteDevModuleID(srcPath string) string {
+	return filepath.ToSlash(util.FilePathJoinAbs(setting.StaticRootPath, srcPath))
 }
 
 // IsViteDevRequest returns true if the request should be proxied to the Vite dev server.


### PR DESCRIPTION
In vite dev mode CSS files loaded twice because the HTML links the stylesheet and `web_src/js/index.ts` imports the same file, so Vite's dev client injected a second `<style>` with identical rules.

Tag the dev `<link>` with `data-vite-dev-id` which makes the vite client reuse it instead of injecting. https://github.com/vitejs/vite/pull/20767 is related. None of the changes here impact the prod build.
