### PR TITLE
fix: keep runner list sorting across pages, make page size configurable

### DIFF
--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -3796,6 +3796,7 @@
   "actions.runners.delete_runner_header": "Confirm to delete this runner",
   "actions.runners.delete_runner_notice": "If a task is running on this runner, it will be terminated and marked as failed. It may break building workflow.",
   "actions.runners.none": "No runners available",
+  "actions.runners.per_page": "%d per page",
   "actions.runners.status.unspecified": "Unknown",
   "actions.runners.status.idle": "Idle",
   "actions.runners.status.active": "Active",

--- a/routers/web/shared/actions/runners.go
+++ b/routers/web/shared/actions/runners.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 
 	actions_model "gitea.dev/models/actions"
 	"gitea.dev/models/db"
@@ -33,6 +34,11 @@ const (
 	tplAdminRunnerEdit templates.TplName = "admin/runners/edit"
 	tplUserRunnerEdit  templates.TplName = "user/settings/runner_edit"
 )
+
+// runnersPageSizes are the selectable "runners per page" values on the runner management page.
+var runnersPageSizes = []int{25, 50, 100, 200}
+
+const runnersDefaultPageSize = 100
 
 type runnersCtx struct {
 	OwnerID            int64
@@ -111,10 +117,15 @@ func Runners(ctx *context.Context) {
 
 	page := max(ctx.FormInt("page"), 1)
 
+	pageSize := ctx.FormInt("limit")
+	if !slices.Contains(runnersPageSizes, pageSize) {
+		pageSize = runnersDefaultPageSize
+	}
+
 	opts := actions_model.FindRunnerOptions{
 		ListOptions: db.ListOptions{
 			Page:     page,
-			PageSize: 100,
+			PageSize: pageSize,
 		},
 		Sort:   ctx.Req.URL.Query().Get("sort"),
 		Filter: ctx.Req.URL.Query().Get("q"),
@@ -160,8 +171,11 @@ func Runners(ctx *context.Context) {
 	ctx.Data["RunnerRepoID"] = opts.RepoID
 	ctx.Data["SortType"] = opts.Sort
 	ctx.Data["AllowBulkActions"] = rCtx.IsAdmin
+	ctx.Data["PageSize"] = pageSize
+	ctx.Data["PageSizes"] = runnersPageSizes
 
 	pager := context.NewPagination(count, opts.PageSize, opts.Page, 5)
+	pager.AddParamFromRequest(ctx.Req)
 
 	ctx.Data["Page"] = pager
 

--- a/templates/shared/actions/runner_list.tmpl
+++ b/templates/shared/actions/runner_list.tmpl
@@ -35,10 +35,24 @@
 
 		</div>
 	</h4>
-	<div class="ui attached segment">
-		<form class="ui form ignore-dirty" id="user-list-search-form" action="{{$.Link}}">
+	<div class="ui attached segment flex-text-block">
+		<form class="ui form ignore-dirty tw-flex-1" id="user-list-search-form" action="{{$.Link}}">
+			{{if .SortType}}<input type="hidden" name="sort" value="{{.SortType}}">{{end}}
+			<input type="hidden" name="limit" value="{{.PageSize}}">
 			{{template "shared/search/combo" dict "Value" .Keyword "Placeholder" (ctx.Locale.Tr "search.runner_kind")}}
 		</form>
+		{{$queryLink := QueryBuild "?" "q" $.Keyword "sort" $.SortType}}
+		<div class="ui dropdown jump">
+			<button class="ui small button">
+				{{ctx.Locale.Tr "actions.runners.per_page" .PageSize}}
+				{{svg "octicon-triangle-down" 14 "dropdown icon"}}
+			</button>
+			<div class="menu">
+				{{range .PageSizes}}
+					<a class="item{{if eq . $.PageSize}} active selected{{end}}" href="{{QueryBuild $queryLink "limit" .}}">{{ctx.Locale.Tr "actions.runners.per_page" .}}</a>
+				{{end}}
+			</div>
+		</div>
 	</div>
 	{{if .AllowBulkActions}}
 	<div class="ui attached segment tw-hidden" data-global-init="initRunnerBulkToolbar">

--- a/tests/integration/actions_runner_modify_test.go
+++ b/tests/integration/actions_runner_modify_test.go
@@ -17,9 +17,43 @@ import (
 	"gitea.dev/modules/base"
 	"gitea.dev/tests"
 
+	"github.com/PuerkitoBio/goquery"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestActionsRunnerListPagination(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	ctx := t.Context()
+	require.NoError(t, db.DeleteAllRecords("action_runner"))
+	for i := range 26 {
+		require.NoError(t, actions_model.CreateRunner(ctx, &actions_model.ActionRunner{
+			Name:      fmt.Sprintf("global-runner-%02d", i),
+			TokenHash: fmt.Sprintf("h%d", i),
+			UUID:      fmt.Sprintf("h%d", i),
+		}))
+	}
+
+	session := loginUser(t, "user1")
+	req := NewRequest(t, "GET", "/-/admin/actions/runners?sort=newest&limit=25")
+	resp := session.MakeRequest(t, req, http.StatusOK)
+	htmlDoc := NewHTMLParser(t, resp.Body)
+
+	// the chosen page size is reflected in the per-page selector
+	assert.Positive(t, htmlDoc.Find(`.dropdown .menu a.item.active[href*="limit=25"]`).Length())
+
+	// pagination links carry both the sort and the page size across pages
+	var pagerHrefs []string
+	htmlDoc.Find(".page.buttons a[href]").Each(func(_ int, s *goquery.Selection) {
+		pagerHrefs = append(pagerHrefs, s.AttrOr("href", ""))
+	})
+	require.NotEmpty(t, pagerHrefs)
+	for _, href := range pagerHrefs {
+		assert.Contains(t, href, "sort=newest", "pagination link must keep the sort: %s", href)
+		assert.Contains(t, href, "limit=25", "pagination link must keep the page size: %s", href)
+	}
+}
 
 func TestActionsRunnerModify(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()


### PR DESCRIPTION
The runner management page (repo / org / user / admin) lost the active
sort and search filter when switching pages: the paginator was never
given the request query params, so page links were bare `?page=N`. The
page size was also hard-coded to 100.

- Carry the query params onto the paginator so sort, filter and page
  size persist across pages.
- Add a "per page" selector next to the search box (25 / 50 / 100 / 200,
  default 100), driven by a validated `limit` query param.

<img width="273" height="281" alt="image" src="https://github.com/user-attachments/assets/c601d0fe-d336-4668-af05-e307653cf2cf" />
