### PR TITLE
fix(feed): use meaningful lines as comment excerpt

### DIFF
--- a/modules/markup/markdown/excerpt.go
+++ b/modules/markup/markdown/excerpt.go
@@ -1,0 +1,111 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package markdown
+
+import (
+	"bytes"
+
+	"gitea.dev/modules/markup/markdown/math"
+
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+var (
+	excerptParser              = goldmarkExcerptParser()
+	excerptAttentionRecognizer = NewASTTransformer(nil)
+)
+
+const (
+	excerptMaxBytes = 64 * 1024
+	excerptMaxLines = 256
+)
+
+func goldmarkExcerptParser() parser.Parser {
+	p := goldmarkDefaultParser()
+	p.AddOptions(math.BlockParserOption(true, true))
+	return p
+}
+
+// FirstExcerptLine returns the first source line belonging to a Markdown paragraph, heading, or text block.
+// It inspects at most 64 KiB and 256 complete physical lines.
+func FirstExcerptLine(input string) string {
+	source := excerptSource(input)
+	reader := text.NewReader(source)
+	document := excerptParser.Parse(reader)
+
+	var excerpt []byte
+	_ = ast.Walk(document, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		switch node.Kind() {
+		case ast.KindParagraph, ast.KindHeading, ast.KindTextBlock:
+			if node.ChildCount() == 0 {
+				return ast.WalkSkipChildren, nil
+			}
+
+			pos := excerptNodePosition(node, reader)
+			if pos < 0 {
+				return ast.WalkSkipChildren, nil
+			}
+			lineStart := bytes.LastIndexByte(source[:pos], '\n') + 1
+			lineEnd := len(source)
+			if newline := bytes.IndexByte(source[pos:], '\n'); newline >= 0 {
+				lineEnd = pos + newline
+			}
+			excerpt = bytes.TrimSpace(source[lineStart:lineEnd])
+			if len(excerpt) == 0 {
+				return ast.WalkSkipChildren, nil
+			}
+			return ast.WalkStop, nil
+		case ast.KindDocument, ast.KindBlockquote, ast.KindList, ast.KindListItem:
+			return ast.WalkContinue, nil
+		default:
+			return ast.WalkSkipChildren, nil
+		}
+	})
+
+	return string(excerpt)
+}
+
+func excerptSource(input string) []byte {
+	limit := min(len(input), excerptMaxBytes)
+	lineCount, lastLineEnd := 0, 0
+	for i := range limit {
+		if input[i] != '\n' {
+			continue
+		}
+		lineCount++
+		lastLineEnd = i + 1
+		if lineCount == excerptMaxLines {
+			break
+		}
+	}
+	if len(input) <= excerptMaxBytes && lineCount < excerptMaxLines {
+		return []byte(input)
+	}
+	return []byte(input[:lastLineEnd])
+}
+
+func excerptNodePosition(node ast.Node, reader text.Reader) int {
+	parent := node.Parent()
+	if parent == nil || parent.Kind() != ast.KindBlockquote || parent.FirstChild() != node {
+		return node.Pos()
+	}
+
+	_, marker := excerptAttentionRecognizer.extractBlockquoteAttention(node, reader)
+	if len(marker) == 0 {
+		return node.Pos()
+	}
+	for next := marker[len(marker)-1].NextSibling(); next != nil; next = next.NextSibling() {
+		if textNode, ok := next.(*ast.Text); ok && len(textNode.Segment.Value(reader.Source())) == 0 {
+			continue
+		}
+		return next.Pos()
+	}
+	return -1
+}

