### PR TITLE
fix(api): avoid pull files panic with whitespace ignored

### DIFF
--- a/modules/git/diff2.go
+++ b/modules/git/diff2.go
@@ -21,6 +21,10 @@ func GetDiffShortStatByCmdArgs(ctx context.Context, repo RepositoryFacade, trust
 	// we get:
 	// " 9902 files changed, 2034198 insertions(+), 298800 deletions(-)\n"
 	cmd := gitcmd.NewCommand("diff", "--shortstat").AddArguments(trustedArgs...).AddDynamicArguments(dynamicArgs...)
+	return GetDiffShortStatByCmd(ctx, repo, cmd)
+}
+
+func GetDiffShortStatByCmd(ctx context.Context, repo RepositoryFacade, cmd *gitcmd.Command) (numFiles, totalAdditions, totalDeletions int, err error) {
 	stdout, _, err := cmd.WithRepo(repo).RunStdString(ctx)
 	if err != nil {
 		return 0, 0, 0, err

--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -1608,8 +1608,6 @@ func GetPullRequestFiles(ctx *context.APIContext) {
 	start, limit := listOptions.GetSkipTake()
 
 	limit = min(limit, totalNumberOfFiles-start)
-	// The shortstat may count files which are omitted from the diff, such as whitespace-only changes.
-	limit = min(limit, len(diff.Files)-start)
 
 	limit = max(limit, 0)
 

--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -1580,22 +1580,22 @@ func GetPullRequestFiles(ctx *context.APIContext) {
 	maxLines := setting.Git.MaxGitDiffLines
 
 	// FIXME: If there are too many files in the repo, may cause some unpredictable issues.
-	diff, err := gitdiff.GetDiffForAPI(ctx, baseGitRepo,
-		&gitdiff.DiffOptions{
-			BeforeCommitID:     startCommitID,
-			AfterCommitID:      endCommitID,
-			SkipTo:             ctx.FormString("skip-to"),
-			MaxLines:           maxLines,
-			MaxLineCharacters:  setting.Git.MaxGitDiffLineCharacters,
-			MaxFiles:           -1, // GetDiff() will return all files
-			WhitespaceBehavior: gitdiff.GetWhitespaceFlag(ctx.FormString("whitespace")),
-		})
+	diffOptions := &gitdiff.DiffOptions{
+		BeforeCommitID:     startCommitID,
+		AfterCommitID:      endCommitID,
+		SkipTo:             ctx.FormString("skip-to"),
+		MaxLines:           maxLines,
+		MaxLineCharacters:  setting.Git.MaxGitDiffLineCharacters,
+		MaxFiles:           -1, // GetDiff() will return all files
+		WhitespaceBehavior: gitdiff.GetWhitespaceFlag(ctx.FormString("whitespace")),
+	}
+	diff, err := gitdiff.GetDiffForAPI(ctx, baseGitRepo, diffOptions)
 	if err != nil {
 		ctx.APIErrorInternal(err)
 		return
 	}
 
-	diffShortStat, err := gitdiff.GetDiffShortStatWithWhitespaceBehavior(ctx, baseGitRepo, startCommitID, endCommitID, gitdiff.GetWhitespaceFlag(ctx.FormString("whitespace")))
+	diffShortStat, err := gitdiff.GetDiffShortStatWithOptions(ctx, baseGitRepo, diffOptions)
 	if err != nil {
 		ctx.APIErrorInternal(err)
 		return

--- a/routers/api/v1/repo/pull.go
+++ b/routers/api/v1/repo/pull.go
@@ -1595,7 +1595,7 @@ func GetPullRequestFiles(ctx *context.APIContext) {
 		return
 	}
 
-	diffShortStat, err := gitdiff.GetDiffShortStat(ctx, baseGitRepo, startCommitID, endCommitID)
+	diffShortStat, err := gitdiff.GetDiffShortStatWithWhitespaceBehavior(ctx, baseGitRepo, startCommitID, endCommitID, gitdiff.GetWhitespaceFlag(ctx.FormString("whitespace")))
 	if err != nil {
 		ctx.APIErrorInternal(err)
 		return
@@ -1608,6 +1608,8 @@ func GetPullRequestFiles(ctx *context.APIContext) {
 	start, limit := listOptions.GetSkipTake()
 
 	limit = min(limit, totalNumberOfFiles-start)
+	// The shortstat may count files which are omitted from the diff, such as whitespace-only changes.
+	limit = min(limit, len(diff.Files)-start)
 
 	limit = max(limit, 0)
 

--- a/routers/web/repo/commit.go
+++ b/routers/web/repo/commit.go
@@ -318,19 +318,20 @@ func Diff(ctx *context.Context) {
 		maxLines, maxFiles = -1, -1
 	}
 
-	diff, err := gitdiff.GetDiffForRender(ctx, ctx.Repo.RepoLink, gitRepo, &gitdiff.DiffOptions{
+	diffOptions := &gitdiff.DiffOptions{
 		AfterCommitID:      commitID,
 		SkipTo:             ctx.FormString("skip-to"),
 		MaxLines:           maxLines,
 		MaxLineCharacters:  setting.Git.MaxGitDiffLineCharacters,
 		MaxFiles:           maxFiles,
 		WhitespaceBehavior: gitdiff.GetWhitespaceFlag(GetWhitespaceBehavior(ctx)),
-	}, files...)
+	}
+	diff, err := gitdiff.GetDiffForRender(ctx, ctx.Repo.RepoLink, gitRepo, diffOptions, files...)
 	if err != nil {
 		ctx.NotFound(err)
 		return
 	}
-	diffShortStat, err := gitdiff.GetDiffShortStat(ctx, gitRepo, "", commitID)
+	diffShortStat, err := gitdiff.GetDiffShortStatWithOptions(ctx, gitRepo, diffOptions, files...)
 	if err != nil {
 		ctx.ServerError("GetDiffShortStat", err)
 		return

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -410,22 +410,22 @@ func (cpi *comparePageInfoType) prepareCompareDiff(ctx *context.Context, whitesp
 
 	fileOnly := ctx.FormBool("file-only")
 
-	diff, err := gitdiff.GetDiffForRender(ctx, ci.HeadRepo.Link(), ci.HeadGitRepo,
-		&gitdiff.DiffOptions{
-			BeforeCommitID:     beforeCommitID,
-			AfterCommitID:      headCommitID,
-			SkipTo:             ctx.FormString("skip-to"),
-			MaxLines:           maxLines,
-			MaxLineCharacters:  setting.Git.MaxGitDiffLineCharacters,
-			MaxFiles:           maxFiles,
-			WhitespaceBehavior: whitespaceBehavior,
-			DirectComparison:   ci.DirectComparison(),
-		}, ctx.FormStrings("files")...)
+	diffOptions := &gitdiff.DiffOptions{
+		BeforeCommitID:     beforeCommitID,
+		AfterCommitID:      headCommitID,
+		SkipTo:             ctx.FormString("skip-to"),
+		MaxLines:           maxLines,
+		MaxLineCharacters:  setting.Git.MaxGitDiffLineCharacters,
+		MaxFiles:           maxFiles,
+		WhitespaceBehavior: whitespaceBehavior,
+		DirectComparison:   ci.DirectComparison(),
+	}
+	diff, err := gitdiff.GetDiffForRender(ctx, ci.HeadRepo.Link(), ci.HeadGitRepo, diffOptions, files...)
 	if err != nil {
 		ctx.ServerError("GetDiff", err)
 		return
 	}
-	diffShortStat, err := gitdiff.GetDiffShortStat(ctx, ci.HeadGitRepo, beforeCommitID, headCommitID)
+	diffShortStat, err := gitdiff.GetDiffShortStatWithOptions(ctx, ci.HeadGitRepo, diffOptions, files...)
 	if err != nil {
 		ctx.ServerError("GetDiffShortStat", err)
 		return

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -803,7 +803,7 @@ func viewPullFiles(ctx *context.Context, beforeCommitID, afterCommitID string) {
 		}
 	}
 
-	diffShortStat, err := gitdiff.GetDiffShortStat(ctx, ctx.Repo.GitRepo, beforeCommitID, afterCommitID)
+	diffShortStat, err := gitdiff.GetDiffShortStatWithOptions(ctx, ctx.Repo.GitRepo, diffOptions, files...)
 	if err != nil {
 		ctx.ServerError("GetDiffShortStat", err)
 		return

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -1504,7 +1504,7 @@ func GetDiffShortStat(ctx context.Context, gitRepo *git.Repository, beforeCommit
 	})
 }
 
-func GetDiffShortStatWithOptions(ctx context.Context, gitRepo *git.Repository, opts *DiffOptions) (*DiffShortStat, error) {
+func GetDiffShortStatWithOptions(ctx context.Context, gitRepo *git.Repository, opts *DiffOptions, files ...string) (*DiffShortStat, error) {
 	afterCommit, err := gitRepo.GetCommit(ctx, opts.AfterCommitID)
 	if err != nil {
 		return nil, err
@@ -1523,6 +1523,7 @@ func GetDiffShortStatWithOptions(ctx context.Context, gitRepo *git.Repository, o
 		cmdDiff.AddOptionFormat("--skip-to=%s", opts.SkipTo)
 	}
 	cmdDiff.AddDynamicArguments(actualBeforeCommitID.String(), opts.AfterCommitID)
+	cmdDiff.AddDashesAndList(files...)
 
 	diff := &DiffShortStat{}
 	diff.NumFiles, diff.TotalAddition, diff.TotalDeletion, err = git.GetDiffShortStatByCmd(ctx, gitRepo, cmdDiff)

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -1498,6 +1498,10 @@ type DiffShortStat struct {
 }
 
 func GetDiffShortStat(ctx context.Context, gitRepo *git.Repository, beforeCommitID, afterCommitID string) (*DiffShortStat, error) {
+	return GetDiffShortStatWithWhitespaceBehavior(ctx, gitRepo, beforeCommitID, afterCommitID, nil)
+}
+
+func GetDiffShortStatWithWhitespaceBehavior(ctx context.Context, gitRepo *git.Repository, beforeCommitID, afterCommitID string, whitespaceBehavior gitcmd.TrustedCmdArgs) (*DiffShortStat, error) {
 	afterCommit, err := gitRepo.GetCommit(ctx, afterCommitID)
 	if err != nil {
 		return nil, err
@@ -1509,7 +1513,7 @@ func GetDiffShortStat(ctx context.Context, gitRepo *git.Repository, beforeCommit
 	}
 
 	diff := &DiffShortStat{}
-	diff.NumFiles, diff.TotalAddition, diff.TotalDeletion, err = git.GetDiffShortStatByCmdArgs(ctx, gitRepo, nil, actualBeforeCommitID.String(), afterCommitID)
+	diff.NumFiles, diff.TotalAddition, diff.TotalDeletion, err = git.GetDiffShortStatByCmdArgs(ctx, gitRepo, whitespaceBehavior, actualBeforeCommitID.String(), afterCommitID)
 	if err != nil {
 		return nil, err
 	}

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -1498,22 +1498,34 @@ type DiffShortStat struct {
 }
 
 func GetDiffShortStat(ctx context.Context, gitRepo *git.Repository, beforeCommitID, afterCommitID string) (*DiffShortStat, error) {
-	return GetDiffShortStatWithWhitespaceBehavior(ctx, gitRepo, beforeCommitID, afterCommitID, nil)
+	return GetDiffShortStatWithOptions(ctx, gitRepo, &DiffOptions{
+		BeforeCommitID: beforeCommitID,
+		AfterCommitID:  afterCommitID,
+	})
 }
 
-func GetDiffShortStatWithWhitespaceBehavior(ctx context.Context, gitRepo *git.Repository, beforeCommitID, afterCommitID string, whitespaceBehavior gitcmd.TrustedCmdArgs) (*DiffShortStat, error) {
-	afterCommit, err := gitRepo.GetCommit(ctx, afterCommitID)
+func GetDiffShortStatWithOptions(ctx context.Context, gitRepo *git.Repository, opts *DiffOptions) (*DiffShortStat, error) {
+	afterCommit, err := gitRepo.GetCommit(ctx, opts.AfterCommitID)
 	if err != nil {
 		return nil, err
 	}
 
-	_, actualBeforeCommitID, err := guessBeforeCommitForDiff(ctx, gitRepo, beforeCommitID, afterCommit)
+	_, actualBeforeCommitID, err := guessBeforeCommitForDiff(ctx, gitRepo, opts.BeforeCommitID, afterCommit)
 	if err != nil {
 		return nil, err
 	}
+
+	cmdDiff := gitcmd.NewCommand().
+		AddArguments("diff", "--shortstat").
+		AddArguments(opts.WhitespaceBehavior...).
+		AddOptionFormat("--find-renames=%s", setting.Git.DiffRenameSimilarityThreshold)
+	if opts.SkipTo != "" && git.DefaultFeatures().CheckVersionAtLeast("2.31") {
+		cmdDiff.AddOptionFormat("--skip-to=%s", opts.SkipTo)
+	}
+	cmdDiff.AddDynamicArguments(actualBeforeCommitID.String(), opts.AfterCommitID)
 
 	diff := &DiffShortStat{}
-	diff.NumFiles, diff.TotalAddition, diff.TotalDeletion, err = git.GetDiffShortStatByCmdArgs(ctx, gitRepo, whitespaceBehavior, actualBeforeCommitID.String(), afterCommitID)
+	diff.NumFiles, diff.TotalAddition, diff.TotalDeletion, err = git.GetDiffShortStatByCmd(ctx, gitRepo, cmdDiff)
 	if err != nil {
 		return nil, err
 	}

--- a/services/gitdiff/gitdiff_test.go
+++ b/services/gitdiff/gitdiff_test.go
@@ -674,7 +674,7 @@ func TestGetDiffRangeWithWhitespaceBehavior(t *testing.T) {
 	}
 }
 
-func TestGetDiffShortStatWithWhitespaceBehavior(t *testing.T) {
+func TestGetDiffShortStatWithOptions(t *testing.T) {
 	repoDir := filepath.Join(t.TempDir(), "temp-repo")
 	require.NoError(t, git.InitRepositoryLocal(t.Context(), repoDir, false, git.Sha1ObjectFormat.Name()))
 
@@ -698,18 +698,19 @@ func TestGetDiffShortStatWithWhitespaceBehavior(t *testing.T) {
 	afterCommit, err := gitRepo.GetBranchCommit(t.Context(), "head")
 	require.NoError(t, err)
 
-	diff, err := GetDiffForAPI(t.Context(), gitRepo, &DiffOptions{
+	diffOptions := &DiffOptions{
 		BeforeCommitID:     beforeCommit.ID.String(),
 		AfterCommitID:      afterCommit.ID.String(),
 		MaxLines:           setting.Git.MaxGitDiffLines,
 		MaxLineCharacters:  setting.Git.MaxGitDiffLineCharacters,
 		MaxFiles:           -1,
 		WhitespaceBehavior: gitcmd.TrustedCmdArgs{"-b"},
-	})
+	}
+	diff, err := GetDiffForAPI(t.Context(), gitRepo, diffOptions)
 	require.NoError(t, err)
 	require.Len(t, diff.Files, 1)
 
-	stat, err := GetDiffShortStatWithWhitespaceBehavior(t.Context(), gitRepo, beforeCommit.ID.String(), afterCommit.ID.String(), gitcmd.TrustedCmdArgs{"-b"})
+	stat, err := GetDiffShortStatWithOptions(t.Context(), gitRepo, diffOptions)
 	require.NoError(t, err)
 	assert.Equal(t, len(diff.Files), stat.NumFiles)
 

--- a/services/gitdiff/gitdiff_test.go
+++ b/services/gitdiff/gitdiff_test.go
@@ -6,6 +6,7 @@ package gitdiff
 
 import (
 	"html/template"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -671,6 +672,50 @@ func TestGetDiffRangeWithWhitespaceBehavior(t *testing.T) {
 			assert.NotEmpty(t, f.Sections, "Diff file %q should have sections", f.Name)
 		}
 	}
+}
+
+func TestGetDiffShortStatWithWhitespaceBehavior(t *testing.T) {
+	repoDir := filepath.Join(t.TempDir(), "temp-repo")
+	require.NoError(t, git.InitRepositoryLocal(t.Context(), repoDir, false, git.Sha1ObjectFormat.Name()))
+
+	gitRepo, err := git.OpenRepositoryLocal(t.Context(), repoDir)
+	require.NoError(t, err)
+	defer gitRepo.Close()
+
+	require.NoError(t, git.ForceFastImport(t.Context(), gitRepo, []git.FastImportCommit{
+		{Ref: "refs/heads/base", Files: []git.FastImportFile{
+			{Path: "real.txt", Content: "a\n"},
+			{Path: "whitespace.txt", Content: "b\n"},
+		}},
+		{Ref: "refs/heads/head", Files: []git.FastImportFile{
+			{Path: "real.txt", Content: "a2\n"},
+			{Path: "whitespace.txt", Content: "b   \n"},
+		}},
+	}))
+
+	beforeCommit, err := gitRepo.GetBranchCommit(t.Context(), "base")
+	require.NoError(t, err)
+	afterCommit, err := gitRepo.GetBranchCommit(t.Context(), "head")
+	require.NoError(t, err)
+
+	diff, err := GetDiffForAPI(t.Context(), gitRepo, &DiffOptions{
+		BeforeCommitID:     beforeCommit.ID.String(),
+		AfterCommitID:      afterCommit.ID.String(),
+		MaxLines:           setting.Git.MaxGitDiffLines,
+		MaxLineCharacters:  setting.Git.MaxGitDiffLineCharacters,
+		MaxFiles:           -1,
+		WhitespaceBehavior: gitcmd.TrustedCmdArgs{"-b"},
+	})
+	require.NoError(t, err)
+	require.Len(t, diff.Files, 1)
+
+	stat, err := GetDiffShortStatWithWhitespaceBehavior(t.Context(), gitRepo, beforeCommit.ID.String(), afterCommit.ID.String(), gitcmd.TrustedCmdArgs{"-b"})
+	require.NoError(t, err)
+	assert.Equal(t, len(diff.Files), stat.NumFiles)
+
+	stat, err = GetDiffShortStat(t.Context(), gitRepo, beforeCommit.ID.String(), afterCommit.ID.String())
+	require.NoError(t, err)
+	assert.Equal(t, 2, stat.NumFiles)
 }
 
 func TestNoCrashes(t *testing.T) {


### PR DESCRIPTION
The pull request files endpoint paginated by the shortstat file count while indexing into the filtered diff. With `whitespace=ignore-change`, git omits whitespace-only files, so the shortstat can report more files than the diff contains and the handler panics with an index out of range error.

Build both the diff and the shortstat from the same `DiffOptions` so whitespace, rename detection, and skip-to stay consistent, and clamp the page to the files actually returned by the diff.

Fixes https://github.com/go-gitea/gitea/issues/39191