### PR TITLE
docs: fix typo in README about app.ini restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Gitea is pronounced [/ɡɪ’ti:/](https://youtu.be/EM71-2uDAoY) as in "gi-tea" 
 
 For dynamic config options, you can change it on your admin panel's configuration section.
 
-For static config options, you can edit your `app.ini` file and resart the instance.
+For static config options, you can edit your `app.ini` file and restart the instance.
 See [app.example.ini](https://github.com/go-gitea/gitea/blob/main/custom/conf/app.example.ini) or [configuration documentation](https://docs.gitea.com/administration/config-cheat-sheet) for more details.
 
 **Where can I find the security patches?**


### PR DESCRIPTION
<!--
Before submitting:
- Target the `main` branch; release branches are for backports only.
- Use a Conventional Commits title, e.g. `fix(repo): handle empty branch names`.
- Read the contributing guidelines: https://github.com/go-gitea/gitea/blob/main/CONTRIBUTING.md
- Documentation changes go to https://gitea.com/gitea/docs

Describe your change below and link any issue it fixes.
-->
`resart`->`restart`