--- a/modules/markup/markdown/excerpt_test.go
+++ b/modules/markup/markdown/excerpt_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package markdown
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFirstExcerptLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "plain", input: "first\nsecond", expected: "first"},
+		{name: "leading blank lines", input: "\n\nfirst", expected: "first"},
+		{name: "CRLF", input: "```go\r\ncode\r\n```\r\n\r\nfirst\r\nsecond", expected: "first"},
+		{name: "inline code", input: "I really like `foo!`, nice job!", expected: "I really like `foo!`, nice job!"},
+		{name: "heading", input: "# first", expected: "# first"},
+		{name: "syntax-only heading", input: "###\n\nfirst", expected: "first"},
+		{name: "tight list", input: "- first", expected: "- first"},
+		{name: "loose list", input: "- first\n\n- second", expected: "- first"},
+		{name: "blockquote", input: "> first", expected: "> first"},
+		{name: "note attention", input: "> [!NOTE]\n> first", expected: "> first"},
+		{name: "escaped attention", input: `> \[!NOTE\]` + "\n> first", expected: "> first"},
+		{name: "emphasis attention", input: "> **note**\n> first", expected: "> first"},
+		{name: "attention separate paragraph", input: "> [!NOTE]\n>\n> first", expected: "> first"},
+		{name: "attention only", input: "> [!NOTE]", expected: ""},
+		{name: "attention with same-line prose", input: "> [!NOTE] first", expected: "> [!NOTE] first"},
+		{name: "unknown attention", input: "> [!UNKNOWN]\n> first", expected: "> [!UNKNOWN]"},
+		{name: "unknown escaped attention", input: `> \[!UNKNOWN\]` + "\n> first", expected: `> \[!UNKNOWN\]`},
+		{name: "unknown emphasis attention", input: "> **unknown**\n> first", expected: "> **unknown**"},
+		{name: "thematic break", input: "---\n\nfirst", expected: "first"},
+		{name: "HTML block", input: "<div>not an excerpt</div>\n\nfirst", expected: "first"},
+		{name: "link reference", input: "[link]: /target\n\nfirst", expected: "first"},
+		{name: "dollar math block", input: "$$\nx + y\n$$\nfirst", expected: "first"},
+		{name: "square math block", input: "\\[\nx + y\n\\]\nfirst", expected: "first"},
+		{name: "fenced code in blockquote", input: "> ```go\n> code\n> ```\n> first", expected: "> first"},
+		{name: "fenced code in list", input: "- ```go\n  code\n  ```\n- first", expected: "- first"},
+		{name: "suggestion", input: "```suggestion\nreplacement\n```\nexplanation", expected: "explanation"},
+		{name: "tilde fence", input: "~~~go\ncode\n~~~\nfirst", expected: "first"},
+		{name: "multiple code blocks", input: "```go\ncode\n```\n\n~~~rust\ncode\n~~~\nfirst", expected: "first"},
+		{name: "indented code", input: "    code\n\nfirst", expected: "first"},
+		{name: "code only", input: "```go\ncode\n```", expected: ""},
+		{name: "unclosed fence", input: "```go\ncode", expected: ""},
+		{name: "over-byte single line", input: strings.Repeat("x", excerptMaxBytes+1), expected: ""},
+		{name: "prose beyond line limit", input: "```\n" + strings.Repeat("code\n", excerptMaxLines) + "```\nfirst", expected: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, FirstExcerptLine(test.input))
+		})
+	}
+}
+
+func TestFirstExcerptLineConcurrent(t *testing.T) {
+	const goroutines = 16
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Go(func() {
+			<-start
+			for range 100 {
+				assert.Equal(t, "first", FirstExcerptLine("```suggestion\nreplacement\n```\n\nfirst\nsecond"))
+			}
+		})
+	}
+	close(start)
+	wg.Wait()
+}

--- a/modules/markup/markdown/math/math.go
+++ b/modules/markup/markdown/math/math.go
@@ -37,6 +37,13 @@ func NewExtension(renderInternal *internal.RenderInternal, opts ...Options) *Ext
 	return r
 }
 
