### PR TITLE
fix(pull): show changed files of pull requests without merge base

### DIFF
--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -742,6 +742,9 @@ func viewPullFiles(ctx *context.Context, beforeCommitID, afterCommitID string) {
 			return
 		}
 		beforeCommitID = beforeCommit.ID.String()
+	} else if beforeCommitID == "" && prCompareInfo.CompareBase == "" {
+		// no merge base (unrelated histories): the pull request brings in the whole head tree
+		beforeCommitID = afterCommit.ID.Type().EmptyTree().String()
 	} else {
 		beforeCommitID = util.IfZero(beforeCommitID, prCompareInfo.CompareBase)
 		beforeCommit = indexCommit(prCompareInfo.Commits, beforeCommitID)
@@ -753,10 +756,10 @@ func viewPullFiles(ctx *context.Context, beforeCommitID, afterCommitID string) {
 				return
 			}
 		}
-	}
-	if beforeCommit == nil {
-		ctx.NotFound(nil)
-		return
+		if beforeCommit == nil {
+			ctx.NotFound(nil)
+			return
+		}
 	}
 
 	ctx.Data["CompareInfo"] = prCompareInfo

--- a/services/gitdiff/git_diff_tree.go
+++ b/services/gitdiff/git_diff_tree.go
@@ -112,6 +112,10 @@ func validateGitDiffTreeArguments(ctx context.Context, gitRepo *git.Repository, 
 		return useMergeBase, baseCommit.ID.String(), headCommitID, nil
 	}
 
+	if baseSha == headCommit.ID.Type().EmptyTree().String() {
+		return false, baseSha, headCommitID, nil // the empty tree is not a commit, but a valid diff base
+	}
+
 	// try and get the base commit
 	baseCommit, err := gitRepo.GetCommit(ctx, baseSha)
 	// propagate the error if we couldn't get the base commit

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -1318,7 +1318,7 @@ func prepareDiffCommits(ctx context.Context, gitRepo *git.Repository, opts *Diff
 
 	commitObjectFormat := afterCommit.ID.Type()
 	isBeforeCommitIDEmpty := opts.BeforeCommitID == "" || opts.BeforeCommitID == commitObjectFormat.EmptyObjectID().String()
-	if isBeforeCommitIDEmpty && afterCommit.ParentCount() == 0 {
+	if (isBeforeCommitIDEmpty && afterCommit.ParentCount() == 0) || opts.BeforeCommitID == commitObjectFormat.EmptyTree().String() {
 		// "git diff 4b825dc642cb6eb9a060e54bf8d69288fbee4904 after-commit" can work with tree ID as before commit ID
 		actualBeforeCommitID = commitObjectFormat.EmptyTree()
 	} else {

--- a/tests/integration/pull_diff_test.go
+++ b/tests/integration/pull_diff_test.go
@@ -4,13 +4,22 @@
 package integration
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
+	auth_model "gitea.dev/models/auth"
+	repo_model "gitea.dev/models/repo"
+	"gitea.dev/models/unittest"
+	user_model "gitea.dev/models/user"
+	"gitea.dev/modules/git/gitcmd"
+	api "gitea.dev/modules/structs"
 	"gitea.dev/tests"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPullDiff(t *testing.T) {
@@ -64,4 +73,37 @@ func testPullDiffAssertPage(t *testing.T, prDiffURL string, reviewBtnDisabled bo
 
 	// Ensure the review button is enabled for full PR reviews
 	assert.Equal(t, reviewBtnDisabled, doc.Find(".js-btn-review").HasClass("disabled"))
+}
+
+func TestPullDiffNoCommonMergeBase(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	user2 := unittest.AssertExistsAndLoadBean(t, &user_model.User{Name: "user2"})
+	repo1 := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{OwnerID: user2.ID, Name: "repo1"})
+	_, _, err := gitcmd.NewCommand("fast-import").WithRepo(repo1).WithStdinBytes([]byte(strings.TrimSpace(`
+commit refs/heads/unrelated-history
+committer User <user@example.com> 1714310400 +0000
+data 13
+Second commit
+M 100644 inline file2.txt
+data 12
+Hello from 2
+`))).RunStdString(t.Context())
+	require.NoError(t, err)
+
+	// the compare page refuses branches without a merge base, but the API (and history rewrites) still produce such pull requests
+	session := loginUser(t, "user2")
+	token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeWriteRepository)
+	req := NewRequestWithJSON(t, "POST", "/api/v1/repos/user2/repo1/pulls", &api.CreatePullRequestOption{
+		Head:  "unrelated-history",
+		Base:  "master",
+		Title: "unrelated histories",
+	}).AddTokenAuth(token)
+	pr := DecodeJSON(t, MakeRequest(t, req, http.StatusCreated), &api.PullRequest{})
+
+	req = NewRequest(t, "GET", fmt.Sprintf("/user2/repo1/pulls/%d/files", pr.Index))
+	resp := session.MakeRequest(t, req, http.StatusOK)
+	doc := NewHTMLParser(t, resp.Body)
+	assert.Equal(t, 1, doc.Find(".diff-file-box").Length())
+	assert.Equal(t, "file2.txt", doc.Find(".diff-file-box").AttrOr("data-new-filename", ""))
 }


### PR DESCRIPTION
When a pull request's head and base have no merge base, GetCompareInfo leaves CompareBase empty and viewPullFiles looks up an empty commit ID, so the Files Changed tab returns 404 (400 on older releases). Such pull requests are still created through the API, or appear when a branch is rewritten after the pull request was opened.

Without a merge base, the pull request brings in the whole head tree, so the files view now diffs against the empty tree, and gitdiff accepts the empty tree SHA as a diff base instead of loading it as a commit. Only the files tab changes: the commits tab still lists no commits for such pull requests and merging them is unaffected. Covered by a new integration test that fails on main and passes with this change.

Fixes https://github.com/go-gitea/gitea/issues/36644
