### PR TITLE
fix(charset): skip undecodable chardet labels such as IBM424_ltr

### DIFF
--- a/modules/charset/charset.go
+++ b/modules/charset/charset.go
@@ -88,7 +88,7 @@ func ToUTF8(content []byte, opts ConvertOpts) []byte {
 
 	encoding, _ := charset.Lookup(charsetLabel)
 	if encoding == nil {
-		setting.PanicInDevOrTesting("unsupported detected charset %q, it shouldn't happen", charsetLabel)
+		// chardet can return Mozilla-only labels such as IBM424_ltr that html/charset cannot decode
 		if opts.ErrorReturnOrigin {
 			return content
 		}
@@ -182,23 +182,37 @@ func DetectEncoding(content []byte) (encoding string, _ error) {
 		return util.IfZero(setting.Repository.AnsiCharset, "UTF-8"), err
 	}
 
-	topConfidence := results[0].Confidence
-	topResult := results[0]
-	priority, has := setting.Repository.DetectedCharsetScore[strings.ToLower(strings.TrimSpace(topResult.Charset))]
+	var (
+		topResult     chardet.Result
+		topConfidence int
+		priority      int
+		has           bool
+		found         bool
+	)
 	for _, result := range results {
-		// As results are sorted in confidence order - if we have a different confidence
-		// we know it's less than the current confidence and can break out of the loop early
+		if !charsetLabelDecodable(result.Charset) {
+			continue
+		}
+		if !found {
+			topResult = result
+			topConfidence = result.Confidence
+			priority, has = setting.Repository.DetectedCharsetScore[strings.ToLower(strings.TrimSpace(result.Charset))]
+			found = true
+			continue
+		}
+		// results are sorted by confidence; once confidence drops, later entries cannot win
 		if result.Confidence != topConfidence {
 			break
 		}
-
-		// Otherwise check if this results is earlier in the DetectedCharsetOrder than our current top guess
 		resultPriority, resultHas := setting.Repository.DetectedCharsetScore[strings.ToLower(strings.TrimSpace(result.Charset))]
 		if resultHas && (!has || resultPriority < priority) {
 			topResult = result
 			priority = resultPriority
 			has = true
 		}
+	}
+	if !found {
+		return util.IfZero(setting.Repository.AnsiCharset, "UTF-8"), nil
 	}
 
 	// FIXME: to properly decouple this function the fallback ANSI charset should be passed as an argument
@@ -207,4 +221,14 @@ func DetectEncoding(content []byte) (encoding string, _ error) {
 	}
 
 	return topResult.Charset, nil
+}
+
+// charsetLabelDecodable reports whether html/charset can decode the label.
+// chardet returns Mozilla names such as IBM424_ltr that are not HTML encodings.
+func charsetLabelDecodable(label string) bool {
+	if strings.EqualFold(strings.TrimSpace(label), "UTF-8") {
+		return true
+	}
+	enc, _ := charset.Lookup(label)
+	return enc != nil
 }

--- a/modules/charset/charset_test.go
+++ b/modules/charset/charset_test.go
@@ -13,6 +13,7 @@ import (
 	"gitea.dev/modules/test"
 
 	"github.com/stretchr/testify/assert"
+	htmlcharset "golang.org/x/net/html/charset"
 )
 
 func TestMain(m *testing.M) {
@@ -205,6 +206,28 @@ func TestDetectEncoding(t *testing.T) {
 
 	defer test.MockVariableValue(&setting.Repository.AnsiCharset, "MyEncoding")()
 	testSuccess(b, "MyEncoding")
+}
+
+func TestCharsetLabelDecodableIBM424(t *testing.T) {
+	// chardet can report these Mozilla names; html/charset has no decoder for them
+	for _, label := range []string{"IBM424_ltr", "IBM424_rtl", "IBM420_ltr", "IBM420_rtl"} {
+		enc, _ := htmlcharset.Lookup(label)
+		assert.Nil(t, enc, label)
+		assert.False(t, charsetLabelDecodable(label), label)
+	}
+	assert.True(t, charsetLabelDecodable("UTF-8"))
+	assert.True(t, charsetLabelDecodable("windows-1252"))
+	assert.True(t, charsetLabelDecodable("ISO-8859-1"))
+}
+
+func TestToUTF8UnsupportedDetectedCharset(t *testing.T) {
+	content := []byte{0x41, 0x42, 0x43, 0x04, 0x40, 0x40, 0xff}
+	assert.NotPanics(t, func() {
+		_ = ToUTF8(content, ConvertOpts{})
+	})
+	assert.NotPanics(t, func() {
+		_ = ToUTF8(content, ConvertOpts{ErrorReturnOrigin: true})
+	})
 }
 
 func stringMustStartWith(t *testing.T, expected string, value []byte) {


### PR DESCRIPTION
chardet can return Mozilla-only labels such as `IBM424_ltr`. `golang.org/x/net/html/charset` cannot decode those, so file conversion logged `unsupported detected charset` as if it were a programming error.

Skip labels that `html/charset` cannot decode, and keep the unknown-encoding fallback instead of treating the miss as unexpected.

Fixes https://github.com/go-gitea/gitea/issues/39182
