### PR TITLE
perf(auth): debounce access token "last used" writes

### DIFF
--- a/models/auth/access_token.go
+++ b/models/auth/access_token.go
@@ -152,6 +152,18 @@ func (opts ListAccessTokensOptions) ToOrders() string {
 	return "created_unix DESC"
 }
 
+// AccessTokenUseInterval is how often access_token.updated_unix ("last used") is
+// persisted after a successful token authentication. Must stay well below the
+// 7-day HasRecentActivity window, which is the only thing the column feeds
+// besides its own display.
+const AccessTokenUseInterval = 30 * time.Second
+
+// ShouldPersistTokenUse reports whether a token's updated_unix is stale enough
+// to be worth writing back. Avoids a DB write on every authenticated request.
+func ShouldPersistTokenUse(last timeutil.TimeStamp, now time.Time) bool {
+	return now.Sub(last.AsTime()) >= AccessTokenUseInterval
+}
+
 // UpdateAccessToken updates information of access token.
 func UpdateAccessToken(ctx context.Context, t *AccessToken) error {
 	_, err := db.GetEngine(ctx).ID(t.ID).AllCols().Update(t)

--- a/models/auth/access_token_test.go
+++ b/models/auth/access_token_test.go
@@ -5,14 +5,51 @@ package auth_test
 
 import (
 	"testing"
+	"time"
 
 	auth_model "gitea.dev/models/auth"
 	"gitea.dev/models/db"
 	"gitea.dev/models/unittest"
+	"gitea.dev/modules/timeutil"
 	"gitea.dev/modules/util"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestShouldPersistTokenUse(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name string
+		last timeutil.TimeStamp
+		want bool
+	}{
+		{
+			name: "fresh, skip write",
+			last: timeutil.TimeStamp(now.Add(-5 * time.Second).Unix()),
+			want: false,
+		},
+		{
+			name: "exactly at interval, write",
+			last: timeutil.TimeStamp(now.Add(-auth_model.AccessTokenUseInterval).Unix()),
+			want: true,
+		},
+		{
+			name: "stale, write",
+			last: timeutil.TimeStamp(now.Add(-2 * auth_model.AccessTokenUseInterval).Unix()),
+			want: true,
+		},
+		{
+			name: "zero (never used), write",
+			last: 0,
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, auth_model.ShouldPersistTokenUse(tt.last, now))
+		})
+	}
+}
 
 func TestNewAccessToken(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())

