### PR TITLE
enhance(packages): add global Go module proxy

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -2850,6 +2850,9 @@ LEVEL = Info
 ;LIMIT_SIZE_GENERIC = -1
 ;; Maximum size of a Go upload (`-1` means no limits, format `1000`, `1 MB`, `1 GiB`)
 ;LIMIT_SIZE_GO = -1
+;; Upstream Go module proxy used by the global /api/packages/go proxy.
+;; Set to an empty value to disable proxying of non-local modules.
+;GO_PROXY_URL = https://proxy.golang.org
 ;; Maximum size of a Helm upload (`-1` means no limits, format `1000`, `1 MB`, `1 GiB`)
 ;LIMIT_SIZE_HELM = -1
 ;; Maximum size of a Maven upload (`-1` means no limits, format `1000`, `1 MB`, `1 GiB`)

--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -2850,7 +2850,8 @@ LEVEL = Info
 ;LIMIT_SIZE_GENERIC = -1
 ;; Maximum size of a Go upload (`-1` means no limits, format `1000`, `1 MB`, `1 GiB`)
 ;LIMIT_SIZE_GO = -1
-;; Upstream Go module proxy used by the global /api/packages/go proxy.
+;; Upstream GOPROXY list used by the global /api/packages/go proxy.
+;; Supports comma and pipe fallback separators, plus "direct" and "off".
 ;; Set to an empty value to disable proxying of non-local modules.
 ;GO_PROXY_URL = https://proxy.golang.org
 ;; Maximum size of a Helm upload (`-1` means no limits, format `1000`, `1 MB`, `1 GiB`)

--- a/modules/setting/packages.go
+++ b/modules/setting/packages.go
@@ -43,9 +43,12 @@ var (
 		LimitSizeVagrant        int64
 
 		DefaultRPMSignEnabled bool
+
+		GoProxyURL string
 	}{
 		Enabled:              true,
 		LimitTotalOwnerCount: -1,
+		GoProxyURL:           "https://proxy.golang.org",
 	}
 )
 

--- a/routers/api/packages/api.go
+++ b/routers/api/packages/api.go
@@ -129,6 +129,9 @@ func CommonRoutes() *web.Router {
 		&chef.Auth{},
 	}, verifyAuthOptions{})
 
