### PR TITLE
refactor: pagination/pager

### DIFF
--- a/CHANGELOG-archived.md
+++ b/CHANGELOG-archived.md
@@ -4726,7 +4726,7 @@ WARNING: v1.10.5 is incorrectly tagged targeting 1.12-dev and should __not__ be 
   * Fix 500 in public activity page (#1901)
   * Center-aligned login topbar (#1880)
   * Migration to fix existing owner team units (#1873)
-  * Fix paginater length (#1866)
+  * Fix paginator length (#1866)
   * Fix bug in removeOrgRepo (#1858)
   * Display draft releases (#1854)
   * Fix 404 for external tracking issues (#1852)

--- a/CHANGELOG-archived.md
+++ b/CHANGELOG-archived.md
@@ -4726,7 +4726,7 @@ WARNING: v1.10.5 is incorrectly tagged targeting 1.12-dev and should __not__ be 
   * Fix 500 in public activity page (#1901)
   * Center-aligned login topbar (#1880)
   * Migration to fix existing owner team units (#1873)
-  * Fix paginator length (#1866)
+  * Fix paginater length (#1866)
   * Fix bug in removeOrgRepo (#1858)
   * Display draft releases (#1854)
   * Fix 404 for external tracking issues (#1852)

--- a/routers/web/admin/badges.go
+++ b/routers/web/admin/badges.go
@@ -308,8 +308,7 @@ func RenderBadgeSearch(ctx *context.Context, opts *user_model.SearchBadgeOptions
 	ctx.Data["Total"] = count
 	ctx.Data["Badges"] = badges
 
-	pager := context.NewPagination(count, opts.PageSize, opts.Page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplName)

--- a/routers/web/admin/badges.go
+++ b/routers/web/admin/badges.go
@@ -203,7 +203,7 @@ func BadgeUsers(ctx *context.Context) {
 
 	ctx.Data["Users"] = users
 	ctx.Data["Total"] = count
-	ctx.Data["Page"] = context.NewPagination(count, setting.UI.Admin.UserPagingNum, page, 5)
+	ctx.Data["Page"] = context.NewPagerBuilder(ctx).TotalCount(count).PerPageLimit(setting.UI.Admin.UserPagingNum).CurPage(page).Build()
 
 	ctx.HTML(http.StatusOK, tplBadgeUsers)
 }
@@ -308,7 +308,7 @@ func RenderBadgeSearch(ctx *context.Context, opts *user_model.SearchBadgeOptions
 	ctx.Data["Total"] = count
 	ctx.Data["Badges"] = badges
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplName)

--- a/routers/web/admin/emails.go
+++ b/routers/web/admin/emails.go
@@ -93,7 +93,7 @@ func Emails(ctx *context.Context) {
 	ctx.Data["Total"] = count
 	ctx.Data["Emails"] = emails
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplEmails)

--- a/routers/web/admin/emails.go
+++ b/routers/web/admin/emails.go
@@ -93,8 +93,7 @@ func Emails(ctx *context.Context) {
 	ctx.Data["Total"] = count
 	ctx.Data["Emails"] = emails
 
-	pager := context.NewPagination(count, opts.PageSize, opts.Page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplEmails)

--- a/routers/web/admin/notice.go
+++ b/routers/web/admin/notice.go
@@ -37,7 +37,7 @@ func Notices(ctx *context.Context) {
 
 	ctx.Data["Total"] = total
 
-	ctx.Data["Page"] = context.NewPagination(total, setting.UI.Admin.NoticePagingNum, page, 5)
+	ctx.Data["Page"] = context.NewPagerBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.Admin.NoticePagingNum).CurPage(page).Build()
 
 	ctx.HTML(http.StatusOK, tplNotices)
 }

--- a/routers/web/admin/packages.go
+++ b/routers/web/admin/packages.go
@@ -73,7 +73,7 @@ func Packages(ctx *context.Context) {
 	ctx.Data["TotalBlobSize"] = totalBlobSize - totalUnreferencedBlobSize
 	ctx.Data["TotalUnreferencedBlobSize"] = totalUnreferencedBlobSize
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.PackagesPagingNum).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.PackagesPagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplPackagesList)

--- a/routers/web/admin/packages.go
+++ b/routers/web/admin/packages.go
@@ -73,8 +73,7 @@ func Packages(ctx *context.Context) {
 	ctx.Data["TotalBlobSize"] = totalBlobSize - totalUnreferencedBlobSize
 	ctx.Data["TotalUnreferencedBlobSize"] = totalUnreferencedBlobSize
 
-	pager := context.NewPagination(total, setting.UI.PackagesPagingNum, page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.PackagesPagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplPackagesList)

--- a/routers/web/admin/repos.go
+++ b/routers/web/admin/repos.go
@@ -83,7 +83,7 @@ func UnadoptedRepos(ctx *context.Context) {
 	q := ctx.FormString("q")
 
 	if !doSearch {
-		pager := context.NewPaginationBuilder(ctx).TotalCount(0).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
+		pager := context.NewPagerBuilder(ctx).TotalCount(0).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
 		ctx.Data["Page"] = pager
 		ctx.HTML(http.StatusOK, tplUnadoptedRepos)
 		return
@@ -96,7 +96,7 @@ func UnadoptedRepos(ctx *context.Context) {
 		return
 	}
 	ctx.Data["Dirs"] = repoNames
-	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
 	ctx.Data["Page"] = pager
 	ctx.HTML(http.StatusOK, tplUnadoptedRepos)
 }

--- a/routers/web/admin/repos.go
+++ b/routers/web/admin/repos.go
@@ -83,8 +83,7 @@ func UnadoptedRepos(ctx *context.Context) {
 	q := ctx.FormString("q")
 
 	if !doSearch {
-		pager := context.NewPagination(0, opts.PageSize, opts.Page, 5)
-		pager.AddParamFromRequest(ctx.Req)
+		pager := context.NewPaginationBuilder(ctx).TotalCount(0).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
 		ctx.Data["Page"] = pager
 		ctx.HTML(http.StatusOK, tplUnadoptedRepos)
 		return
@@ -97,8 +96,7 @@ func UnadoptedRepos(ctx *context.Context) {
 		return
 	}
 	ctx.Data["Dirs"] = repoNames
-	pager := context.NewPagination(count, opts.PageSize, opts.Page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
 	ctx.Data["Page"] = pager
 	ctx.HTML(http.StatusOK, tplUnadoptedRepos)
 }

--- a/routers/web/explore/code.go
+++ b/routers/web/explore/code.go
@@ -123,8 +123,7 @@ func Code(ctx *context.Context) {
 	ctx.Data["SearchResults"] = searchResults
 	ctx.Data["SearchResultLanguages"] = searchResultLanguages
 
-	pager := context.NewPagination(total, setting.UI.RepoSearchPagingNum, page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.RepoSearchPagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplExploreCode)

--- a/routers/web/explore/code.go
+++ b/routers/web/explore/code.go
@@ -123,7 +123,7 @@ func Code(ctx *context.Context) {
 	ctx.Data["SearchResults"] = searchResults
 	ctx.Data["SearchResultLanguages"] = searchResultLanguages
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.RepoSearchPagingNum).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.RepoSearchPagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplExploreCode)

--- a/routers/web/explore/repo.go
+++ b/routers/web/explore/repo.go
@@ -137,8 +137,7 @@ func RenderRepoSearch(ctx *context.Context, opts *RepoSearchOptions) {
 	ctx.Data["Repos"] = repos
 	ctx.Data["IsRepoIndexerEnabled"] = setting.Indexer.RepoIndexerEnabled
 
-	pager := context.NewPagination(count, opts.PageSize, page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, opts.TplName)

--- a/routers/web/explore/repo.go
+++ b/routers/web/explore/repo.go
@@ -137,7 +137,7 @@ func RenderRepoSearch(ctx *context.Context, opts *RepoSearchOptions) {
 	ctx.Data["Repos"] = repos
 	ctx.Data["IsRepoIndexerEnabled"] = setting.Indexer.RepoIndexerEnabled
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, opts.TplName)

--- a/routers/web/explore/user.go
+++ b/routers/web/explore/user.go
@@ -115,8 +115,7 @@ func RenderUserSearch(ctx *context.Context, opts user_model.SearchUserOptions, t
 	ctx.Data["ShowUserEmail"] = setting.UI.ShowUserEmail
 	ctx.Data["IsRepoIndexerEnabled"] = setting.Indexer.RepoIndexerEnabled
 
-	pager := context.NewPagination(count, opts.PageSize, opts.Page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplName)

--- a/routers/web/explore/user.go
+++ b/routers/web/explore/user.go
@@ -115,7 +115,7 @@ func RenderUserSearch(ctx *context.Context, opts user_model.SearchUserOptions, t
 	ctx.Data["ShowUserEmail"] = setting.UI.ShowUserEmail
 	ctx.Data["IsRepoIndexerEnabled"] = setting.Indexer.RepoIndexerEnabled
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplName)

--- a/routers/web/org/home.go
+++ b/routers/web/org/home.go
@@ -161,8 +161,7 @@ func home(ctx *context.Context, viewRepositories bool) {
 	ctx.Data["Repos"] = repos
 	ctx.Data["Total"] = count
 
-	pager := context.NewPagination(count, setting.UI.User.RepoPagingNum, page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(setting.UI.User.RepoPagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplOrgHome)

--- a/routers/web/org/home.go
+++ b/routers/web/org/home.go
@@ -161,7 +161,7 @@ func home(ctx *context.Context, viewRepositories bool) {
 	ctx.Data["Repos"] = repos
 	ctx.Data["Total"] = count
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(setting.UI.User.RepoPagingNum).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(count).PerPageLimit(setting.UI.User.RepoPagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplOrgHome)

--- a/routers/web/org/members.go
+++ b/routers/web/org/members.go
@@ -62,9 +62,8 @@ func Members(ctx *context.Context) {
 	}
 
 	pageSize := setting.UI.MembersPagingNum
-	pager := context.NewPagination(total, pageSize, page, 5)
-	pager.AddParamFromRequest(ctx.Req)
-	opts.ListOptions.Page = pager.Paginater.Current()
+	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(pageSize).CurPage(page).Build()
+	opts.ListOptions.Page = pager.Paginator.Current()
 	opts.ListOptions.PageSize = pageSize
 	members, membersIsPublic, err := organization.FindOrgMembers(ctx, opts)
 	if err != nil {

--- a/routers/web/org/members.go
+++ b/routers/web/org/members.go
@@ -62,7 +62,7 @@ func Members(ctx *context.Context) {
 	}
 
 	pageSize := setting.UI.MembersPagingNum
-	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(pageSize).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(total).PerPageLimit(pageSize).CurPage(page).Build()
 	opts.ListOptions.Page = pager.Paginator.Current()
 	opts.ListOptions.PageSize = pageSize
 	members, membersIsPublic, err := organization.FindOrgMembers(ctx, opts)

--- a/routers/web/org/projects.go
+++ b/routers/web/org/projects.go
@@ -103,8 +103,7 @@ func Projects(ctx *context.Context) {
 		project.RenderedContent = renderUtils.MarkdownToHtml(project.Description)
 	}
 
-	pager := context.NewPagination(total, setting.UI.IssuePagingNum, page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.IssuePagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.Data["CanWriteProjects"] = canWriteProjects(ctx)

--- a/routers/web/org/projects.go
+++ b/routers/web/org/projects.go
@@ -103,7 +103,7 @@ func Projects(ctx *context.Context) {
 		project.RenderedContent = renderUtils.MarkdownToHtml(project.Description)
 	}
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.IssuePagingNum).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.IssuePagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.Data["CanWriteProjects"] = canWriteProjects(ctx)

--- a/routers/web/org/teams.go
+++ b/routers/web/org/teams.go
@@ -103,8 +103,7 @@ func Teams(ctx *context.Context) {
 
 	ctx.Data["OrgListTeams"] = teams
 	ctx.Data["Keyword"] = keyword
-	pager := context.NewPagination(count, setting.UI.MembersPagingNum, page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(setting.UI.MembersPagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplTeams)

--- a/routers/web/org/teams.go
+++ b/routers/web/org/teams.go
@@ -103,7 +103,7 @@ func Teams(ctx *context.Context) {
 
 	ctx.Data["OrgListTeams"] = teams
 	ctx.Data["Keyword"] = keyword
-	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(setting.UI.MembersPagingNum).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(count).PerPageLimit(setting.UI.MembersPagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplTeams)

--- a/routers/web/repo/actions/actions.go
+++ b/routers/web/repo/actions/actions.go
@@ -503,8 +503,7 @@ func (data *actionRunListData) prepareFullPageRuns(ctx *context.Context, otherWo
 		ctx.ServerError("FindAndCount", err)
 		return false
 	}
-	data.pager = context.NewPagination(total, opts.PageSize, opts.Page, 5)
-	data.pager.AddParamFromRequest(ctx.Req)
+	data.pager = context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
 	data.ActionRuns = runs
 	return true
 }

--- a/routers/web/repo/actions/actions.go
+++ b/routers/web/repo/actions/actions.go
@@ -503,7 +503,7 @@ func (data *actionRunListData) prepareFullPageRuns(ctx *context.Context, otherWo
 		ctx.ServerError("FindAndCount", err)
 		return false
 	}
-	data.pager = context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
+	data.pager = context.NewPagerBuilder(ctx).TotalCount(total).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
 	data.ActionRuns = runs
 	return true
 }

--- a/routers/web/repo/branch.go
+++ b/routers/web/repo/branch.go
@@ -82,8 +82,7 @@ func Branches(ctx *context.Context) {
 	ctx.Data["CommitStatus"] = commitStatus
 	ctx.Data["CommitStatuses"] = commitStatuses
 	ctx.Data["DefaultBranchBranch"] = defaultBranchOptional
-	pager := context.NewPagination(branchesCount, pageSize, page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(branchesCount).PerPageLimit(pageSize).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 	ctx.HTML(http.StatusOK, tplBranch)
 }

--- a/routers/web/repo/branch.go
+++ b/routers/web/repo/branch.go
@@ -82,7 +82,7 @@ func Branches(ctx *context.Context) {
 	ctx.Data["CommitStatus"] = commitStatus
 	ctx.Data["CommitStatuses"] = commitStatuses
 	ctx.Data["DefaultBranchBranch"] = defaultBranchOptional
-	pager := context.NewPaginationBuilder(ctx).TotalCount(branchesCount).PerPageLimit(pageSize).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(branchesCount).PerPageLimit(pageSize).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 	ctx.HTML(http.StatusOK, tplBranch)
 }

--- a/routers/web/repo/commit.go
+++ b/routers/web/repo/commit.go
@@ -96,8 +96,7 @@ func Commits(ctx *context.Context) {
 	}
 	ctx.Data["CommitCount"] = commitsCount
 
-	pager := context.NewPagination(commitsCount, pageSize, page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(commitsCount).PerPageLimit(pageSize).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 	ctx.HTML(http.StatusOK, tplCommits)
 }
@@ -258,11 +257,10 @@ func FileHistory(ctx *context.Context) {
 		return
 	}
 
-	pager := context.NewPagination(commitsCount, setting.Git.CommitsRangeSize, page, 5)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(commitsCount).PerPageLimit(setting.Git.CommitsRangeSize).CurPage(page).Build()
 	if commitsCount == -1 {
 		pager.WithUnlimitedPaging(len(commits), hasMore)
 	}
-	pager.AddParamFromRequest(ctx.Req)
 	ctx.Data["Page"] = pager
 	ctx.HTML(http.StatusOK, tplCommits)
 }

--- a/routers/web/repo/commit.go
+++ b/routers/web/repo/commit.go
@@ -19,6 +19,7 @@ import (
 	repo_model "gitea.dev/models/repo"
 	user_model "gitea.dev/models/user"
 	"gitea.dev/modules/base"
+	"gitea.dev/modules/container"
 	"gitea.dev/modules/fileicon"
 	"gitea.dev/modules/git"
 	"gitea.dev/modules/htmlutil"
@@ -96,7 +97,7 @@ func Commits(ctx *context.Context) {
 	}
 	ctx.Data["CommitCount"] = commitsCount
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(commitsCount).PerPageLimit(pageSize).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(commitsCount).PerPageLimit(pageSize).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 	ctx.HTML(http.StatusOK, tplCommits)
 }
@@ -163,10 +164,8 @@ func Graph(ctx *context.Context) {
 	ctx.Data["AllRefs"] = gitRefs
 
 	divOnly := ctx.FormBool("div-only")
-	queryParams := ctx.Req.URL.Query()
-	queryParams.Del("div-only")
-	paginator := context.NewPagination(graphCommitsCount, setting.UI.GraphMaxCommitNum, page, 5)
-	paginator.AddParamFromQuery(queryParams)
+	paginator := context.NewPagerBuilder(ctx).TotalCount(graphCommitsCount).PerPageLimit(setting.UI.GraphMaxCommitNum).CurPage(page).Build()
+	paginator.RemoveParam(container.SetOf("div-only"))
 	ctx.Data["Page"] = paginator
 	if divOnly {
 		ctx.HTML(http.StatusOK, tplGraphDiv)
@@ -257,7 +256,7 @@ func FileHistory(ctx *context.Context) {
 		return
 	}
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(commitsCount).PerPageLimit(setting.Git.CommitsRangeSize).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(commitsCount).PerPageLimit(setting.Git.CommitsRangeSize).CurPage(page).Build()
 	if commitsCount == -1 {
 		pager.WithUnlimitedPaging(len(commits), hasMore)
 	}

--- a/routers/web/repo/issue_list.go
+++ b/routers/web/repo/issue_list.go
@@ -509,7 +509,7 @@ func prepareIssueFilterAndList(ctx *context.Context, milestoneID int64, projectI
 		total = util.Iif(isShowClosed.Value(), issueStats.ClosedCount, issueStats.OpenCount)
 	}
 	page := max(ctx.FormInt("page"), 1)
-	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.IssuePagingNum).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.IssuePagingNum).CurPage(page).Build()
 
 	// prepare real issue list:
 	var issues issues_model.IssueList

--- a/routers/web/repo/issue_list.go
+++ b/routers/web/repo/issue_list.go
@@ -509,7 +509,7 @@ func prepareIssueFilterAndList(ctx *context.Context, milestoneID int64, projectI
 		total = util.Iif(isShowClosed.Value(), issueStats.ClosedCount, issueStats.OpenCount)
 	}
 	page := max(ctx.FormInt("page"), 1)
-	pager := context.NewPagination(total, setting.UI.IssuePagingNum, page, 5)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.IssuePagingNum).CurPage(page).Build()
 
 	// prepare real issue list:
 	var issues issues_model.IssueList
@@ -519,7 +519,7 @@ func prepareIssueFilterAndList(ctx *context.Context, milestoneID int64, projectI
 		// In either case, no need to use keyword anymore
 		searchResult, err := db_indexer.GetIndexer().FindWithIssueOptions(ctx, &issues_model.IssuesOptions{
 			Paginator: &db.ListOptions{
-				Page:     pager.Paginater.Current(),
+				Page:     pager.Paginator.Current(),
 				PageSize: setting.UI.IssuePagingNum,
 			},
 			RepoIDs:           []int64{repo.ID},
@@ -645,7 +645,6 @@ func prepareIssueFilterAndList(ctx *context.Context, milestoneID int64, projectI
 	default:
 		ctx.Data["State"] = "open"
 	}
-	pager.AddParamFromRequest(ctx.Req)
 	ctx.Data["Page"] = pager
 }
 

--- a/routers/web/repo/milestone.go
+++ b/routers/web/repo/milestone.go
@@ -88,7 +88,7 @@ func Milestones(ctx *context.Context) {
 	ctx.Data["Keyword"] = keyword
 	ctx.Data["IsShowClosed"] = isShowClosed
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.IssuePagingNum).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.IssuePagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplMilestone)

--- a/routers/web/repo/milestone.go
+++ b/routers/web/repo/milestone.go
@@ -88,8 +88,7 @@ func Milestones(ctx *context.Context) {
 	ctx.Data["Keyword"] = keyword
 	ctx.Data["IsShowClosed"] = isShowClosed
 
-	pager := context.NewPagination(total, setting.UI.IssuePagingNum, page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.IssuePagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplMilestone)

--- a/routers/web/repo/packages.go
+++ b/routers/web/repo/packages.go
@@ -64,7 +64,7 @@ func Packages(ctx *context.Context) {
 	ctx.Data["Total"] = total
 	ctx.Data["RepositoryAccessMap"] = map[int64]bool{ctx.Repo.Repository.ID: true} // There is only the current repository
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.PackagesPagingNum).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.PackagesPagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplPackagesList)

--- a/routers/web/repo/packages.go
+++ b/routers/web/repo/packages.go
@@ -64,8 +64,7 @@ func Packages(ctx *context.Context) {
 	ctx.Data["Total"] = total
 	ctx.Data["RepositoryAccessMap"] = map[int64]bool{ctx.Repo.Repository.ID: true} // There is only the current repository
 
-	pager := context.NewPagination(total, setting.UI.PackagesPagingNum, page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.PackagesPagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplPackagesList)

--- a/routers/web/repo/projects.go
+++ b/routers/web/repo/projects.go
@@ -103,8 +103,7 @@ func Projects(ctx *context.Context) {
 		ctx.Data["State"] = "open"
 	}
 
-	pager := context.NewPagination(count, setting.UI.IssuePagingNum, page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(setting.UI.IssuePagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.Data["CanWriteProjects"] = ctx.Repo.Permission.CanWrite(unit.TypeProjects)

--- a/routers/web/repo/projects.go
+++ b/routers/web/repo/projects.go
@@ -103,7 +103,7 @@ func Projects(ctx *context.Context) {
 		ctx.Data["State"] = "open"
 	}
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(setting.UI.IssuePagingNum).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(count).PerPageLimit(setting.UI.IssuePagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.Data["CanWriteProjects"] = ctx.Repo.Permission.CanWrite(unit.TypeProjects)

--- a/routers/web/repo/release.go
+++ b/routers/web/repo/release.go
@@ -192,7 +192,7 @@ func Releases(ctx *context.Context) {
 	ctx.Data["Releases"] = releases
 
 	numReleases := ctx.Data["NumReleases"].(int64) //nolint:forcetypeassert // must exist
-	pager := context.NewPaginationBuilder(ctx).TotalCount(numReleases).PerPageLimit(listOptions.PageSize).CurPage(listOptions.Page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(numReleases).PerPageLimit(listOptions.PageSize).CurPage(listOptions.Page).Build()
 	ctx.Data["Page"] = pager
 	ctx.HTML(http.StatusOK, tplReleasesList)
 }
@@ -243,7 +243,7 @@ func TagsList(ctx *context.Context) {
 	ctx.Data["Releases"] = releases
 	ctx.Data["TagCount"] = count
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
 	ctx.Data["Page"] = pager
 	ctx.Data["PageIsViewCode"] = !ctx.Repo.Repository.UnitEnabled(ctx, unit.TypeReleases)
 	ctx.HTML(http.StatusOK, tplTagsList)

--- a/routers/web/repo/release.go
+++ b/routers/web/repo/release.go
@@ -192,8 +192,7 @@ func Releases(ctx *context.Context) {
 	ctx.Data["Releases"] = releases
 
 	numReleases := ctx.Data["NumReleases"].(int64) //nolint:forcetypeassert // must exist
-	pager := context.NewPagination(numReleases, listOptions.PageSize, listOptions.Page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(numReleases).PerPageLimit(listOptions.PageSize).CurPage(listOptions.Page).Build()
 	ctx.Data["Page"] = pager
 	ctx.HTML(http.StatusOK, tplReleasesList)
 }
@@ -244,8 +243,7 @@ func TagsList(ctx *context.Context) {
 	ctx.Data["Releases"] = releases
 	ctx.Data["TagCount"] = count
 
-	pager := context.NewPagination(count, opts.PageSize, opts.Page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
 	ctx.Data["Page"] = pager
 	ctx.Data["PageIsViewCode"] = !ctx.Repo.Repository.UnitEnabled(ctx, unit.TypeReleases)
 	ctx.HTML(http.StatusOK, tplTagsList)

--- a/routers/web/repo/search.go
+++ b/routers/web/repo/search.go
@@ -71,8 +71,7 @@ func Search(ctx *context.Context) {
 	ctx.Data["SearchResults"] = searchResults
 	ctx.Data["SearchResultLanguages"] = searchResultLanguages
 
-	pager := context.NewPagination(total, setting.UI.RepoSearchPagingNum, page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.RepoSearchPagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplSearch)

--- a/routers/web/repo/search.go
+++ b/routers/web/repo/search.go
@@ -71,7 +71,7 @@ func Search(ctx *context.Context) {
 	ctx.Data["SearchResults"] = searchResults
 	ctx.Data["SearchResultLanguages"] = searchResultLanguages
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.RepoSearchPagingNum).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.RepoSearchPagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplSearch)

--- a/routers/web/repo/setting/lfs.go
+++ b/routers/web/repo/setting/lfs.go
@@ -56,7 +56,7 @@ func LFSFiles(ctx *context.Context) {
 	pager := context.NewPagination(total, setting.UI.ExplorePagingNum, page, 5)
 	ctx.Data["Title"] = ctx.Tr("repo.settings.lfs")
 	ctx.Data["PageIsSettingsLFS"] = true
-	lfsMetaObjects, err := git_model.GetLFSMetaObjects(ctx, ctx.Repo.Repository.ID, pager.Paginater.Current(), setting.UI.ExplorePagingNum)
+	lfsMetaObjects, err := git_model.GetLFSMetaObjects(ctx, ctx.Repo.Repository.ID, pager.Paginator.Current(), setting.UI.ExplorePagingNum)
 	if err != nil {
 		ctx.ServerError("LFSFiles", err)
 		return
@@ -85,7 +85,7 @@ func LFSLocks(ctx *context.Context) {
 	pager := context.NewPagination(total, setting.UI.ExplorePagingNum, page, 5)
 	ctx.Data["Title"] = ctx.Tr("repo.settings.lfs_locks")
 	ctx.Data["PageIsSettingsLFS"] = true
-	lfsLocks, err := git_model.GetLFSLockByRepoID(ctx, ctx.Repo.Repository.ID, pager.Paginater.Current(), setting.UI.ExplorePagingNum)
+	lfsLocks, err := git_model.GetLFSLockByRepoID(ctx, ctx.Repo.Repository.ID, pager.Paginator.Current(), setting.UI.ExplorePagingNum)
 	if err != nil {
 		ctx.ServerError("LFSLocks", err)
 		return

--- a/routers/web/repo/setting/lfs.go
+++ b/routers/web/repo/setting/lfs.go
@@ -53,7 +53,7 @@ func LFSFiles(ctx *context.Context) {
 	}
 	ctx.Data["Total"] = total
 
-	pager := context.NewPagination(total, setting.UI.ExplorePagingNum, page, 5)
+	pager := context.NewPagerBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.ExplorePagingNum).CurPage(page).Build()
 	ctx.Data["Title"] = ctx.Tr("repo.settings.lfs")
 	ctx.Data["PageIsSettingsLFS"] = true
 	lfsMetaObjects, err := git_model.GetLFSMetaObjects(ctx, ctx.Repo.Repository.ID, pager.Paginator.Current(), setting.UI.ExplorePagingNum)
@@ -82,7 +82,7 @@ func LFSLocks(ctx *context.Context) {
 	}
 	ctx.Data["Total"] = total
 
-	pager := context.NewPagination(total, setting.UI.ExplorePagingNum, page, 5)
+	pager := context.NewPagerBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.ExplorePagingNum).CurPage(page).Build()
 	ctx.Data["Title"] = ctx.Tr("repo.settings.lfs_locks")
 	ctx.Data["PageIsSettingsLFS"] = true
 	lfsLocks, err := git_model.GetLFSLockByRepoID(ctx, ctx.Repo.Repository.ID, pager.Paginator.Current(), setting.UI.ExplorePagingNum)

--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -342,7 +342,7 @@ func RenderUserCards(ctx *context.Context, total int, getter func(opts db.ListOp
 	if page <= 0 {
 		page = 1
 	}
-	pager := context.NewPagination(int64(total), setting.ItemsPerPage, page, 5)
+	pager := context.NewPagerBuilder(ctx).TotalCount(int64(total)).PerPageLimit(setting.ItemsPerPage).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	items, err := getter(db.ListOptions{
@@ -400,7 +400,7 @@ func Forks(ctx *context.Context) {
 		return
 	}
 
-	pager := context.NewPagination(total, pageSize, page, 5)
+	pager := context.NewPagerBuilder(ctx).TotalCount(total).PerPageLimit(pageSize).CurPage(page).Build()
 	ctx.Data["ShowRepoOwnerAvatar"] = true
 	ctx.Data["ShowRepoOwnerOnList"] = true
 	ctx.Data["Page"] = pager

--- a/routers/web/repo/view.go
+++ b/routers/web/repo/view.go
@@ -346,7 +346,7 @@ func RenderUserCards(ctx *context.Context, total int, getter func(opts db.ListOp
 	ctx.Data["Page"] = pager
 
 	items, err := getter(db.ListOptions{
-		Page:     pager.Paginater.Current(),
+		Page:     pager.Paginator.Current(),
 		PageSize: setting.ItemsPerPage,
 	})
 	if err != nil {

--- a/routers/web/repo/wiki.go
+++ b/routers/web/repo/wiki.go
@@ -366,7 +366,7 @@ func renderRevisionPage(ctx *context.Context) (*git.Repository, *git.TreeEntry) 
 		return nil, nil
 	}
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(commitsCount).PerPageLimit(setting.Git.CommitsRangeSize).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(commitsCount).PerPageLimit(setting.Git.CommitsRangeSize).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	return wikiGitRepo, entry

--- a/routers/web/repo/wiki.go
+++ b/routers/web/repo/wiki.go
@@ -366,8 +366,7 @@ func renderRevisionPage(ctx *context.Context) (*git.Repository, *git.TreeEntry) 
 		return nil, nil
 	}
 
-	pager := context.NewPagination(commitsCount, setting.Git.CommitsRangeSize, page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(commitsCount).PerPageLimit(setting.Git.CommitsRangeSize).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	return wikiGitRepo, entry

--- a/routers/web/shared/actions/runners.go
+++ b/routers/web/shared/actions/runners.go
@@ -161,7 +161,7 @@ func Runners(ctx *context.Context) {
 	ctx.Data["SortType"] = opts.Sort
 	ctx.Data["AllowBulkActions"] = rCtx.IsAdmin
 
-	pager := context.NewPagination(count, opts.PageSize, opts.Page, 5)
+	pager := context.NewPagerBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
 
 	ctx.Data["Page"] = pager
 
@@ -222,7 +222,7 @@ func RunnersEdit(ctx *context.Context) {
 	}
 
 	ctx.Data["Tasks"] = tasks
-	pager := context.NewPagination(count, opts.PageSize, opts.Page, 5)
+	pager := context.NewPagerBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, rCtx.RunnerEditTemplate)

--- a/routers/web/user/code.go
+++ b/routers/web/user/code.go
@@ -103,8 +103,7 @@ func CodeSearch(ctx *context.Context) {
 	ctx.Data["SearchResults"] = searchResults
 	ctx.Data["SearchResultLanguages"] = searchResultLanguages
 
-	pager := context.NewPagination(total, setting.UI.RepoSearchPagingNum, page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.RepoSearchPagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplUserCode)

--- a/routers/web/user/code.go
+++ b/routers/web/user/code.go
@@ -103,7 +103,7 @@ func CodeSearch(ctx *context.Context) {
 	ctx.Data["SearchResults"] = searchResults
 	ctx.Data["SearchResultLanguages"] = searchResultLanguages
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.RepoSearchPagingNum).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.RepoSearchPagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplUserCode)

--- a/routers/web/user/home.go
+++ b/routers/web/user/home.go
@@ -128,7 +128,7 @@ func Dashboard(ctx *context.Context) {
 
 	// FIXME: UNLIMITE-PAGING-ONE-MORE-ROW: here is still an edge case: when curRows==pagingNum, then the "next page" will be an empty page.
 	// Ideally we should query one more row to determine if there is really a next page, but it's impossible in current framework.
-	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(pageSize).CurPage(page).Build().WithUnlimitedPaging(len(feeds), len(feeds) == pageSize)
+	pager := context.NewPagerBuilder(ctx).TotalCount(count).PerPageLimit(pageSize).CurPage(page).Build().WithUnlimitedPaging(len(feeds), len(feeds) == pageSize)
 	ctx.Data["Page"] = pager
 	ctx.Data["Feeds"] = feeds
 
@@ -319,7 +319,7 @@ func Milestones(ctx *context.Context) {
 	ctx.Data["RepoIDs"] = repoIDs
 	ctx.Data["IsShowClosed"] = isShowClosed
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(pagerCount).PerPageLimit(setting.UI.IssuePagingNum).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(pagerCount).PerPageLimit(setting.UI.IssuePagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplMilestones)
@@ -626,7 +626,7 @@ func buildIssueOverview(ctx *context.Context, unitType unit.Type) {
 		ctx.Data["State"] = "open"
 	}
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(shownIssues).PerPageLimit(setting.UI.IssuePagingNum).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(shownIssues).PerPageLimit(setting.UI.IssuePagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplIssues)

--- a/routers/web/user/home.go
+++ b/routers/web/user/home.go
@@ -128,9 +128,7 @@ func Dashboard(ctx *context.Context) {
 
 	// FIXME: UNLIMITE-PAGING-ONE-MORE-ROW: here is still an edge case: when curRows==pagingNum, then the "next page" will be an empty page.
 	// Ideally we should query one more row to determine if there is really a next page, but it's impossible in current framework.
-	pager := context.NewPagination(count, pageSize, page, 5).WithUnlimitedPaging(len(feeds), len(feeds) == pageSize)
-
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(pageSize).CurPage(page).Build().WithUnlimitedPaging(len(feeds), len(feeds) == pageSize)
 	ctx.Data["Page"] = pager
 	ctx.Data["Feeds"] = feeds
 
@@ -321,8 +319,7 @@ func Milestones(ctx *context.Context) {
 	ctx.Data["RepoIDs"] = repoIDs
 	ctx.Data["IsShowClosed"] = isShowClosed
 
-	pager := context.NewPagination(pagerCount, setting.UI.IssuePagingNum, page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(pagerCount).PerPageLimit(setting.UI.IssuePagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplMilestones)
@@ -629,8 +626,7 @@ func buildIssueOverview(ctx *context.Context, unitType unit.Type) {
 		ctx.Data["State"] = "open"
 	}
 
-	pager := context.NewPagination(shownIssues, setting.UI.IssuePagingNum, page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(shownIssues).PerPageLimit(setting.UI.IssuePagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplIssues)

--- a/routers/web/user/home_test.go
+++ b/routers/web/user/home_test.go
@@ -117,7 +117,7 @@ func TestMilestonesForSpecificRepo(t *testing.T) {
 
 func TestDashboardPagination(t *testing.T) {
 	ctx, _ := contexttest.MockContext(t, "/", contexttest.MockContextOption{Render: templates.PageRenderer()})
-	page := context.NewPagination(10, 3, 1, 3)
+	page := context.NewPagerBuilder(ctx).TotalCount(10).PerPageLimit(3).CurPage(1).NavPageNum(3).Build()
 
 	setting.AppSubURL = "/SubPath"
 	out, err := ctx.RenderToHTML("base/paginate", map[string]any{"Link": setting.AppSubURL, "Page": page})

--- a/routers/web/user/notification.go
+++ b/routers/web/user/notification.go
@@ -63,11 +63,11 @@ func prepareUserNotificationsData(ctx *context.Context) {
 		return
 	}
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(perPage).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(total).PerPageLimit(perPage).CurPage(page).Build()
 	if pager.Paginator.Current() < page {
 		// use the last page if the requested page is more than total pages
 		page = pager.Paginator.Current()
-		pager = context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(perPage).CurPage(page).Build()
+		pager = context.NewPagerBuilder(ctx).TotalCount(total).PerPageLimit(perPage).CurPage(page).Build()
 	}
 
 	statuses := []activities_model.NotificationStatus{queryStatus, activities_model.NotificationStatusPinned}
@@ -304,7 +304,7 @@ func NotificationSubscriptions(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("notification.subscriptions")
 
 	// redirect to last page if request page is more than total pages
-	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(setting.UI.IssuePagingNum).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(count).PerPageLimit(setting.UI.IssuePagingNum).CurPage(page).Build()
 	if pager.Paginator.Current() < page {
 		ctx.Redirect(fmt.Sprintf("/notifications/subscriptions?page=%d", pager.Paginator.Current()))
 		return
@@ -398,7 +398,7 @@ func NotificationWatching(ctx *context.Context) {
 	ctx.Data["Watches"] = watches
 
 	// redirect to last page if request page is more than total pages
-	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(setting.UI.User.RepoPagingNum).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(count).PerPageLimit(setting.UI.User.RepoPagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.Data["Status"] = 2

--- a/routers/web/user/notification.go
+++ b/routers/web/user/notification.go
@@ -63,11 +63,11 @@ func prepareUserNotificationsData(ctx *context.Context) {
 		return
 	}
 
-	pager := context.NewPagination(total, perPage, page, 5)
-	if pager.Paginater.Current() < page {
+	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(perPage).CurPage(page).Build()
+	if pager.Paginator.Current() < page {
 		// use the last page if the requested page is more than total pages
-		page = pager.Paginater.Current()
-		pager = context.NewPagination(total, perPage, page, 5)
+		page = pager.Paginator.Current()
+		pager = context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(perPage).CurPage(page).Build()
 	}
 
 	statuses := []activities_model.NotificationStatus{queryStatus, activities_model.NotificationStatusPinned}
@@ -138,7 +138,6 @@ func prepareUserNotificationsData(ctx *context.Context) {
 	ctx.Data["Link"] = setting.AppSubURL + "/notifications"
 	ctx.Data["SequenceNumber"] = ctx.FormString("sequence-number")
 
-	pager.AddParamFromRequest(ctx.Req)
 	pager.RemoveParam(container.SetOf("div-only", "sequence-number"))
 	ctx.Data["Page"] = pager
 }
@@ -305,12 +304,11 @@ func NotificationSubscriptions(ctx *context.Context) {
 	ctx.Data["Title"] = ctx.Tr("notification.subscriptions")
 
 	// redirect to last page if request page is more than total pages
-	pager := context.NewPagination(count, setting.UI.IssuePagingNum, page, 5)
-	if pager.Paginater.Current() < page {
-		ctx.Redirect(fmt.Sprintf("/notifications/subscriptions?page=%d", pager.Paginater.Current()))
+	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(setting.UI.IssuePagingNum).CurPage(page).Build()
+	if pager.Paginator.Current() < page {
+		ctx.Redirect(fmt.Sprintf("/notifications/subscriptions?page=%d", pager.Paginator.Current()))
 		return
 	}
-	pager.AddParamFromRequest(ctx.Req)
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplNotificationSubscriptions)
@@ -400,8 +398,7 @@ func NotificationWatching(ctx *context.Context) {
 	ctx.Data["Watches"] = watches
 
 	// redirect to last page if request page is more than total pages
-	pager := context.NewPagination(count, setting.UI.User.RepoPagingNum, page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(setting.UI.User.RepoPagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.Data["Status"] = 2

--- a/routers/web/user/package.go
+++ b/routers/web/user/package.go
@@ -128,8 +128,7 @@ func ListPackages(ctx *context.Context) {
 			ctx.Data["IsOrganizationOwner"] = false
 		}
 	}
-	pager := context.NewPagination(total, setting.UI.PackagesPagingNum, page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.PackagesPagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 	ctx.HTML(http.StatusOK, tplPackagesList)
 }
@@ -400,8 +399,7 @@ func ListPackageVersions(ctx *context.Context) {
 
 	ctx.Data["Total"] = total
 
-	pager := context.NewPagination(total, setting.UI.PackagesPagingNum, page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.PackagesPagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplPackageVersionList)

--- a/routers/web/user/package.go
+++ b/routers/web/user/package.go
@@ -128,7 +128,7 @@ func ListPackages(ctx *context.Context) {
 			ctx.Data["IsOrganizationOwner"] = false
 		}
 	}
-	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.PackagesPagingNum).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.PackagesPagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 	ctx.HTML(http.StatusOK, tplPackagesList)
 }
@@ -399,7 +399,7 @@ func ListPackageVersions(ctx *context.Context) {
 
 	ctx.Data["Total"] = total
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.PackagesPagingNum).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(total).PerPageLimit(setting.UI.PackagesPagingNum).CurPage(page).Build()
 	ctx.Data["Page"] = pager
 
 	ctx.HTML(http.StatusOK, tplPackageVersionList)

--- a/routers/web/user/profile.go
+++ b/routers/web/user/profile.go
@@ -312,12 +312,11 @@ func prepareUserProfileTabData(ctx *context.Context, profileDbRepo *repo_model.R
 		return
 	}
 
-	pager := context.NewPagination(total, pagingNum, page, 5)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(pagingNum).CurPage(page).Build()
 	if tab == "activity" {
 		// FIXME: UNLIMITE-PAGING-ONE-MORE-ROW: see another comment
 		pager.WithUnlimitedPaging(curRows, curRows == pagingNum)
 	}
-	pager.AddParamFromRequest(ctx.Req)
 	ctx.Data["Page"] = pager
 }
 

--- a/routers/web/user/profile.go
+++ b/routers/web/user/profile.go
@@ -312,7 +312,7 @@ func prepareUserProfileTabData(ctx *context.Context, profileDbRepo *repo_model.R
 		return
 	}
 
-	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(pagingNum).CurPage(page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(total).PerPageLimit(pagingNum).CurPage(page).Build()
 	if tab == "activity" {
 		// FIXME: UNLIMITE-PAGING-ONE-MORE-ROW: see another comment
 		pager.WithUnlimitedPaging(curRows, curRows == pagingNum)

--- a/routers/web/user/setting/profile.go
+++ b/routers/web/user/setting/profile.go
@@ -214,8 +214,7 @@ func Organization(ctx *context.Context) {
 	}
 
 	ctx.Data["Orgs"] = orgs
-	pager := context.NewPagination(total, opts.PageSize, opts.Page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
 	ctx.Data["Page"] = pager
 	ctx.HTML(http.StatusOK, tplSettingsOrganization)
 }
@@ -320,8 +319,7 @@ func Repos(ctx *context.Context) {
 		ctx.Data["Repos"] = repos
 	}
 	ctx.Data["ContextUser"] = ctxUser
-	pager := context.NewPagination(count, opts.PageSize, opts.Page, 5)
-	pager.AddParamFromRequest(ctx.Req)
+	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
 	ctx.Data["Page"] = pager
 	ctx.HTML(http.StatusOK, tplSettingsRepositories)
 }

--- a/routers/web/user/setting/profile.go
+++ b/routers/web/user/setting/profile.go
@@ -214,7 +214,7 @@ func Organization(ctx *context.Context) {
 	}
 
 	ctx.Data["Orgs"] = orgs
-	pager := context.NewPaginationBuilder(ctx).TotalCount(total).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(total).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
 	ctx.Data["Page"] = pager
 	ctx.HTML(http.StatusOK, tplSettingsOrganization)
 }
@@ -319,7 +319,7 @@ func Repos(ctx *context.Context) {
 		ctx.Data["Repos"] = repos
 	}
 	ctx.Data["ContextUser"] = ctxUser
-	pager := context.NewPaginationBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
+	pager := context.NewPagerBuilder(ctx).TotalCount(count).PerPageLimit(opts.PageSize).CurPage(opts.Page).Build()
 	ctx.Data["Page"] = pager
 	ctx.HTML(http.StatusOK, tplSettingsRepositories)
 }

--- a/services/context/api.go
+++ b/services/context/api.go
@@ -20,6 +20,7 @@ import (
 	"gitea.dev/modules/git"
 	"gitea.dev/modules/httpcache"
 	"gitea.dev/modules/log"
+	"gitea.dev/modules/paginator"
 	"gitea.dev/modules/reqctx"
 	"gitea.dev/modules/setting"
 	"gitea.dev/modules/util"
@@ -196,27 +197,26 @@ func GetAPIContext(req *http.Request) *APIContext {
 }
 
 func genAPILinks(curURL *url.URL, total int64, pageSize, curPage int) []string {
-	page := NewPagination(total, pageSize, curPage, 0)
-	paginater := page.Paginater
+	p := paginator.New(int(total), pageSize, curPage, 0)
 	links := make([]string, 0, 4)
 
-	if paginater.HasNext() {
+	if p.HasNext() {
 		u := *curURL
 		queries := u.Query()
-		queries.Set("page", strconv.Itoa(paginater.Next()))
+		queries.Set("page", strconv.Itoa(p.Next()))
 		u.RawQuery = queries.Encode()
 
 		links = append(links, fmt.Sprintf("<%s%s>; rel=\"next\"", setting.AppURL, u.RequestURI()[1:]))
 	}
-	if !paginater.IsLast() {
+	if !p.IsLast() {
 		u := *curURL
 		queries := u.Query()
-		queries.Set("page", strconv.Itoa(paginater.TotalPages()))
+		queries.Set("page", strconv.Itoa(p.TotalPages()))
 		u.RawQuery = queries.Encode()
 
 		links = append(links, fmt.Sprintf("<%s%s>; rel=\"last\"", setting.AppURL, u.RequestURI()[1:]))
 	}
-	if !paginater.IsFirst() {
+	if !p.IsFirst() {
 		u := *curURL
 		queries := u.Query()
 		queries.Set("page", "1")
@@ -224,10 +224,10 @@ func genAPILinks(curURL *url.URL, total int64, pageSize, curPage int) []string {
 
 		links = append(links, fmt.Sprintf("<%s%s>; rel=\"first\"", setting.AppURL, u.RequestURI()[1:]))
 	}
-	if paginater.HasPrevious() {
+	if p.HasPrevious() {
 		u := *curURL
 		queries := u.Query()
-		queries.Set("page", strconv.Itoa(paginater.Previous()))
+		queries.Set("page", strconv.Itoa(p.Previous()))
 		u.RawQuery = queries.Encode()
 
 		links = append(links, fmt.Sprintf("<%s%s>; rel=\"prev\"", setting.AppURL, u.RequestURI()[1:]))

--- a/services/context/pagination.go
+++ b/services/context/pagination.go
@@ -17,7 +17,7 @@ import (
 	"gitea.dev/modules/paginator"
 )
 
-type PaginationBuilder struct {
+type PagerBuilder struct {
 	ctx          *Context
 	total        int64
 	curPage      int
@@ -25,33 +25,33 @@ type PaginationBuilder struct {
 	navPageNum   *int
 }
 
-func NewPaginationBuilder(ctx *Context) *PaginationBuilder {
-	return &PaginationBuilder{ctx: ctx}
+func NewPagerBuilder(ctx *Context) *PagerBuilder {
+	return &PagerBuilder{ctx: ctx}
 }
 
-func (pb *PaginationBuilder) TotalCount(n int64) *PaginationBuilder {
+func (pb *PagerBuilder) TotalCount(n int64) *PagerBuilder {
 	pb.total = n
 	return pb
 }
 
-func (pb *PaginationBuilder) PerPageLimit(n int) *PaginationBuilder {
+func (pb *PagerBuilder) PerPageLimit(n int) *PagerBuilder {
 	pb.perPageLimit = n
 	return pb
 }
 
-func (pb *PaginationBuilder) CurPage(n int) *PaginationBuilder {
+func (pb *PagerBuilder) CurPage(n int) *PagerBuilder {
 	pb.curPage = n
 	return pb
 }
 
-func (pb *PaginationBuilder) NavPageNum(n int) *PaginationBuilder {
+func (pb *PagerBuilder) NavPageNum(n int) *PagerBuilder {
 	pb.navPageNum = &n
 	return pb
 }
 
-func (pb *PaginationBuilder) Build() *Pagination {
+func (pb *PagerBuilder) Build() *Pagination {
 	navPageNum := optional.FromPtr(pb.navPageNum).ValueOrDefault(5)
-	p := NewPagination(pb.total, pb.perPageLimit, pb.curPage, navPageNum)
+	p := newPagination(pb.total, pb.perPageLimit, pb.curPage, navPageNum)
 	p.AddParamFromRequest(pb.ctx.Req)
 	return p
 }
@@ -62,11 +62,11 @@ type Pagination struct {
 	urlParams []string
 }
 
-// NewPagination creates a new instance of the Pagination struct.
+// newPagination creates a new instance of the Pagination struct.
 // "total" is usually from database result "count int64", so it also uses int64
 // "pagingNum" is "page size" or "limit", "current" is "page"
 // total=-1 means only showing prev/next
-func NewPagination(total int64, pagingNum, current, numPages int) *Pagination {
+func newPagination(total int64, pagingNum, current, numPages int) *Pagination {
 	totalInt := int(min(total, int64(math.MaxInt)))
 	p := &Pagination{}
 	p.Paginator = paginator.New(totalInt, pagingNum, current, numPages)

--- a/services/context/pagination.go
+++ b/services/context/pagination.go
@@ -13,12 +13,52 @@ import (
 	"strings"
 
 	"gitea.dev/modules/container"
+	"gitea.dev/modules/optional"
 	"gitea.dev/modules/paginator"
 )
 
+type PaginationBuilder struct {
+	ctx          *Context
+	total        int64
+	curPage      int
+	perPageLimit int
+	navPageNum   *int
+}
+
+func NewPaginationBuilder(ctx *Context) *PaginationBuilder {
+	return &PaginationBuilder{ctx: ctx}
+}
+
+func (pb *PaginationBuilder) TotalCount(n int64) *PaginationBuilder {
+	pb.total = n
+	return pb
+}
+
+func (pb *PaginationBuilder) PerPageLimit(n int) *PaginationBuilder {
+	pb.perPageLimit = n
+	return pb
+}
+
+func (pb *PaginationBuilder) CurPage(n int) *PaginationBuilder {
+	pb.curPage = n
+	return pb
+}
+
+func (pb *PaginationBuilder) NavPageNum(n int) *PaginationBuilder {
+	pb.navPageNum = &n
+	return pb
+}
+
+func (pb *PaginationBuilder) Build() *Pagination {
+	navPageNum := optional.FromPtr(pb.navPageNum).ValueOrDefault(5)
+	p := NewPagination(pb.total, pb.perPageLimit, pb.curPage, navPageNum)
+	p.AddParamFromRequest(pb.ctx.Req)
+	return p
+}
+
 // Pagination provides a pagination via paginator.Paginator and additional configurations for the link params used in rendering
 type Pagination struct {
-	Paginater *paginator.Paginator
+	Paginator *paginator.Paginator
 	urlParams []string
 }
 
@@ -29,12 +69,12 @@ type Pagination struct {
 func NewPagination(total int64, pagingNum, current, numPages int) *Pagination {
 	totalInt := int(min(total, int64(math.MaxInt)))
 	p := &Pagination{}
-	p.Paginater = paginator.New(totalInt, pagingNum, current, numPages)
+	p.Paginator = paginator.New(totalInt, pagingNum, current, numPages)
 	return p
 }
 
 func (p *Pagination) WithUnlimitedPaging(curRows int, hasNext bool) *Pagination {
-	p.Paginater.SetUnlimitedPaging(curRows, hasNext)
+	p.Paginator.SetUnlimitedPaging(curRows, hasNext)
 	return p
 }
 

--- a/services/context/pagination_test.go
+++ b/services/context/pagination_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestPagination(t *testing.T) {
-	p := NewPagination(1, 1, 1, 1)
+	p := newPagination(1, 1, 1, 1)
 	params := url.Values{}
 	params.Add("k1", "11")
 	params.Add("k1", "12")
@@ -33,22 +33,22 @@ func TestPagination(t *testing.T) {
 	v, _ = url.ParseQuery(string(p.GetParams()))
 	assert.Equal(t, params, v)
 
-	p = NewPagination(-1, 1, 1, 1)
+	p = newPagination(-1, 1, 1, 1)
 	p.WithUnlimitedPaging(0, false)
 	assert.Zero(t, p.Paginator.TotalPages())
 	assert.False(t, p.Paginator.HasNext())
 
-	p = NewPagination(-1, 1, 1, 1)
+	p = newPagination(-1, 1, 1, 1)
 	p.WithUnlimitedPaging(10, false)
 	assert.Equal(t, 1, p.Paginator.TotalPages()) // first page, no next, so it should know that the total page number is 1
 	assert.False(t, p.Paginator.HasNext())
 
-	p = NewPagination(-1, 1, 2, 1)
+	p = newPagination(-1, 1, 2, 1)
 	p.WithUnlimitedPaging(10, false)
 	assert.Equal(t, -1, p.Paginator.TotalPages())
 	assert.False(t, p.Paginator.HasNext())
 
-	p = NewPagination(-1, 1, 1, 1)
+	p = newPagination(-1, 1, 1, 1)
 	p.WithUnlimitedPaging(10, true)
 	assert.Equal(t, -1, p.Paginator.TotalPages())
 	assert.True(t, p.Paginator.HasNext())

--- a/services/context/pagination_test.go
+++ b/services/context/pagination_test.go
@@ -35,21 +35,21 @@ func TestPagination(t *testing.T) {
 
 	p = NewPagination(-1, 1, 1, 1)
 	p.WithUnlimitedPaging(0, false)
-	assert.Zero(t, p.Paginater.TotalPages())
-	assert.False(t, p.Paginater.HasNext())
+	assert.Zero(t, p.Paginator.TotalPages())
+	assert.False(t, p.Paginator.HasNext())
 
 	p = NewPagination(-1, 1, 1, 1)
 	p.WithUnlimitedPaging(10, false)
-	assert.Equal(t, 1, p.Paginater.TotalPages()) // first page, no next, so it should know that the total page number is 1
-	assert.False(t, p.Paginater.HasNext())
+	assert.Equal(t, 1, p.Paginator.TotalPages()) // first page, no next, so it should know that the total page number is 1
+	assert.False(t, p.Paginator.HasNext())
 
 	p = NewPagination(-1, 1, 2, 1)
 	p.WithUnlimitedPaging(10, false)
-	assert.Equal(t, -1, p.Paginater.TotalPages())
-	assert.False(t, p.Paginater.HasNext())
+	assert.Equal(t, -1, p.Paginator.TotalPages())
+	assert.False(t, p.Paginator.HasNext())
 
 	p = NewPagination(-1, 1, 1, 1)
 	p.WithUnlimitedPaging(10, true)
-	assert.Equal(t, -1, p.Paginater.TotalPages())
-	assert.True(t, p.Paginater.HasNext())
+	assert.Equal(t, -1, p.Paginator.TotalPages())
+	assert.True(t, p.Paginator.HasNext())
 }

--- a/templates/admin/packages/list.tmpl
+++ b/templates/admin/packages/list.tmpl
@@ -73,7 +73,7 @@
 							<td>{{DateUtils.AbsoluteShort .Version.CreatedUnix}}</td>
 							<td>
 								<a class="tw-text-red show-modal" href data-modal="#admin-package-delete-modal"
-									data-modal-form.url="{{$.Link}}/delete?page={{$.Page.Paginater.Current}}&sort={{$.SortType}}&id={{.Version.ID}}"
+									data-modal-form.url="{{$.Link}}/delete?page={{$.Page.Paginator.Current}}&sort={{$.SortType}}&id={{.Version.ID}}"
 									data-modal-package-name="{{.Package.Name}}" data-modal-package-version="{{.Version.Version}}"
 								>{{svg "octicon-trash"}}</a>
 							</td>

--- a/templates/admin/repo/list.tmpl
+++ b/templates/admin/repo/list.tmpl
@@ -86,7 +86,7 @@
 							<td>{{DateUtils.AbsoluteShort .CreatedUnix}}</td>
 							<td>
 								<a class="tw-text-red show-modal" href data-modal="#admin-repo-delete-modal"
-									data-modal-form.url="{{$.Link}}/delete?page={{$.Page.Paginater.Current}}&sort={{$.SortType}}&id={{.ID}}"
+									data-modal-form.url="{{$.Link}}/delete?page={{$.Page.Paginator.Current}}&sort={{$.SortType}}&id={{.ID}}"
 									data-modal-repo-name="{{.Name}}"
 								>{{svg "octicon-trash"}}</a>
 							</td>

--- a/templates/base/paginate.tmpl
+++ b/templates/base/paginate.tmpl
@@ -3,7 +3,7 @@
 {{if eq $paginationLink nil}}{{$paginationLink = ctx.RootData.Link}}{{end}}
 {{if eq $paginationLink AppSubUrl}}{{$paginationLink = print $paginationLink "/"}}{{end}}
 {{$paginationParams := $page.GetParams}}
-{{with $page.Paginater}}
+{{with $page.Paginator}}
 	{{if or (eq .TotalPages -1) (gt .TotalPages 1)}}
 		{{$showFirstLast := gt .TotalPages 1}}
 		<div class="center page buttons">

--- a/templates/repo/actions/list.tmpl
+++ b/templates/repo/actions/list.tmpl
@@ -65,7 +65,7 @@
 			</div>
 			<div class="flex-container-main">
 				<div class="ui top attached header flex-left-right">
-					<strong>{{ctx.Locale.TrN .Page.Paginater.Total "actions.runs.workflow_run_count_1" "actions.runs.workflow_run_count_n" .Page.Paginater.Total}}</strong>
+					<strong>{{ctx.Locale.TrN .Page.Paginator.Total "actions.runs.workflow_run_count_1" "actions.runs.workflow_run_count_n" .Page.Paginator.Total}}</strong>
 					<div class="ui secondary filter menu flex-text-block tw-m-0">
 						<!-- Actor -->
 						<div class="ui{{if not .Actors}} disabled{{end}} dropdown jump item">

--- a/templates/repo/branch/list.tmpl
+++ b/templates/repo/branch/list.tmpl
@@ -194,13 +194,13 @@
 								{{end}}
 								{{if and $.IsWriter $.Repository.CanContentChange (not .IsProtected)}}
 									{{if .DBBranch.IsDeleted}}
-										<button class="btn interact-bg tw-p-2 link-action restore-branch-button" data-url="{{$.Link}}/restore?branch_id={{.DBBranch.ID}}&name={{.DBBranch.Name}}&page={{$.Page.Paginater.Current}}" data-tooltip-content="{{ctx.Locale.Tr "repo.branch.restore" (.DBBranch.Name)}}">
+										<button class="btn interact-bg tw-p-2 link-action restore-branch-button" data-url="{{$.Link}}/restore?branch_id={{.DBBranch.ID}}&name={{.DBBranch.Name}}&page={{$.Page.Paginator.Current}}" data-tooltip-content="{{ctx.Locale.Tr "repo.branch.restore" (.DBBranch.Name)}}">
 											<span class="tw-text-blue">
 												{{svg "octicon-reply"}}
 											</span>
 										</button>
 									{{else}}
-										<button class="btn interact-bg tw-p-2 show-modal delete-branch-button tw-text-red" data-modal="#delete-branch-modal" data-modal-form.url="{{$.Link}}/delete?name={{.DBBranch.Name}}&page={{$.Page.Paginater.Current}}" data-tooltip-content="{{ctx.Locale.Tr "repo.branch.delete" (.DBBranch.Name)}}" data-modal-name="{{.DBBranch.Name}}">
+										<button class="btn interact-bg tw-p-2 show-modal delete-branch-button tw-text-red" data-modal="#delete-branch-modal" data-modal-form.url="{{$.Link}}/delete?name={{.DBBranch.Name}}&page={{$.Page.Paginator.Current}}" data-tooltip-content="{{ctx.Locale.Tr "repo.branch.delete" (.DBBranch.Name)}}" data-modal-name="{{.DBBranch.Name}}">
 											{{svg "octicon-trash"}}
 										</button>
 									{{end}}

--- a/templates/user/dashboard/dashboard.tmpl
+++ b/templates/user/dashboard/dashboard.tmpl
@@ -5,7 +5,7 @@
 		<div class="flex-container-main">
 			{{template "base/alert" .}}
 			{{template "user/heatmap" .}}
-			{{if .Page.Paginater.TotalPages}}
+			{{if .Page.Paginator.TotalPages}}
 				{{template "user/dashboard/feeds" .}}
 			{{else}}
 				{{template "user/dashboard/guide" .}}

--- a/templates/user/notification/notification_div.tmpl
+++ b/templates/user/notification/notification_div.tmpl
@@ -53,7 +53,7 @@
 							{{DateUtils.TimeSince $one.UpdatedUnix}}
 						{{end}}
 					</div>
-					<form class="notifications-buttons form-fetch-action" action="{{AppSubUrl}}/notifications/status?type={{$.PageType}}&page={{$.Page.Paginater.Current}}&perPage={{$.Page.Paginater.PagingNum}}" method="post"
+					<form class="notifications-buttons form-fetch-action" action="{{AppSubUrl}}/notifications/status?type={{$.PageType}}&page={{$.Page.Paginator.Current}}&perPage={{$.Page.Paginator.PagingNum}}" method="post"
 								data-fetch-sync="$body #notification_div"
 					>
 						<input type="hidden" name="notification_id" value="{{$one.ID}}">


### PR DESCRIPTION
Make sure the request query parameters are always correctly added into the page links

The backport fix for 1.27 is #39163