### PR TITLE
feat(api): add endpoints to set/unset stale flag on pull request review

### DIFF
--- a/models/issues/review.go
+++ b/models/issues/review.go
@@ -636,6 +636,12 @@ func MarkReviewsAsNotStale(ctx context.Context, issueID int64, commitID string) 
 	return err
 }
 
+// UpdateReviewStale updates the stale flag for a single review by ID
+func UpdateReviewStale(ctx context.Context, reviewID int64, stale bool) error {
+	_, err := db.GetEngine(ctx).ID(reviewID).Cols("stale").Update(&Review{Stale: stale})
+	return err
+}
+
 // DismissReview change the dismiss status of a review
 func DismissReview(ctx context.Context, review *Review, isDismiss bool) (err error) {
 	if review.Dismissed == isDismiss || (review.Type != ReviewTypeApprove && review.Type != ReviewTypeReject) {

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -1531,6 +1531,8 @@ func Routes() *web.Router {
 									Get(repo.GetPullReviewComments)
 								m.Post("/dismissals", reqToken(), bind(api.DismissPullReviewOptions{}), repo.DismissPullReview)
 								m.Post("/undismissals", reqToken(), repo.UnDismissPullReview)
+								m.Put("/stale", reqToken(), repo.MarkPullReviewStale)
+								m.Delete("/stale", reqToken(), repo.UnmarkPullReviewStale)
 							})
 						})
 						m.Combo("/requested_reviewers", reqToken()).

--- a/routers/api/v1/repo/pull_review.go
+++ b/routers/api/v1/repo/pull_review.go
@@ -1060,6 +1060,104 @@ func UnDismissPullReview(ctx *context.APIContext) {
 	dismissReview(ctx, "", false, false)
 }
 
+// MarkPullReviewStale marks a pull request review as stale
+func MarkPullReviewStale(ctx *context.APIContext) {
+	// swagger:operation PUT /repos/{owner}/{repo}/pulls/{index}/reviews/{id}/stale repository markPullReviewStale
+	// ---
+	// summary: Mark a pull request review as stale
+	// produces:
+	// - application/json
+	// parameters:
+	// - name: owner
+	//   in: path
+	//   description: owner of the repo
+	//   type: string
+	//   required: true
+	// - name: repo
+	//   in: path
+	//   description: name of the repo
+	//   type: string
+	//   required: true
+	// - name: index
+	//   in: path
+	//   description: index of the pull request
+	//   type: integer
+	//   format: int64
+	//   required: true
+	// - name: id
+	//   in: path
+	//   description: id of the review
+	//   type: integer
+	//   format: int64
+	//   required: true
+	// responses:
+	//   "200":
+	//     "$ref": "#/responses/PullReview"
+	//   "403":
+	//     "$ref": "#/responses/forbidden"
+	//   "404":
+	//     "$ref": "#/responses/notFound"
+	setReviewStale(ctx, true)
+}
+
+// UnmarkPullReviewStale removes the stale flag from a pull request review
+func UnmarkPullReviewStale(ctx *context.APIContext) {
+	// swagger:operation DELETE /repos/{owner}/{repo}/pulls/{index}/reviews/{id}/stale repository unmarkPullReviewStale
+	// ---
+	// summary: Remove the stale flag from a pull request review
+	// produces:
+	// - application/json
+	// parameters:
+	// - name: owner
+	//   in: path
+	//   description: owner of the repo
+	//   type: string
+	//   required: true
+	// - name: repo
+	//   in: path
+	//   description: name of the repo
+	//   type: string
+	//   required: true
+	// - name: index
+	//   in: path
+	//   description: index of the pull request
+	//   type: integer
+	//   format: int64
+	//   required: true
+	// - name: id
+	//   in: path
+	//   description: id of the review
+	//   type: integer
+	//   format: int64
+	//   required: true
+	// responses:
+	//   "200":
+	//     "$ref": "#/responses/PullReview"
+	//   "403":
+	//     "$ref": "#/responses/forbidden"
+	//   "404":
+	//     "$ref": "#/responses/notFound"
+	setReviewStale(ctx, false)
+}
+
+func setReviewStale(ctx *context.APIContext, stale bool) {
+	review, _, isWrong := prepareSingleReview(ctx)
+	if isWrong {
+		return
+	}
+	if err := issues_model.UpdateReviewStale(ctx, review.ID, stale); err != nil {
+		ctx.APIErrorInternal(err)
+		return
+	}
+	review.Stale = stale
+	apiReview, err := convert.ToPullReview(ctx, review, ctx.Doer)
+	if err != nil {
+		ctx.APIErrorInternal(err)
+		return
+	}
+	ctx.JSON(http.StatusOK, apiReview)
+}
+
 func dismissReview(ctx *context.APIContext, msg string, isDismiss, dismissPriors bool) {
 	if !ctx.Repo.Permission.IsAdmin() {
 		ctx.APIError(http.StatusForbidden, "Must be repo admin")

--- a/templates/swagger/v1-openapi3.generated.json
+++ b/templates/swagger/v1-openapi3.generated.json
@@ -30216,6 +30216,124 @@
         ]
       }
     },