+	// Unlike the per-owner /{username}/go registry, this global endpoint serves
+	// any module path: Gitea repositories are resolved directly, while all other
+	// modules are transparently proxied to the configured upstream GOPROXY.
 	r.Group("/go", func() {
 		r.Get("/sumdb/sum.golang.org/supported", http.NotFound)
 

--- a/routers/api/packages/api.go
+++ b/routers/api/packages/api.go
@@ -129,6 +129,19 @@ func CommonRoutes() *web.Router {
 		&chef.Auth{},
 	}, verifyAuthOptions{})
 
+	r.Group("/go", func() {
+		r.Get("/sumdb/sum.golang.org/supported", http.NotFound)
+
+		// https://go.dev/ref/mod#goproxy-protocol
+		r.PathGroup("/*", func(g *web.RouterPathGroup) {
+			g.MatchPath("GET", "/<name:*>/@<version:latest>", goproxy.GlobalPackageVersionMetadata)
+			g.MatchPath("GET", "/<name:*>/@v/list", goproxy.GlobalEnumeratePackageVersions)
+			g.MatchPath("GET", "/<name:*>/@v/<version>.zip", goproxy.GlobalDownloadPackageFile)
+			g.MatchPath("GET", "/<name:*>/@v/<version>.info", goproxy.GlobalPackageVersionMetadata)
+			g.MatchPath("GET", "/<name:*>/@v/<version>.mod", goproxy.GlobalPackageVersionGoModContent)
+		})
+	})
+
 	r.Group("/{username}", func() {
 		r.Group("/alpine", func() {
 			r.Get("/key", alpine.GetRepositoryKey)

--- a/routers/api/packages/goproxy/global.go
+++ b/routers/api/packages/goproxy/global.go
@@ -4,20 +4,17 @@
 package goproxy
 
 import (
-	stdcontext "context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"path"
 	"strings"
 	"time"
 
 	auth_model "gitea.dev/models/auth"
-	"gitea.dev/modules/globallock"
 	"gitea.dev/modules/httplib"
 	"gitea.dev/modules/setting"
 	"gitea.dev/modules/storage"
@@ -37,19 +34,12 @@ func GlobalEnumeratePackageVersions(ctx *context.Context) {
 		return
 	}
 	if !local {
-		proxyUpstream(ctx, modulePath, "", "")
+		proxyThroughList(ctx, modulePath, "", "")
 		return
 	}
 
-	versions, err := repo.ListVersions(ctx)
-	if err != nil {
-		apiError(ctx, http.StatusInternalServerError, err)
-		return
-	}
-
-	ctx.Resp.Header().Set("Content-Type", "text/plain;charset=utf-8")
-	for _, version := range versions {
-		fmt.Fprintln(ctx.Resp, version)
+	if err := serveRepositoryModule(ctx, repo, "", ""); err != nil {
+		writeProxyError(ctx, err)
 	}
 }
 
@@ -62,23 +52,13 @@ func GlobalPackageVersionMetadata(ctx *context.Context) {
 		return
 	}
 	if !local {
-		proxyUpstream(ctx, modulePath, version, "info")
+		proxyThroughList(ctx, modulePath, version, "info")
 		return
 	}
 
-	v, err := repo.ResolveVersion(ctx, version)
-	if err != nil {
-		globalVersionError(ctx, err)
-		return
+	if err := serveRepositoryModule(ctx, repo, version, "info"); err != nil {
+		writeProxyError(ctx, err)
 	}
-
-	ctx.JSON(http.StatusOK, struct {
-		Version string    `json:"Version"`
-		Time    time.Time `json:"Time"`
-	}{
-		Version: v.Version,
-		Time:    v.Time,
-	})
 }
 
 func GlobalPackageVersionGoModContent(ctx *context.Context) {
@@ -90,23 +70,13 @@ func GlobalPackageVersionGoModContent(ctx *context.Context) {
 		return
 	}
 	if !local {
-		proxyUpstream(ctx, modulePath, version, "mod")
+		proxyThroughList(ctx, modulePath, version, "mod")
 		return
 	}
 
-	v, err := repo.ResolveVersion(ctx, version)
-	if err != nil {
-		globalVersionError(ctx, err)
-		return
+	if err := serveRepositoryModule(ctx, repo, version, "mod"); err != nil {
+		writeProxyError(ctx, err)
 	}
-
-	goMod, err := v.GoMod(ctx)
-	if err != nil {
-		globalVersionError(ctx, err)
-		return
-	}
-
-	ctx.PlainText(http.StatusOK, string(goMod))
 }
 
 func GlobalDownloadPackageFile(ctx *context.Context) {
@@ -118,38 +88,13 @@ func GlobalDownloadPackageFile(ctx *context.Context) {
 		return
 	}
 	if !local {
-		proxyUpstream(ctx, modulePath, version, "zip")
+		proxyThroughList(ctx, modulePath, version, "zip")
 		return
 	}
 
-	v, err := repo.ResolveVersion(ctx, version)
-	if err != nil {
-		globalVersionError(ctx, err)
-		return
+	if err := serveRepositoryModule(ctx, repo, version, "zip"); err != nil {
+		writeProxyError(ctx, err)
 	}
-
-	tmpFile, cleanup, err := setting.AppDataTempDir("goproxy").CreateTempFileRandom("module-*.zip")
-	if err != nil {
-		apiError(ctx, http.StatusInternalServerError, err)
-		return
-	}
-	defer cleanup()
-
-	if err := v.CreateZip(ctx, tmpFile); err != nil {
-		globalVersionError(ctx, err)
-		return
-	}
-
-	if _, err := tmpFile.Seek(0, io.SeekStart); err != nil {
-		apiError(ctx, http.StatusInternalServerError, err)
-		return
-	}
-
-	ctx.ServeContent(tmpFile, context.ServeHeaderOptions{
-		ContentType:  "application/zip",
-		Filename:     v.Version + ".zip",
-		LastModified: v.Time,
-	})
 }
 
 func globalLocalRepo(ctx *context.Context, modulePath string) (*goproxy_service.Repository, bool, bool) {
@@ -184,119 +129,81 @@ func globalLocalRepo(ctx *context.Context, modulePath string) (*goproxy_service.
 	return repo, true, true
 }
 
-func globalVersionError(ctx *context.Context, err error) {
-	status := http.StatusInternalServerError
-	if errors.Is(err, goproxy_service.ErrNotFound) || errors.Is(err, goproxy_service.ErrGoModNotFound) || errors.Is(err, util.ErrNotExist) {
-		status = http.StatusNotFound
-	} else if errors.Is(err, goproxy_service.ErrInvalidVersion) || errors.Is(err, goproxy_service.ErrGoModMismatch) || errors.Is(err, goproxy_service.ErrGoModTooLarge) {
-		status = http.StatusBadRequest
-	}
-	apiError(ctx, status, err)
-}
-
-func proxyUpstream(ctx *context.Context, modulePath, version, file string) {
-	if setting.Packages.GoProxyURL == "" {
-		apiError(ctx, http.StatusNotFound, goproxy_service.ErrNotFound)
-		return
-	}
-
-	upstreamURL, err := buildUpstreamURL(modulePath, version, file)
-	if err != nil {
-		globalVersionError(ctx, err)
-		return
-	}
-
-	if (file == "info" && version != "latest") || file == "mod" || file == "zip" {
-		proxyUpstreamImmutable(ctx, upstreamURL, modulePath, version, file)
-		return
-	}
-
-	resp, err := upstreamGet(ctx, upstreamURL)
-	if err != nil {
-		apiError(ctx, http.StatusInternalServerError, err)
-		return
-	}
-	defer resp.Body.Close()
-
-	forwardUpstreamResponse(ctx, resp)
-}
-
-func proxyUpstreamImmutable(ctx *context.Context, upstreamURL, modulePath, version, file string) {
-	if version == "latest" {
-		// The Go command requests the latest version through @latest; the
-		// per-owner registry also accepts latest.info/mod/zip, but that is
-		// not part of the upstream proxy protocol.
-		apiError(ctx, http.StatusNotFound, goproxy_service.ErrNotFound)
-		return
-	}
-
-	cacheKey := goProxyCacheKey(modulePath, version, file)
-	if obj, err := storage.Packages.Open(cacheKey); err == nil {
-		serveCachedGoProxyObject(ctx, obj, version+"."+file, goProxyContentType(file))
-		return
-	} else if !errors.Is(err, os.ErrNotExist) {
-		apiError(ctx, http.StatusInternalServerError, err)
-		return
-	}
-
-	handled := false
-	err := globallock.LockAndDo(ctx, "goproxy-cache:"+cacheKey, func(stdcontext.Context) error {
-		if obj, err := storage.Packages.Open(cacheKey); err == nil {
-			_ = obj.Close()
-			return nil
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return err
-		}
-
-		resp, err := upstreamGet(ctx, upstreamURL)
+func serveRepositoryModule(ctx *context.Context, repo *goproxy_service.Repository, version, file string) *proxyError {
+	if file == "" {
+		versions, err := repo.ListVersions(ctx)
 		if err != nil {
-			return err
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			forwardUpstreamResponse(ctx, resp)
-			handled = true
-			return nil
+			return &proxyError{status: http.StatusInternalServerError, body: err.Error()}
 		}
 
-		if err := storage.SaveFrom(storage.Packages, cacheKey, func(w io.Writer) error {
-			_, err := io.Copy(w, resp.Body)
-			return err
-		}); err != nil {
-			_ = storage.Packages.Delete(cacheKey)
-			return err
+		ctx.Resp.Header().Set("Content-Type", "text/plain;charset=utf-8")
+		for _, v := range versions {
+			fmt.Fprintln(ctx.Resp, v)
 		}
 		return nil
-	})
-	if handled {
-		return
-	}
-	if err != nil {
-		apiError(ctx, http.StatusInternalServerError, err)
-		return
 	}
 
-	obj, err := storage.Packages.Open(cacheKey)
+	v, err := repo.ResolveVersion(ctx, version)
 	if err != nil {
-		apiError(ctx, http.StatusInternalServerError, err)
-		return
+		return versionProxyError(err)
 	}
-	serveCachedGoProxyObject(ctx, obj, version+"."+file, goProxyContentType(file))
+
+	switch file {
+	case "info":
+		ctx.JSON(http.StatusOK, struct {
+			Version string    `json:"Version"`
+			Time    time.Time `json:"Time"`
+		}{
+			Version: v.Version,
+			Time:    v.Time,
+		})
+		return nil
+	case "mod":
+		goMod, err := v.GoMod(ctx)
+		if err != nil {
+			return versionProxyError(err)
+		}
+		ctx.PlainText(http.StatusOK, string(goMod))
+		return nil
+	case "zip":
+		tmpFile, cleanup, err := setting.AppDataTempDir("goproxy").CreateTempFileRandom("module-*.zip")
+		if err != nil {
+			return &proxyError{status: http.StatusInternalServerError, body: err.Error()}
+		}
+		defer cleanup()
+
+		if err := v.CreateZip(ctx, tmpFile); err != nil {
+			return versionProxyError(err)
+		}
+
+		if _, err := tmpFile.Seek(0, io.SeekStart); err != nil {
+			return &proxyError{status: http.StatusInternalServerError, body: err.Error()}
+		}
+
+		ctx.ServeContent(tmpFile, context.ServeHeaderOptions{
+			ContentType:  "application/zip",
+			Filename:     v.Version + ".zip",
+			LastModified: v.Time,
+		})
+		return nil
+	}
+
+	return &proxyError{status: http.StatusInternalServerError, body: "unknown Go proxy file type"}
 }
 
 func serveCachedGoProxyObject(ctx *context.Context, obj storage.Object, filename, contentType string) {
 	defer obj.Close()
 
-	lastModified := time.Time{}
-	if info, err := obj.Stat(); err == nil {
-		lastModified = info.ModTime()
+	info, err := obj.Stat()
+	if err != nil {
+		apiError(ctx, http.StatusInternalServerError, err)
+		return
 	}
 
-	ctx.ServeContent(obj, context.ServeHeaderOptions{
+	httplib.ServeUserContentByReader(ctx.Req, ctx.Resp, info.Size(), obj, httplib.ServeHeaderOptions{
 		ContentType:  contentType,
 		Filename:     filename,
-		LastModified: lastModified,
+		LastModified: info.ModTime(),
 	})
 }
 
@@ -331,13 +238,13 @@ func forwardUpstreamResponse(ctx *context.Context, resp *http.Response) {
 	_, _ = io.Copy(ctx.Resp, resp.Body)
 }
 
-func buildUpstreamURL(modulePath, version, file string) (string, error) {
+func buildUpstreamURL(baseURL, modulePath, version, file string) (string, error) {
 	escapedPath, err := module.EscapePath(modulePath)
 	if err != nil {
 		return "", err
 	}
 
-	base := strings.TrimRight(setting.Packages.GoProxyURL, "/") + "/" + escapedPath
+	base := strings.TrimRight(baseURL, "/") + "/" + escapedPath
 	switch file {
 	case "":
 		return base + "/@v/list", nil

--- a/routers/api/packages/goproxy/global.go
+++ b/routers/api/packages/goproxy/global.go
@@ -1,0 +1,361 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package goproxy
+
+import (
+	stdcontext "context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	auth_model "gitea.dev/models/auth"
+	"gitea.dev/modules/globallock"
+	"gitea.dev/modules/httplib"
+	"gitea.dev/modules/setting"
+	"gitea.dev/modules/storage"
+	"gitea.dev/modules/util"
+	"gitea.dev/services/context"
+	goproxy_service "gitea.dev/services/packages/goproxy"
+
+	"golang.org/x/mod/module"
+)
+
+// Global routes serve any module path from /api/packages/go.
+
+func GlobalEnumeratePackageVersions(ctx *context.Context) {
+	modulePath := ctx.PathParam("name")
+	repo, local, ok := globalLocalRepo(ctx, modulePath)
+	if !ok {
+		return
+	}
+	if !local {
+		proxyUpstream(ctx, modulePath, "", "")
+		return
+	}
+
+	versions, err := repo.ListVersions(ctx)
+	if err != nil {
+		apiError(ctx, http.StatusInternalServerError, err)
+		return
+	}
+
+	ctx.Resp.Header().Set("Content-Type", "text/plain;charset=utf-8")
+	for _, version := range versions {
+		fmt.Fprintln(ctx.Resp, version)
+	}
+}
+
+func GlobalPackageVersionMetadata(ctx *context.Context) {
+	modulePath := ctx.PathParam("name")
+	version := ctx.PathParam("version")
+
+	repo, local, ok := globalLocalRepo(ctx, modulePath)
+	if !ok {
+		return
+	}
+	if !local {
+		proxyUpstream(ctx, modulePath, version, "info")
+		return
+	}
+
+	v, err := repo.ResolveVersion(ctx, version)
+	if err != nil {
+		globalVersionError(ctx, err)
+		return
+	}
+
+	ctx.JSON(http.StatusOK, struct {
+		Version string    `json:"Version"`
+		Time    time.Time `json:"Time"`
+	}{
+		Version: v.Version,
+		Time:    v.Time,
+	})
+}
+
+func GlobalPackageVersionGoModContent(ctx *context.Context) {
+	modulePath := ctx.PathParam("name")
+	version := ctx.PathParam("version")
+
+	repo, local, ok := globalLocalRepo(ctx, modulePath)
+	if !ok {
+		return
+	}
+	if !local {
+		proxyUpstream(ctx, modulePath, version, "mod")
+		return
+	}
+
+	v, err := repo.ResolveVersion(ctx, version)
+	if err != nil {
+		globalVersionError(ctx, err)
+		return
+	}
+
+	goMod, err := v.GoMod(ctx)
+	if err != nil {
+		globalVersionError(ctx, err)
+		return
+	}
+
+	ctx.PlainText(http.StatusOK, string(goMod))
+}
+
+func GlobalDownloadPackageFile(ctx *context.Context) {
+	modulePath := ctx.PathParam("name")
+	version := ctx.PathParam("version")
+
+	repo, local, ok := globalLocalRepo(ctx, modulePath)
+	if !ok {
+		return
+	}
+	if !local {
+		proxyUpstream(ctx, modulePath, version, "zip")
+		return
+	}
+
+	v, err := repo.ResolveVersion(ctx, version)
+	if err != nil {
+		globalVersionError(ctx, err)
+		return
+	}
+
+	tmpFile, cleanup, err := setting.AppDataTempDir("goproxy").CreateTempFileRandom("module-*.zip")
+	if err != nil {
+		apiError(ctx, http.StatusInternalServerError, err)
+		return
+	}
+	defer cleanup()
+
+	if err := v.CreateZip(ctx, tmpFile); err != nil {
+		globalVersionError(ctx, err)
+		return
+	}
+
+	if _, err := tmpFile.Seek(0, io.SeekStart); err != nil {
+		apiError(ctx, http.StatusInternalServerError, err)
+		return
+	}
+
+	ctx.ServeContent(tmpFile, context.ServeHeaderOptions{
+		ContentType:  "application/zip",
+		Filename:     v.Version + ".zip",
+		LastModified: v.Time,
+	})
+}
+
+func globalLocalRepo(ctx *context.Context, modulePath string) (*goproxy_service.Repository, bool, bool) {
+	if err := module.CheckPath(modulePath); err != nil {
+		apiError(ctx, http.StatusBadRequest, err)
+		return nil, false, false
+	}
+
+	repo, local, err := goproxy_service.ResolveRepository(ctx, modulePath)
+	if err != nil {
+		apiError(ctx, http.StatusInternalServerError, err)
+		return nil, false, false
+	}
+	if !local {
+		return nil, false, true
+	}
+	if repo == nil {
+		apiError(ctx, http.StatusNotFound, goproxy_service.ErrNotFound)
+		return nil, false, false
+	}
+
+	scope, _ := ctx.Data["ApiTokenScope"].(auth_model.AccessTokenScope)
+	if err := repo.CheckAccess(ctx, ctx.Doer, scope); err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, goproxy_service.ErrNotFound) || errors.Is(err, util.ErrNotExist) {
+			status = http.StatusNotFound
+		}
+		apiError(ctx, status, err)
+		return nil, false, false
+	}
+
+	return repo, true, true
+}
+
+func globalVersionError(ctx *context.Context, err error) {
+	status := http.StatusInternalServerError
+	if errors.Is(err, goproxy_service.ErrNotFound) || errors.Is(err, goproxy_service.ErrGoModNotFound) || errors.Is(err, util.ErrNotExist) {
+		status = http.StatusNotFound
+	} else if errors.Is(err, goproxy_service.ErrInvalidVersion) || errors.Is(err, goproxy_service.ErrGoModMismatch) || errors.Is(err, goproxy_service.ErrGoModTooLarge) {
+		status = http.StatusBadRequest
+	}
+	apiError(ctx, status, err)
+}
+
+func proxyUpstream(ctx *context.Context, modulePath, version, file string) {
+	if setting.Packages.GoProxyURL == "" {
+		apiError(ctx, http.StatusNotFound, goproxy_service.ErrNotFound)
+		return
+	}
+
+	upstreamURL, err := buildUpstreamURL(modulePath, version, file)
+	if err != nil {
+		globalVersionError(ctx, err)
+		return
+	}
+
+	if (file == "info" && version != "latest") || file == "mod" || file == "zip" {
+		proxyUpstreamImmutable(ctx, upstreamURL, modulePath, version, file)
+		return
+	}
+
+	resp, err := upstreamGet(ctx, upstreamURL)
+	if err != nil {
+		apiError(ctx, http.StatusInternalServerError, err)
+		return
+	}
+	defer resp.Body.Close()
+
+	forwardUpstreamResponse(ctx, resp)
+}
+
+func proxyUpstreamImmutable(ctx *context.Context, upstreamURL, modulePath, version, file string) {
+	if version == "latest" {
+		// The Go command requests the latest version through @latest; the
+		// per-owner registry also accepts latest.info/mod/zip, but that is
+		// not part of the upstream proxy protocol.
+		apiError(ctx, http.StatusNotFound, goproxy_service.ErrNotFound)
+		return
+	}
+
+	cacheKey := goProxyCacheKey(modulePath, version, file)
+	if obj, err := storage.Packages.Open(cacheKey); err == nil {
+		serveCachedGoProxyObject(ctx, obj, version+"."+file, goProxyContentType(file))
+		return
+	} else if !errors.Is(err, os.ErrNotExist) {
+		apiError(ctx, http.StatusInternalServerError, err)
+		return
+	}
+
+	handled := false
+	err := globallock.LockAndDo(ctx, "goproxy-cache:"+cacheKey, func(stdcontext.Context) error {
+		if obj, err := storage.Packages.Open(cacheKey); err == nil {
+			_ = obj.Close()
+			return nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+
+		resp, err := upstreamGet(ctx, upstreamURL)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			forwardUpstreamResponse(ctx, resp)
+			handled = true
+			return nil
+		}
+
+		if err := storage.SaveFrom(storage.Packages, cacheKey, func(w io.Writer) error {
+			_, err := io.Copy(w, resp.Body)
+			return err
+		}); err != nil {
+			_ = storage.Packages.Delete(cacheKey)
+			return err
+		}
+		return nil
+	})
+	if handled {
+		return
+	}
+	if err != nil {
+		apiError(ctx, http.StatusInternalServerError, err)
+		return
+	}
+
+	obj, err := storage.Packages.Open(cacheKey)
+	if err != nil {
+		apiError(ctx, http.StatusInternalServerError, err)
+		return
+	}
+	serveCachedGoProxyObject(ctx, obj, version+"."+file, goProxyContentType(file))
+}
+
+func serveCachedGoProxyObject(ctx *context.Context, obj storage.Object, filename, contentType string) {
+	defer obj.Close()
+
+	lastModified := time.Time{}
+	if info, err := obj.Stat(); err == nil {
+		lastModified = info.ModTime()
+	}
+
+	ctx.ServeContent(obj, context.ServeHeaderOptions{
+		ContentType:  contentType,
+		Filename:     filename,
+		LastModified: lastModified,
+	})
+}
+
+func goProxyContentType(file string) string {
+	switch file {
+	case "info":
+		return "application/json"
+	case "mod":
+		return "text/plain;charset=utf-8"
+	case "zip":
+		return "application/zip"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+func goProxyCacheKey(modulePath, version, file string) string {
+	sum := sha256.Sum256([]byte(modulePath + "@" + version + "." + file))
+	encoded := hex.EncodeToString(sum[:])
+	return path.Join("goproxy", encoded[:2], encoded[2:4], encoded)
+}
+
+func upstreamGet(ctx *context.Context, upstreamURL string) (*http.Response, error) {
+	return httplib.NewRequest(upstreamURL, http.MethodGet).SetContext(ctx).Response()
+}
+
+func forwardUpstreamResponse(ctx *context.Context, resp *http.Response) {
+	if contentType := resp.Header.Get("Content-Type"); contentType != "" {
+		ctx.Resp.Header().Set("Content-Type", contentType)
+	}
+	ctx.Resp.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(ctx.Resp, resp.Body)
+}
+
+func buildUpstreamURL(modulePath, version, file string) (string, error) {
+	escapedPath, err := module.EscapePath(modulePath)
+	if err != nil {
+		return "", err
+	}
+
+	base := strings.TrimRight(setting.Packages.GoProxyURL, "/") + "/" + escapedPath
+	switch file {
+	case "":
+		return base + "/@v/list", nil
+	case "latest":
+		return base + "/@latest", nil
+	case "info":
+		if version == "latest" {
+			return base + "/@latest", nil
+		}
+	case "mod", "zip":
+		if version == "latest" {
+			return "", goproxy_service.ErrInvalidVersion
+		}
+	}
+
+	escapedVersion, err := module.EscapeVersion(version)
+	if err != nil {
+		return "", err
+	}
+	return base + "/@v/" + escapedVersion + "." + file, nil
+}

--- a/routers/api/packages/goproxy/proxy.go
+++ b/routers/api/packages/goproxy/proxy.go
@@ -1,0 +1,255 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package goproxy
+
+import (
+	stdcontext "context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"gitea.dev/modules/globallock"
+	"gitea.dev/modules/setting"
+	"gitea.dev/modules/storage"
+	"gitea.dev/modules/util"
+	"gitea.dev/services/context"
+	goproxy_service "gitea.dev/services/packages/goproxy"
+)
+
+type proxyKind uint8
+
+const (
+	proxyKindURL proxyKind = iota
+	proxyKindDirect
+	proxyKindOff
+)
+
+type proxySpec struct {
+	kind            proxyKind
+	url             string
+	fallbackOnError bool
+}
+
+type proxyError struct {
+	status int
+	body   string
+}
+
+func (e *proxyError) Error() string {
+	return e.body
+}
+
+func writeProxyError(ctx *context.Context, err *proxyError) {
+	if err == nil {
+		return
+	}
+	if err.status == 0 {
+		err.status = http.StatusInternalServerError
+	}
+	apiError(ctx, err.status, err)
+}
+
+func versionProxyError(err error) *proxyError {
+	status := http.StatusInternalServerError
+	if errors.Is(err, goproxy_service.ErrNotFound) || errors.Is(err, goproxy_service.ErrGoModNotFound) || errors.Is(err, util.ErrNotExist) {
+		status = http.StatusNotFound
+	} else if errors.Is(err, goproxy_service.ErrInvalidVersion) || errors.Is(err, goproxy_service.ErrGoModMismatch) || errors.Is(err, goproxy_service.ErrGoModTooLarge) {
+		status = http.StatusBadRequest
+	}
+	return &proxyError{status: status, body: err.Error()}
+}
+
+func parseGoProxyList(raw string) ([]proxySpec, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, errors.New("empty GOPROXY list")
+	}
+
+	var specs []proxySpec
+	for raw != "" {
+		item := raw
+		fallbackOnError := false
+		if i := strings.IndexAny(raw, ",|"); i >= 0 {
+			item = raw[:i]
+			fallbackOnError = raw[i] == '|'
+			raw = raw[i+1:]
+		} else {
+			raw = ""
+		}
+
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+
+		switch item {
+		case "off":
+			specs = append(specs, proxySpec{kind: proxyKindOff, fallbackOnError: fallbackOnError})
+			return specs, nil
+		case "direct":
+			specs = append(specs, proxySpec{kind: proxyKindDirect, fallbackOnError: fallbackOnError})
+		case "noproxy":
+			// noproxy is a client-side concept, so skip it when parsing a server-side list.
+			continue
+		default:
+			u, err := url.Parse(item)
+			if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+				return nil, fmt.Errorf("invalid GOPROXY URL %q", item)
+			}
+			specs = append(specs, proxySpec{kind: proxyKindURL, url: item, fallbackOnError: fallbackOnError})
+		}
+	}
+
+	if len(specs) == 0 {
+		return nil, errors.New("empty GOPROXY list")
+	}
+	return specs, nil
+}
+
+func proxyThroughList(ctx *context.Context, modulePath, version, file string) {
+	specs, err := parseGoProxyList(setting.Packages.GoProxyURL)
+	if err != nil {
+		apiError(ctx, http.StatusInternalServerError, err)
+		return
+	}
+
+	var lastErr *proxyError
+	for _, spec := range specs {
+		err := serveProxySpec(ctx, spec, modulePath, version, file)
+		if err == nil {
+			return
+		}
+		lastErr = err
+
+		if spec.fallbackOnError {
+			continue
+		}
+		if err.status == http.StatusNotFound || err.status == http.StatusGone {
+			continue
+		}
+		break
+	}
+
+	if lastErr == nil {
+		lastErr = &proxyError{status: http.StatusNotFound, body: "module not found"}
+	}
+	writeProxyError(ctx, lastErr)
+}
+
+func serveProxySpec(ctx *context.Context, spec proxySpec, modulePath, version, file string) *proxyError {
+	switch spec.kind {
+	case proxyKindOff:
+		return &proxyError{status: http.StatusNotFound, body: "module proxy is off"}
+	case proxyKindDirect:
+		return serveDirectModule(ctx, modulePath, version, file)
+	default:
+		return serveURLProxy(ctx, spec.url, modulePath, version, file)
+	}
+}
+
+func serveURLProxy(ctx *context.Context, upstream, modulePath, version, file string) *proxyError {
+	upstreamURL, err := buildUpstreamURL(upstream, modulePath, version, file)
+	if err != nil {
+		return &proxyError{status: http.StatusBadRequest, body: err.Error()}
+	}
+
+	if (file == "info" && version != "latest") || file == "mod" || file == "zip" {
+		return serveURLProxyImmutable(ctx, upstreamURL, modulePath, version, file)
+	}
+
+	resp, err := upstreamGet(ctx, upstreamURL)
+	if err != nil {
+		return &proxyError{status: http.StatusInternalServerError, body: err.Error()}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return readProxyError(resp)
+	}
+
+	forwardUpstreamResponse(ctx, resp)
+	return nil
+}
+
+func serveURLProxyImmutable(ctx *context.Context, upstreamURL, modulePath, version, file string) *proxyError {
+	if version == "latest" {
+		return &proxyError{status: http.StatusNotFound, body: "latest must be requested through @latest"}
+	}
+
+	cacheKey := goProxyCacheKey(modulePath, version, file)
+	if obj, err := storage.Packages.Open(cacheKey); err == nil {
+		serveCachedGoProxyObject(ctx, obj, version+"."+file, goProxyContentType(file))
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return &proxyError{status: http.StatusInternalServerError, body: err.Error()}
+	}
+
+	var result *proxyError
+	handled := false
+	err := globallock.LockAndDo(ctx, "goproxy-cache:"+cacheKey, func(stdcontext.Context) error {
+		if obj, err := storage.Packages.Open(cacheKey); err == nil {
+			_ = obj.Close()
+			return nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+
+		resp, err := upstreamGet(ctx, upstreamURL)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			result = readProxyError(resp)
+			handled = true
+			return nil
+		}
+
+		if err := storage.SaveFrom(storage.Packages, cacheKey, func(w io.Writer) error {
+			_, err := io.Copy(w, resp.Body)
+			return err
+		}); err != nil {
+			_ = storage.Packages.Delete(cacheKey)
+			return err
+		}
+		return nil
+	})
+
+	if handled {
+		return result
+	}
+	if err != nil {
+		return &proxyError{status: http.StatusInternalServerError, body: err.Error()}
+	}
+
+	obj, err := storage.Packages.Open(cacheKey)
+	if err != nil {
+		return &proxyError{status: http.StatusInternalServerError, body: err.Error()}
+	}
+	serveCachedGoProxyObject(ctx, obj, version+"."+file, goProxyContentType(file))
+	return nil
+}
+
+func serveDirectModule(ctx *context.Context, modulePath, version, file string) *proxyError {
+	repo, cleanup, err := goproxy_service.NewDirectRepository(ctx, modulePath)
+	if err != nil {
+		if errors.Is(err, util.ErrNotExist) {
+			return &proxyError{status: http.StatusNotFound, body: err.Error()}
+		}
+		return &proxyError{status: http.StatusInternalServerError, body: err.Error()}
+	}
+	defer cleanup()
+
+	return serveRepositoryModule(ctx, repo, version, file)
+}
+
+func readProxyError(resp *http.Response) *proxyError {
+	data, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	return &proxyError{status: resp.StatusCode, body: string(data)}
+}

--- a/routers/api/packages/goproxy/proxy_test.go
+++ b/routers/api/packages/goproxy/proxy_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package goproxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGoProxyList(t *testing.T) {
+	t.Run("default list", func(t *testing.T) {
+		specs, err := parseGoProxyList("https://proxy.golang.org,direct")
+		require.NoError(t, err)
+		require.Len(t, specs, 2)
+		assert.Equal(t, proxyKindURL, specs[0].kind)
+		assert.Equal(t, "https://proxy.golang.org", specs[0].url)
+		assert.False(t, specs[0].fallbackOnError)
+		assert.Equal(t, proxyKindDirect, specs[1].kind)
+		assert.False(t, specs[1].fallbackOnError)
+	})
+
+	t.Run("pipe fallback", func(t *testing.T) {
+		specs, err := parseGoProxyList("https://first.example|https://second.example")
+		require.NoError(t, err)
+		require.Len(t, specs, 2)
+		assert.True(t, specs[0].fallbackOnError)
+		assert.False(t, specs[1].fallbackOnError)
+	})
+
+	t.Run("off stops parsing", func(t *testing.T) {
+		specs, err := parseGoProxyList("https://first.example,off,https://ignored.example")
+		require.NoError(t, err)
+		require.Len(t, specs, 2)
+		assert.Equal(t, proxyKindURL, specs[0].kind)
+		assert.Equal(t, proxyKindOff, specs[1].kind)
+	})
+
+	t.Run("rejects invalid url", func(t *testing.T) {
+		_, err := parseGoProxyList("ftp://example.com")
+		assert.Error(t, err)
+	})
+
+	t.Run("rejects empty list", func(t *testing.T) {
+		_, err := parseGoProxyList("")
+		assert.Error(t, err)
+	})
+}

--- a/services/packages/goproxy/direct.go
+++ b/services/packages/goproxy/direct.go
@@ -1,0 +1,39 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package goproxy
+
+import (
+	"context"
+	"net/url"
+	"path/filepath"
+
+	"gitea.dev/modules/git"
+	"gitea.dev/modules/git/gitrepo"
+	"gitea.dev/modules/setting"
+)
+
+// NewDirectRepository creates a temporary bare clone for a module path fetched
+// directly from its VCS. The returned cleanup function removes the clone.
+func NewDirectRepository(ctx context.Context, modulePath string) (*Repository, func(), error) {
+	directURL, err := url.Parse("https://" + modulePath)
+	if err != nil || directURL.Scheme != "https" {
+		return nil, nil, ErrInvalidVersion
+	}
+
+	tmpDir, cleanup, err := setting.AppDataTempDir("goproxy-direct").MkdirTempRandom("repo")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	clonePath := filepath.Join(tmpDir, "repo.git")
+	if err := git.Clone(ctx, directURL.String(), clonePath, git.CloneRepoOptions{Bare: true}); err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+
+	return &Repository{
+		RepoFacade: gitrepo.RepositoryUnmanaged(clonePath),
+		ModulePath: modulePath,
+	}, cleanup, nil
+}

--- a/services/packages/goproxy/repository.go
+++ b/services/packages/goproxy/repository.go
@@ -18,6 +18,7 @@ import (
 	"gitea.dev/models/unit"
 	user_model "gitea.dev/models/user"
 	"gitea.dev/modules/git"
+	"gitea.dev/modules/git/gitrepo"
 	"gitea.dev/modules/setting"
 	"gitea.dev/modules/util"
 
@@ -39,6 +40,7 @@ const maxGoModFileSize = 16 * 1024 * 1024
 // Repository is a Gitea repository that can be served as a Go module.
 type Repository struct {
 	Repo       *repo_model.Repository
+	RepoFacade gitrepo.RepositoryFacade
 	Subdir     string
 	ModulePath string
 }
@@ -70,6 +72,7 @@ func ResolveRepository(ctx context.Context, modulePath string) (*Repository, boo
 
 	return &Repository{
 		Repo:       repo,
+		RepoFacade: repo,
 		Subdir:     subdir,
 		ModulePath: modulePath,
 	}, true, nil
@@ -147,7 +150,7 @@ func (r *Repository) CheckAccess(ctx context.Context, doer *user_model.User, sco
 
 // ListVersions returns canonical module versions that exist for the repository module.
 func (r *Repository) ListVersions(ctx context.Context) ([]string, error) {
-	gitRepo, err := git.OpenRepository(ctx, r.Repo)
+	gitRepo, err := git.OpenRepository(ctx, r.RepoFacade)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +204,7 @@ func (r *Repository) ResolveVersion(ctx context.Context, version string) (*Versi
 		return nil, ErrInvalidVersion
 	}
 
-	gitRepo, err := git.OpenRepository(ctx, r.Repo)
+	gitRepo, err := git.OpenRepository(ctx, r.RepoFacade)
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +247,7 @@ func (r *Repository) hasGoMod(ctx context.Context, gitRepo *git.Repository, comm
 
 // GoMod returns and validates the go.mod file for the version.
 func (v *Version) GoMod(ctx context.Context) ([]byte, error) {
-	gitRepo, err := git.OpenRepository(ctx, v.Repo)
+	gitRepo, err := git.OpenRepository(ctx, v.RepoFacade)
 	if err != nil {
 		return nil, err
 	}

--- a/services/packages/goproxy/repository.go
+++ b/services/packages/goproxy/repository.go
@@ -1,0 +1,294 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package goproxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+
+	auth_model "gitea.dev/models/auth"
+	access_model "gitea.dev/models/perm/access"
+	repo_model "gitea.dev/models/repo"
+	"gitea.dev/models/unit"
+	user_model "gitea.dev/models/user"
+	"gitea.dev/modules/git"
+	"gitea.dev/modules/setting"
+	"gitea.dev/modules/util"
+
+	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/module"
+	"golang.org/x/mod/semver"
+)
+
+var (
+	ErrNotFound       = util.NewNotExistErrorf("module or version not found")
+	ErrInvalidVersion = util.NewInvalidArgumentErrorf("invalid module version")
+	ErrGoModNotFound  = util.NewNotExistErrorf("go.mod not found")
+	ErrGoModMismatch  = util.NewInvalidArgumentErrorf("go.mod module path does not match the requested module")
+	ErrGoModTooLarge  = util.NewInvalidArgumentErrorf("go.mod is too large")
+)
+
+const maxGoModFileSize = 16 * 1024 * 1024
+
+// Repository is a Gitea repository that can be served as a Go module.
+type Repository struct {
+	Repo       *repo_model.Repository
+	Subdir     string
+	ModulePath string
+}
+
+// Version is a Go module version resolved from a repository tag.
+type Version struct {
+	Repository
+	Version  string
+	TagName  string
+	CommitID string
+	Time     time.Time
+}
+
+// ResolveRepository resolves a module path to a repository hosted on this Gitea instance.
+// The second return value reports whether the path looked like a local Gitea module path.
+func ResolveRepository(ctx context.Context, modulePath string) (*Repository, bool, error) {
+	ownerName, repoName, subdir, ok := splitLocalModulePath(modulePath)
+	if !ok {
+		return nil, false, nil
+	}
+
+	repo, err := repo_model.GetRepositoryByOwnerAndName(ctx, ownerName, repoName)
+	if err != nil {
+		if errors.Is(err, util.ErrNotExist) {
+			return nil, true, nil
+		}
+		return nil, true, err
+	}
+
+	return &Repository{
+		Repo:       repo,
+		Subdir:     subdir,
+		ModulePath: modulePath,
+	}, true, nil
+}
+
+func splitLocalModulePath(modulePath string) (ownerName, repoName, subdir string, ok bool) {
+	appURL, err := url.Parse(setting.AppURL)
+	if err != nil {
+		return "", "", "", false
+	}
+
+	parts := strings.Split(modulePath, "/")
+	if len(parts) < 3 || !strings.EqualFold(parts[0], appURL.Hostname()) {
+		return "", "", "", false
+	}
+	parts = parts[1:]
+
+	if setting.AppSubURL != "" {
+		prefix := strings.Split(strings.Trim(setting.AppSubURL, "/"), "/")
+		if len(parts) < len(prefix) {
+			return "", "", "", false
+		}
+		for i, p := range prefix {
+			if parts[i] != p {
+				return "", "", "", false
+			}
+		}
+		parts = parts[len(prefix):]
+	}
+
+	if len(parts) < 2 {
+		return "", "", "", false
+	}
+
+	return parts[0], parts[1], strings.Join(parts[2:], "/"), true
+}
+
+// CheckAccess verifies that doer may read the repository code.
+func (r *Repository) CheckAccess(ctx context.Context, doer *user_model.User, scope auth_model.AccessTokenScope) error {
+	if err := r.Repo.LoadOwner(ctx); err != nil {
+		return err
+	}
+
+	if scope != "" {
+		publicOnly, err := scope.PublicOnly()
+		if err != nil {
+			return err
+		}
+		if publicOnly && (r.Repo.IsPrivate || !r.Repo.Owner.Visibility.IsPublic()) {
+			return ErrNotFound
+		}
+		hasScope, err := scope.HasScope(auth_model.AccessTokenScopeReadRepository)
+		if err != nil {
+			return err
+		}
+		if !hasScope {
+			return ErrNotFound
+		}
+	}
+
+	if !user_model.IsUserVisibleToViewer(ctx, r.Repo.Owner, doer) {
+		return ErrNotFound
+	}
+
+	permission, err := access_model.GetDoerRepoPermission(ctx, r.Repo, doer)
+	if err != nil {
+		return err
+	}
+	if !permission.CanRead(unit.TypeCode) {
+		return ErrNotFound
+	}
+
+	return nil
+}
+
+// ListVersions returns canonical module versions that exist for the repository module.
+func (r *Repository) ListVersions(ctx context.Context) ([]string, error) {
+	gitRepo, err := git.OpenRepository(ctx, r.Repo)
+	if err != nil {
+		return nil, err
+	}
+	defer gitRepo.Close()
+
+	tags, _, err := gitRepo.GetTagInfos(ctx, 0, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	versions := make(map[string]bool, len(tags))
+	for _, tag := range tags {
+		version, ok := canonicalVersion(tag.Name)
+		if !ok {
+			continue
+		}
+		if err := module.Check(r.ModulePath, version); err != nil {
+			continue
+		}
+		if r.hasGoMod(ctx, gitRepo, tag.Object.String()) {
+			versions[version] = true
+		}
+	}
+
+	list := make([]string, 0, len(versions))
+	for version := range versions {
+		list = append(list, version)
+	}
+	semver.Sort(list)
+	return list, nil
+}
+
+// ResolveVersion returns the version requested by the Go command, or the latest
+// version when version is "latest".
+func (r *Repository) ResolveVersion(ctx context.Context, version string) (*Version, error) {
+	if version == "latest" {
+		versions, err := r.ListVersions(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if len(versions) == 0 {
+			return nil, ErrNotFound
+		}
+		version = versions[len(versions)-1]
+	}
+
+	if !semver.IsValid(version) || !strings.HasPrefix(version, "v") {
+		return nil, ErrInvalidVersion
+	}
+	if err := module.Check(r.ModulePath, version); err != nil {
+		return nil, ErrInvalidVersion
+	}
+
+	gitRepo, err := git.OpenRepository(ctx, r.Repo)
+	if err != nil {
+		return nil, err
+	}
+	defer gitRepo.Close()
+
+	tags, _, err := gitRepo.GetTagInfos(ctx, 0, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, tag := range tags {
+		tagVersion, ok := canonicalVersion(tag.Name)
+		if !ok || tagVersion != version {
+			continue
+		}
+		if !r.hasGoMod(ctx, gitRepo, tag.Object.String()) {
+			continue
+		}
+
+		return &Version{
+			Repository: *r,
+			Version:    version,
+			TagName:    tag.Name,
+			CommitID:   tag.Object.String(),
+			Time:       tag.CommitDate.UTC(),
+		}, nil
+	}
+
+	return nil, ErrNotFound
+}
+
+func (r *Repository) hasGoMod(ctx context.Context, gitRepo *git.Repository, commitID string) bool {
+	commit, err := gitRepo.GetCommit(ctx, commitID)
+	if err != nil {
+		return false
+	}
+	entry, err := commit.GetTreeEntryByPath(ctx, gitRepo, path.Join(r.Subdir, "go.mod"))
+	return err == nil && entry.IsRegular()
+}
+
+// GoMod returns and validates the go.mod file for the version.
+func (v *Version) GoMod(ctx context.Context) ([]byte, error) {
+	gitRepo, err := git.OpenRepository(ctx, v.Repo)
+	if err != nil {
+		return nil, err
+	}
+	defer gitRepo.Close()
+
+	commit, err := gitRepo.GetCommit(ctx, v.CommitID)
+	if err != nil {
+		return nil, err
+	}
+	entry, err := commit.GetTreeEntryByPath(ctx, gitRepo, path.Join(v.Subdir, "go.mod"))
+	if err != nil {
+		return nil, ErrGoModNotFound
+	}
+	if !entry.IsRegular() {
+		return nil, ErrGoModNotFound
+	}
+
+	blob := entry.Blob(gitRepo)
+	if blob.Size(ctx) > maxGoModFileSize {
+		return nil, ErrGoModTooLarge
+	}
+
+	data, err := blob.GetBlobContent(ctx, maxGoModFileSize)
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := modfile.Parse("go.mod", []byte(data), nil)
+	if err != nil {
+		return nil, fmt.Errorf("parse go.mod: %w", err)
+	}
+	if file.Module == nil || file.Module.Mod.Path != v.ModulePath {
+		return nil, ErrGoModMismatch
+	}
+
+	return []byte(data), nil
+}
+
+func canonicalVersion(tagName string) (string, bool) {
+	if strings.HasPrefix(tagName, "v") && semver.IsValid(tagName) {
+		return semver.Canonical(tagName), true
+	}
+	if !strings.HasPrefix(tagName, "v") && semver.IsValid("v"+tagName) {
+		return semver.Canonical("v" + tagName), true
+	}
+	return "", false
+}

--- a/services/packages/goproxy/repository_git_test.go
+++ b/services/packages/goproxy/repository_git_test.go
@@ -60,6 +60,7 @@ func TestRepositoryModule(t *testing.T) {
 	repo := &repo_model.Repository{OwnerName: "user", Name: "repo"}
 	moduleRepo := &Repository{
 		Repo:       repo,
+		RepoFacade: repo,
 		ModulePath: "gitea.example.com/user/repo",
 	}
 

--- a/services/packages/goproxy/repository_git_test.go
+++ b/services/packages/goproxy/repository_git_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package goproxy
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	repo_model "gitea.dev/models/repo"
+	"gitea.dev/modules/git"
+	"gitea.dev/modules/setting"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepositoryModule(t *testing.T) {
+	gitBin, err := exec.LookPath("git")
+	require.NoError(t, err)
+
+	root := t.TempDir()
+	oldRepoRootPath, oldAppDataPath := setting.RepoRootPath, setting.AppDataPath
+	oldGitHomePath := setting.Git.HomePath
+	setting.RepoRootPath = root
+	setting.AppDataPath = t.TempDir()
+	setting.Git.HomePath = t.TempDir()
+	defer func() {
+		setting.RepoRootPath, setting.AppDataPath, setting.Git.HomePath = oldRepoRootPath, oldAppDataPath, oldGitHomePath
+	}()
+	require.NoError(t, git.InitSimple())
+
+	workTree := filepath.Join(root, "worktree")
+	require.NoError(t, os.MkdirAll(workTree, os.ModePerm))
+	runGit := func(dir string, args ...string) {
+		cmd := exec.Command(gitBin, args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=Gitea", "GIT_AUTHOR_EMAIL=gitea@example.com", "GIT_COMMITTER_NAME=Gitea", "GIT_COMMITTER_EMAIL=gitea@example.com")
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+
+	runGit(workTree, "init")
+	runGit(workTree, "config", "user.name", "Gitea")
+	runGit(workTree, "config", "user.email", "gitea@example.com")
+	require.NoError(t, os.WriteFile(filepath.Join(workTree, "go.mod"), []byte("module gitea.example.com/user/repo\n\ngo 1.27\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workTree, "main.go"), []byte("package main\n"), 0o644))
+	runGit(workTree, "add", "go.mod", "main.go")
+	runGit(workTree, "commit", "-m", "initial")
+	runGit(workTree, "tag", "v1.2.3")
+
+	barePath := filepath.Join(root, "user", "repo.git")
+	require.NoError(t, os.MkdirAll(filepath.Dir(barePath), os.ModePerm))
+	runGit(root, "clone", "--bare", workTree, barePath)
+
+	repo := &repo_model.Repository{OwnerName: "user", Name: "repo"}
+	moduleRepo := &Repository{
+		Repo:       repo,
+		ModulePath: "gitea.example.com/user/repo",
+	}
+
+	versions, err := moduleRepo.ListVersions(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"v1.2.3"}, versions)
+
+	version, err := moduleRepo.ResolveVersion(t.Context(), "v1.2.3")
+	require.NoError(t, err)
+	assert.Equal(t, "v1.2.3", version.Version)
+	assert.False(t, version.Time.IsZero())
+
+	goMod, err := version.GoMod(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "module gitea.example.com/user/repo\n\ngo 1.27\n", string(goMod))
+
+	var buf bytes.Buffer
+	require.NoError(t, version.CreateZip(t.Context(), &buf))
+
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(zr.File), 2)
+	assert.Equal(t, "gitea.example.com/user/repo@v1.2.3/go.mod", zr.File[0].Name)
+}

--- a/services/packages/goproxy/repository_test.go
+++ b/services/packages/goproxy/repository_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package goproxy
+
+import (
+	"testing"
+
+	"gitea.dev/modules/setting"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitLocalModulePath(t *testing.T) {
+	oldAppURL, oldAppSubURL := setting.AppURL, setting.AppSubURL
+	defer func() {
+		setting.AppURL, setting.AppSubURL = oldAppURL, oldAppSubURL
+	}()
+
+	setting.AppURL = "https://gitea.example.com/"
+	setting.AppSubURL = ""
+
+	tests := []struct {
+		modulePath string
+		owner      string
+		repo       string
+		subdir     string
+		local      bool
+	}{
+		{"gitea.example.com/user/repo", "user", "repo", "", true},
+		{"gitea.example.com/user/repo/sub/pkg", "user", "repo", "sub/pkg", true},
+		{"GITEA.EXAMPLE.COM/user/repo", "user", "repo", "", true},
+		{"github.com/user/repo", "", "", "", false},
+		{"gitea.example.com/user", "", "", "", false},
+	}
+
+	for _, test := range tests {
+		owner, repo, subdir, local := splitLocalModulePath(test.modulePath)
+		assert.Equal(t, test.local, local, test.modulePath)
+		assert.Equal(t, test.owner, owner, test.modulePath)
+		assert.Equal(t, test.repo, repo, test.modulePath)
+		assert.Equal(t, test.subdir, subdir, test.modulePath)
+	}
+}
+
+func TestSplitLocalModulePathWithSubURL(t *testing.T) {
+	oldAppURL, oldAppSubURL := setting.AppURL, setting.AppSubURL
+	defer func() {
+		setting.AppURL, setting.AppSubURL = oldAppURL, oldAppSubURL
+	}()
+
+	setting.AppURL = "https://gitea.example.com/gitea/"
+	setting.AppSubURL = "/gitea"
+
+	owner, repo, subdir, local := splitLocalModulePath("gitea.example.com/gitea/user/repo/pkg")
+	assert.True(t, local)
+	assert.Equal(t, "user", owner)
+	assert.Equal(t, "repo", repo)
+	assert.Equal(t, "pkg", subdir)
+
+	_, _, _, local = splitLocalModulePath("gitea.example.com/user/repo")
+	assert.False(t, local)
+}
+
+func TestCanonicalVersion(t *testing.T) {
+	tests := []struct {
+		tag      string
+		version  string
+		expected bool
+	}{
+		{"v1.2.3", "v1.2.3", true},
+		{"1.2.3", "v1.2.3", true},
+		{"v2.0.0-rc1", "v2.0.0-rc1", true},
+		{"release", "", false},
+		{"v1.2", "v1.2.0", true},
+	}
+
+	for _, test := range tests {
+		version, ok := canonicalVersion(test.tag)
+		assert.Equal(t, test.expected, ok, test.tag)
+		assert.Equal(t, test.version, version, test.tag)
+	}
+}

--- a/services/packages/goproxy/zip.go
+++ b/services/packages/goproxy/zip.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package goproxy
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+
+	"gitea.dev/modules/git"
+	"gitea.dev/modules/git/gitcmd"
+	"gitea.dev/modules/git/gitrepo"
+	"gitea.dev/modules/setting"
+
+	"golang.org/x/mod/module"
+	"golang.org/x/mod/zip"
+)
+
+// CreateZip writes a valid Go module zip for the version to w.
+func (v *Version) CreateZip(ctx context.Context, w io.Writer) error {
+	if _, err := v.GoMod(ctx); err != nil {
+		return err
+	}
+
+	tmpDir, cleanup, err := setting.AppDataTempDir("goproxy").MkdirTempRandom("module")
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	repoPath := gitrepo.RepoLocalPath(v.Repo)
+	if err := git.Clone(ctx, repoPath, tmpDir, git.CloneRepoOptions{Shared: true, NoCheckout: true}); err != nil {
+		return err
+	}
+
+	if _, _, err := gitcmd.NewCommand("checkout", "--detach").AddDynamicArguments(v.CommitID).WithDir(tmpDir).RunStdString(ctx); err != nil {
+		return err
+	}
+
+	dir := tmpDir
+	if v.Subdir != "" {
+		dir = filepath.Join(tmpDir, filepath.FromSlash(v.Subdir))
+	}
+
+	return zip.CreateFromDir(w, module.Version{Path: v.ModulePath, Version: v.Version}, dir)
+}

--- a/services/packages/goproxy/zip.go
+++ b/services/packages/goproxy/zip.go
@@ -29,7 +29,7 @@ func (v *Version) CreateZip(ctx context.Context, w io.Writer) error {
 	}
 	defer cleanup()
 
-	repoPath := gitrepo.RepoLocalPath(v.Repo)
+	repoPath := gitrepo.RepoLocalPath(v.RepoFacade)
 	if err := git.Clone(ctx, repoPath, tmpDir, git.CloneRepoOptions{Shared: true, NoCheckout: true}); err != nil {
 		return err
 	}

--- a/tests/integration/api_packages_goproxy_global_test.go
+++ b/tests/integration/api_packages_goproxy_global_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	auth_model "gitea.dev/models/auth"
+	repo_model "gitea.dev/models/repo"
+	"gitea.dev/models/unittest"
+	user_model "gitea.dev/models/user"
+	"gitea.dev/modules/git"
+	"gitea.dev/modules/git/gitrepo"
+	"gitea.dev/modules/setting"
+	"gitea.dev/tests"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setGlobalGoProxyAppURL(t *testing.T) {
+	t.Helper()
+
+	oldAppURL, oldAppSubURL := setting.AppURL, setting.AppSubURL
+	setting.AppURL = "http://gitea.example.com/"
+	setting.AppSubURL = ""
+	t.Cleanup(func() {
+		setting.AppURL, setting.AppSubURL = oldAppURL, oldAppSubURL
+	})
+}
+
+func prepareGoModuleRepo(t *testing.T, repo *repo_model.Repository, modulePath string) {
+	t.Helper()
+
+	gitBin, err := exec.LookPath("git")
+	require.NoError(t, err)
+	runGit := func(dir string, args ...string) {
+		cmd := exec.Command(gitBin, args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=Gitea", "GIT_AUTHOR_EMAIL=gitea@example.com", "GIT_COMMITTER_NAME=Gitea", "GIT_COMMITTER_EMAIL=gitea@example.com")
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+
+	workTree := t.TempDir()
+	repoPath := gitrepo.RepoLocalPath(repo)
+	require.NoError(t, git.Clone(t.Context(), repoPath, workTree, git.CloneRepoOptions{Shared: true}))
+	require.NoError(t, os.WriteFile(filepath.Join(workTree, "go.mod"), []byte("module "+modulePath+"\n\ngo 1.27\n"), 0o644))
+	runGit(workTree, "add", "go.mod")
+	runGit(workTree, "commit", "-m", "add go.mod")
+	runGit(workTree, "tag", "v1.0.0")
+	runGit(repoPath, "fetch", workTree, "+refs/heads/*:refs/heads/*", "+refs/tags/*:refs/tags/*")
+}
+
+func TestGlobalGoProxyUpstream(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	var listHits, modHits atomic.Int64
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/github.com/foo/bar/@v/list":
+			listHits.Add(1)
+			w.Header().Set("Content-Type", "text/plain;charset=utf-8")
+			_, _ = w.Write([]byte("v1.0.0\n"))
+		case "/github.com/foo/bar/@v/v1.0.0.info":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"Version":"v1.0.0","Time":"2025-01-01T00:00:00Z"}`))
+		case "/github.com/foo/bar/@latest":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"Version":"v1.0.0","Time":"2025-01-01T00:00:00Z"}`))
+		case "/github.com/foo/bar/@v/v1.0.0.mod":
+			modHits.Add(1)
+			w.Header().Set("Content-Type", "text/plain;charset=utf-8")
+			_, _ = w.Write([]byte("module github.com/foo/bar\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	oldGoProxyURL := setting.Packages.GoProxyURL
+	setting.Packages.GoProxyURL = upstream.URL
+	defer func() {
+		setting.Packages.GoProxyURL = oldGoProxyURL
+	}()
+
+	req := NewRequest(t, http.MethodGet, "/api/packages/go/github.com/foo/bar/@v/list")
+	resp := MakeRequest(t, req, http.StatusOK)
+	assert.Equal(t, "v1.0.0\n", resp.Body.String())
+	assert.Equal(t, int64(1), listHits.Load())
+
+	req = NewRequest(t, http.MethodGet, "/api/packages/go/github.com/foo/bar/@v/v1.0.0.mod")
+	resp = MakeRequest(t, req, http.StatusOK)
+	assert.Equal(t, "module github.com/foo/bar\n", resp.Body.String())
+	assert.Equal(t, int64(1), modHits.Load())
+
+	// Immutable module files are cached after the first successful fetch.
+	req = NewRequest(t, http.MethodGet, "/api/packages/go/github.com/foo/bar/@v/v1.0.0.mod")
+	resp = MakeRequest(t, req, http.StatusOK)
+	assert.Equal(t, "module github.com/foo/bar\n", resp.Body.String())
+	assert.Equal(t, int64(1), modHits.Load())
+
+	req = NewRequest(t, http.MethodGet, fmt.Sprintf("/api/packages/go/github.com/foo/bar/@v/%s.info", "v1.0.0"))
+	resp = MakeRequest(t, req, http.StatusOK)
+	assert.Contains(t, resp.Body.String(), `"Version":"v1.0.0"`)
+
+	req = NewRequest(t, http.MethodGet, "/api/packages/go/github.com/foo/bar/@latest")
+	resp = MakeRequest(t, req, http.StatusOK)
+	assert.Contains(t, resp.Body.String(), `"Version":"v1.0.0"`)
+}
+
+func TestGlobalGoProxyLocalRepository(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+	setGlobalGoProxyAppURL(t)
+
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+	prepareGoModuleRepo(t, repo, "gitea.example.com/user2/repo1")
+
+	req := NewRequest(t, http.MethodGet, "/api/packages/go/gitea.example.com/user2/repo1/@v/list")
+	resp := MakeRequest(t, req, http.StatusOK)
+	assert.Equal(t, "v1.0.0\n", resp.Body.String())
+
+	req = NewRequest(t, http.MethodGet, "/api/packages/go/gitea.example.com/user2/repo1/@v/v1.0.0.mod")
+	resp = MakeRequest(t, req, http.StatusOK)
+	assert.Equal(t, "module gitea.example.com/user2/repo1\n\ngo 1.27\n", resp.Body.String())
+
+	req = NewRequest(t, http.MethodGet, "/api/packages/go/gitea.example.com/user2/repo1/@v/v1.0.0.zip")
+	resp = MakeRequest(t, req, http.StatusOK)
+	assert.Equal(t, "application/zip", resp.Header().Get("Content-Type"))
+}
+
+func TestGlobalGoProxyPrivateRepository(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+	setGlobalGoProxyAppURL(t)
+
+	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 16})
+	prepareGoModuleRepo(t, repo, "gitea.example.com/user2/repo16")
+
+	req := NewRequest(t, http.MethodGet, "/api/packages/go/gitea.example.com/user2/repo16/@v/list")
+	MakeRequest(t, req, http.StatusNotFound)
+
+	session := loginUser(t, user.Name)
+	token := getTokenForLoggedInUser(t, session, auth_model.AccessTokenScopeReadRepository)
+
+	req = NewRequest(t, http.MethodGet, "/api/packages/go/gitea.example.com/user2/repo16/@v/list").
+		AddTokenAuth(token)
+	resp := MakeRequest(t, req, http.StatusOK)
+	assert.Equal(t, "v1.0.0\n", resp.Body.String())
+}

--- a/tests/integration/api_packages_goproxy_global_test.go
+++ b/tests/integration/api_packages_goproxy_global_test.go
@@ -117,6 +117,37 @@ func TestGlobalGoProxyUpstream(t *testing.T) {
 	assert.Contains(t, resp.Body.String(), `"Version":"v1.0.0"`)
 }
 
+func TestGlobalGoProxyPipeFallback(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	var upstreamHits atomic.Int64
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/github.com/foo/bar/@v/list" {
+			upstreamHits.Add(1)
+			_, _ = w.Write([]byte("v1.0.0\n"))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer upstream.Close()
+
+	failing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream failed", http.StatusInternalServerError)
+	}))
+	defer failing.Close()
+
+	oldGoProxyURL := setting.Packages.GoProxyURL
+	setting.Packages.GoProxyURL = failing.URL + "|" + upstream.URL
+	defer func() {
+		setting.Packages.GoProxyURL = oldGoProxyURL
+	}()
+
+	req := NewRequest(t, http.MethodGet, "/api/packages/go/github.com/foo/bar/@v/list")
+	resp := MakeRequest(t, req, http.StatusOK)
+	assert.Equal(t, "v1.0.0\n", resp.Body.String())
+	assert.Equal(t, int64(1), upstreamHits.Load())
+}
+
 func TestGlobalGoProxyLocalRepository(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
 	setGlobalGoProxyAppURL(t)


### PR DESCRIPTION
Add a global Go module proxy at `/api/packages/go`.

It serves modules directly from Gitea repositories by resolving semantic
version tags to Go module versions, and transparently proxies non-local
modules to an upstream GOPROXY with immutable-file caching. Private
repositories are protected by Gitea's existing PAT/OAuth2 authentication.

New config: `[packages] GO_PROXY_URL` (default `https://proxy.golang.org`).
