### PR TITLE
fix(compare): show the diff when a comparison has no commits

### DIFF
--- a/templates/repo/commits_table.tmpl
+++ b/templates/repo/commits_table.tmpl
@@ -1,7 +1,7 @@
 <div class="ui top attached header flex-left-right">
 	<div class="flex-text-block">
-		{{if .Commits}}
-			{{if gt .CommitCount 0}}{{.CommitCount}}{{end}}{{/* CommitCount is -1 when "follow rename" */}}
+		{{if or .Commits .IsDiffCompare}}
+			{{if ge .CommitCount 0}}{{.CommitCount}}{{end}}{{/* CommitCount is -1 when "follow rename" */}}
 			{{ctx.Locale.Tr "repo.commits.commits"}}
 		{{else if .IsNothingToCompare}}
 			{{ctx.Locale.Tr "repo.commits.nothing_to_compare"}}

--- a/templates/repo/diff/compare.tmpl
+++ b/templates/repo/diff/compare.tmpl
@@ -168,7 +168,7 @@
 			</div>
 		</div>
 
-		{{$showDiffBox := and .CommitCount (not .IsNothingToCompare)}}
+		{{$showDiffBox := and (not .IsNothingToCompare) (or .CommitCount (not .DiffNotAvailable))}}
 		{{if and .IsSigned .PageIsComparePull}}
 			{{$allowCreatePR := and ($.CompareInfo.BaseRef.IsBranch) ($.CompareInfo.HeadRef.IsBranch) (not $.CompareInfo.DirectComparison) (or $.AllowEmptyPr (not .IsNothingToCompare))}}
 			{{if .IsNothingToCompare}}
@@ -211,7 +211,7 @@
 				</div>
 			{{end}}
 		{{else}}{{/* not signed-in or not for pull-request */}}
-			{{if and (not .CommitCount) $.CompareInfo.CompareBase}}
+			{{if and (not $showDiffBox) $.CompareInfo.CompareBase}}
 				<div class="ui segment">{{ctx.Locale.Tr "repo.commits.nothing_to_compare"}}</div>
 			{{end}}
 		{{end}}

--- a/tests/integration/compare_test.go
+++ b/tests/integration/compare_test.go
@@ -16,6 +16,7 @@ import (
 	"gitea.dev/modules/git"
 	"gitea.dev/modules/git/gitcmd"
 	"gitea.dev/modules/test"
+	"gitea.dev/modules/translation"
 	"gitea.dev/modules/util"
 	"gitea.dev/routers/common"
 	repo_service "gitea.dev/services/repository"
@@ -136,6 +137,24 @@ func TestCompareBranches(t *testing.T) {
 	diffChanges = []string{"test.txt"}
 
 	inspectCompare(t, htmlDoc, diffCount, diffChanges)
+}
+
+// Direct compare of two commits where the head (add-csv) is an ancestor of the base (remove-files-b).
+// This is what the "Compare" link of a force-push comment points to after the push has dropped
+// commits: "base..head" lists no commits, but the diff is not empty and must still be shown.
+func TestCompareDirectHeadIsAncestor(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	session := loginUser(t, "user2")
+	req := NewRequest(t, "GET", "/user2/repo20/compare/8babce967f21b9dfa6987f943b91093dac58a4f0..c8e31bc7688741a5287fcde4fbb8fc129ca07027")
+	resp := session.MakeRequest(t, req, http.StatusOK)
+	htmlDoc := NewHTMLParser(t, resp.Body)
+
+	// 'link_hi' and 'test.csv' are restored, 'test.txt' is deleted
+	inspectCompare(t, htmlDoc, 3, []string{"link_hi", "test.csv", "test.txt"})
+	assert.NotContains(t, resp.Body.String(), translation.NewLocale("en-US").TrString("repo.commits.nothing_to_compare"))
+	commitsHeader := strings.Join(strings.Fields(htmlDoc.doc.Find(".ui.top.attached.header .flex-text-block").First().Text()), " ")
+	assert.Equal(t, "0 "+translation.NewLocale("en-US").TrString("repo.commits.commits"), commitsHeader)
 }
 
 func TestCompareWithRefSuffix(t *testing.T) {

--- a/tests/integration/compare_test.go
+++ b/tests/integration/compare_test.go
@@ -139,9 +139,7 @@ func TestCompareBranches(t *testing.T) {
 	inspectCompare(t, htmlDoc, diffCount, diffChanges)
 }
 
-// Direct compare of two commits where the head (add-csv) is an ancestor of the base (remove-files-b).
-// This is what the "Compare" link of a force-push comment points to after the push has dropped
-// commits: "base..head" lists no commits, but the diff is not empty and must still be shown.
+// Head is an ancestor of base, as after a force-push drops commits: no commits, but a non-empty diff.
 func TestCompareDirectHeadIsAncestor(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
 
@@ -152,7 +150,7 @@ func TestCompareDirectHeadIsAncestor(t *testing.T) {
 
 	// 'link_hi' and 'test.csv' are restored, 'test.txt' is deleted
 	inspectCompare(t, htmlDoc, 3, []string{"link_hi", "test.csv", "test.txt"})
-	assert.NotContains(t, resp.Body.String(), translation.NewLocale("en-US").TrString("repo.commits.nothing_to_compare"))
+	assert.NotContains(t, htmlDoc.doc.Text(), translation.NewLocale("en-US").TrString("repo.commits.nothing_to_compare"))
 	commitsHeader := strings.Join(strings.Fields(htmlDoc.doc.Find(".ui.top.attached.header .flex-text-block").First().Text()), " ")
 	assert.Equal(t, "0 "+translation.NewLocale("en-US").TrString("repo.commits.commits"), commitsHeader)
 }


### PR DESCRIPTION
The compare page only rendered the diff box when the comparison had at least one commit, and otherwise printed "There are no differences to show." A direct comparison whose head is an ancestor of its base hits that case: `base..head` lists no commits, yet the diff is not empty. This is where the Compare link on a force-push comment leads after the push dropped commits, so the link opened an empty page.

The diff box is now shown whenever there are commits or a non-empty diff, and the "no differences" message only appears when there is neither. The commits table header, which was hidden together with the diff box before, reads "0 Commits" in that case. An integration test on the repo20 fixture covers it.

Fixes https://github.com/go-gitea/gitea/issues/36390