+// BlockParserOption returns the Goldmark option for Gitea math blocks.
+func BlockParserOption(parseDollars, parseSquare bool) parser.Option {
+	return parser.WithBlockParsers(
+		util.Prioritized(NewBlockParser(parseDollars, parseSquare), 701),
+	)
+}
+
 // Extend extends goldmark with our parsers and renderers
 func (e *Extension) Extend(m goldmark.Markdown) {
 	if !e.options.Enabled {
@@ -50,9 +57,7 @@ func (e *Extension) Extend(m goldmark.Markdown) {
 	inlines = append(inlines, util.Prioritized(NewInlineDollarParser(e.options.ParseInlineDollar), 502))
 
 	m.Parser().AddOptions(parser.WithInlineParsers(inlines...))
-	m.Parser().AddOptions(parser.WithBlockParsers(
-		util.Prioritized(NewBlockParser(e.options.ParseBlockDollar, e.options.ParseBlockSquareBrackets), 701),
-	))
+	m.Parser().AddOptions(BlockParserOption(e.options.ParseBlockDollar, e.options.ParseBlockSquareBrackets))
 	m.Renderer().AddOptions(renderer.WithNodeRenderers(
 		util.Prioritized(NewBlockRenderer(e.renderInternal), 501),
 		util.Prioritized(NewInlineRenderer(e.renderInternal), 502),

--- a/modules/markup/markdown/transform_blockquote.go
+++ b/modules/markup/markdown/transform_blockquote.go
@@ -77,6 +77,12 @@ func (g *ASTTransformer) extractBlockquoteAttention2(firstParagraph ast.Node, re
 			return attentionType, []ast.Node{node1, node2}
 		}
 	}
+	if val1 == `\[` && strings.HasPrefix(val2, "!") && strings.HasSuffix(val2, `\]`) {
+		attentionType := strings.ToLower(val2[1 : len(val2)-2])
+		if g.attentionTypes.Contains(attentionType) {
+			return attentionType, []ast.Node{node1, node2}
+		}
+	}
 	return "", nil
 }
 
@@ -110,6 +116,17 @@ func (g *ASTTransformer) extractBlockquoteAttention3(firstParagraph ast.Node, re
 	return "", nil
 }
 
+func (g *ASTTransformer) extractBlockquoteAttention(firstParagraph ast.Node, reader text.Reader) (string, []ast.Node) {
+	attentionType, processedNodes := g.extractBlockquoteAttentionEmphasis(firstParagraph, reader)
+	if attentionType == "" {
+		attentionType, processedNodes = g.extractBlockquoteAttention2(firstParagraph, reader)
+	}
+	if attentionType == "" {
+		attentionType, processedNodes = g.extractBlockquoteAttention3(firstParagraph, reader)
+	}
+	return attentionType, processedNodes
+}
+
 func (g *ASTTransformer) transformBlockquote(v *ast.Blockquote, reader text.Reader) (ast.WalkStatus, error) {
 	// We only want attention blockquotes when the AST looks like:
 	// > Text("[") Text("!TYPE") Text("]")
@@ -123,13 +140,7 @@ func (g *ASTTransformer) transformBlockquote(v *ast.Blockquote, reader text.Read
 	}
 	g.applyElementDir(firstParagraph)
 
-	attentionType, processedNodes := g.extractBlockquoteAttentionEmphasis(firstParagraph, reader)
-	if attentionType == "" {
-		attentionType, processedNodes = g.extractBlockquoteAttention2(firstParagraph, reader)
-	}
-	if attentionType == "" {
-		attentionType, processedNodes = g.extractBlockquoteAttention3(firstParagraph, reader)
-	}
+	attentionType, processedNodes := g.extractBlockquoteAttention(firstParagraph, reader)
 	if attentionType == "" {
 		return ast.WalkContinue, nil
 	}

--- a/services/feed/notifier.go
+++ b/services/feed/notifier.go
@@ -16,6 +16,7 @@ import (
 	"gitea.dev/modules/git"
 	"gitea.dev/modules/json"
 	"gitea.dev/modules/log"
+	"gitea.dev/modules/markup/markdown"
 	"gitea.dev/modules/repository"
 	"gitea.dev/modules/util"
 	notify_service "gitea.dev/services/notify"
@@ -109,7 +110,7 @@ func (a *actionNotifier) CreateIssueComment(ctx context.Context, doer *user_mode
 		IsPrivate: issue.Repo.IsPrivate,
 	}
 
-	truncatedContent, truncatedRight := util.EllipsisDisplayStringX(comment.Content, 200)
+	truncatedContent, truncatedRight := util.EllipsisDisplayStringX(markdown.FirstExcerptLine(comment.Content), 200)
 	if truncatedRight != "" {
 		// in case the content is in a Latin family language, we remove the last broken word.
 		lastSpaceIdx := strings.LastIndex(truncatedContent, " ")
@@ -229,7 +230,7 @@ func (a *actionNotifier) PullRequestReview(ctx context.Context, pr *issues_model
 				actions = append(actions, &activities_model.Action{
 					ActUserID: review.Reviewer.ID,
 					ActUser:   review.Reviewer,
-					Content:   fmt.Sprintf("%d|%s", review.Issue.Index, strings.Split(comm.Content, "\n")[0]),
+					Content:   fmt.Sprintf("%d|%s", review.Issue.Index, markdown.FirstExcerptLine(comm.Content)),
 					OpType:    activities_model.ActionCommentPull,
 					RepoID:    review.Issue.RepoID,
 					Repo:      review.Issue.Repo,
@@ -245,7 +246,7 @@ func (a *actionNotifier) PullRequestReview(ctx context.Context, pr *issues_model
 		action := &activities_model.Action{
 			ActUserID: review.Reviewer.ID,
 			ActUser:   review.Reviewer,
-			Content:   fmt.Sprintf("%d|%s", review.Issue.Index, strings.Split(comment.Content, "\n")[0]),
+			Content:   fmt.Sprintf("%d|%s", review.Issue.Index, markdown.FirstExcerptLine(comment.Content)),
 			RepoID:    review.Issue.RepoID,
 			Repo:      review.Issue.Repo,
 			IsPrivate: review.Issue.Repo.IsPrivate,

--- a/services/feed/notifier_test.go
+++ b/services/feed/notifier_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	activities_model "gitea.dev/models/activities"
+	"gitea.dev/models/db"
+	issues_model "gitea.dev/models/issues"
 	repo_model "gitea.dev/models/repo"
 	"gitea.dev/models/unittest"
 	user_model "gitea.dev/models/user"
@@ -49,4 +51,51 @@ func TestRenameRepoAction(t *testing.T) {
 
 	unittest.AssertExistsAndLoadBean(t, actionBean)
 	unittest.CheckConsistencyFor(t, &activities_model.Action{})
+}
+
+func TestCommentActionExcerpts(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	doer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 1})
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+	issue := unittest.AssertExistsAndLoadBean(t, &issues_model.Issue{ID: 1})
+	issue.Repo = repo
+	comment := &issues_model.Comment{
+		Type: issues_model.CommentTypeComment, PosterID: doer.ID, IssueID: issue.ID,
+		Content: "```suggestion\nreplacement\n```\n\nFirst meaningful **excerpt**\nSecond line",
+	}
+	assert.NoError(t, db.Insert(t.Context(), comment))
+
+	NewNotifier().CreateIssueComment(t.Context(), doer, repo, issue, comment, nil)
+	action := unittest.AssertExistsAndLoadBean(t, &activities_model.Action{
+		ActUserID: doer.ID, UserID: doer.ID, RepoID: repo.ID,
+		OpType: activities_model.ActionCommentIssue, CommentID: comment.ID,
+	})
+	assert.Equal(t, "1|First meaningful **excerpt**", action.Content)
+
+	codeComment := &issues_model.Comment{
+		Type: issues_model.CommentTypeCode, PosterID: doer.ID, IssueID: issue.ID,
+		Content: "```suggestion\nreplacement\n```\n\nInline **excerpt**",
+	}
+	reviewComment := &issues_model.Comment{
+		Type: issues_model.CommentTypeReview, PosterID: doer.ID, IssueID: issue.ID,
+		Content: "\n\n# Review **excerpt**",
+	}
+	assert.NoError(t, db.Insert(t.Context(), codeComment, reviewComment))
+	review := &issues_model.Review{
+		Type: issues_model.ReviewTypeComment, Reviewer: doer, ReviewerID: doer.ID,
+		Issue: issue, IssueID: issue.ID,
+		CodeComments: issues_model.CodeComments{"file.txt": {1: {codeComment}}},
+	}
+	NewNotifier().PullRequestReview(t.Context(), nil, review, reviewComment, nil)
+	inlineAction := unittest.AssertExistsAndLoadBean(t, &activities_model.Action{
+		ActUserID: doer.ID, UserID: doer.ID, RepoID: repo.ID,
+		OpType: activities_model.ActionCommentPull, CommentID: codeComment.ID,
+	})
+	reviewAction := unittest.AssertExistsAndLoadBean(t, &activities_model.Action{
+		ActUserID: doer.ID, UserID: doer.ID, RepoID: repo.ID,
+		OpType: activities_model.ActionCommentPull, CommentID: reviewComment.ID,
+	})
+	assert.Equal(t, "1|Inline **excerpt**", inlineAction.Content)
+	assert.Equal(t, "1|# Review **excerpt**", reviewAction.Content)
 }


### PR DESCRIPTION
Comment excerpts in activity feeds previously used either the first 200 display characters of a comment or, for review comments, its first physical line. That excerpt is rendered as Markdown in the feed, so if the excerpt began with a leading blank lines or structural markdown syntax, the excerpt would render as empty or produce broken output. For example, a review comment beginning with a code fence stored only the opening fence, which rendered as an empty code block.

This commit instead parses a bounded portion of the comment as Markdown and selects its first meaningful source line. Concretely, it:

1. Reads at most 256 lines or 64 KiB of the comment.
2. Parses that content as Markdown using Goldmark.
3. Skips blocks unsuitable for excerpts, such as code, HTML, and math.
4. Returns the first nonempty text belonging to a paragraph, heading, or text block.

This produces meaningful excerpts in more cases while preserving their original Markdown.

---

For a comment that contains the following:

````
```
some code
```

hello
````

This previously rendered as:
 
<img width="816" height="118" alt="Screenshot 2026-09-08 at 5 06 47 PM" src="https://github.com/user-attachments/assets/9d125363-72de-46bf-b47a-961245a79c5f" />

And now renders as:

<img width="807" height="89" alt="Screenshot 2026-09-08 at 5 08 30 PM" src="https://github.com/user-attachments/assets/d2dcdc6d-d7a9-437f-8e9c-b845fe99fa5e" />



