### PR TITLE
enhance(issue): add "r" shortcut to quote selected text in a reply

### DIFF
--- a/web_src/js/features/repo-issue-edit.test.ts
+++ b/web_src/js/features/repo-issue-edit.test.ts
@@ -1,0 +1,124 @@
+import {initRepoIssueCommentEdit} from './repo-issue-edit.ts';
+
+type EditorStub = {value: (v?: string) => string, focus: () => void, moveCursorToEnd: () => void};
+
+initRepoIssueCommentEdit();
+
+function mockEditor(container: HTMLElement): EditorStub {
+  let content = '';
+  const editor: EditorStub = {
+    value(v?: string) {
+      if (v !== undefined) content = v;
+      return content;
+    },
+    focus() {},
+    moveCursorToEnd() {},
+  };
+  Object.assign(container, {_giteaComboMarkdownEditor: editor});
+  return editor;
+}
+
+function commentHtml(id: string, text: string): string {
+  return `<div class="timeline-item comment" id="issuecomment-${id}">
+    <div class="ui attached segment comment-body">
+      <div class="render-content markup"><p>${text}</p></div>
+      <div id="issuecomment-${id}-raw" class="raw-content tw-hidden">${text}</div>
+    </div>
+  </div>`;
+}
+
+function setupIssuePage(): EditorStub {
+  document.body.innerHTML = `<div class="page-content repository view issue">
+    <div class="comment-list">
+      ${commentHtml('1', 'first comment')}
+      ${commentHtml('2', 'second comment')}
+      <form id="comment-form"><div class="combo-markdown-editor"></div></form>
+    </div>
+  </div>`;
+  return mockEditor(document.querySelector('#comment-form .combo-markdown-editor')!);
+}
+
+function textNodeOf(commentId: string): Node {
+  return document.querySelector(`#issuecomment-${commentId} .render-content.markup p`)!.firstChild!;
+}
+
+function selectRange(start: Node, startOffset: number, end: Node, endOffset: number) {
+  const range = document.createRange();
+  range.setStart(start, startOffset);
+  range.setEnd(end, endOffset);
+  const selection = window.getSelection()!;
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+async function pressR() {
+  document.body.dispatchEvent(new KeyboardEvent('keydown', {key: 'r', bubbles: true}));
+  await Promise.resolve();
+}
+
+test('quote reply shortcut quotes the selected text', async () => {
+  const editor = setupIssuePage();
+  const node = textNodeOf('2');
+  selectRange(node, 0, node, 6);
+  await pressR();
+  expect(editor.value()).toBe('> second\n\n');
+
+  // a second quote appends below the existing content
+  selectRange(textNodeOf('1'), 0, textNodeOf('1'), 5);
+  await pressR();
+  expect(editor.value()).toBe('> second\n\n\n\n> first\n\n');
+});
+
+test('quote reply shortcut ignores unusable selections', async () => {
+  const editor = setupIssuePage();
+
+  window.getSelection()!.removeAllRanges();
+  await pressR();
+  expect(editor.value()).toBe('');
+
+  // a caret with no selected text
+  selectRange(textNodeOf('1'), 3, textNodeOf('1'), 3);
+  await pressR();
+  expect(editor.value()).toBe('');
+
+  // spanning two comments, so no single comment can be quoted
+  selectRange(textNodeOf('1'), 0, textNodeOf('2'), 6);
+  await pressR();
+  expect(editor.value()).toBe('');
+});
+
+test('quote reply shortcut ignores modifiers and text inputs', async () => {
+  const editor = setupIssuePage();
+  selectRange(textNodeOf('1'), 0, textNodeOf('1'), 5);
+
+  document.body.dispatchEvent(new KeyboardEvent('keydown', {key: 'r', ctrlKey: true, bubbles: true}));
+  await Promise.resolve();
+  expect(editor.value()).toBe('');
+
+  const input = document.createElement('input');
+  document.body.append(input);
+  input.dispatchEvent(new KeyboardEvent('keydown', {key: 'r', bubbles: true}));
+  await Promise.resolve();
+  expect(editor.value()).toBe('');
+});
+
+test('quote reply shortcut is a no-op without a comment form', async () => {
+  const editor = setupIssuePage();
+  document.querySelector('#comment-form')!.removeAttribute('id'); // anonymous user, or archived/locked repo
+
+  selectRange(textNodeOf('1'), 0, textNodeOf('1'), 5);
+  await pressR();
+  await new Promise((resolve) => setTimeout(resolve, 0)); // an unguarded editor rejects here, failing the run
+  expect(editor.value()).toBe('');
+});
+
+test('quote reply shortcut is a no-op in a code comment with no reply button', async () => {
+  const mainEditor = setupIssuePage();
+  document.querySelector('.comment-list')!.insertAdjacentHTML('beforeend',
+    `<div class="comment-code-cloud">${commentHtml('3', 'code comment')}</div>`); // no reply button
+
+  selectRange(textNodeOf('3'), 0, textNodeOf('3'), 4);
+  await pressR();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  expect(mainEditor.value()).toBe(''); // must not fall through to the main comment form
+});

--- a/web_src/js/features/repo-issue-edit.ts
+++ b/web_src/js/features/repo-issue-edit.ts
@@ -120,26 +120,29 @@ function extractSelectedMarkdown(container: HTMLElement) {
   return convertHtmlToMarkdown(el);
 }
 
-async function tryOnQuoteReply(e: Event) {
-  const clickTarget = (e.target as HTMLElement).closest('.quote-reply');
-  if (!clickTarget) return;
+function findSelectedCommentMarkup(): HTMLElement | null {
+  const selection = window.getSelection();
+  if (!selection?.rangeCount || selection.isCollapsed) return null;
+  const node = selection.getRangeAt(0).commonAncestorContainer;
+  const el = node instanceof HTMLElement ? node : node.parentElement;
+  return el?.closest<HTMLElement>('.render-content.markup') ?? null; // null when the selection spans two comments
+}
 
-  e.preventDefault();
-  const contentToQuoteId = clickTarget.getAttribute('data-target');
-  const targetRawToQuote = document.querySelector<HTMLElement>(`#${contentToQuoteId}.raw-content`)!;
-  const targetMarkupToQuote = targetRawToQuote.parentElement!.querySelector<HTMLElement>('.render-content.markup')!;
-  let contentToQuote = extractSelectedMarkdown(targetMarkupToQuote);
-  if (!contentToQuote) contentToQuote = targetRawToQuote.textContent;
+// absent for anonymous users and archived repos, where the context menu was not rendered either
+async function resolveReplyEditor(targetMarkupToQuote: HTMLElement) {
+  const codeCloud = targetMarkupToQuote.closest('.comment-code-cloud');
+  if (codeCloud) {
+    const replyBtn = codeCloud.querySelector<HTMLElement>('button.comment-form-reply');
+    return replyBtn ? await handleReply(replyBtn) : null;
+  }
+  return getComboMarkdownEditor(document.querySelector('#comment-form .combo-markdown-editor'));
+}
+
+async function quoteToEditor(targetMarkupToQuote: HTMLElement, contentToQuote: string) {
   const quotedContent = `${contentToQuote.replace(/^/mg, '> ')}\n\n`;
 
-  let editor;
-  if (clickTarget.classList.contains('quote-reply-diff')) {
-    const replyBtn = clickTarget.closest('.comment-code-cloud')!.querySelector<HTMLElement>('button.comment-form-reply')!;
-    editor = await handleReply(replyBtn);
-  } else {
-    // for normal issue/comment page
-    editor = getComboMarkdownEditor(document.querySelector('#comment-form .combo-markdown-editor'))!;
-  }
+  const editor = await resolveReplyEditor(targetMarkupToQuote);
+  if (!editor) return;
 
   if (editor.value()) {
     editor.value(`${editor.value()}\n\n${quotedContent}`);
@@ -150,9 +153,37 @@ async function tryOnQuoteReply(e: Event) {
   editor.moveCursorToEnd();
 }
 
+async function tryOnQuoteReply(e: Event) {
+  const clickTarget = (e.target as HTMLElement).closest('.quote-reply');
+  if (!clickTarget) return;
+
+  e.preventDefault();
+  const contentToQuoteId = clickTarget.getAttribute('data-target');
+  const targetRawToQuote = document.querySelector<HTMLElement>(`#${contentToQuoteId}.raw-content`)!;
+  const targetMarkupToQuote = targetRawToQuote.parentElement!.querySelector<HTMLElement>('.render-content.markup')!;
+  let contentToQuote = extractSelectedMarkdown(targetMarkupToQuote);
+  if (!contentToQuote) contentToQuote = targetRawToQuote.textContent;
+  await quoteToEditor(targetMarkupToQuote, contentToQuote);
+}
+
+async function tryOnQuoteReplyShortcut(e: KeyboardEvent) {
+  if (e.key !== 'r' || e.ctrlKey || e.metaKey || e.altKey || e.isComposing || e.repeat) return;
+  const target = e.target as HTMLElement;
+  if (target.matches('input, textarea, select') || target.isContentEditable) return;
+
+  const targetMarkupToQuote = findSelectedCommentMarkup();
+  if (!targetMarkupToQuote) return;
+  const contentToQuote = extractSelectedMarkdown(targetMarkupToQuote);
+  if (!contentToQuote) return;
+
+  e.preventDefault(); // before the first await, otherwise the key could still reach the page
+  await quoteToEditor(targetMarkupToQuote, contentToQuote);
+}
+
 export function initRepoIssueCommentEdit() {
   document.addEventListener('click', (e) => {
     tryOnEditContent(e); // Edit issue or comment content
     tryOnQuoteReply(e); // Quote reply to the comment editor
   });
+  document.addEventListener('keydown', tryOnQuoteReplyShortcut); // "r": quote the selected text
 }


### PR DESCRIPTION
Selecting text in an issue, pull request, or code review comment and pressing `r` quotes it into the reply editor — the same result as Quote Reply in the context menu, which already quotes a selection when one exists. With no selection, or one spanning two comments, the key does nothing.

Refs https://github.com/go-gitea/gitea/issues/5796

Not built on the `<kbd>`/`data-shortcut-keys` module from https://github.com/go-gitea/gitea/pull/36416, which focuses an input rather than running an action. Happy to generalize that instead.

No visual change; a `<kbd>R</kbd>` hint on the menu item could be added if wanted.

Two reviewer calls:

- `quote-reply-diff` is now unused: both entry points resolve `.comment-code-cloud` structurally. Removing it touches five templates, left as a follow-up.
- Pre-existing, inherited here: programmatic `editor.value()` does not fire `EventEditorContentChanged`, so the Comment button stays disabled until the user types.

Written by Claude Opus 5 (Claude Code).
