### PR TITLE
fix(repo): surface unrelated histories on Sync Fork

### DIFF
--- a/routers/api/v1/repo/branch.go
+++ b/routers/api/v1/repo/branch.go
@@ -1331,6 +1331,8 @@ func MergeUpstream(ctx *context.APIContext) {
 	//     "$ref": "#/responses/error"
 	//   "404":
 	//     "$ref": "#/responses/notFound"
+	//   "409":
+	//     "$ref": "#/responses/error"
 	form := web.GetForm[*api.MergeUpstreamRequest](ctx)
 	mergeStyle, err := repo_service.MergeUpstream(ctx, ctx.Doer, ctx.Repo.Repository, form.Branch, form.FfOnly)
 	if err != nil {
@@ -1342,6 +1344,9 @@ func MergeUpstream(ctx *context.APIContext) {
 			return
 		} else if errors.Is(err, util.ErrPermissionDenied) {
 			ctx.APIError(http.StatusForbidden, err.Error())
+			return
+		} else if pull_service.IsErrMergeConflicts(err) || pull_service.IsErrMergeUnrelatedHistories(err) {
+			ctx.APIError(http.StatusConflict, err.Error())
 			return
 		}
 		ctx.APIErrorInternal(err)

--- a/routers/web/repo/branch.go
+++ b/routers/web/repo/branch.go
@@ -240,6 +240,9 @@ func MergeUpstream(ctx *context.Context) {
 		} else if pull_service.IsErrMergeConflicts(err) {
 			ctx.JSONError(ctx.Tr("repo.pulls.merge_conflict"))
 			return
+		} else if pull_service.IsErrMergeUnrelatedHistories(err) {
+			ctx.JSONError(ctx.Tr("repo.pulls.unrelated_histories"))
+			return
 		}
 		ctx.ServerError("MergeUpstream", err)
 		return

--- a/templates/swagger/v1-openapi3.generated.json
+++ b/templates/swagger/v1-openapi3.generated.json
@@ -27149,6 +27149,9 @@
           },
           "404": {
             "$ref": "#/components/responses/notFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/error"
           }
         },
         "summary": "Merge a branch from upstream",

--- a/templates/swagger/v1-swagger.generated.json
+++ b/templates/swagger/v1-swagger.generated.json
@@ -14991,6 +14991,9 @@
           },
           "404": {
             "$ref": "#/responses/notFound"
+          },
+          "409": {
+            "$ref": "#/responses/error"
           }
         }
       }


### PR DESCRIPTION
Sync Fork already maps merge conflicts to a JSON error. Unrelated histories still went through `ServerError`, so the UI showed a 500 HTML snippet instead of the same user-facing message PR merge already uses (`repo.pulls.unrelated_histories`).

The API path returned 500 for the same git error; PR merge returns 409. Match that.

Fixes #36772

AI assistance was used to locate the handler gap and draft the mapping. I reviewed and take responsibility for the change.