### PR TITLE
fix(api): hide cross-repo PR head repository/SHA from public-only tokens

### DIFF
--- a/routers/api/v1/repo/commits.go
+++ b/routers/api/v1/repo/commits.go
@@ -416,5 +416,7 @@ func GetCommitPullRequest(ctx *context.APIContext) {
 		ctx.APIErrorInternal(err)
 		return
 	}
-	ctx.JSON(http.StatusOK, convert.ToAPIPullRequest(ctx, pr, ctx.Doer))
+	apiPR := convert.ToAPIPullRequest(ctx, pr, ctx.Doer)
+	hideCrossRepoPRHead(ctx, pr, apiPR)
+	ctx.JSON(http.StatusOK, apiPR)
 }

--- a/routers/api/v1/repo/issue_pin.go
+++ b/routers/api/v1/repo/issue_pin.go
@@ -262,6 +262,7 @@ func ListPinnedPullRequests(ctx *context.APIContext) {
 		}
 
 		apiPrs[i] = convert.ToAPIPullRequest(ctx, pr, ctx.Doer)
+		hideCrossRepoPRHead(ctx, pr, apiPrs[i])
 	}
 
 	ctx.JSON(http.StatusOK, &apiPrs)

--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -152,6 +152,7 @@ func ListPullRequests(ctx *context.APIContext) {
 		ctx.APIErrorInternal(err)
 		return
 	}
+	hideCrossRepoPRHeads(ctx, prs, apiPrs)
 
 	ctx.SetLinkHeader(maxResults, listOptions.PageSize)
 	ctx.SetTotalCountHeader(maxResults)
@@ -210,7 +211,9 @@ func GetPullRequest(ctx *context.APIContext) {
 	// Consider API access a view for delayed checking.
 	pull_service.StartPullRequestCheckOnView(ctx, pr)
 
-	ctx.JSON(http.StatusOK, convert.ToAPIPullRequest(ctx, pr, ctx.Doer))
+	apiPR := convert.ToAPIPullRequest(ctx, pr, ctx.Doer)
+	hideCrossRepoPRHead(ctx, pr, apiPR)
+	ctx.JSON(http.StatusOK, apiPR)
 }
 
 // GetPullRequest returns a single PR based on index
@@ -299,7 +302,9 @@ func GetPullRequestByBaseHead(ctx *context.APIContext) {
 	// Consider API access a view for delayed checking.
 	pull_service.StartPullRequestCheckOnView(ctx, pr)
 
-	ctx.JSON(http.StatusOK, convert.ToAPIPullRequest(ctx, pr, ctx.Doer))
+	apiPR := convert.ToAPIPullRequest(ctx, pr, ctx.Doer)
+	hideCrossRepoPRHead(ctx, pr, apiPR)
+	ctx.JSON(http.StatusOK, apiPR)
 }
 
 // DownloadPullDiffOrPatch render a pull's raw diff or patch
@@ -829,8 +834,11 @@ func EditPullRequest(ctx *context.APIContext) {
 		return
 	}
 
+	apiPR := convert.ToAPIPullRequest(ctx, pr, ctx.Doer)
+	hideCrossRepoPRHead(ctx, pr, apiPR)
+
 	// TODO this should be 200, not 201
-	ctx.JSON(http.StatusCreated, convert.ToAPIPullRequest(ctx, pr, ctx.Doer))
+	ctx.JSON(http.StatusCreated, apiPR)
 }
 
 // IsPullRequestMerged checks if a PR exists given an index
@@ -1074,6 +1082,34 @@ func MergePullRequest(ctx *context.APIContext) {
 	}
 
 	ctx.Status(http.StatusOK)
