### PR TITLE
fix(pull): prevent merge from using stale approvals right after a push

### DIFF
--- a/services/pull/check.go
+++ b/services/pull/check.go
@@ -139,6 +139,17 @@ const (
 //   - rebase, rebase-merge, squash: Gitea rewrites the commits and signs each, so only Gitea's
 //     signing ability is checked.
 func CheckPullMergeable(stdCtx context.Context, doer *user_model.User, perm *access_model.Permission, pr *issues_model.PullRequest, mergeCheckType MergeCheckType, mergeStyle repo_model.MergeStyle, forceMerge bool) error {
+	// Push-triggered stale-review marking/dismissal (see AddTestPullRequestTask) runs
+	// asynchronously under the same per-PR lock. Acquire it here too, so a merge request
+	// arriving right after a push can't race that goroutine and observe reviews that are
+	// approved-but-actually-stale, or not-yet-dismissed. See go-gitea/gitea#39172.
+	releaser, err := globallock.Lock(stdCtx, getPullWorkingLockKey(pr.ID))
+	if err != nil {
+		log.Error("lock.Lock(): %v", err)
+		return fmt.Errorf("lock.Lock: %w", err)
+	}
+	defer releaser()
+
 	return db.WithTx(stdCtx, func(ctx context.Context) error {
 		if pr.HasMerged {
 			return ErrHasMerged

--- a/services/pull/pull.go
+++ b/services/pull/pull.go
@@ -444,38 +444,48 @@ func AddTestPullRequestTask(opts TestPullRequestOptions) {
 				for _, pr := range headBranchPRs {
 					objectFormat := git.ObjectFormatFromName(pr.BaseRepo.ObjectFormatName)
 					if opts.NewCommitID != "" && opts.NewCommitID != objectFormat.EmptyObjectID().String() {
-						changed, newMergeBase, err := checkIfPRContentChanged(ctx, pr, opts.OldCommitID, opts.NewCommitID)
-						if err != nil {
-							log.Error("checkIfPRContentChanged: %v", err)
-						}
-						if newMergeBase != "" && pr.MergeBase != newMergeBase {
-							pr.MergeBase = newMergeBase
-							if _, err := pr.UpdateColsIfNotMerged(ctx, "merge_base"); err != nil {
-								log.Error("Update merge base for %-v: %v", pr, err)
-							}
-						}
-						if changed {
-							// Mark old reviews as stale if diff to mergebase has changed
-							if err := issues_model.MarkReviewsAsStale(ctx, pr.IssueID); err != nil {
-								log.Error("MarkReviewsAsStale: %v", err)
-							}
-
-							// dismiss all approval reviews if protected branch rule item enabled.
-							pb, err := git_model.GetFirstMatchProtectedBranchRule(ctx, pr.BaseRepoID, pr.BaseBranch)
+						// Hold the same per-PR lock that merge-time checks acquire (see
+						// CheckPullMergeable), so a concurrent merge request cannot observe
+						// stale/approved review rows while this goroutine is still marking
+						// reviews as stale or dismissing them for the new head commit.
+						lockErr := globallock.LockAndDo(ctx, getPullWorkingLockKey(pr.ID), func(ctx context.Context) error {
+							changed, newMergeBase, err := checkIfPRContentChanged(ctx, pr, opts.OldCommitID, opts.NewCommitID)
 							if err != nil {
-								log.Error("GetFirstMatchProtectedBranchRule: %v", err)
+								log.Error("checkIfPRContentChanged: %v", err)
 							}
-							if pb != nil && pb.DismissStaleApprovals {
-								if err := DismissApprovalReviews(ctx, opts.Doer, pr); err != nil {
-									log.Error("DismissApprovalReviews: %v", err)
+							if newMergeBase != "" && pr.MergeBase != newMergeBase {
+								pr.MergeBase = newMergeBase
+								if _, err := pr.UpdateColsIfNotMerged(ctx, "merge_base"); err != nil {
+									log.Error("Update merge base for %-v: %v", pr, err)
 								}
 							}
-						}
-						if err := issues_model.MarkReviewsAsNotStale(ctx, pr.IssueID, opts.NewCommitID); err != nil {
-							log.Error("MarkReviewsAsNotStale: %v", err)
-						}
-						if err = syncCommitDivergence(ctx, pr); err != nil {
-							log.Error("syncCommitDivergence: %v", err)
+							if changed {
+								// Mark old reviews as stale if diff to mergebase has changed
+								if err := issues_model.MarkReviewsAsStale(ctx, pr.IssueID); err != nil {
+									log.Error("MarkReviewsAsStale: %v", err)
+								}
+
+								// dismiss all approval reviews if protected branch rule item enabled.
+								pb, err := git_model.GetFirstMatchProtectedBranchRule(ctx, pr.BaseRepoID, pr.BaseBranch)
+								if err != nil {
+									log.Error("GetFirstMatchProtectedBranchRule: %v", err)
+								}
+								if pb != nil && pb.DismissStaleApprovals {
+									if err := DismissApprovalReviews(ctx, opts.Doer, pr); err != nil {
+										log.Error("DismissApprovalReviews: %v", err)
+									}
+								}
+							}
+							if err := issues_model.MarkReviewsAsNotStale(ctx, pr.IssueID, opts.NewCommitID); err != nil {
+								log.Error("MarkReviewsAsNotStale: %v", err)
+							}
+							if err := syncCommitDivergence(ctx, pr); err != nil {
+								log.Error("syncCommitDivergence: %v", err)
+							}
+							return nil
+						})
+						if lockErr != nil {
+							log.Error("lock.Lock(): %v", lockErr)
 						}
 					}
 


### PR DESCRIPTION
Fixes #39172

Push-triggered stale-review marking/dismissal runs in a detached
goroutine, unsynchronized with merge-time approval checks. A merge
called right after a push can land in that window and use an
approval from the previous head commit.

Both paths now acquire the existing per-PR lock
(`getPullWorkingLockKey`), so a merge can't proceed until any
in-flight stale-dismissal work for that PR has finished.

- `services/pull/pull.go`: lock around the stale-marking/dismissal
  block in `AddTestPullRequestTask`
- `services/pull/check.go`: lock in `CheckPullMergeable` before
  branch protection checks