--- a/services/auth/basic.go
+++ b/services/auth/basic.go
@@ -7,6 +7,7 @@ package auth
 import (
 	"errors"
 	"net/http"
+	"time"
 
 	actions_model "gitea.dev/models/actions"
 	auth_model "gitea.dev/models/auth"
@@ -96,9 +97,11 @@ func (b *Basic) VerifyAuthToken(req *http.Request, w http.ResponseWriter, store 
 			return nil, err
 		}
 
-		token.UpdatedUnix = timeutil.TimeStampNow()
-		if err = auth_model.UpdateAccessToken(req.Context(), token); err != nil {
-			log.Error("UpdateAccessToken:  %v", err)
+		if auth_model.ShouldPersistTokenUse(token.UpdatedUnix, time.Now()) {
+			token.UpdatedUnix = timeutil.TimeStampNow()
+			if err = auth_model.UpdateAccessToken(req.Context(), token); err != nil {
+				log.Error("UpdateAccessToken:  %v", err)
+			}
 		}
 
 		store.GetData()["LoginMethod"] = AccessTokenMethodName

--- a/services/auth/oauth2.go
+++ b/services/auth/oauth2.go
@@ -136,9 +136,11 @@ func (o *OAuth2) userFromToken(ctx context.Context, tokenSHA string, store DataS
 		return nil, err
 	}
 
-	t.UpdatedUnix = timeutil.TimeStampNow()
-	if err = auth_model.UpdateAccessToken(ctx, t); err != nil {
-		log.Error("UpdateAccessToken: %v", err)
+	if auth_model.ShouldPersistTokenUse(t.UpdatedUnix, time.Now()) {
+		t.UpdatedUnix = timeutil.TimeStampNow()
+		if err = auth_model.UpdateAccessToken(ctx, t); err != nil {
+			log.Error("UpdateAccessToken: %v", err)
+		}
 	}
 	store.GetData()["ApiTokenScope"] = t.Scope
 	return user_model.GetUserByID(ctx, t.UID)


### PR DESCRIPTION
Fixes #39174.

Every successful token authentication performs a full-row `UPDATE` of the token's own `access_token` row, purely to advance `updated_unix` ("last used"). `UpdateAccessToken` uses `AllCols()`, so all eight columns are rewritten, and it is called **synchronously in the request path** from `services/auth/basic.go` (PAT via Basic/Bearer/`?token=`) and `services/auth/oauth2.go` (legacy non-JWT SHA tokens), with no condition, debounce or sampling on either path.

The consequence is that every concurrent request presenting the *same* token serialises on that one row's exclusive lock. While the database is healthy the lock is held for well under a millisecond and this is invisible, but the per-row ceiling degrades in proportion to database latency: once it falls below the request arrival rate the queue grows without bound, so a modest database slowdown turns into a full serialisation collapse rather than proportional degradation. #39174 has the measurements and the incident this caused on our instance.

## The change

A staleness guard, and both call sites wrapped in it:

```go
const AccessTokenUseInterval = 30 * time.Second

func ShouldPersistTokenUse(last timeutil.TimeStamp, now time.Time) bool {
	return now.Sub(last.AsTime()) >= AccessTokenUseInterval
}
```

This is a deliberate mirror of `RunnerHeartbeatInterval` / `ShouldPersistLastOnline`, added in #38281 for the equivalent per-poll write on `action_runner.last_online` — **same naming, same 30s interval, same call-site guard placement**. The intent is that this reads as an extension of a pattern already accepted here rather than a novel proposal; if you would prefer a different interval, a shared constant across both tables, or the guard pushed down into `UpdateAccessToken` itself, I am happy to rework it.

## Why this is safe

- **`updated_unix` is display-only.** It feeds the "last used" column in the UI and the 7-day `HasRecentActivity` flag set in `AfterLoad()`. It is never consulted for an authorization decision, so bounding its freshness to 30s is not security-relevant. The worst observable effect is a token's "last used" reading up to 30s stale — well inside the 7-day window, which is the only thing besides display that reads the column.
- **Correct across multiple Gitea processes.** `GetAccessTokenBySHA` re-reads the row from the database on every call — even on a token-cache hit, where the cache stores only the row *ID* and the row itself is re-fetched via `db.GetEngine(ctx).ID(cached.TokenID).Get(accessToken)`. So the `UpdatedUnix` the guard compares against is always the committed value, never a per-process cached one.
- **Not a change to token validation.** Only the write is skipped; lookup, hash comparison, scope and user resolution are untouched.
- **Other writers are unaffected.** Editing a token's scope in the UI still goes through `UpdateAccessToken` unguarded, and the column carries xorm's `updated` tag, so those writes still advance the timestamp as before.

## Testing

`TestShouldPersistTokenUse` added in `models/auth/access_token_test.go`, table-driven in the same shape as the existing `TestShouldPersistLastOnline` (fresh / exactly-at-interval / stale / never-used).

```
$ go build ./...
$ go test -tags 'sqlite sqlite_unlock_notify' -count=1 ./models/auth/... ./services/auth/...
ok  	gitea.dev/models/auth	1.795s
ok  	gitea.dev/services/auth	1.460s
ok  	gitea.dev/services/auth/source	2.004s
ok  	gitea.dev/services/auth/source/oauth2	2.529s
...
$ go vet -tags 'sqlite sqlite_unlock_notify' ./models/auth/... ./services/auth/...
```

Full tree builds clean; `gofmt` clean on all four changed files.
