### PR TITLE
enhance(packages): implement npm single-version API and add per-version repository

### DIFF
--- a/modules/packages/npm/creator.go
+++ b/modules/packages/npm/creator.go
@@ -60,7 +60,7 @@ type PackageMetadata struct {
 	Time           map[string]time.Time               `json:"time,omitempty"`
 	Homepage       string                             `json:"homepage,omitempty"`
 	Keywords       []string                           `json:"keywords,omitempty"`
-	Repository     Repository                         `json:"repository"`
+	Repository     Repository                         `json:"repository,omitzero"`
 	Author         User                               `json:"author"`
 	ReadmeFilename string                             `json:"readmeFilename,omitempty"`
 	Users          map[string]bool                    `json:"users,omitempty"`
@@ -98,7 +98,7 @@ type PackageMetadataVersion struct {
 	Author               User                `json:"author"`
 	Homepage             string              `json:"homepage,omitempty"`
 	License              License             `json:"license,omitempty"`
-	Repository           Repository          `json:"repository"`
+	Repository           Repository          `json:"repository,omitzero"`
 	Keywords             []string            `json:"keywords,omitempty"`
 	Dependencies         map[string]string   `json:"dependencies,omitempty"`
 	BundleDependencies   []string            `json:"bundleDependencies,omitempty"`

--- a/routers/api/packages/api.go
+++ b/routers/api/packages/api.go
@@ -404,10 +404,9 @@ func CommonRoutes() *web.Router {
 			}, reqPackageAccess(perm.AccessModeRead))
 		})
 		r.Group("/npm", func() {
-			r.Group("/@{scope:(?:[^%]|%[^2]|%2[^fF])+}/{id}", func() { // "%2F"-encoded scoped names are one segment
+			r.Group("/@{scope}/{id}", func() {
 				r.Get("", npm.PackageMetadata)
 				r.Put("", reqPackageAccess(perm.AccessModeWrite), npm.UploadPackage)
-				r.Get("/{version}", npm.PackageVersionMetadata)
 				r.Group("/-/{version}/{filename}", func() {
 					r.Get("", npm.DownloadPackageFile)
 					r.Delete("/-rev/{revision}", reqPackageAccess(perm.AccessModeWrite), npm.DeletePackageVersion)
@@ -420,8 +419,8 @@ func CommonRoutes() *web.Router {
 			})
 			r.Group("/{id}", func() {
 				r.Get("", npm.PackageMetadata)
+				r.Get("/{version}", npm.PackageMetadata)
 				r.Put("", reqPackageAccess(perm.AccessModeWrite), npm.UploadPackage)
-				r.Get("/{version}", npm.PackageVersionMetadata)
 				r.Group("/-/{version}/{filename}", func() {
 					r.Get("", npm.DownloadPackageFile)
 					r.Delete("/-rev/{revision}", reqPackageAccess(perm.AccessModeWrite), npm.DeletePackageVersion)

--- a/routers/api/packages/api.go
+++ b/routers/api/packages/api.go
@@ -404,9 +404,10 @@ func CommonRoutes() *web.Router {
 			}, reqPackageAccess(perm.AccessModeRead))
 		})
 		r.Group("/npm", func() {
-			r.Group("/@{scope}/{id}", func() {
+			r.Group("/@{scope:(?:[^%]|%[^2]|%2[^fF])+}/{id}", func() { // "%2F"-encoded scoped names are one segment and must match "/{id}"
 				r.Get("", npm.PackageMetadata)
 				r.Put("", reqPackageAccess(perm.AccessModeWrite), npm.UploadPackage)
+				r.Get("/{version}", npm.PackageVersionMetadata)
 				r.Group("/-/{version}/{filename}", func() {
 					r.Get("", npm.DownloadPackageFile)
 					r.Delete("/-rev/{revision}", reqPackageAccess(perm.AccessModeWrite), npm.DeletePackageVersion)
@@ -420,6 +421,7 @@ func CommonRoutes() *web.Router {
 			r.Group("/{id}", func() {
 				r.Get("", npm.PackageMetadata)
 				r.Put("", reqPackageAccess(perm.AccessModeWrite), npm.UploadPackage)
+				r.Get("/{version}", npm.PackageVersionMetadata)
 				r.Group("/-/{version}/{filename}", func() {
 					r.Get("", npm.DownloadPackageFile)
 					r.Delete("/-rev/{revision}", reqPackageAccess(perm.AccessModeWrite), npm.DeletePackageVersion)

--- a/routers/api/packages/api.go
+++ b/routers/api/packages/api.go
@@ -404,7 +404,7 @@ func CommonRoutes() *web.Router {
 			}, reqPackageAccess(perm.AccessModeRead))
 		})
 		r.Group("/npm", func() {
-			r.Group("/@{scope:(?:[^%]|%[^2]|%2[^fF])+}/{id}", func() { // "%2F"-encoded scoped names are one segment and must match "/{id}"
+			r.Group("/@{scope:(?:[^%]|%[^2]|%2[^fF])+}/{id}", func() { // "%2F"-encoded scoped names are one segment
 				r.Get("", npm.PackageMetadata)
 				r.Put("", reqPackageAccess(perm.AccessModeWrite), npm.UploadPackage)
 				r.Get("/{version}", npm.PackageVersionMetadata)

--- a/routers/api/packages/npm/api.go
+++ b/routers/api/packages/npm/api.go
@@ -78,6 +78,7 @@ func createPackageMetadataVersion(registryURL string, pd *packages_model.Package
 		Maintainers:          []npm_module.User{{Name: pd.Owner.Name}},
 		Homepage:             metadata.ProjectURL,
 		License:              metadata.License,
+		Repository:           metadata.Repository,
 		Keywords:             metadata.Keywords,
 		Dependencies:         metadata.Dependencies,
 		BundleDependencies:   metadata.BundleDependencies,

--- a/routers/api/packages/npm/api.go
+++ b/routers/api/packages/npm/api.go
@@ -4,6 +4,7 @@
 package npm
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -13,7 +14,6 @@ import (
 
 	packages_model "gitea.dev/models/packages"
 	npm_module "gitea.dev/modules/packages/npm"
-	"gitea.dev/modules/setting"
 )
 
 func createPackageMetadataResponse(registryURL string, pds []*packages_model.PackageDescriptor) *npm_module.PackageMetadata {
@@ -105,7 +105,7 @@ func createPackageMetadataVersion(registryURL string, pd *packages_model.Package
 	}
 }
 
-func createPackageSearchResponse(pds []*packages_model.PackageDescriptor, total int64) *npm_module.PackageSearch {
+func createPackageSearchResponse(ctx context.Context, pds []*packages_model.PackageDescriptor, total int64) *npm_module.PackageSearch {
 	objects := make([]*npm_module.PackageSearchObject, 0, len(pds))
 	for _, pd := range pds {
 		metadata := packages_model.DescriptorMetadata[*npm_module.Metadata](pd)
@@ -127,7 +127,7 @@ func createPackageSearchResponse(pds []*packages_model.PackageDescriptor, total 
 				Maintainers: []npm_module.User{}, // npm cli needs this field
 				Keywords:    metadata.Keywords,
 				Links: &npm_module.PackageSearchPackageLinks{
-					Registry: setting.AppURL + "api/packages/" + pd.Owner.Name + "/npm",
+					Registry: buildNpmRegistryURL(ctx, pd.Owner),
 					Homepage: metadata.ProjectURL,
 				},
 			},

--- a/routers/api/packages/npm/api_test.go
+++ b/routers/api/packages/npm/api_test.go
@@ -9,6 +9,7 @@ import (
 
 	packages_model "gitea.dev/models/packages"
 	user_model "gitea.dev/models/user"
+	"gitea.dev/modules/json"
 	npm_module "gitea.dev/modules/packages/npm"
 	"gitea.dev/modules/timeutil"
 
@@ -17,13 +18,14 @@ import (
 )
 
 func TestCreatePackageMetadataResponse(t *testing.T) {
-	descriptor := func(v string, publishedUnix int64) *packages_model.PackageDescriptor {
+	repository := npm_module.Repository{Type: "git", URL: "https://gitea.dev/alice/test.git"}
+	descriptor := func(v string, publishedUnix int64, repo npm_module.Repository) *packages_model.PackageDescriptor {
 		return &packages_model.PackageDescriptor{
 			Package:  &packages_model.Package{Name: "@scope/test"},
 			Owner:    &user_model.User{Name: "alice"},
 			Version:  &packages_model.PackageVersion{Version: v, CreatedUnix: timeutil.TimeStamp(publishedUnix)},
 			SemVer:   version.Must(version.NewVersion(v)),
-			Metadata: &npm_module.Metadata{Keywords: []string{"gitea"}},
+			Metadata: &npm_module.Metadata{Keywords: []string{"gitea"}, Repository: repo},
 			Files: []*packages_model.PackageFileDescriptor{{
 				File: &packages_model.PackageFile{LowerName: "test-" + v + ".tgz"},
 				Blob: &packages_model.PackageBlob{},
@@ -32,8 +34,8 @@ func TestCreatePackageMetadataResponse(t *testing.T) {
 	}
 
 	result := createPackageMetadataResponse("https://gitea.dev/api/packages/alice/npm", []*packages_model.PackageDescriptor{
-		descriptor("1.1.0", 1000),
-		descriptor("1.0.0", 2000),
+		descriptor("1.1.0", 1000, npm_module.Repository{}),
+		descriptor("1.0.0", 2000, repository),
 	})
 
 	assert.Equal(t, map[string]time.Time{
@@ -50,4 +52,15 @@ func TestCreatePackageMetadataResponse(t *testing.T) {
 		"https://gitea.dev/api/packages/alice/npm/@scope%2Ftest/-/1.0.0/test-1.0.0.tgz",
 		result.Versions["1.0.0"].Dist.Tarball,
 	)
+	assert.Equal(t, repository, result.Versions["1.0.0"].Repository)
+
+	withoutRepository, err := json.Marshal(result.Versions["1.1.0"])
+	assert.NoError(t, err)
+	assert.NotContains(t, string(withoutRepository), `"repository"`)
+
+	raw, err := json.Marshal(result)
+	assert.NoError(t, err)
+	var doc map[string]any
+	assert.NoError(t, json.Unmarshal(raw, &doc))
+	assert.NotContains(t, doc, "repository")
 }

--- a/routers/api/packages/npm/api_test.go
+++ b/routers/api/packages/npm/api_test.go
@@ -17,6 +17,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestSplitPackagePath(t *testing.T) {
+	for _, c := range []struct{ path, name, version string }{
+		{path: "pkg", name: "pkg"},
+		{path: "pkg/1.0.0", name: "pkg", version: "1.0.0"},
+		{path: "@scope/pkg", name: "@scope/pkg"},
+		{path: "@scope/pkg/1.0.0", name: "@scope/pkg", version: "1.0.0"},
+	} {
+		name, version := splitPackagePath(c.path)
+		assert.Equal(t, c.name, name, c.path)
+		assert.Equal(t, c.version, version, c.path)
+	}
+}
+
 func TestCreatePackageMetadataResponse(t *testing.T) {
 	repository := npm_module.Repository{Type: "git", URL: "https://gitea.dev/alice/test.git"}
 	descriptor := func(v string, publishedUnix int64, repo npm_module.Repository) *packages_model.PackageDescriptor {

--- a/routers/api/packages/npm/npm.go
+++ b/routers/api/packages/npm/npm.go
@@ -79,6 +79,43 @@ func PackageMetadata(ctx *context.Context) {
 	ctx.JSON(http.StatusOK, resp)
 }
 
+// PackageVersionMetadata returns the metadata of a single version, addressed by version or dist-tag
+func PackageVersionMetadata(ctx *context.Context) {
+	versionOrTag := ctx.PathParam("version")
+
+	opts := &packages_model.PackageSearchOptions{
+		OwnerID:    ctx.Package.Owner.ID,
+		Type:       packages_model.TypeNpm,
+		Name:       packages_model.SearchValue{ExactMatch: true, Value: packageNameFromParams(ctx)},
+		IsInternal: optional.Some(false),
+	}
+	if _, err := version.NewVersion(versionOrTag); err == nil {
+		opts.Version = packages_model.SearchValue{ExactMatch: true, Value: versionOrTag}
+	} else { // setPackageTag rejects tags that parse as versions, so this is a tag
+		opts.Properties = map[string]string{npm_module.TagProperty: versionOrTag}
+	}
+	pvs, _, err := packages_model.SearchVersions(ctx, opts)
+	if err != nil {
+		apiError(ctx, http.StatusInternalServerError, err)
+		return
+	}
+	if len(pvs) != 1 {
+		apiError(ctx, http.StatusNotFound, "version not found: "+versionOrTag)
+		return
+	}
+
+	pd, err := packages_model.GetPackageDescriptor(ctx, pvs[0])
+	if err != nil {
+		apiError(ctx, http.StatusInternalServerError, err)
+		return
+	}
+
+	ctx.JSON(http.StatusOK, createPackageMetadataVersion(
+		setting.AppURL+"api/packages/"+ctx.Package.Owner.Name+"/npm",
+		pd,
+	))
+}
+
 // DownloadPackageFile serves the content of a package
 func DownloadPackageFile(ctx *context.Context) {
 	packageName := packageNameFromParams(ctx)

--- a/routers/api/packages/npm/npm.go
+++ b/routers/api/packages/npm/npm.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"gitea.dev/models/db"
@@ -17,6 +18,8 @@ import (
 	access_model "gitea.dev/models/perm/access"
 	repo_model "gitea.dev/models/repo"
 	"gitea.dev/models/unit"
+	user_model "gitea.dev/models/user"
+	"gitea.dev/modules/httplib"
 	"gitea.dev/modules/json"
 	"gitea.dev/modules/optional"
 	packages_module "gitea.dev/modules/packages"
@@ -59,6 +62,10 @@ func packageNameFromParams(ctx *context.Context) string {
 	return fullOrSub // id is the full package name, e.g.: "@angular/core" or "lodash"
 }
 
+func buildNpmRegistryURL(ctx std_ctx.Context, owner *user_model.User) string {
+	return httplib.MakeAbsoluteURL(ctx, setting.AppSubURL+"/api/packages/"+url.PathEscape(owner.Name)+"/npm")
+}
+
 // PackageMetadata returns the metadata for a single package
 func PackageMetadata(ctx *context.Context) {
 	packageName := packageNameFromParams(ctx)
@@ -79,11 +86,7 @@ func PackageMetadata(ctx *context.Context) {
 		return
 	}
 
-	resp := createPackageMetadataResponse(
-		setting.AppURL+"api/packages/"+ctx.Package.Owner.Name+"/npm",
-		pds,
-	)
-
+	resp := createPackageMetadataResponse(buildNpmRegistryURL(ctx, ctx.Package.Owner), pds)
 	ctx.JSON(http.StatusOK, resp)
 }
 
@@ -118,10 +121,7 @@ func PackageVersionMetadata(ctx *context.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, createPackageMetadataVersion(
-		setting.AppURL+"api/packages/"+ctx.Package.Owner.Name+"/npm",
-		pd,
-	))
+	ctx.JSON(http.StatusOK, createPackageMetadataVersion(buildNpmRegistryURL(ctx, ctx.Package.Owner), pd))
 }
 
 // DownloadPackageFile serves the content of a package
@@ -560,10 +560,7 @@ func PackageSearch(ctx *context.Context) {
 		return
 	}
 
-	resp := createPackageSearchResponse(
-		pds,
-		total,
-	)
+	resp := createPackageSearchResponse(ctx, pds, total)
 
 	ctx.JSON(http.StatusOK, resp)
 }

--- a/routers/api/packages/npm/npm.go
+++ b/routers/api/packages/npm/npm.go
@@ -24,7 +24,6 @@ import (
 	"gitea.dev/modules/optional"
 	packages_module "gitea.dev/modules/packages"
 	npm_module "gitea.dev/modules/packages/npm"
-	"gitea.dev/modules/setting"
 	"gitea.dev/modules/util"
 	"gitea.dev/routers/api/packages/helper"
 	"gitea.dev/services/context"
@@ -63,7 +62,7 @@ func packageNameFromParams(ctx *context.Context) string {
 }
 
 func buildNpmRegistryURL(ctx std_ctx.Context, owner *user_model.User) string {
-	return httplib.MakeAbsoluteURL(ctx, setting.AppSubURL+"/api/packages/"+url.PathEscape(owner.Name)+"/npm")
+	return httplib.GuessCurrentAppURL(ctx) + "api/packages/" + url.PathEscape(owner.Name) + "/npm"
 }
 
 // PackageMetadata returns the metadata for a single package

--- a/routers/api/packages/npm/npm.go
+++ b/routers/api/packages/npm/npm.go
@@ -40,6 +40,15 @@ func apiError(ctx *context.Context, status int, obj any) {
 	})
 }
 
+func splitPackagePath(path string) (name, version string) {
+	parts := strings.Split(path, "/")
+	nameLen := util.Iif(strings.HasPrefix(path, "@"), 2, 1)
+	if len(parts) <= nameLen {
+		return path, ""
+	}
+	return strings.Join(parts[:nameLen], "/"), parts[nameLen]
+}
+
 // packageNameFromParams gets the package name from the url parameters
 // Variations: /name/, /@scope/name/, /@scope%2Fname/
 func packageNameFromParams(ctx *context.Context) string {
@@ -51,9 +60,14 @@ func packageNameFromParams(ctx *context.Context) string {
 	return id
 }
 
-// PackageMetadata returns the metadata for a single package
+// PackageMetadata returns the metadata for a package or one of its versions
 func PackageMetadata(ctx *context.Context) {
-	packageName := packageNameFromParams(ctx)
+	packageName, packageVersion := splitPackagePath(packageNameFromParams(ctx))
+	packageVersion = util.IfZero(packageVersion, ctx.PathParam("version"))
+	if packageVersion != "" {
+		packageVersionMetadata(ctx, packageName, packageVersion)
+		return
+	}
 
 	pvs, err := packages_model.GetVersionsByPackageName(ctx, ctx.Package.Owner.ID, packages_model.TypeNpm, packageName)
 	if err != nil {
@@ -79,15 +93,13 @@ func PackageMetadata(ctx *context.Context) {
 	ctx.JSON(http.StatusOK, resp)
 }
 
-// PackageVersionMetadata returns the metadata of a single version, addressed by version or dist-tag
-func PackageVersionMetadata(ctx *context.Context) {
-	versionOrTag := ctx.PathParam("version")
-
+func packageVersionMetadata(ctx *context.Context, packageName, versionOrTag string) {
 	opts := &packages_model.PackageSearchOptions{
 		OwnerID:    ctx.Package.Owner.ID,
 		Type:       packages_model.TypeNpm,
-		Name:       packages_model.SearchValue{ExactMatch: true, Value: packageNameFromParams(ctx)},
+		Name:       packages_model.SearchValue{ExactMatch: true, Value: packageName},
 		IsInternal: optional.Some(false),
+		Paginator:  db.NewAbsoluteListOptions(0, 1),
 	}
 	if _, err := version.NewVersion(versionOrTag); err == nil {
 		opts.Version = packages_model.SearchValue{ExactMatch: true, Value: versionOrTag}
@@ -99,7 +111,7 @@ func PackageVersionMetadata(ctx *context.Context) {
 		apiError(ctx, http.StatusInternalServerError, err)
 		return
 	}
-	if len(pvs) != 1 {
+	if len(pvs) == 0 {
 		apiError(ctx, http.StatusNotFound, "version not found: "+versionOrTag)
 		return
 	}

--- a/tests/integration/api_packages_npm_test.go
+++ b/tests/integration/api_packages_npm_test.go
@@ -231,14 +231,17 @@ func TestPackageNpm(t *testing.T) {
 		assert.Equal(t, "https://example.com/fund", pmv.Funding)
 		assert.Equal(t, map[string]string{"left-pad": "1.x"}, pmv.AcceptDependencies)
 		assert.Empty(t, pmv.Deprecated)
+
+		req = NewRequest(t, "GET", fmt.Sprintf("/api/packages/%s/npm/%s", user.Name, packageName)).
+			AddTokenAuth(token)
+		resp = MakeRequest(t, req, http.StatusOK)
+		assert.Equal(t, packageName, DecodeJSON(t, resp, &npm.PackageMetadata{}).Name)
 	})
 
 	t.Run("PackageVersionMetadata", func(t *testing.T) {
 		defer tests.PrintCurrentTest(t)()
 
-		unescapedRoot := fmt.Sprintf("/api/packages/%s/npm/%s", user.Name, packageName)
-		overEncodedRoot := fmt.Sprintf("/api/packages/%s/npm/@%%73cope/test-package", user.Name)
-		for _, path := range []string{root + "/" + packageVersion, root + "/" + packageTag, unescapedRoot + "/" + packageVersion, unescapedRoot + "/" + packageTag, overEncodedRoot + "/" + packageVersion} {
+		for _, path := range []string{root + "/" + packageVersion, root + "/" + packageTag} {
 			req := NewRequest(t, "GET", path).
 				AddTokenAuth(token)
 			resp := MakeRequest(t, req, http.StatusOK)
@@ -246,7 +249,6 @@ func TestPackageNpm(t *testing.T) {
 			pmv := DecodeJSON(t, resp, &npm.PackageMetadataVersion{})
 			assert.Equal(t, fmt.Sprintf("%s@%s", packageName, packageVersion), pmv.ID)
 			assert.Equal(t, npm.Repository{Type: repoType, URL: repoURL, Directory: repoDirectory}, pmv.Repository)
-			assert.Equal(t, fmt.Sprintf("%s%s/-/%s/%s", setting.AppURL, root[1:], packageVersion, filename), pmv.Dist.Tarball)
 		}
 
 		for _, missing := range []string{"9.9.9", "no-such-tag"} {
@@ -308,11 +310,6 @@ func TestPackageNpm(t *testing.T) {
 		assert.Equal(t, packageVersion, result.DistTags[packageTag])
 		assert.Contains(t, result.DistTags, packageTag2)
 		assert.Equal(t, packageVersion, result.DistTags[packageTag2])
-
-		req = NewRequest(t, "GET", root+"/"+packageTag2).
-			AddTokenAuth(token)
-		resp = MakeRequest(t, req, http.StatusOK)
-		assert.Equal(t, packageVersion, DecodeJSON(t, resp, &npm.PackageMetadataVersion{}).Version)
 	})
 
 	t.Run("DeleteTag", func(t *testing.T) {
@@ -328,10 +325,6 @@ func TestPackageNpm(t *testing.T) {
 		test(t, http.StatusBadRequest, "1.0")
 		test(t, http.StatusOK, "dummy")
 		test(t, http.StatusOK, packageTag2)
-
-		req := NewRequest(t, "GET", root+"/"+packageTag2).
-			AddTokenAuth(token)
-		MakeRequest(t, req, http.StatusNotFound)
 	})
 
 	t.Run("Search", func(t *testing.T) {
@@ -509,6 +502,52 @@ func TestPackageNpm(t *testing.T) {
 
 		// Clean up so the subsequent Delete subtest's version counts match.
 		req = NewRequest(t, "DELETE", claimRoot+"/-rev/dummy").AddTokenAuth(token)
+		MakeRequest(t, req, http.StatusOK)
+	})
+
+	t.Run("UnscopedPackageVersionMetadata", func(t *testing.T) {
+		defer tests.PrintCurrentTest(t)()
+
+		unscopedName := "test-unscoped"
+		unscopedRoot := fmt.Sprintf("/api/packages/%s/npm/%s", user.Name, unscopedName)
+		body := `{
+			"_id": "` + unscopedName + `",
+			"name": "` + unscopedName + `",
+			"dist-tags": {
+			  "` + packageTag + `": "1.0.0"
+			},
+			"versions": {
+				"1.0.0": {
+					"name": "` + unscopedName + `",
+					"version": "1.0.0",
+					"dist": {
+					  "integrity": "` + integrity + `",
+					  "shasum": "` + sha1SumHex + `"
+					}
+				}
+			},
+			"_attachments": {
+			  "` + unscopedName + `-1.0.0.tgz": {
+				"data": "` + attachmentData + `"
+			  }
+			}
+		  }`
+		req := NewRequestWithBody(t, "PUT", unscopedRoot, strings.NewReader(body)).
+			AddTokenAuth(token)
+		MakeRequest(t, req, http.StatusCreated)
+
+		for _, selector := range []string{"1.0.0", packageTag} {
+			req = NewRequest(t, "GET", unscopedRoot+"/"+selector).
+				AddTokenAuth(token)
+			resp := MakeRequest(t, req, http.StatusOK)
+			assert.Equal(t, unscopedName+"@1.0.0", DecodeJSON(t, resp, &npm.PackageMetadataVersion{}).ID)
+		}
+
+		req = NewRequest(t, "GET", unscopedRoot+"/9.9.9").
+			AddTokenAuth(token)
+		MakeRequest(t, req, http.StatusNotFound)
+
+		req = NewRequest(t, "DELETE", unscopedRoot+"/-rev/dummy").AddTokenAuth(token)
 		MakeRequest(t, req, http.StatusOK)
 	})
 

--- a/tests/integration/api_packages_npm_test.go
+++ b/tests/integration/api_packages_npm_test.go
@@ -219,6 +219,7 @@ func TestPackageNpm(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("%s%s/-/%s/%s", setting.AppURL, root[1:], packageVersion, filename), pmv.Dist.Tarball)
 		assert.Equal(t, repoType, result.Repository.Type)
 		assert.Equal(t, repoURL, result.Repository.URL)
+		assert.Equal(t, npm.Repository{Type: repoType, URL: repoURL, Directory: repoDirectory}, pmv.Repository)
 		assert.Equal(t, map[string]string{"tea": "2.x", "soy-milk": "1.2"}, pmv.PeerDependencies)
 		assert.Equal(t, map[string]any{"soy-milk": map[string]any{"optional": true}}, pmv.PeerDependenciesMeta)
 		assert.True(t, pmv.HasInstallScript)
@@ -230,6 +231,29 @@ func TestPackageNpm(t *testing.T) {
 		assert.Equal(t, "https://example.com/fund", pmv.Funding)
 		assert.Equal(t, map[string]string{"left-pad": "1.x"}, pmv.AcceptDependencies)
 		assert.Empty(t, pmv.Deprecated)
+	})
+
+	t.Run("PackageVersionMetadata", func(t *testing.T) {
+		defer tests.PrintCurrentTest(t)()
+
+		unescapedRoot := fmt.Sprintf("/api/packages/%s/npm/%s", user.Name, packageName)
+		overEncodedRoot := fmt.Sprintf("/api/packages/%s/npm/@%%73cope/test-package", user.Name)
+		for _, path := range []string{root + "/" + packageVersion, root + "/" + packageTag, unescapedRoot + "/" + packageVersion, unescapedRoot + "/" + packageTag, overEncodedRoot + "/" + packageVersion} {
+			req := NewRequest(t, "GET", path).
+				AddTokenAuth(token)
+			resp := MakeRequest(t, req, http.StatusOK)
+
+			pmv := DecodeJSON(t, resp, &npm.PackageMetadataVersion{})
+			assert.Equal(t, fmt.Sprintf("%s@%s", packageName, packageVersion), pmv.ID)
+			assert.Equal(t, npm.Repository{Type: repoType, URL: repoURL, Directory: repoDirectory}, pmv.Repository)
+			assert.Equal(t, fmt.Sprintf("%s%s/-/%s/%s", setting.AppURL, root[1:], packageVersion, filename), pmv.Dist.Tarball)
+		}
+
+		for _, missing := range []string{"9.9.9", "no-such-tag"} {
+			req := NewRequest(t, "GET", root+"/"+missing).
+				AddTokenAuth(token)
+			MakeRequest(t, req, http.StatusNotFound)
+		}
 	})
 
 	t.Run("AddTag", func(t *testing.T) {
@@ -284,6 +308,11 @@ func TestPackageNpm(t *testing.T) {
 		assert.Equal(t, packageVersion, result.DistTags[packageTag])
 		assert.Contains(t, result.DistTags, packageTag2)
 		assert.Equal(t, packageVersion, result.DistTags[packageTag2])
+
+		req = NewRequest(t, "GET", root+"/"+packageTag2).
+			AddTokenAuth(token)
+		resp = MakeRequest(t, req, http.StatusOK)
+		assert.Equal(t, packageVersion, DecodeJSON(t, resp, &npm.PackageMetadataVersion{}).Version)
 	})
 
 	t.Run("DeleteTag", func(t *testing.T) {
@@ -299,6 +328,10 @@ func TestPackageNpm(t *testing.T) {
 		test(t, http.StatusBadRequest, "1.0")
 		test(t, http.StatusOK, "dummy")
 		test(t, http.StatusOK, packageTag2)
+
+		req := NewRequest(t, "GET", root+"/"+packageTag2).
+			AddTokenAuth(token)
+		MakeRequest(t, req, http.StatusNotFound)
 	})
 
 	t.Run("Search", func(t *testing.T) {


### PR DESCRIPTION
Implements `GET /{package}/{version}`. It resolves a version number or a dist-tag, as per https://github.com/npm/registry/blob/main/docs/REGISTRY-API.md.

Also fills `repository` on each version of the packument, and omits it for packages that declare none.

Assisted-by: Claude Code:claude-fable-5-1