+    "/repos/{owner}/{repo}/pulls/{index}/reviews/{id}/stale": {
+      "delete": {
+        "operationId": "unmarkPullReviewStale",
+        "parameters": [
+          {
+            "description": "owner of the repo",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "name of the repo",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "index of the pull request",
+            "in": "path",
+            "name": "index",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "id of the review",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PullReview"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/notFound"
+          }
+        },
+        "summary": "Remove the stale flag from a pull request review",
+        "tags": [
+          "repository"
+        ]
+      },
+      "put": {
+        "operationId": "markPullReviewStale",
+        "parameters": [
+          {
+            "description": "owner of the repo",
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "name of the repo",
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "index of the pull request",
+            "in": "path",
+            "name": "index",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "id of the review",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/PullReview"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/notFound"
+          }
+        },
+        "summary": "Mark a pull request review as stale",
+        "tags": [
+          "repository"
+        ]
+      }
+    },
     "/repos/{owner}/{repo}/pulls/{index}/reviews/{id}/undismissals": {
       "post": {
         "operationId": "repoUnDismissPullReview",

--- a/templates/swagger/v1-swagger.generated.json
+++ b/templates/swagger/v1-swagger.generated.json
@@ -17779,6 +17779,114 @@
         }
       }
     },
+    "/repos/{owner}/{repo}/pulls/{index}/reviews/{id}/stale": {
+      "put": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "repository"
+        ],
+        "summary": "Mark a pull request review as stale",
+        "operationId": "markPullReviewStale",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "owner of the repo",
+            "name": "owner",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "name of the repo",
+            "name": "repo",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "format": "int64",
+            "description": "index of the pull request",
+            "name": "index",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "format": "int64",
+            "description": "id of the review",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/PullReview"
+          },
+          "403": {
+            "$ref": "#/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/responses/notFound"
+          }
+        }
+      },
+      "delete": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "repository"
+        ],
+        "summary": "Remove the stale flag from a pull request review",
+        "operationId": "unmarkPullReviewStale",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "owner of the repo",
+            "name": "owner",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "description": "name of the repo",
+            "name": "repo",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "format": "int64",
+            "description": "index of the pull request",
+            "name": "index",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "format": "int64",
+            "description": "id of the review",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/PullReview"
+          },
+          "403": {
+            "$ref": "#/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/responses/notFound"
+          }
+        }
+      }
+    },
     "/repos/{owner}/{repo}/pulls/{index}/reviews/{id}/undismissals": {
       "post": {
         "produces": [

--- a/tests/integration/api_pull_review_test.go
+++ b/tests/integration/api_pull_review_test.go
@@ -147,6 +147,22 @@ func testAPIPullReviewGeneral(t *testing.T) {
 	assert.EqualValues(t, 6, review.ID)
 	assert.False(t, review.Dismissed)
 
+	// test mark review stale
+	req = NewRequest(t, http.MethodPut, fmt.Sprintf("/api/v1/repos/%s/%s/pulls/%d/reviews/%d/stale", repo.OwnerName, repo.Name, pullIssue.Index, review.ID)).
+		AddTokenAuth(token)
+	resp = MakeRequest(t, req, http.StatusOK)
+	review = DecodeJSON(t, resp, &api.PullReview{})
+	assert.EqualValues(t, 6, review.ID)
+	assert.True(t, review.Stale)
+
+	// test unmark review stale
+	req = NewRequest(t, http.MethodDelete, fmt.Sprintf("/api/v1/repos/%s/%s/pulls/%d/reviews/%d/stale", repo.OwnerName, repo.Name, pullIssue.Index, review.ID)).
+		AddTokenAuth(token)
+	resp = MakeRequest(t, req, http.StatusOK)
+	review = DecodeJSON(t, resp, &api.PullReview{})
+	assert.EqualValues(t, 6, review.ID)
+	assert.False(t, review.Stale)
+
 	// test DeletePullReview
 	req = NewRequestWithJSON(t, http.MethodPost, fmt.Sprintf("/api/v1/repos/%s/%s/pulls/%d/reviews", repo.OwnerName, repo.Name, pullIssue.Index), &api.CreatePullReviewOptions{
 		Body:  "just a comment",


### PR DESCRIPTION
Add API endpoints to manually override the `stale` flag on pull request reviews

Closes #39257 