+}
+
+// hideCrossRepoPRHead clears the head-repository fields of an API pull-request response when the
+// current token is not permitted to see the head repository (e.g. a public-only token and a
+// private/limited head repo). services/convert.ToAPIPullRequest(s) cannot apply this check itself
+// -- it only receives a doer, not the APIContext the token scope lives on -- so every handler that
+// serializes a PR's head must call this after conversion. Mirrors the guard already applied to
+// UpdatePullRequest and parseCompareInfo; without it, a public-only read:repository token can
+// read a private head repository's metadata and latest commit SHA through the base repo's PR
+// endpoints even though it was never granted access to that head repository.
+func hideCrossRepoPRHead(ctx *context.APIContext, pr *issues_model.PullRequest, apiPR *api.PullRequest) {
+	if apiPR == nil || pr.HeadRepo == nil || pr.HeadRepoID == pr.BaseRepoID {
+		return
+	}
+	if ctx.TokenCanAccessRepo(pr.HeadRepo) {
+		return
+	}
+	apiPR.Head.Repository = nil
+	apiPR.Head.Sha = ""
+}
+
+// hideCrossRepoPRHeads applies hideCrossRepoPRHead to every pull request in a listing response.
+func hideCrossRepoPRHeads(ctx *context.APIContext, prs issues_model.PullRequestList, apiPRs []*api.PullRequest) {
+	for i, pr := range prs {
+		if i < len(apiPRs) {
+			hideCrossRepoPRHead(ctx, pr, apiPRs[i])
+		}
+	}
 }
 
 // parseCompareInfo returns non-nil if it succeeds, it always writes to the context and returns nil if it fails

--- a/tests/integration/api_pull_public_only_test.go
+++ b/tests/integration/api_pull_public_only_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	auth_model "gitea.dev/models/auth"
+	repo_model "gitea.dev/models/repo"
+	"gitea.dev/models/unittest"
+	user_model "gitea.dev/models/user"
+	api "gitea.dev/modules/structs"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A public-only token must not be able to read a cross-repo PR's head-repository metadata or
+// latest commit SHA when that head repository is private -- see GHSA-m78w-jjjx-gp8r. The base
+// repository (and the PR itself) stays public and visible either way; only Head.Repository/Head.Sha
+// must be hidden for the restricted token.
+func TestAPIGetPullRequestPublicOnlyToken(t *testing.T) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
+		user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+		org26 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 26})
+		pr := createOutdatedPR(t, user, org26)
+		require.NoError(t, pr.LoadBaseRepo(t.Context()))
+		require.NoError(t, pr.LoadHeadRepo(t.Context()))
+
+		require.NoError(t, repo_model.UpdateRepositoryColsNoAutoTime(t.Context(),
+			&repo_model.Repository{ID: pr.HeadRepo.ID, IsPrivate: true}, "is_private"))
+
+		prURL := fmt.Sprintf("/api/v1/repos/%s/pulls/%d", pr.BaseRepo.FullName(), pr.Index)
+
+		fullToken := getUserToken(t, user.Name, auth_model.AccessTokenScopeReadRepository)
+		resp := MakeRequest(t, NewRequest(t, "GET", prURL).AddTokenAuth(fullToken), http.StatusOK)
+		fullResp := DecodeJSON(t, resp, &api.PullRequest{})
+		require.NotNil(t, fullResp.Head.Repository, "full token should still see the private head repo")
+		assert.NotEmpty(t, fullResp.Head.Sha, "full token should still see the head commit SHA")
+
+		publicOnlyToken := getUserToken(t, user.Name, auth_model.AccessTokenScopeReadRepository, auth_model.AccessTokenScopePublicOnly)
+		resp = MakeRequest(t, NewRequest(t, "GET", prURL).AddTokenAuth(publicOnlyToken), http.StatusOK)
+		publicResp := DecodeJSON(t, resp, &api.PullRequest{})
+		assert.Nil(t, publicResp.Head.Repository, "public-only token must not see the private head repo")
+		assert.Empty(t, publicResp.Head.Sha, "public-only token must not see the head commit SHA")
+	})
+}
+
+func TestAPIListPullRequestsPublicOnlyToken(t *testing.T) {
+	onGiteaRun(t, func(t *testing.T, _ *url.URL) {
+		user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+		org26 := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 26})
+		pr := createOutdatedPR(t, user, org26)
+		require.NoError(t, pr.LoadBaseRepo(t.Context()))
+		require.NoError(t, pr.LoadHeadRepo(t.Context()))
+
+		require.NoError(t, repo_model.UpdateRepositoryColsNoAutoTime(t.Context(),
+			&repo_model.Repository{ID: pr.HeadRepo.ID, IsPrivate: true}, "is_private"))
+
+		listURL := fmt.Sprintf("/api/v1/repos/%s/pulls?state=all", pr.BaseRepo.FullName())
+
+		publicOnlyToken := getUserToken(t, user.Name, auth_model.AccessTokenScopeReadRepository, auth_model.AccessTokenScopePublicOnly)
+		resp := MakeRequest(t, NewRequest(t, "GET", listURL).AddTokenAuth(publicOnlyToken), http.StatusOK)
+		var prs []*api.PullRequest
+		DecodeJSON(t, resp, &prs)
+
+		require.NotEmpty(t, prs)
+		found := false
+		for _, p := range prs {
+			if p.Index == pr.Index {
+				found = true
+				assert.Nil(t, p.Head.Repository, "public-only token must not see the private head repo in list results")
+				assert.Empty(t, p.Head.Sha, "public-only token must not see the head commit SHA in list results")
+			}
+		}
+		assert.True(t, found, "expected PR to appear in the list")
+	})
+}


