### PR TITLE
fix: require the passcode to disable two-factor authentication

### DIFF
--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -911,6 +911,8 @@
   "settings.twofa_scratch_token_regenerated": "Your single-use recovery key is now %s. Store it in a safe place, as it will not be shown again.",
   "settings.twofa_enroll": "Enroll in Two-Factor Authentication",
   "settings.twofa_disable_note": "You can disable two-factor authentication if needed.",
+  "settings.twofa_disable_passcode_label": "Passcode or single-use recovery key",
+  "settings.twofa_disable_passcode_incorrect": "The passcode or single-use recovery key is incorrect.",
   "settings.twofa_disable_desc": "Disabling two-factor authentication will make your account less secure. Continue?",
   "settings.regenerate_scratch_token_desc": "If you misplaced your recovery key or have already used it to sign in, you can reset it here.",
   "settings.twofa_disabled": "Two-factor authentication has been disabled.",

--- a/routers/web/user/setting/security/2fa.go
+++ b/routers/web/user/setting/security/2fa.go
@@ -82,6 +82,18 @@ func DisableTwoFactor(ctx *context.Context) {
 		return
 	}
 
+	// a live session alone must not be enough to remove MFA
+	passcode := ctx.FormString("passcode")
+	valid, err := t.ValidateAndConsumeTOTP(ctx, passcode)
+	if err != nil {
+		ctx.ServerError("SettingsTwoFactor: Failed to ValidateAndConsumeTOTP", err)
+		return
+	}
+	if !valid && !t.VerifyScratchToken(passcode) { // recovery key, for a lost authenticator
+		ctx.JSONError(ctx.Tr("settings.twofa_disable_passcode_incorrect"))
+		return
+	}
+
 	if err = auth.DeleteTwoFactorByID(ctx, t.ID, ctx.Doer.ID); err != nil {
 		if auth.IsErrTwoFactorNotEnrolled(err) {
 			// There is a potential DB race here - we must have been disabled by another request in the intervening period

--- a/templates/user/settings/security/twofa.tmpl
+++ b/templates/user/settings/security/twofa.tmpl
@@ -9,8 +9,12 @@
 		<p>{{ctx.Locale.Tr "settings.regenerate_scratch_token_desc"}}</p>
 		<button class="ui primary button">{{ctx.Locale.Tr "settings.twofa_scratch_token_regenerate"}}</button>
 	</form>
-	<form class="ui form form-fetch-action" action="{{AppSubUrl}}/user/settings/security/two_factor/disable" method="post">
+	<form class="ui form ignore-dirty form-fetch-action" action="{{AppSubUrl}}/user/settings/security/two_factor/disable" method="post">
 		<p>{{ctx.Locale.Tr "settings.twofa_disable_note"}}</p>
+		<div class="required field">
+			<label for="twofa-disable-passcode">{{ctx.Locale.Tr "settings.twofa_disable_passcode_label"}}</label>
+			<input id="twofa-disable-passcode" name="passcode" autocomplete="one-time-code" required>
+		</div>
 		<button class="ui red button" data-modal-confirm="#disable-twofa">{{ctx.Locale.Tr "settings.twofa_disable"}}</button>
 	</form>
 	{{else}}

--- a/tests/integration/user_settings_test.go
+++ b/tests/integration/user_settings_test.go
@@ -7,15 +7,19 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	auth_model "gitea.dev/models/auth"
 	"gitea.dev/models/unittest"
+	user_model "gitea.dev/models/user"
 	"gitea.dev/modules/container"
 	"gitea.dev/modules/setting"
 	"gitea.dev/modules/test"
 	"gitea.dev/tests"
 
+	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Validate that each navbar setting is correct. This checks that the
@@ -268,6 +272,48 @@ func TestUserSettingsSecurity(t *testing.T) {
 		session := loginUser(t, "user2")
 		req := NewRequest(t, "GET", "/user/settings/security")
 		session.MakeRequest(t, req, http.StatusNotFound)
+	})
+
+	t.Run("disabling two-factor requires the passcode", func(t *testing.T) {
+		defer tests.PrintCurrentTest(t)()
+
+		user := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user2"})
+		session := loginUser(t, user.Name) // signed in before enrolling: a live session must not be enough
+
+		enroll := func() (secret, recoveryKey string) {
+			t.Helper()
+			if existing, err := auth_model.GetTwoFactorByUID(t.Context(), user.ID); err == nil {
+				require.NoError(t, auth_model.DeleteTwoFactorByID(t.Context(), existing.ID, user.ID))
+			}
+			otpKey, err := totp.Generate(totp.GenerateOpts{SecretSize: 40, Issuer: "gitea-test", AccountName: user.Name})
+			require.NoError(t, err)
+			tfa := &auth_model.TwoFactor{UID: user.ID}
+			require.NoError(t, tfa.SetSecret(otpKey.Secret()))
+			token, err := tfa.GenerateScratchToken()
+			require.NoError(t, err)
+			require.NoError(t, auth_model.NewTwoFactor(t.Context(), tfa))
+			return otpKey.Secret(), token
+		}
+		disable := func(passcode string, expectedStatus int) {
+			t.Helper()
+			req := NewRequestWithValues(t, "POST", "/user/settings/security/two_factor/disable", map[string]string{"passcode": passcode})
+			session.MakeRequest(t, req, expectedStatus)
+		}
+
+		enroll()
+		disable("", http.StatusBadRequest)
+		disable("000000", http.StatusBadRequest)
+		unittest.AssertExistsAndLoadBean(t, &auth_model.TwoFactor{UID: user.ID})
+
+		secret, _ := enroll()
+		passcode, err := totp.GenerateCode(secret, time.Now())
+		require.NoError(t, err)
+		disable(passcode, http.StatusSeeOther)
+		unittest.AssertNotExistsBean(t, &auth_model.TwoFactor{UID: user.ID})
+
+		_, recoveryKey := enroll()
+		disable(recoveryKey, http.StatusSeeOther)
+		unittest.AssertNotExistsBean(t, &auth_model.TwoFactor{UID: user.ID})
 	})
 }
 


### PR DESCRIPTION
Disabling TOTP performed no re-authentication: the handler checked the feature flag, loaded the enrollment and deleted it. Reaching an already authenticated session — an unattended browser, a stolen session cookie — was enough to strip MFA from an account.

The passcode is now verified before the enrollment is deleted, the way password reset already does it, and the settings form gains a field for it. The single-use recovery key is accepted too, so a lost authenticator does not lock the user out. A password is deliberately not used: OAuth2/LDAP accounts may not have one set, while every account reaching this handler is enrolled in TOTP. Admins can still reset a user's 2FA.

Extends `TestUserSettingsSecurity`; the added assertions fail on `main`.

`regenerate_scratch` has the same missing check, left out to keep this focused.

Closes https://github.com/go-gitea/gitea/issues/27690
