### PR TITLE
enhance(diff): add plain view for long line files

### DIFF
--- a/modules/git/diff.go
+++ b/modules/git/diff.go
@@ -27,8 +27,13 @@ const (
 )
 
 // GetRawDiff dumps diff results of repository in given commit ID to io.Writer.
-func GetRawDiff(ctx context.Context, repo *Repository, commitID string, diffType RawDiffType, writer io.Writer) (retErr error) {
-	cmd, err := getRepoRawDiffForFileCmd(ctx, repo, "", commitID, diffType, "")
+func GetRawDiff(ctx context.Context, repo *Repository, commitID string, diffType RawDiffType, writer io.Writer) error {
+	return WriteRawDiff(ctx, repo, "", commitID, diffType, writer)
+}
+
+// WriteRawDiff writes a raw diff between commits, optionally limited to literal pathspecs.
+func WriteRawDiff(ctx context.Context, repo *Repository, startCommit, endCommit string, diffType RawDiffType, writer io.Writer, files ...string) error {
+	cmd, err := getRepoRawDiffForFileCmd(ctx, repo, startCommit, endCommit, diffType, files...)
 	if err != nil {
 		return fmt.Errorf("getRepoRawDiffForFileCmd: %w", err)
 	}
@@ -40,7 +45,11 @@ func GetFileDiffCutAroundLine(
 	ctx context.Context, repo *Repository, startCommit, endCommit, treePath string,
 	line int64, old bool, numbersOfLine int,
 ) (ret string, retErr error) {
-	cmd, err := getRepoRawDiffForFileCmd(ctx, repo, startCommit, endCommit, RawDiffNormal, treePath)
+	var files []string
+	if treePath != "" {
+		files = []string{treePath}
+	}
+	cmd, err := getRepoRawDiffForFileCmd(ctx, repo, startCommit, endCommit, RawDiffNormal, files...)
 	if err != nil {
 		return "", fmt.Errorf("getRepoRawDiffForFileCmd: %w", err)
 	}
@@ -53,19 +62,16 @@ func GetFileDiffCutAroundLine(
 	return ret, cmd.RunWithStderr(ctx)
 }
 
-// getRepoRawDiffForFile returns an io.Reader for the diff results of file in given commit ID
-// and a "finish" function to wait for the git command and clean up resources after reading is done.
-func getRepoRawDiffForFileCmd(ctx context.Context, repo *Repository, startCommit, endCommit string, diffType RawDiffType, file string) (*gitcmd.Command, error) {
-	commit, err := repo.GetCommit(ctx, endCommit)
-	if err != nil {
-		return nil, err
-	}
-	var files []string
-	if len(file) > 0 {
-		files = append(files, file)
+func getRepoRawDiffForFileCmd(ctx context.Context, repo *Repository, startCommit, endCommit string, diffType RawDiffType, files ...string) (*gitcmd.Command, error) {
+	var commit *Commit
+	if startCommit == "" {
+		var err error
+		if commit, err = repo.GetCommit(ctx, endCommit); err != nil {
+			return nil, err
+		}
 	}
 
-	cmd := gitcmd.NewCommand().WithRepo(repo)
+	cmd := gitcmd.NewCommand("--literal-pathspecs").WithRepo(repo)
 	switch diffType {
 	case RawDiffNormal:
 		if len(startCommit) != 0 {

--- a/modules/git/diff_test.go
+++ b/modules/git/diff_test.go
@@ -4,11 +4,58 @@
 package git
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"gitea.dev/modules/git/gitcmd"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestRawDiffLiteralFile(t *testing.T) {
+	repoDir := filepath.Join(t.TempDir(), "repo.git")
+	require.NoError(t, gitcmd.NewCommand("init", "--bare").AddDynamicArguments(repoDir).Run(t.Context()))
+	_, _, runErr := gitcmd.NewCommand("fast-import").WithDir(repoDir).WithStdinBytes([]byte(`commit refs/heads/base
+committer Test <test@example.com> 1700000000 +0000
+data 0
+M 100644 inline ":(glob)**"
+data 4
+old
+M 100644 inline other.txt
+data 5
+base
+
+commit refs/heads/head
+committer Test <test@example.com> 1700000001 +0000
+data 0
+from refs/heads/base
+M 100644 inline ":(glob)**"
+data 4
+new
+M 100644 inline other.txt
+data 6
+other
+`)).RunStdString(t.Context())
+	require.NoError(t, runErr)
+	repo, err := OpenRepositoryLocal(t.Context(), repoDir)
+	require.NoError(t, err)
+	defer repo.Close()
+
+	var diff strings.Builder
+	require.NoError(t, WriteRawDiff(t.Context(), repo, "", "base", RawDiffNormal, &diff, ":(glob)**"))
+	assert.Contains(t, diff.String(), "diff --git a/:(glob)** b/:(glob)**")
+	assert.Contains(t, diff.String(), "+old\n")
+	assert.NotContains(t, diff.String(), "other.txt")
+
+	diff.Reset()
+	require.NoError(t, WriteRawDiff(t.Context(), repo, "base", "head", RawDiffNormal, &diff, ":(glob)**"))
+	header, hunk, found := strings.Cut(diff.String(), "@@ -1 +1 @@\n")
+	require.True(t, found)
+	assert.Contains(t, header, "diff --git a/:(glob)** b/:(glob)**")
+	assert.Equal(t, "-old\n+new\n", hunk)
+}
 
 const exampleDiff = `diff --git a/README.md b/README.md
 --- a/README.md

--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -2601,6 +2601,7 @@
   "repo.diff.file_mode_changed": "File mode changed.",
   "repo.diff.file_whitespace_only_changes": "Whitespace-only changes.",
   "repo.diff.view_file": "View File",
+  "repo.diff.view_plain": "View plain diff",
   "repo.diff.file_before": "Before",
   "repo.diff.file_after": "After",
   "repo.diff.file_image_width": "Width",

--- a/routers/web/repo/commit.go
+++ b/routers/web/repo/commit.go
@@ -311,9 +311,13 @@ func Diff(ctx *context.Context) {
 		commitID = commit.ID.String()
 	}
 
+	files := ctx.FormStrings("files")
+	if ctx.FormBool("plain") {
+		writePlainDiff(ctx, gitRepo, "", commitID, files)
+		return
+	}
 	fileOnly := ctx.FormBool("file-only")
 	maxLines, maxFiles := setting.Git.MaxGitDiffLines, setting.Git.MaxGitDiffFiles
-	files := ctx.FormStrings("files")
 	if fileOnly && (len(files) == 2 || len(files) == 1) {
 		maxLines, maxFiles = -1, -1
 	}

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -402,8 +402,12 @@ func (cpi *comparePageInfoType) prepareCompareDiff(ctx *context.Context, whitesp
 
 	beforeCommitID := ci.CompareBase
 
-	maxLines, maxFiles := setting.Git.MaxGitDiffLines, setting.Git.MaxGitDiffFiles
 	files := ctx.FormStrings("files")
+	if ctx.FormBool("plain") {
+		writePlainDiff(ctx, ci.HeadGitRepo, beforeCommitID, headCommitID, files)
+		return
+	}
+	maxLines, maxFiles := setting.Git.MaxGitDiffLines, setting.Git.MaxGitDiffFiles
 	if len(files) == 2 || len(files) == 1 {
 		maxLines, maxFiles = -1, -1
 	}
@@ -420,7 +424,7 @@ func (cpi *comparePageInfoType) prepareCompareDiff(ctx *context.Context, whitesp
 			MaxFiles:           maxFiles,
 			WhitespaceBehavior: whitespaceBehavior,
 			DirectComparison:   ci.DirectComparison(),
-		}, ctx.FormStrings("files")...)
+		}, files...)
 	if err != nil {
 		ctx.ServerError("GetDiff", err)
 		return

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -11,6 +11,7 @@ import (
 	"html"
 	"html/template"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -60,6 +61,25 @@ const (
 
 	pullRequestTemplateKey = "PullRequestTemplate"
 )
+
+func writePlainDiff(ctx *context.Context, repo *git.Repository, before, after string, files []string) {
+	if len(files) == 0 || len(files) > 2 || slices.Contains(files, "") {
+		ctx.Status(http.StatusBadRequest)
+		return
+	}
+	ctx.Resp.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	if err := git.WriteRawDiff(ctx, repo, before, after, git.RawDiffNormal, ctx.Resp, files...); err != nil {
+		if gitcmd.IsErrorCanceledOrKilled(err) {
+			return
+		}
+		log.Error("WriteRawDiff: %v", err)
+		if !ctx.Written() {
+			ctx.Status(http.StatusInternalServerError)
+		}
+	} else if !ctx.Written() {
+		ctx.Status(http.StatusOK)
+	}
+}
 
 var pullRequestTemplateCandidates = []string{
 	"PULL_REQUEST_TEMPLATE.md",
@@ -763,8 +783,12 @@ func viewPullFiles(ctx *context.Context, beforeCommitID, afterCommitID string) {
 	ctx.Data["AfterCommitID"] = afterCommitID
 	ctx.Data["BeforeCommitID"] = beforeCommitID
 
-	maxLines, maxFiles := setting.Git.MaxGitDiffLines, setting.Git.MaxGitDiffFiles
 	files := ctx.FormStrings("files")
+	if ctx.FormBool("plain") {
+		writePlainDiff(ctx, gitRepo, beforeCommitID, afterCommitID, files)
+		return
+	}
+	maxLines, maxFiles := setting.Git.MaxGitDiffLines, setting.Git.MaxGitDiffFiles
 	fileOnly := ctx.FormBool("file-only")
 	if fileOnly && (len(files) == 2 || len(files) == 1) {
 		maxLines, maxFiles = -1, -1

--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -174,7 +174,7 @@
 									<div class="tw-p-3">
 										{{if $file.IsIncomplete}}
 											{{if $file.IsIncompleteLineTooLong}}
-												{{ctx.Locale.Tr "repo.diff.file_suppressed_line_too_long"}}
+												{{ctx.Locale.Tr "repo.diff.file_suppressed_line_too_long"}} <a class="ui basic tiny button" href="?file-only=true&plain=true&files={{QueryEscape $file.Name}}&files={{QueryEscape $file.OldName}}" target="_blank" rel="nofollow">{{ctx.Locale.Tr "repo.diff.view_plain"}}</a>
 											{{else}}
 												{{ctx.Locale.Tr "repo.diff.file_suppressed"}}
 												<a class="ui basic tiny button" data-global-click="diffLoadFileBody" data-href="?file-only=true&files={{$file.Name}}&files={{$file.OldName}}">{{ctx.Locale.Tr "repo.diff.load"}}</a>

--- a/tests/integration/pull_diff_test.go
+++ b/tests/integration/pull_diff_test.go
@@ -4,13 +4,23 @@
 package integration
 
 import (
+	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 	"testing"
 
+	auth_model "gitea.dev/models/auth"
+	repo_model "gitea.dev/models/repo"
+	"gitea.dev/models/unittest"
+	"gitea.dev/modules/git"
+	"gitea.dev/modules/git/gitcmd"
+	"gitea.dev/modules/setting"
 	"gitea.dev/tests"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPullDiff(t *testing.T) {
@@ -25,6 +35,91 @@ func TestPullDiff(t *testing.T) {
 		testPullDiffAssertPage(t, "/user2/commitsonpr/pulls/1/files/4ca8bcaf27e28504df7bf996819665986b01c847..23576dd018294e476c06e569b6b0f170d0558705", true, []string{"test2.txt", "test3.txt", "test4.txt"})
 	})
 	t.Run("SingleHeadCommitReviewFormAction", testPullDiffSingleHeadCommitReviewFormAction)
+}
+
+func TestLongLinePlainDiff(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	const oldPath, newPath = "old&file.txt", "new&file.txt"
+	longLine := strings.Repeat("x", setting.Git.MaxGitDiffLineCharacters+1)
+	baseContent, headContent := longLine+"\nold\n", longLine+"\nnew\n"
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{OwnerName: "user2", Name: "repo1"})
+	masterID, err := git.GetBranchCommitID(t.Context(), repo, "master")
+	require.NoError(t, err)
+	fastImport := fmt.Sprintf(`commit refs/heads/master
+mark :1
+committer User <user@example.com> 1700000000 +0000
+data 0
+from %s
+M 100644 inline "%s"
+data %d
+%sM 100644 inline unrelated.txt
+data 4
+old
+
+commit refs/heads/long-line
+committer User <user@example.com> 1700000001 +0000
+data 0
+from :1
+R "%s" "%s"
+M 100644 inline "%s"
+data %d
+%sM 100644 inline unrelated.txt
+data 8
+changed
+`, masterID, oldPath, len(baseContent), baseContent, oldPath, newPath, newPath, len(headContent), headContent)
+	_, _, runErr := gitcmd.NewCommand("fast-import").WithRepo(repo).WithStdinBytes([]byte(fastImport)).RunStdString(t.Context())
+	require.NoError(t, runErr)
+
+	apiContext := NewAPITestContext(t, repo.OwnerName, repo.Name, auth_model.AccessTokenScopeWriteRepository)
+	pullRequest, err := doAPICreatePullRequest(apiContext, repo.OwnerName, repo.Name, repo.DefaultBranch, "long-line")(t)
+	require.NoError(t, err)
+	headID, err := git.GetBranchCommitID(t.Context(), repo, "long-line")
+	require.NoError(t, err)
+	session := apiContext.Session
+	pullPath := fmt.Sprintf("/%s/%s/pulls/%d/files", repo.OwnerName, repo.Name, pullRequest.Index)
+	query := url.Values{"file-only": {"true"}, "plain": {"true"}, "files": {newPath, oldPath}}.Encode()
+
+	t.Run("link", func(t *testing.T) {
+		resp := session.MakeRequest(t, NewRequest(t, http.MethodGet, pullPath), http.StatusOK)
+		file := NewHTMLParser(t, resp.Body).Find(`.diff-file-box[data-new-filename="new&file.txt"]`)
+		require.Equal(t, 1, file.Length())
+		suppressed := file.Find(".diff-file-body > .file-body.code-diff > .tw-p-3")
+		require.Equal(t, 1, suppressed.Length())
+		link := suppressed.Find(`a[href*="plain=true"]`)
+		require.Equal(t, 1, link.Length())
+		href, _ := link.Attr("href")
+		plainURL, err := url.Parse(href)
+		require.NoError(t, err)
+		assert.Equal(t, []string{newPath, oldPath}, plainURL.Query()["files"])
+		assert.Equal(t, "_blank", link.AttrOr("target", ""))
+		assert.Equal(t, "nofollow", link.AttrOr("rel", ""))
+	})
+
+	for name, path := range map[string]string{
+		"commit":  "/user2/repo1/commit/" + headID,
+		"pull":    pullPath,
+		"compare": "/user2/repo1/compare/master...long-line",
+	} {
+		t.Run(name, func(t *testing.T) {
+			resp := session.MakeRequest(t, NewRequest(t, http.MethodGet, path+"?"+query), http.StatusOK)
+			body := resp.Body.String()
+			assert.Equal(t, "text/plain; charset=utf-8", resp.Header().Get("Content-Type"))
+			if !strings.Contains(body, " "+longLine+"\n") {
+				t.Error("plain diff omitted complete long line")
+			}
+			assert.NotContains(t, body, "unrelated.txt")
+			assert.NotContains(t, body, "<div")
+		})
+	}
+
+	for name, files := range map[string][]string{"no files": nil, "empty file": {newPath, ""}, "three files": {newPath, oldPath, "unrelated.txt"}} {
+		t.Run(name, func(t *testing.T) {
+			values := url.Values{"plain": {"true"}, "file-only": {"true"}, "files": files}
+			resp := session.MakeRequest(t, NewRequest(t, http.MethodGet, "/user2/repo1/commit/"+headID+"?"+values.Encode()), NoExpectedStatus)
+			assert.Equal(t, http.StatusBadRequest, resp.Code)
+		})
+	}
 }
 
 func testPullDiffSingleHeadCommitReviewFormAction(t *testing.T) {


### PR DESCRIPTION
Add a "View plain diff" button when a file contains lines that exceed the configured rendering limit. The button opens the complete Git patch for that file as plain text in a new tab, without syntax highlighting.

The link adds `plain=true` to existing diff URLs. The commit, comparison, and pull-request handlers then stream the selected patch as text/plain, reusing the existing files parameters to identify the file, including both paths of a rename. Plain requests validate that selection and pass the names to Git literally (using `--literal-pathspecs`) so they cannot expand to unrelated files.

The existing rendered-diff limits and repository access checks remain unchanged. Tests were added to exercise the new behavior.

<img width="536" height="110" alt="Screenshot 2026-09-01 at 3 03 12 PM" src="https://github.com/user-attachments/assets/110341e9-3b20-437f-acdc-ef7352fbb49d" />