### PR DESCRIPTION
## Summary

Follow-up to GHSA-m78w-jjjx-gp8r. Alongside the `parseCompareInfo` scope gap (already fixed), the
advisory noted a second, distinct code path: `services/convert.ToAPIPullRequest(s)` serializes
`pr.HeadRepo` (repository metadata, clone URLs, `private` flag) and the head commit SHA with no
check on whether the current API token is scoped to see that repository.

`convert.ToAPIPullRequest(s)` can't apply the check itself — it only receives a `doer`, not the
`APIContext` the token scope lives on — so the guard has to live in every handler that serializes a
PR's head. These didn't have it:

- `GetPullRequest`
- `GetPullRequestByBaseHead`
- `GetPullRequestByMergedCommit`
- `ListPullRequests`
- `ListPinnedPullRequests`
- `EditPullRequest`

A public-only, `read:repository` token can reach any of these through a public base repository and
read a private (or otherwise restricted) head repository's metadata and latest commit SHA, even
though it was never granted access to the head repository itself.

## Fix

Adds `hideCrossRepoPRHead(s)` in `routers/api/v1/repo`, called after `convert.ToAPIPullRequest(s)`
in every affected handler. It nulls `Head.Repository`/`Head.Sha` when
`ctx.TokenCanAccessRepo(pr.HeadRepo)` fails — mirroring the guard already applied to
`UpdatePullRequest` and `parseCompareInfo`.

`CreatePullRequest` is intentionally left alone: the caller must already have push access to the
head branch to open the PR, so there's no token-scope gap there.

## Test plan

Added `TestAPIGetPullRequestPublicOnlyToken` and `TestAPIListPullRequestsPublicOnlyToken`
(`tests/integration/api_pull_public_only_test.go`), modeled on the existing
`TestAPIComparePublicOnlyToken`. Ran locally end-to-end against a real sqlite-backed instance:

- [x] Both new tests pass — full token still sees the private head repo/SHA, public-only token sees
      neither, base repo/PR stays visible either way.
- [x] No regression in `TestAPIViewPulls`, `TestAPIViewPullsByBaseHead`, `TestAPIEditPull`,
      `TestAPIViewPullFilesWithHeadRepoDeleted`, `TestAPIListPinnedPullrequests`.
- [ ] Didn't add a dedicated test for `GetPullRequestByMergedCommit` (couldn't find an existing API
      test file for that endpoint to model one on) — happy to add if useful.