### PR TITLE
docs: correct ALLOW_LOCALNETWORKS description in app.example.ini

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -2774,7 +2774,8 @@ LEVEL = Info
 ;BLOCKED_DOMAINS =
 ;;
 ;; Allow private addresses defined by RFC 1918, RFC 1122, RFC 4632 and RFC 4291 (false by default)
-;; If a domain is allowed by ALLOWED_DOMAINS, this option will be ignored.
+;; When false, migration URLs are rejected if any resolved address is private or loopback,
+;; even when the host matches ALLOWED_DOMAINS: the block list is applied before the allow list.
 ;ALLOW_LOCALNETWORKS = false
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Fixes the `app.example.ini` half of #39224.

The comment says:

> If a domain is allowed by `ALLOWED_DOMAINS`, this option will be ignored.

That is no longer true. `checkByAllowBlockList` in `services/migrations/migrate.go` consults the block list **first** and returns immediately:

```go
if blockList.MatchHostName(hostName) || ipBlocked {
    return &git.ErrInvalidCloneAddr{Host: hostName, IsPermissionDenied: true}
}
// if we have an allow-list, check the allow-list before return to get the more accurate error
if !allowList.IsEmpty() { ... }
```

`IsMigrateURLAllowed` resolves the host with `net.LookupIP` and passes the addresses in, so with `ALLOW_LOCALNETWORKS = false` a host that appears in `ALLOWED_DOMAINS` is still rejected once any resolved address is private or loopback — the allow list never gets a look. The reporter traced this to the validation hardening in #38324 / #38400, and the code matches their description.

The new wording states the precedence rather than the old override claim.

Scope: this only covers `custom/conf/app.example.ini`, which lives here. The same stale sentence is on the config cheat sheet in `gitea/docs` (both the English and zh-cn pages) per the issue; that is a separate repository, and the PR template says documentation changes go there, so I have not touched it. Happy to send that one too.

I did not change behaviour — I have no opinion on whether block-before-allow is the right precedence, only that the comment describes the opposite of what the code does.

Disclosure: prepared with AI assistance (Claude, via Claude Code); the commit carries an `Assisted-by:` trailer. I read the validation path rather than inferring it, and every quote above is from current `main`. Per your contributing guide, review replies here will be mine rather than an AI's.