### PR TITLE
fix(git): return no submodule web link when the URL cannot be parsed

### DIFF
--- a/modules/git/commit_submodule_file.go
+++ b/modules/git/commit_submodule_file.go
@@ -46,11 +46,11 @@ func (sf *CommitSubmoduleFile) getWebLinkInTargetRepo(ctx context.Context, moreL
 		return &SubmoduleWebLink{RepoWebLink: targetLink, CommitWebLink: targetLink + moreLinkPath}
 	}
 	if !sf.parsed {
-		sf.parsed = true
 		parsedURL, err := giturl.ParseRepositoryURL(ctx, sf.refURL)
 		if err != nil {
-			return nil
+			return nil // do not mark as parsed, otherwise later calls would return a link with an empty target
 		}
+		sf.parsed = true
 		sf.parsedTargetLink = giturl.MakeRepositoryWebLink(parsedURL)
 	}
 	return &SubmoduleWebLink{RepoWebLink: sf.parsedTargetLink, CommitWebLink: sf.parsedTargetLink + moreLinkPath}

--- a/modules/git/commit_submodule_file_test.go
+++ b/modules/git/commit_submodule_file_test.go
@@ -38,3 +38,9 @@ func TestCommitSubmoduleLink(t *testing.T) {
 		assert.Equal(t, "/subpath/user/repo/compare/1111...2222", wl.CommitWebLink)
 	})
 }
+
+func TestCommitSubmoduleLinkUnparsableURL(t *testing.T) {
+	sf := NewCommitSubmoduleFile("/any/repo-link", "full-path", "git@github.com:", "aaaa")
+	assert.Nil(t, sf.SubmoduleWebLinkTree(t.Context()))
+	assert.Nil(t, sf.SubmoduleWebLinkCompare(t.Context(), "1111", "2222"))
+}

--- a/modules/git/commit_submodule_file_test.go
+++ b/modules/git/commit_submodule_file_test.go
@@ -37,10 +37,11 @@ func TestCommitSubmoduleLink(t *testing.T) {
 		assert.Equal(t, "/subpath/user/repo", wl.RepoWebLink)
 		assert.Equal(t, "/subpath/user/repo/compare/1111...2222", wl.CommitWebLink)
 	})
-}
 
-func TestCommitSubmoduleLinkUnparsableURL(t *testing.T) {
-	sf := NewCommitSubmoduleFile("/any/repo-link", "full-path", "git@github.com:", "aaaa")
-	assert.Nil(t, sf.SubmoduleWebLinkTree(t.Context()))
-	assert.Nil(t, sf.SubmoduleWebLinkCompare(t.Context(), "1111", "2222"))
+	t.Run("UnparsableURL", func(t *testing.T) {
+		// both calls share one instance on purpose: the second one used to see the cached parse result
+		sf := NewCommitSubmoduleFile("/any/repo-link", "full-path", "git@github.com:", "aaaa")
+		assert.Nil(t, sf.SubmoduleWebLinkTree(t.Context()))
+		assert.Nil(t, sf.SubmoduleWebLinkCompare(t.Context(), "1111", "2222"))
+	})
 }


### PR DESCRIPTION
`getWebLinkInTargetRepo` set `sf.parsed = true` before it knew the parse had succeeded. The first call returned `nil` correctly, but every later call on the same `CommitSubmoduleFile` skipped the block and returned a link with an empty `RepoWebLink` and a bare `CommitWebLink` like `/compare/1111...2222`, which resolves against the site root.

`templates/repo/diff/box.tmpl` calls `SubmoduleRepoLinkHTML` and then `CompareRefIDLinkHTML` on the same object. So on a diff touching a submodule whose `.gitmodules` URL cannot be parsed (`git@github.com:` for example, SCP syntax with an empty path), the submodule name renders as plain text while the commit range beside it renders as a dead link.

The new test asserts both calls return `nil`; on main only the second one fails.

Not fixed here, and I would rather ask than guess: when the URL parses but `MakeRepositoryWebLink` returns `""` (a `file` scheme, e.g. `url = ./sub`), the link is non-nil with an empty target on every call. Same symptom, different cause. Worth a follow-up?

Assisted-by: Claude Code:claude-opus-5
