### PR TITLE
feat: inline comments on commit diff (#4898)

### DIFF
--- a/modelmigration/migrations.go
+++ b/modelmigration/migrations.go
@@ -426,6 +426,7 @@ func prepareMigrationTasks() []*migration {
 		newMigration(350, "Add published_unix column to release", v28.AddPublishedUnixToRelease),
 		newMigration(351, "Track transfer recipient access grants", v28.AddRecipientAccessGrantedToRepoTransfer),
 		newMigration(352, "Add token columns to deploy_key", v28.AddTokenToDeployKey),
+		newMigration(353, "Add commit_comment junction table", v28.AddCommitCommentJunction),
 	}
 	return preparedMigrations
 }

--- a/modelmigration/v28/v353.go
+++ b/modelmigration/v28/v353.go
@@ -1,0 +1,32 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v28
+
+import (
+	"context"
+
+	"gitea.dev/modelmigration/base"
+
+	"xorm.io/xorm"
+)
+
+// AddCommitCommentJunction creates the commit_comment junction table that
+// anchors Comment rows (CommentTypeCommitComment) onto a repo commit diff
+// coordinate without adding indexes to the main comment table.
+func AddCommitCommentJunction(_ context.Context, x base.EngineMigration) error {
+	type CommitComment struct {
+		ID        int64  `xorm:"pk autoincr"`
+		RepoID    int64  `xorm:"INDEX(s) NOT NULL"`
+		CommitSHA string `xorm:"VARCHAR(64) INDEX(s) NOT NULL"`
+		TreePath  string `xorm:"VARCHAR(4000) NOT NULL"`
+		Line      int64  `xorm:"NOT NULL"`
+		CommentID int64  `xorm:"UNIQUE INDEX NOT NULL"`
+	}
+
+	_, err := x.SyncWithOptions(xorm.SyncOptions{
+		IgnoreConstrains:  true,
+		IgnoreDropIndices: true,
+	}, new(CommitComment))
+	return err
+}

--- a/models/issues/comment.go
+++ b/models/issues/comment.go
@@ -120,6 +120,8 @@ const (
 	CommentTypeUnpin // 37 unpin Issue/PullRequest
 
 	CommentTypeChangeTimeEstimate // 38 Change time estimate
+
+	CommentTypeCommitComment // 39 Inline comment on a commit diff (no issue/PR)
 )
 
 var commentStrings = []string{
@@ -162,6 +164,7 @@ var commentStrings = []string{
 	"pin",
 	"unpin",
 	"change_time_estimate",
+	"commit_comment",
 }
 
 func (t CommentType) String() string {
@@ -179,7 +182,7 @@ func AsCommentType(typeName string) CommentType {
 
 func (t CommentType) HasContentSupport() bool {
 	switch t {
-	case CommentTypeComment, CommentTypeCode, CommentTypeReview, CommentTypeDismissReview:
+	case CommentTypeComment, CommentTypeCode, CommentTypeReview, CommentTypeDismissReview, CommentTypeCommitComment:
 		return true
 	}
 	return false
@@ -187,7 +190,7 @@ func (t CommentType) HasContentSupport() bool {
 
 func (t CommentType) HasAttachmentSupport() bool {
 	switch t {
-	case CommentTypeComment, CommentTypeCode, CommentTypeReview:
+	case CommentTypeComment, CommentTypeCode, CommentTypeReview, CommentTypeCommitComment:
 		return true
 	}
 	return false
@@ -363,6 +366,10 @@ func (c *Comment) GetPushActionContent() (*PushActionContent, error) {
 // LoadIssue loads the issue reference for the comment
 func (c *Comment) LoadIssue(ctx context.Context) (err error) {
 	if c.Issue != nil {
+		return nil
+	}
+	// Commit comments live outside the issue/PR graph (IssueID is always 0).
+	if c.Type == CommentTypeCommitComment {
 		return nil
 	}
 	c.Issue, err = GetIssueByID(ctx, c.IssueID)

--- a/models/issues/commit_comment.go
+++ b/models/issues/commit_comment.go
@@ -94,10 +94,7 @@ func CreateCommitComment(ctx context.Context, opts *CreateCommitCommentOptions) 
 			return fmt.Errorf("insert commit_comment junction: %w", err)
 		}
 
-		if err := UpdateCommitCommentAttachments(ctx, opts.Repo.ID, comment, opts.Attachments); err != nil {
-			return err
-		}
-		return nil
+		return UpdateCommitCommentAttachments(ctx, opts.Repo.ID, comment, opts.Attachments)
 	})
 	if err != nil {
 		return nil, err

--- a/models/issues/commit_comment.go
+++ b/models/issues/commit_comment.go
@@ -1,0 +1,289 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package issues
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"gitea.dev/models/db"
+	repo_model "gitea.dev/models/repo"
+	user_model "gitea.dev/models/user"
+	"gitea.dev/modules/container"
+	"gitea.dev/modules/util"
+
+	"xorm.io/builder"
+)
+
+// ErrInvalidCommitCommentLine is returned when the comment line is zero.
+// Diff line numbers are signed (negative = old side, positive = new side).
+var ErrInvalidCommitCommentLine = errors.New("commit comment line must be non-zero")
+
+// CommitComment is the junction that anchors a Comment (Type=CommentTypeCommitComment)
+// onto a repository commit diff coordinate. Location lives here so the main
+// comment table does not need a (repo_id, commit_sha) index.
+type CommitComment struct {
+	ID        int64  `xorm:"pk autoincr"`
+	RepoID    int64  `xorm:"INDEX(s) NOT NULL"`
+	CommitSHA string `xorm:"VARCHAR(64) INDEX(s) NOT NULL"`
+	TreePath  string `xorm:"VARCHAR(4000) NOT NULL"`
+	Line      int64  `xorm:"NOT NULL"`
+	CommentID int64  `xorm:"UNIQUE INDEX NOT NULL"`
+
+	Comment *Comment `xorm:"-"`
+}
+
+func init() {
+	db.RegisterModel(new(CommitComment))
+}
+
+// CreateCommitCommentOptions holds the data needed to create an inline commit comment.
+type CreateCommitCommentOptions struct {
+	Repo        *repo_model.Repository
+	Doer        *user_model.User
+	CommitSHA   string
+	TreePath    string
+	Line        int64 // signed: negative = previous, positive = proposed
+	Content     string
+	Patch       string
+	Attachments []string // attachment UUIDs to bind to the Comment
+}
+
+// CreateCommitComment inserts a Comment (type CommitComment) and a junction row
+// in one transaction, then binds any attachments to the comment so orphan
+// cleanup (DeleteOrphanedAttachments / checkStorage) cannot delete them.
+func CreateCommitComment(ctx context.Context, opts *CreateCommitCommentOptions) (*Comment, error) {
+	if opts.Line == 0 {
+		return nil, ErrInvalidCommitCommentLine
+	}
+	if opts.Repo == nil || opts.Doer == nil {
+		return nil, errors.New("repo and doer are required")
+	}
+	if opts.CommitSHA == "" || opts.TreePath == "" || opts.Content == "" {
+		return nil, errors.New("commit sha, path and content are required")
+	}
+
+	var comment *Comment
+	err := db.WithTx(ctx, func(ctx context.Context) error {
+		comment = &Comment{
+			Type:      CommentTypeCommitComment,
+			PosterID:  opts.Doer.ID,
+			Poster:    opts.Doer,
+			IssueID:   0,
+			CommitSHA: opts.CommitSHA,
+			TreePath:  opts.TreePath,
+			Line:      opts.Line,
+			Content:   opts.Content,
+			Patch:     opts.Patch,
+		}
+		if err := db.Insert(ctx, comment); err != nil {
+			return fmt.Errorf("insert comment: %w", err)
+		}
+
+		junction := &CommitComment{
+			RepoID:    opts.Repo.ID,
+			CommitSHA: opts.CommitSHA,
+			TreePath:  opts.TreePath,
+			Line:      opts.Line,
+			CommentID: comment.ID,
+			Comment:   comment,
+		}
+		if err := db.Insert(ctx, junction); err != nil {
+			return fmt.Errorf("insert commit_comment junction: %w", err)
+		}
+
+		if err := UpdateCommitCommentAttachments(ctx, opts.Repo.ID, comment, opts.Attachments); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return comment, nil
+}
+
+// UpdateCommitCommentAttachments binds uploaded attachment UUIDs to a commit
+// comment. Binding sets comment_id (and repo_id), which is enough for:
+//   - GetUnlinkedAttachmentsByUserID (requires comment_id = 0 to count as unlinked)
+//   - checkStorage Attachments orphan check (ExistAttachmentsByUUID)
+//   - DeleteOrphanedAttachments (only removes rows whose issue_id/release_id
+//     point at missing parents — comment_id-only rows are left alone)
+func UpdateCommitCommentAttachments(ctx context.Context, repoID int64, c *Comment, uuids []string) error {
+	if len(uuids) == 0 {
+		return nil
+	}
+	if c == nil || c.ID == 0 {
+		return errors.New("comment must be persisted before binding attachments")
+	}
+	attachments, err := repo_model.GetAttachmentsByUUIDs(ctx, uuids)
+	if err != nil {
+		return fmt.Errorf("getAttachmentsByUUIDs [uuids: %v]: %w", uuids, err)
+	}
+	for i := range attachments {
+		a := attachments[i]
+		if a.RepoID != 0 && a.RepoID != repoID {
+			return util.NewPermissionDeniedErrorf("attachment belongs to a different repository")
+		}
+		if a.IssueID != 0 {
+			return util.NewPermissionDeniedErrorf("attachment is already linked to an issue")
+		}
+		if a.ReleaseID != 0 {
+			return util.NewPermissionDeniedErrorf("attachment is already linked to a release")
+		}
+		if a.CommentID != 0 && a.CommentID != c.ID {
+			return util.NewPermissionDeniedErrorf("attachment is already linked to another comment")
+		}
+		a.RepoID = repoID
+		a.CommentID = c.ID
+		if err := repo_model.UpdateAttachment(ctx, a); err != nil {
+			return fmt.Errorf("update attachment [id: %d]: %w", a.ID, err)
+		}
+	}
+	c.Attachments = attachments
+	return nil
+}
+
+// DeleteCommitComment deletes a commit comment and its junction row, scoped to repo.
+func DeleteCommitComment(ctx context.Context, repoID, commentID int64) error {
+	return db.WithTx(ctx, func(ctx context.Context) error {
+		comment, err := GetCommitCommentByID(ctx, repoID, commentID)
+		if err != nil {
+			return err
+		}
+		if _, err := db.GetEngine(ctx).
+			Where("repo_id = ? AND comment_id = ?", repoID, commentID).
+			Delete(&CommitComment{}); err != nil {
+			return err
+		}
+		// Drop bound attachments (storage + rows) then the Comment row.
+		if _, err := repo_model.DeleteAttachmentsByComment(ctx, comment.ID, true); err != nil {
+			return err
+		}
+		_, err = db.GetEngine(ctx).ID(comment.ID).Delete(&Comment{})
+		return err
+	})
+}
+
+// GetCommitCommentByID returns the Comment for a commit comment, scoped to repo.
+func GetCommitCommentByID(ctx context.Context, repoID, commentID int64) (*Comment, error) {
+	var junction CommitComment
+	has, err := db.GetEngine(ctx).
+		Where("repo_id = ? AND comment_id = ?", repoID, commentID).
+		Get(&junction)
+	if err != nil {
+		return nil, err
+	}
+	if !has {
+		return nil, db.ErrNotExist{Resource: "CommitComment", ID: commentID}
+	}
+	comment, err := GetCommentByID(ctx, commentID)
+	if err != nil {
+		return nil, err
+	}
+	if comment.Type != CommentTypeCommitComment {
+		return nil, db.ErrNotExist{Resource: "CommitComment", ID: commentID}
+	}
+	return comment, nil
+}
+
+func findCommitComments(ctx context.Context, cond builder.Cond) (CommentList, error) {
+	var junctions []*CommitComment
+	if err := db.GetEngine(ctx).
+		Where(cond).
+		OrderBy("id ASC").
+		Find(&junctions); err != nil {
+		return nil, err
+	}
+	if len(junctions) == 0 {
+		return nil, nil
+	}
+
+	commentIDs := make([]int64, len(junctions))
+	for i, j := range junctions {
+		commentIDs[i] = j.CommentID
+	}
+
+	comments := make(CommentList, 0, len(commentIDs))
+	if err := db.GetEngine(ctx).
+		In("id", commentIDs).
+		Asc("created_unix").
+		Asc("id").
+		Find(&comments); err != nil {
+		return nil, err
+	}
+
+	// Preserve junction order (which follows creation) while filtering missing rows.
+	byID := make(map[int64]*Comment, len(comments))
+	for _, c := range comments {
+		byID[c.ID] = c
+	}
+	ordered := make(CommentList, 0, len(junctions))
+	for _, j := range junctions {
+		if c, ok := byID[j.CommentID]; ok {
+			// Ensure location fields match the junction (source of truth).
+			c.CommitSHA = j.CommitSHA
+			c.TreePath = j.TreePath
+			c.Line = j.Line
+			ordered = append(ordered, c)
+		}
+	}
+
+	if err := ordered.LoadPosters(ctx); err != nil {
+		return nil, err
+	}
+	if err := ordered.LoadAttachments(ctx); err != nil {
+		return nil, err
+	}
+	return ordered, nil
+}
+
+// FindCommitCommentsByCommitSHA returns all inline comments for a commit.
+func FindCommitCommentsByCommitSHA(ctx context.Context, repoID int64, commitSHA string) (CommentList, error) {
+	return findCommitComments(ctx, builder.Eq{"repo_id": repoID, "commit_sha": commitSHA})
+}
+
+// FindCommitCommentsByLine returns comments anchored on one diff coordinate.
+func FindCommitCommentsByLine(ctx context.Context, repoID int64, commitSHA, treePath string, line int64) (CommentList, error) {
+	return findCommitComments(ctx, builder.Eq{
+		"repo_id":    repoID,
+		"commit_sha": commitSHA,
+		"tree_path":  treePath,
+		"line":       line,
+	})
+}
+
+// FindCommitCommentsForFile returns comments for one file of a commit.
+func FindCommitCommentsForFile(ctx context.Context, repoID int64, commitSHA, treePath string) (CommentList, error) {
+	return findCommitComments(ctx, builder.Eq{
+		"repo_id":    repoID,
+		"commit_sha": commitSHA,
+		"tree_path":  treePath,
+	})
+}
+
+// DeleteCommitCommentsByRepoID removes all commit comments (junction + Comment + attachments) for a repo.
+func DeleteCommitCommentsByRepoID(ctx context.Context, repoID int64) error {
+	var junctions []*CommitComment
+	if err := db.GetEngine(ctx).Where("repo_id = ?", repoID).Find(&junctions); err != nil {
+		return err
+	}
+	if len(junctions) == 0 {
+		return nil
+	}
+	commentIDs := container.FilterSlice(junctions, func(j *CommitComment) (int64, bool) {
+		return j.CommentID, j.CommentID > 0
+	})
+	if _, err := db.GetEngine(ctx).Where("repo_id = ?", repoID).Delete(&CommitComment{}); err != nil {
+		return err
+	}
+	for _, id := range commentIDs {
+		if _, err := repo_model.DeleteAttachmentsByComment(ctx, id, true); err != nil {
+			return err
+		}
+	}
+	_, err := db.GetEngine(ctx).In("id", commentIDs).And(builder.Eq{"type": CommentTypeCommitComment}).Delete(&Comment{})
+	return err
+}

--- a/models/issues/commit_comment_test.go
+++ b/models/issues/commit_comment_test.go
@@ -77,7 +77,6 @@ func TestCreateCommitCommentRejectsZeroLine(t *testing.T) {
 	assert.ErrorIs(t, err, issues_model.ErrInvalidCommitCommentLine)
 }
 
-
 func TestUpdateCommitCommentAttachmentsBindsCommentID(t *testing.T) {
 	require.NoError(t, unittest.PrepareTestDatabase())
 

--- a/models/issues/commit_comment_test.go
+++ b/models/issues/commit_comment_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package issues_test
+
+import (
+	"testing"
+
+	"gitea.dev/models/db"
+	issues_model "gitea.dev/models/issues"
+	repo_model "gitea.dev/models/repo"
+	"gitea.dev/models/unittest"
+	user_model "gitea.dev/models/user"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateCommitComment(t *testing.T) {
+	require.NoError(t, unittest.PrepareTestDatabase())
+
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+	doer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+
+	comment, err := issues_model.CreateCommitComment(t.Context(), &issues_model.CreateCommitCommentOptions{
+		Repo:      repo,
+		Doer:      doer,
+		CommitSHA: "65f1bf27bc3bf70f64657658635e66094edbcb4d",
+		TreePath:  "README.md",
+		Line:      1,
+		Content:   "unit test commit comment",
+		Patch:     "@@ -0,0 +1 @@\n+line",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, comment)
+	assert.Equal(t, issues_model.CommentTypeCommitComment, comment.Type)
+	assert.Equal(t, int64(0), comment.IssueID)
+	assert.Equal(t, "unit test commit comment", comment.Content)
+
+	unittest.AssertExistsAndLoadBean(t, &issues_model.CommitComment{
+		RepoID:    repo.ID,
+		CommitSHA: "65f1bf27bc3bf70f64657658635e66094edbcb4d",
+		CommentID: comment.ID,
+	})
+
+	found, err := issues_model.FindCommitCommentsByCommitSHA(t.Context(), repo.ID, "65f1bf27bc3bf70f64657658635e66094edbcb4d")
+	require.NoError(t, err)
+	assert.NotEmpty(t, found)
+
+	byLine, err := issues_model.FindCommitCommentsByLine(t.Context(), repo.ID, "65f1bf27bc3bf70f64657658635e66094edbcb4d", "README.md", 1)
+	require.NoError(t, err)
+	require.Len(t, byLine, 1)
+	assert.Equal(t, comment.ID, byLine[0].ID)
+
+	// Wrong repo must not see the comment
+	_, err = issues_model.GetCommitCommentByID(t.Context(), repo.ID+999, comment.ID)
+	assert.Error(t, err)
+
+	require.NoError(t, issues_model.DeleteCommitComment(t.Context(), repo.ID, comment.ID))
+	unittest.AssertNotExistsBean(t, &issues_model.CommitComment{CommentID: comment.ID})
+	unittest.AssertNotExistsBean(t, &issues_model.Comment{ID: comment.ID})
+}
+
+func TestCreateCommitCommentRejectsZeroLine(t *testing.T) {
+	require.NoError(t, unittest.PrepareTestDatabase())
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+	doer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+
+	_, err := issues_model.CreateCommitComment(t.Context(), &issues_model.CreateCommitCommentOptions{
+		Repo:      repo,
+		Doer:      doer,
+		CommitSHA: "abc",
+		TreePath:  "a.go",
+		Line:      0,
+		Content:   "nope",
+	})
+	assert.ErrorIs(t, err, issues_model.ErrInvalidCommitCommentLine)
+}
+
+
+func TestUpdateCommitCommentAttachmentsBindsCommentID(t *testing.T) {
+	require.NoError(t, unittest.PrepareTestDatabase())
+
+	repo := unittest.AssertExistsAndLoadBean(t, &repo_model.Repository{ID: 1})
+	doer := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 2})
+
+	comment, err := issues_model.CreateCommitComment(t.Context(), &issues_model.CreateCommitCommentOptions{
+		Repo:      repo,
+		Doer:      doer,
+		CommitSHA: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		TreePath:  "file.txt",
+		Line:      2,
+		Content:   "with attachment path",
+	})
+	require.NoError(t, err)
+
+	a := &repo_model.Attachment{
+		UUID:       "commit-comment-attach-uuid-1",
+		RepoID:     repo.ID,
+		UploaderID: doer.ID,
+		Name:       "note.txt",
+	}
+	require.NoError(t, db.Insert(t.Context(), a))
+
+	require.NoError(t, issues_model.UpdateCommitCommentAttachments(t.Context(), repo.ID, comment, []string{a.UUID}))
+
+	reloaded := unittest.AssertExistsAndLoadBean(t, &repo_model.Attachment{UUID: a.UUID})
+	assert.Equal(t, comment.ID, reloaded.CommentID)
+	assert.Equal(t, repo.ID, reloaded.RepoID)
+	assert.Equal(t, int64(0), reloaded.IssueID)
+	assert.Equal(t, int64(0), reloaded.ReleaseID)
+
+	unlinked, err := repo_model.GetUnlinkedAttachmentsByUserID(t.Context(), doer.ID)
+	require.NoError(t, err)
+	for _, u := range unlinked {
+		assert.NotEqual(t, a.UUID, u.UUID)
+	}
+}

--- a/routers/web/repo/commit.go
+++ b/routers/web/repo/commit.go
@@ -30,6 +30,7 @@ import (
 	"gitea.dev/modules/util"
 	asymkey_service "gitea.dev/services/asymkey"
 	"gitea.dev/services/context"
+	"gitea.dev/services/context/upload"
 	git_service "gitea.dev/services/git"
 	"gitea.dev/services/gitdiff"
 	repo_service "gitea.dev/services/repository"
@@ -281,14 +282,16 @@ func Diff(ctx *context.Context) {
 	repoName := ctx.Repo.Repository.Name
 	commitID := ctx.PathParam("sha")
 
+	isWiki := ctx.Data["PageIsWiki"] != nil
 	diffBlobExcerptData := &gitdiff.DiffBlobExcerptData{
 		BaseLink:      ctx.Repo.RepoLink + "/blob_excerpt",
 		DiffStyle:     GetDiffViewStyle(ctx),
 		AfterCommitID: commitID,
+		IsCommitDiff:  !isWiki,
 	}
 	gitRepo := ctx.Repo.GitRepo // don't access ctx.Repo.GitRepo anymore, because it might not be right for wiki repo
 
-	if ctx.Data["PageIsWiki"] != nil {
+	if isWiki {
 		var err error
 		gitRepo, err = git.RepositoryFromRequestContextOrOpen(ctx, ctx.Repo.Repository.WikiStorageRepo())
 		if err != nil {
@@ -368,6 +371,19 @@ func Diff(ctx *context.Context) {
 	ctx.Data["Commit"] = commit
 	ctx.Data["Diff"] = diff
 	ctx.Data["DiffBlobExcerptData"] = diffBlobExcerptData
+
+	if !isWiki {
+		commitComments, err := diff.LoadCommitComments(ctx, ctx.Repo.Repository.ID, commitID)
+		if err != nil {
+			log.Error("LoadCommitComments: %v", err)
+		} else {
+			renderCommitComments(ctx, commitComments)
+		}
+		ctx.Data["CanCommentOnCommit"] = canCommentOnCommit(ctx)
+		ctx.Data["DiffNewCommentURL"] = commitCommentURL(ctx, commitID)
+		ctx.Data["IsAttachmentEnabled"] = setting.Attachment.Enabled
+		upload.AddUploadContext(ctx, "comment")
+	}
 
 	if !fileOnly {
 		diffTree, err := gitdiff.GetDiffTree(ctx, gitRepo, false, parentCommitID, commitID)

--- a/routers/web/repo/commit_comment.go
+++ b/routers/web/repo/commit_comment.go
@@ -1,0 +1,157 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package repo
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"gitea.dev/models/db"
+	issues_model "gitea.dev/models/issues"
+	"gitea.dev/models/renderhelper"
+	unit_model "gitea.dev/models/unit"
+	"gitea.dev/modules/git"
+	"gitea.dev/modules/log"
+	"gitea.dev/modules/markup/markdown"
+	"gitea.dev/modules/setting"
+	"gitea.dev/modules/templates"
+	"gitea.dev/services/context"
+	"gitea.dev/services/context/upload"
+	repo_service "gitea.dev/services/repository"
+)
+
+var (
+	tplNewCommitComment   templates.TplName = "repo/diff/new_commit_comment"
+	tplCommitConversation templates.TplName = "repo/diff/commit_conversation"
+)
+
+func canCommentOnCommit(ctx *context.Context) bool {
+	return ctx.Doer != nil && !ctx.Repo.Repository.IsArchived && ctx.Repo.Permission.CanRead(unit_model.TypeCode)
+}
+
+func commitCommentURL(ctx *context.Context, commitSHA string) string {
+	return ctx.Repo.RepoLink + "/commit/" + commitSHA + "/comment"
+}
+
+func renderCommitComments(ctx *context.Context, comments issues_model.CommentList) {
+	for _, c := range comments {
+		rctx := renderhelper.NewRenderContextRepoComment(ctx, ctx.Repo.Repository, renderhelper.RepoCommentOptions{
+			FootnoteContextID: strconv.FormatInt(c.ID, 10),
+		})
+		var err error
+		if c.RenderedContent, err = markdown.RenderString(rctx, c.Content); err != nil {
+			log.Error("RenderString for commit comment %d: %v", c.ID, err)
+		}
+	}
+}
+
+// RenderNewCommitCommentForm renders the form used by the diff "+" button.
+func RenderNewCommitCommentForm(ctx *context.Context) {
+	if !canCommentOnCommit(ctx) {
+		ctx.HTTPError(http.StatusForbidden)
+		return
+	}
+	commitSHA := ctx.PathParam("sha")
+	ctx.Data["CanCommentOnCommit"] = true
+	ctx.Data["DiffNewCommentURL"] = commitCommentURL(ctx, commitSHA)
+	ctx.Data["IsAttachmentEnabled"] = setting.Attachment.Enabled
+	upload.AddUploadContext(ctx, "comment")
+	ctx.HTML(http.StatusOK, tplNewCommitComment)
+}
+
+// CreateCommitComment creates an inline comment on a commit diff.
+func CreateCommitComment(ctx *context.Context) {
+	if !canCommentOnCommit(ctx) {
+		ctx.HTTPError(http.StatusForbidden)
+		return
+	}
+
+	commitSHA := ctx.PathParam("sha")
+	if commitSHA == "" {
+		ctx.NotFound(nil)
+		return
+	}
+
+	content := ctx.FormString("content")
+	treePath := ctx.FormString("path")
+	side := ctx.FormString("side")
+	line := ctx.FormInt64("line")
+	attachments := ctx.FormStrings("files")
+
+	if content == "" || treePath == "" || line <= 0 {
+		ctx.JSONError("content, path, and a positive line are required")
+		return
+	}
+	if side != "previous" && side != "proposed" {
+		ctx.JSONError("side must be either 'previous' or 'proposed'")
+		return
+	}
+	if side == "previous" {
+		line = -line
+	}
+
+	comment, err := repo_service.CreateCommitComment(ctx, ctx.Doer, ctx.Repo.Repository, ctx.Repo.GitRepo, commitSHA, treePath, line, content, attachments)
+	switch {
+	case err == nil:
+	case git.IsErrNotExist(err):
+		ctx.NotFound(err)
+		return
+	case errors.Is(err, repo_service.ErrCommitCommentCoordinates), errors.Is(err, repo_service.ErrCommitCommentRootPrevious):
+		ctx.JSONError(err.Error())
+		return
+	default:
+		ctx.ServerError("CreateCommitComment", err)
+		return
+	}
+
+	comments, err := issues_model.FindCommitCommentsByLine(ctx, ctx.Repo.Repository.ID, comment.CommitSHA, treePath, line)
+	if err != nil {
+		ctx.ServerError("FindCommitCommentsByLine", err)
+		return
+	}
+	renderCommitComments(ctx, comments)
+
+	ctx.Data["CanCommentOnCommit"] = canCommentOnCommit(ctx)
+	ctx.Data["DiffNewCommentURL"] = commitCommentURL(ctx, comment.CommitSHA)
+	ctx.Data["IsAttachmentEnabled"] = setting.Attachment.Enabled
+	upload.AddUploadContext(ctx, "comment")
+	ctx.Data["comments"] = comments
+	ctx.HTML(http.StatusOK, tplCommitConversation)
+}
+
+// DeleteCommitComment deletes an inline commit comment.
+func DeleteCommitComment(ctx *context.Context) {
+	if ctx.Doer == nil {
+		ctx.HTTPError(http.StatusForbidden)
+		return
+	}
+
+	commentID := ctx.PathParamInt64("id")
+	if commentID <= 0 {
+		ctx.NotFound(nil)
+		return
+	}
+
+	comment, err := issues_model.GetCommitCommentByID(ctx, ctx.Repo.Repository.ID, commentID)
+	if err != nil {
+		ctx.NotFoundOrServerError("GetCommitCommentByID", db.IsErrNotExist, err)
+		return
+	}
+
+	canDelete := comment.PosterID == ctx.Doer.ID ||
+		ctx.Repo.Permission.IsAdmin() ||
+		ctx.Repo.Permission.CanWrite(unit_model.TypeCode)
+	if !canDelete {
+		ctx.HTTPError(http.StatusForbidden)
+		return
+	}
+
+	if err := issues_model.DeleteCommitComment(ctx, ctx.Repo.Repository.ID, commentID); err != nil {
+		ctx.ServerError("DeleteCommitComment", err)
+		return
+	}
+
+	ctx.JSON(http.StatusOK, map[string]any{"ok": true})
+}

--- a/routers/web/repo/compare.go
+++ b/routers/web/repo/compare.go
@@ -782,6 +782,19 @@ func ExcerptBlob(ctx *context.Context) {
 				}
 			}
 		}
+	} else if ctx.FormBool("commit_diff") && ctx.Data["PageIsWiki"] != true {
+		// Commit diff excerpt: keep comment buttons + conversations on expanded rows.
+		fullSHA := commit.ID.String()
+		diffBlobExcerptData.IsCommitDiff = true
+		ctx.Data["CanCommentOnCommit"] = canCommentOnCommit(ctx)
+		ctx.Data["DiffNewCommentURL"] = commitCommentURL(ctx, fullSHA)
+
+		fileComments, err := issues_model.FindCommitCommentsForFile(ctx, ctx.Repo.Repository.ID, fullSHA, filePath)
+		if err != nil {
+			log.Error("FindCommitCommentsForFile error: %v", err)
+		} else {
+			renderCommitComments(ctx, gitdiff.AttachCommitCommentsToLines(section.Lines, fileComments))
+		}
 	}
 
 	ctx.Data["section"] = section

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1465,6 +1465,13 @@ func registerWebRoutes(m *web.Router, webAuth *AuthMiddleware) {
 			}, repo.MustBeAbleToUpload, reqRepoCodeWriter)
 		}, repo.MustBeEditable, context.RepoMustNotBeArchived())
 
+		// Inline comments on commit diffs (fixes go-gitea/gitea#4898)
+		m.Group("/commit/{sha:[a-f0-9]{7,64}}", func() {
+			m.Get("/comment", repo.RenderNewCommitCommentForm)
+			m.Post("/comment", context.RepoMustNotBeArchived(), repo.CreateCommitComment)
+			m.Post("/comment/{id}/delete", context.RepoMustNotBeArchived(), repo.DeleteCommitComment)
+		})
+
 		m.Group("/branches", func() {
 			m.Group("/_new", func() {
 				m.Post("/branch/*", context.RepoRefByType(git.RefTypeBranch), repo.CreateBranch)

--- a/services/gitdiff/gitdiff.go
+++ b/services/gitdiff/gitdiff.go
@@ -80,6 +80,12 @@ type DiffLine struct {
 	Comments    issues_model.CommentList // related PR code comments
 	SectionInfo *DiffLineSectionInfo
 
+	// CommitCommentsLeft/Right hold CommentTypeCommitComment threads. Kept
+	// separate from Comments because a context line has both an old and a new
+	// index and either side may carry its own thread.
+	CommitCommentsLeft  issues_model.CommentList
+	CommitCommentsRight issues_model.CommentList
+
 	cachedDiffInline *DiffInline
 }
 
@@ -164,6 +170,24 @@ func (d *DiffLine) CanComment() bool {
 	return len(d.Comments) == 0 && d.Type != DiffLineSection
 }
 
+// CanCommentLeft returns whether the old side of the line can get a commit comment.
+func (d *DiffLine) CanCommentLeft() bool {
+	return d.Type != DiffLineSection && len(d.CommitCommentsLeft) == 0
+}
+
+// CanCommentRight returns whether the new side of the line can get a commit comment.
+func (d *DiffLine) CanCommentRight() bool {
+	return d.Type != DiffLineSection && len(d.CommitCommentsRight) == 0
+}
+
+// CanCommentUnified answers for the single button of the unified view.
+func (d *DiffLine) CanCommentUnified() bool {
+	if d.RightIdx > 0 {
+		return d.CanCommentRight()
+	}
+	return d.CanCommentLeft()
+}
+
 // GetCommentSide returns the comment side of the first comment, if not set returns empty string
 func (d *DiffLine) GetCommentSide() string {
 	if len(d.Comments) == 0 {
@@ -219,6 +243,9 @@ type DiffBlobExcerptData struct {
 	PullIssueIndex int64
 	DiffStyle      string
 	AfterCommitID  string
+	// IsCommitDiff marks excerpts of a single commit's diff so expanded rows
+	// keep commit-comment buttons and conversations. Compare views must not set it.
+	IsCommitDiff bool
 }
 
 const (
@@ -235,6 +262,9 @@ func (d *DiffLine) RenderBlobExcerptButtons(fileNameHash string, data *DiffBlobE
 		link := data.BaseLink + "/" + data.AfterCommitID + fmt.Sprintf("?style=%s&direction=%s&anchor=%s", url.QueryEscape(style), direction, url.QueryEscape(anchor)) + "&" + d.getBlobExcerptQuery()
 		if data.PullIssueIndex > 0 {
 			link += fmt.Sprintf("&pull_issue_index=%d", data.PullIssueIndex)
+		}
+		if data.IsCommitDiff {
+			link += "&commit_diff=1"
 		}
 		return htmlutil.HTMLFormat(
 			`<button class="code-expander-button" data-fetch-sync="$closest(tr)" data-fetch-url="%s" data-hidden-comment-ids=",%s,">%s</button>`,
@@ -681,6 +711,64 @@ func (diff *Diff) LoadComments(ctx context.Context, issue *issues_model.Issue, c
 		}
 	}
 	return nil
+}
+
+// LoadCommitComments attaches CommentTypeCommitComment threads to each diff line
+// and returns the ones that landed on a rendered line (so callers only render
+// markdown that is actually displayed).
+func (diff *Diff) LoadCommitComments(ctx context.Context, repoID int64, commitSHA string) (issues_model.CommentList, error) {
+	comments, err := issues_model.FindCommitCommentsByCommitSHA(ctx, repoID, commitSHA)
+	if err != nil {
+		return nil, err
+	}
+	byPath := make(map[string]issues_model.CommentList, len(comments))
+	for _, c := range comments {
+		byPath[c.TreePath] = append(byPath[c.TreePath], c)
+	}
+	attached := make(issues_model.CommentList, 0, len(comments))
+	for _, file := range diff.Files {
+		fileComments, ok := byPath[file.Name]
+		if !ok {
+			continue
+		}
+		byLine := commitCommentsByLine(fileComments)
+		for _, section := range file.Sections {
+			attached = append(attached, attachCommitCommentsToLines(section.Lines, byLine)...)
+		}
+	}
+	return attached, nil
+}
+
+// AttachCommitCommentsToLines anchors one file's commit comments on the diff
+// lines they were written against and returns the ones that found a line.
+func AttachCommitCommentsToLines(lines []*DiffLine, comments issues_model.CommentList) issues_model.CommentList {
+	if len(comments) == 0 {
+		return nil
+	}
+	return attachCommitCommentsToLines(lines, commitCommentsByLine(comments))
+}
+
+func commitCommentsByLine(comments issues_model.CommentList) map[int64]issues_model.CommentList {
+	byLine := make(map[int64]issues_model.CommentList, len(comments))
+	for _, c := range comments {
+		byLine[c.Line] = append(byLine[c.Line], c)
+	}
+	return byLine
+}
+
+func attachCommitCommentsToLines(lines []*DiffLine, byLine map[int64]issues_model.CommentList) issues_model.CommentList {
+	var attached issues_model.CommentList
+	for _, line := range lines {
+		if line.LeftIdx > 0 {
+			line.CommitCommentsLeft = byLine[int64(-line.LeftIdx)]
+			attached = append(attached, line.CommitCommentsLeft...)
+		}
+		if line.RightIdx > 0 {
+			line.CommitCommentsRight = byLine[int64(line.RightIdx)]
+			attached = append(attached, line.CommitCommentsRight...)
+		}
+	}
+	return attached
 }
 
 const cmdDiffHead = "diff --git "

--- a/services/repository/commit_comment.go
+++ b/services/repository/commit_comment.go
@@ -1,0 +1,88 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package repository
+
+import (
+	"context"
+	"errors"
+
+	issues_model "gitea.dev/models/issues"
+	repo_model "gitea.dev/models/repo"
+	user_model "gitea.dev/models/user"
+	"gitea.dev/modules/git"
+	"gitea.dev/modules/log"
+	"gitea.dev/modules/setting"
+	"gitea.dev/services/gitdiff"
+)
+
+// ErrCommitCommentCoordinates is returned when the requested diff coordinate
+// does not resolve to a real line of the commit.
+var ErrCommitCommentCoordinates = errors.New("comment coordinates do not resolve to a line in this commit")
+
+// ErrCommitCommentRootPrevious is returned when commenting on the old side of a
+// root commit that has no parent.
+var ErrCommitCommentRootPrevious = errors.New("cannot comment on the previous side of a root commit")
+
+// CreateCommitComment stores an inline comment on a commit diff.
+// line is signed: negative for the old side, positive for the new one.
+// attachments are UUIDs of already-uploaded files to bind onto the Comment.
+func CreateCommitComment(ctx context.Context, doer *user_model.User, repo *repo_model.Repository, gitRepo *git.Repository, commitSHA, treePath string, line int64, content string, attachments []string) (*issues_model.Comment, error) {
+	commit, err := gitRepo.GetCommit(ctx, commitSHA)
+	if err != nil {
+		return nil, err
+	}
+	fullSHA := commit.ID.String()
+
+	var parentSHA string
+	if commit.ParentCount() > 0 {
+		parentID, err := commit.ParentID(0)
+		if err == nil {
+			parentSHA = parentID.String()
+		}
+	}
+	if parentSHA == "" && line < 0 {
+		return nil, ErrCommitCommentRootPrevious
+	}
+
+	patch, err := commitCommentPatch(ctx, gitRepo, parentSHA, fullSHA, treePath, line)
+	if err != nil {
+		return nil, err
+	}
+
+	return issues_model.CreateCommitComment(ctx, &issues_model.CreateCommitCommentOptions{
+		Repo:        repo,
+		Doer:        doer,
+		CommitSHA:   fullSHA,
+		TreePath:    treePath,
+		Line:        line,
+		Content:     content,
+		Patch:       patch,
+		Attachments: attachments,
+	})
+}
+
+func commitCommentPatch(ctx context.Context, gitRepo *git.Repository, parentSHA, fullSHA, treePath string, line int64) (string, error) {
+	if parentSHA != "" {
+		patch, err := git.GetFileDiffCutAroundLine(ctx, gitRepo, parentSHA, fullSHA, treePath, max(line, -line), line < 0, setting.UI.CodeCommentLines)
+		if err != nil {
+			log.Debug("GetFileDiffCutAroundLine failed for commit comment: %v", err)
+		}
+		if patch != "" {
+			return patch, nil
+		}
+	}
+
+	contextSHA := fullSHA
+	if line < 0 {
+		contextSHA = parentSHA
+	}
+	patch, err := gitdiff.GeneratePatchForUnchangedLine(ctx, gitRepo, contextSHA, treePath, line, setting.UI.CodeCommentLines)
+	if err != nil {
+		log.Debug("GeneratePatchForUnchangedLine failed for commit comment: %v", err)
+	}
+	if patch == "" {
+		return "", ErrCommitCommentCoordinates
+	}
+	return patch, nil
+}

--- a/services/repository/delete.go
+++ b/services/repository/delete.go
@@ -195,6 +195,11 @@ func DeleteRepositoryDirectly(ctx context.Context, repoID int64, ignoreOrgTeams 
 		return fmt.Errorf("deleteBeans: %w", err)
 	}
 
+	// Commit comments (junction + CommentTypeCommitComment + bound attachments).
+	if err := issues_model.DeleteCommitCommentsByRepoID(ctx, repoID); err != nil {
+		return fmt.Errorf("DeleteCommitCommentsByRepoID: %w", err)
+	}
+
 	// Delete Labels and related objects
 	if err := issues_model.DeleteLabelsByRepoID(ctx, repoID); err != nil {
 		return err

--- a/templates/repo/commit_page.tmpl
+++ b/templates/repo/commit_page.tmpl
@@ -135,7 +135,7 @@
 				<span class="flex-text-inline tw-text-text-light">{{ctx.Locale.Tr "repo.diff.committed_at" $authors $committedAt}}</span>
 			{{else}}
 				{{$committerAvatar := ""}}{{$committerDisplayName := ""}}
-				{{if .Verification.CommittingUser}}
+				{{if and .Verification .Verification.CommittingUser}}
 					{{$committerAvatar = ctx.AvatarUtils.Avatar .Verification.CommittingUser 20}}
 					{{$committerDisplayName = .Verification.CommittingUser.GetShortDisplayNameLinkHTML}}
 				{{else}}

--- a/templates/repo/diff/blob_excerpt.tmpl
+++ b/templates/repo/diff/blob_excerpt.tmpl
@@ -1,5 +1,7 @@
 {{$diffBlobExcerptData := .DiffBlobExcerptData}}
 {{$canCreateComment := and ctx.RootData.SignedUserID $diffBlobExcerptData.PullIssueIndex}}
+{{/* the commit diff has its own standalone inline comments, keyed by real diff side */}}
+{{$canCommitComment := and ctx.RootData.SignedUserID ctx.RootData.CanCommentOnCommit}}
 {{if $.IsSplitStyle}}
 	{{range $k, $line := $.section.Lines}}
 	<tr class="{{.GetHTMLDiffLineType}}-code nl-{{$k}} ol-{{$k}} line-expanded" data-line-type="{{.GetHTMLDiffLineType}}">
@@ -20,6 +22,10 @@
 					<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-right{{if (not $line.CanComment)}} tw-invisible{{end}}" data-side="right" data-idx="{{$line.RightIdx}}">
 						{{- svg "octicon-plus" -}}
 					</button>
+				{{- else if and $canCommitComment $line.LeftIdx -}}
+					<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-left{{if not $line.CanCommentLeft}} tw-invisible{{end}}" data-side="left" data-idx="{{$line.LeftIdx}}">
+						{{- svg "octicon-plus" -}}
+					</button>
 				{{- end -}}
 				{{- if $line.LeftIdx -}}
 					{{- template "repo/diff/section_code" dict "diff" $inlineDiff -}}
@@ -31,8 +37,8 @@
 			<td class="lines-escape lines-escape-new">{{if and $line.RightIdx}}{{ctx.RenderUtils.RenderUnicodeEscapeToggleButton $inlineDiff.EscapeStatus}}{{end}}</td>
 			<td class="lines-type-marker lines-type-marker-new">{{if $line.RightIdx}}<span class="tw-font-mono" data-type-marker=""></span>{{end}}</td>
 			<td class="lines-code lines-code-new">
-				{{- if and $canCreateComment $line.RightIdx -}}
-					<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-right{{if (not $line.CanComment)}} tw-invisible{{end}}" data-side="right" data-idx="{{$line.RightIdx}}">
+				{{- if and (or $canCreateComment $canCommitComment) $line.RightIdx -}}
+					<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-right{{if not $line.CanCommentRight}} tw-invisible{{end}}" data-side="right" data-idx="{{$line.RightIdx}}">
 						{{- svg "octicon-plus" -}}
 					</button>
 				{{- end -}}
@@ -58,6 +64,7 @@
 			</td>
 		</tr>
 	{{end}}
+	{{template "repo/diff/commit_conversation_row" dict "root" $ "left" $line.CommitCommentsLeft "right" $line.CommitCommentsRight "lineType" $line.GetHTMLDiffLineType "split" true}}
 	{{end}}
 {{else}}
 	{{range $k, $line := $.section.Lines}}
@@ -72,8 +79,8 @@
 		<td class="lines-escape">{{ctx.RenderUtils.RenderUnicodeEscapeToggleButton $inlineDiff.EscapeStatus}}</td>
 		<td class="lines-type-marker"><span class="tw-font-mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span></td>
 		<td class="lines-code{{if (not $line.RightIdx)}} lines-code-old{{end}}">
-			{{- if and $canCreateComment -}}
-				<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-{{if $line.RightIdx}}right{{else}}left{{end}}{{if (not $line.CanComment)}} tw-invisible{{end}}" data-side="{{if $line.RightIdx}}right{{else}}left{{end}}" data-idx="{{if $line.RightIdx}}{{$line.RightIdx}}{{else}}{{$line.LeftIdx}}{{end}}">
+			{{- if or $canCreateComment $canCommitComment -}}
+				<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-{{if $line.RightIdx}}right{{else}}left{{end}}{{if not $line.CanCommentUnified}} tw-invisible{{end}}" data-side="{{if $line.RightIdx}}right{{else}}left{{end}}" data-idx="{{if $line.RightIdx}}{{$line.RightIdx}}{{else}}{{$line.LeftIdx}}{{end}}">
 					{{- svg "octicon-plus" -}}
 				</button>
 			{{- end -}}
@@ -87,5 +94,6 @@
 			</td>
 		</tr>
 	{{end}}
+	{{template "repo/diff/commit_conversation_row" dict "root" $ "left" $line.CommitCommentsLeft "right" $line.CommitCommentsRight "lineType" $line.GetHTMLDiffLineType}}
 	{{end}}
 {{end}}

--- a/templates/repo/diff/box.tmpl
+++ b/templates/repo/diff/box.tmpl
@@ -195,7 +195,7 @@
 										{{end}}
 									</div>
 								{{else if $file.Sections}}
-									<table class="chroma" data-new-comment-url="{{$.Issue.Link}}/files/reviews/new_comment" data-path="{{$file.Name}}">
+									<table class="chroma" data-new-comment-url="{{if $.DiffNewCommentURL}}{{$.DiffNewCommentURL}}{{else}}{{$.Issue.Link}}/files/reviews/new_comment{{end}}" data-path="{{$file.Name}}">
 										{{if $.IsSplitStyle}}
 											{{template "repo/diff/section_split" dict "file" . "root" $}}
 										{{else}}

--- a/templates/repo/diff/commit_comment_form.tmpl
+++ b/templates/repo/diff/commit_comment_form.tmpl
@@ -1,0 +1,29 @@
+{{if ctx.RootData.CanCommentOnCommit}}
+	{{/* on the reply path a parent comment is passed, so the reply submits with the parent's coordinates */}}
+	<form class="ui form {{if $.hidden}}tw-hidden comment-form{{end}}" action="{{$.root.DiffNewCommentURL}}" method="post">
+		<input type="hidden" name="side" value="{{with $.comment}}{{.DiffSide}}{{end}}">
+		<input type="hidden" name="line" value="{{with $.comment}}{{.UnsignedLine}}{{end}}">
+		<input type="hidden" name="path" value="{{with $.comment}}{{.TreePath}}{{end}}">
+		<div class="field">
+		{{template "shared/combomarkdowneditor" (dict
+			"CustomInit" true
+			"MarkdownEditorContext" (ctx.MiscUtils.MarkdownEditorComment ctx.RootData.Repository)
+			"TextareaName" "content"
+			"TextareaPlaceholder" (ctx.Locale.Tr "repo.diff.comment.placeholder")
+			"DropzoneParentContainer" "form"
+			"DisableAutosize" "true"
+		)}}
+		</div>
+		{{if $.root.IsAttachmentEnabled}}
+			<div class="field">
+				{{template "repo/upload" dict "UploadOptions" ctx.RootData.UploadOptions}}
+			</div>
+		{{end}}
+		<div class="field footer">
+			<div class="flex-text-block tw-justify-end">
+				<button type="submit" class="ui submit primary tiny button btn-add-single">{{ctx.Locale.Tr "repo.diff.comment.add_single_comment"}}</button>
+				<button type="button" class="ui submit tiny basic button btn-cancel cancel-code-comment">{{ctx.Locale.Tr "cancel"}}</button>
+			</div>
+		</div>
+	</form>
+{{end}}

--- a/templates/repo/diff/commit_comments.tmpl
+++ b/templates/repo/diff/commit_comments.tmpl
@@ -1,0 +1,39 @@
+{{range .comments}}
+{{$createdStr := DateUtils.TimeSince .CreatedUnix}}
+<div class="comment" id="{{.HashTag}}">
+	<div class="tw-mt-2 tw-mr-4">
+		{{template "shared/user/avatarlink" dict "user" .Poster}}
+	</div>
+	<div class="content comment-container">
+		<div class="comment-header avatar-content-left-arrow">
+			<div class="comment-header-left">
+				<span class="tw-text-text-light muted-links">
+					{{template "shared/user/namelink" .Poster}}
+					{{ctx.Locale.Tr "repo.issues.commented_at" .HashTag $createdStr}}
+				</span>
+			</div>
+			<div class="comment-header-right">
+				{{$canDelete := and $.root.CanCommentOnCommit (or (eq $.root.SignedUserID .PosterID) $.root.Permission.IsAdmin ($.root.Permission.CanWrite ctx.Consts.RepoUnitTypeCode))}}
+				{{if $canDelete}}
+					<div class="item context js-aria-clickable delete-comment" data-comment-id="{{.HashTag}}" data-url="{{$.root.RepoLink}}/commit/{{.CommitSHA}}/comment/{{.ID}}/delete" data-locale="{{ctx.Locale.Tr "repo.issues.delete_comment_confirm"}}">
+						{{svg "octicon-trash" 14}}
+					</div>
+				{{end}}
+			</div>
+		</div>
+		<div class="ui attached segment comment-body">
+			<div class="render-content markup">
+			{{if .RenderedContent}}
+				{{.RenderedContent}}
+			{{else}}
+				<span class="no-content">{{ctx.Locale.Tr "repo.issues.no_content"}}</span>
+			{{end}}
+			</div>
+			<div id="{{.HashTag}}-raw" class="raw-content tw-hidden">{{.Content}}</div>
+			{{if .Attachments}}
+				{{template "repo/issue/view_content/attachments" dict "Attachments" .Attachments "RenderedContent" .RenderedContent}}
+			{{end}}
+		</div>
+	</div>
+</div>
+{{end}}

--- a/templates/repo/diff/commit_conversation.tmpl
+++ b/templates/repo/diff/commit_conversation.tmpl
@@ -9,15 +9,15 @@
 			</div>
 			<div class="flex-text-block tw-mt-2 tw-flex-wrap tw-justify-end">
 				<div class="ui buttons">
-					<button class="ui icon tiny basic button previous-conversation">
+					<button type="button" class="ui icon tiny basic button previous-conversation">
 						{{svg "octicon-arrow-up" 12}} {{ctx.Locale.Tr "repo.issues.previous"}}
 					</button>
-					<button class="ui icon tiny basic button next-conversation">
+					<button type="button" class="ui icon tiny basic button next-conversation">
 						{{svg "octicon-arrow-down" 12}} {{ctx.Locale.Tr "repo.issues.next"}}
 					</button>
 				</div>
 				{{if $.CanCommentOnCommit}}
-					<button class="comment-form-reply ui primary icon tiny button">
+					<button type="button" class="comment-form-reply ui primary icon tiny button">
 						{{svg "octicon-reply" 12}}{{ctx.Locale.Tr "repo.diff.comment.reply"}}
 					</button>
 				{{end}}

--- a/templates/repo/diff/commit_conversation.tmpl
+++ b/templates/repo/diff/commit_conversation.tmpl
@@ -1,0 +1,28 @@
+{{if len .comments}}
+	{{$comment := index .comments 0}}
+	<div class="conversation-holder" data-path="{{$comment.TreePath}}" data-side="{{if lt $comment.Line 0}}left{{else}}right{{end}}" data-idx="{{$comment.UnsignedLine}}">
+		<div id="code-comments-{{$comment.ID}}" class="field comment-code-cloud">
+			<div class="comment-list">
+				<div class="ui comments commit-conversation">
+					{{template "repo/diff/commit_comments" dict "root" $ "comments" .comments}}
+				</div>
+			</div>
+			<div class="flex-text-block tw-mt-2 tw-flex-wrap tw-justify-end">
+				<div class="ui buttons">
+					<button class="ui icon tiny basic button previous-conversation">
+						{{svg "octicon-arrow-up" 12}} {{ctx.Locale.Tr "repo.issues.previous"}}
+					</button>
+					<button class="ui icon tiny basic button next-conversation">
+						{{svg "octicon-arrow-down" 12}} {{ctx.Locale.Tr "repo.issues.next"}}
+					</button>
+				</div>
+				{{if $.CanCommentOnCommit}}
+					<button class="comment-form-reply ui primary icon tiny button">
+						{{svg "octicon-reply" 12}}{{ctx.Locale.Tr "repo.diff.comment.reply"}}
+					</button>
+				{{end}}
+			</div>
+			{{template "repo/diff/commit_comment_form" dict "hidden" true "root" $ "comment" $comment}}
+		</div>
+	</div>
+{{end}}

--- a/templates/repo/diff/commit_conversation_row.tmpl
+++ b/templates/repo/diff/commit_conversation_row.tmpl
@@ -1,0 +1,17 @@
+{{if or .left .right}}
+	<tr class="add-comment" data-line-type="{{.lineType}}">
+		{{if .split}}
+			<td class="add-comment-left" colspan="4">
+				{{if .left}}{{template "repo/diff/commit_conversation" dict "." .root "comments" .left}}{{end}}
+			</td>
+			<td class="add-comment-right" colspan="4">
+				{{if .right}}{{template "repo/diff/commit_conversation" dict "." .root "comments" .right}}{{end}}
+			</td>
+		{{else}}
+			<td class="add-comment-left add-comment-right" colspan="5">
+				{{if .right}}{{template "repo/diff/commit_conversation" dict "." .root "comments" .right}}{{end}}
+				{{if .left}}{{template "repo/diff/commit_conversation" dict "." .root "comments" .left}}{{end}}
+			</td>
+		{{end}}
+	</tr>
+{{end}}

--- a/templates/repo/diff/new_commit_comment.tmpl
+++ b/templates/repo/diff/new_commit_comment.tmpl
@@ -1,0 +1,5 @@
+<div class="conversation-holder">
+	<div class="field comment-code-cloud">
+		{{template "repo/diff/commit_comment_form" dict "root" $}}
+	</div>
+</div>

--- a/templates/repo/diff/section_split.tmpl
+++ b/templates/repo/diff/section_split.tmpl
@@ -28,8 +28,8 @@
 					<td class="lines-escape del-code lines-escape-old">{{if $line.LeftIdx}}{{ctx.RenderUtils.RenderUnicodeEscapeToggleButton $leftDiff.EscapeStatus}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-old del-code"><span class="tw-font-mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span></td>
 					<td class="lines-code lines-code-old del-code">
-						{{- if and $.root.SignedUserID $.root.PageIsPullFiles -}}
-							<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-left{{if (not $line.CanComment)}} tw-invisible{{end}}" data-side="left" data-idx="{{$line.LeftIdx}}">
+						{{- $canAddComment := and $.root.SignedUserID (or $.root.PageIsPullFiles $.root.CanCommentOnCommit) (not $.root.Repository.IsArchived) -}}{{- if $canAddComment -}}
+							<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-left{{if and $.root.PageIsPullFiles (not $line.CanComment)}} tw-invisible{{else if and $.root.CanCommentOnCommit (not $line.CanCommentLeft)}} tw-invisible{{end}}" data-side="left" data-idx="{{$line.LeftIdx}}">
 								{{- svg "octicon-plus" -}}
 							</button>
 						{{- end -}}
@@ -43,8 +43,8 @@
 					<td class="lines-escape add-code lines-escape-new">{{if $match.RightIdx}}{{ctx.RenderUtils.RenderUnicodeEscapeToggleButton $rightDiff.EscapeStatus}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-new add-code">{{if $match.RightIdx}}<span class="tw-font-mono" data-type-marker="{{$match.GetLineTypeMarker}}"></span>{{end}}</td>
 					<td class="lines-code lines-code-new add-code">
-						{{- if and $.root.SignedUserID $.root.PageIsPullFiles -}}
-							<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-right{{if (not $match.CanComment)}} tw-invisible{{end}}" data-side="right" data-idx="{{$match.RightIdx}}">
+						{{- $canAddComment := and $.root.SignedUserID (or $.root.PageIsPullFiles $.root.CanCommentOnCommit) (not $.root.Repository.IsArchived) -}}{{- if $canAddComment -}}
+							<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-right{{if and $.root.PageIsPullFiles (not $match.CanComment)}} tw-invisible{{else if and $.root.CanCommentOnCommit (not $match.CanCommentRight)}} tw-invisible{{end}}" data-side="right" data-idx="{{$match.RightIdx}}">
 								{{- svg "octicon-plus" -}}
 							</button>
 						{{- end -}}
@@ -60,8 +60,8 @@
 					<td class="lines-escape lines-escape-old">{{if $line.LeftIdx}}{{ctx.RenderUtils.RenderUnicodeEscapeToggleButton $inlineDiff.EscapeStatus}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-old">{{if $line.LeftIdx}}<span class="tw-font-mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
 					<td class="lines-code lines-code-old">
-						{{- if and $.root.SignedUserID $.root.PageIsPullFiles (not (eq .GetType 2)) -}}
-							<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-left{{if (not $line.CanComment)}} tw-invisible{{end}}" data-side="left" data-idx="{{$line.LeftIdx}}">
+						{{- $canAddComment := and $.root.SignedUserID (or $.root.PageIsPullFiles $.root.CanCommentOnCommit) (not $.root.Repository.IsArchived) (not (eq .GetType 2)) -}}{{- if $canAddComment -}}
+							<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-left{{if and $.root.PageIsPullFiles (not $line.CanComment)}} tw-invisible{{else if and $.root.CanCommentOnCommit (not $line.CanCommentLeft)}} tw-invisible{{end}}" data-side="left" data-idx="{{$line.LeftIdx}}">
 								{{- svg "octicon-plus" -}}
 							</button>
 						{{- end -}}
@@ -75,8 +75,8 @@
 					<td class="lines-escape lines-escape-new">{{if $line.RightIdx}}{{ctx.RenderUtils.RenderUnicodeEscapeToggleButton $inlineDiff.EscapeStatus}}{{end}}</td>
 					<td class="lines-type-marker lines-type-marker-new">{{if $line.RightIdx}}<span class="tw-font-mono" data-type-marker="{{$line.GetLineTypeMarker}}"></span>{{end}}</td>
 					<td class="lines-code lines-code-new">
-						{{- if and $.root.SignedUserID $.root.PageIsPullFiles (not (eq .GetType 3)) -}}
-							<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-right{{if (not $line.CanComment)}} tw-invisible{{end}}" data-side="right" data-idx="{{$line.RightIdx}}">
+						{{- $canAddComment := and $.root.SignedUserID (or $.root.PageIsPullFiles $.root.CanCommentOnCommit) (not $.root.Repository.IsArchived) (not (eq .GetType 3)) -}}{{- if $canAddComment -}}
+							<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-right{{if and $.root.PageIsPullFiles (not $line.CanComment)}} tw-invisible{{else if and $.root.CanCommentOnCommit (not $line.CanCommentRight)}} tw-invisible{{end}}" data-side="right" data-idx="{{$line.RightIdx}}">
 								{{- svg "octicon-plus" -}}
 							</button>
 						{{- end -}}
@@ -132,6 +132,9 @@
 					</td>
 				</tr>
 			{{end}}
+			{{$rightCC := $line.CommitCommentsRight}}
+			{{if and (eq .GetType 3) $hasmatch}}{{$rightCC = (index $section.Lines $line.Match).CommitCommentsRight}}{{end}}
+			{{template "repo/diff/commit_conversation_row" dict "root" $.root "left" $line.CommitCommentsLeft "right" $rightCC "lineType" $line.GetHTMLDiffLineType "split" true}}
 		{{end}}
 	{{end}}
 {{end}}

--- a/templates/repo/diff/section_unified.tmpl
+++ b/templates/repo/diff/section_unified.tmpl
@@ -31,8 +31,9 @@
 				<td class="chroma lines-code blob-hunk">{{template "repo/diff/section_code" dict "diff" $inlineDiff}}</td>
 			{{else}}
 				<td class="chroma lines-code{{if (not $line.RightIdx)}} lines-code-old{{end}}">
-					{{- if and $.root.SignedUserID $.root.PageIsPullFiles -}}
-						<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-{{if $line.RightIdx}}right{{else}}left{{end}}{{if (not $line.CanComment)}} tw-invisible{{end}}" data-side="{{if $line.RightIdx}}right{{else}}left{{end}}" data-idx="{{if $line.RightIdx}}{{$line.RightIdx}}{{else}}{{$line.LeftIdx}}{{end}}">
+					{{- $canAddComment := and $.root.SignedUserID (or $.root.PageIsPullFiles $.root.CanCommentOnCommit) (not $.root.Repository.IsArchived) -}}
+					{{- if $canAddComment -}}
+						<button type="button" aria-label="{{ctx.Locale.Tr "repo.diff.comment.add_line_comment"}}" class="ui primary button add-code-comment add-code-comment-{{if $line.RightIdx}}right{{else}}left{{end}}{{if and $.root.PageIsPullFiles (not $line.CanComment)}} tw-invisible{{else if and $.root.CanCommentOnCommit (not $line.CanCommentUnified)}} tw-invisible{{end}}" data-side="{{if $line.RightIdx}}right{{else}}left{{end}}" data-idx="{{if $line.RightIdx}}{{$line.RightIdx}}{{else}}{{$line.LeftIdx}}{{end}}">
 							{{- svg "octicon-plus" -}}
 						</button>
 					{{- end -}}
@@ -40,12 +41,13 @@
 				</td>
 			{{end}}
 		</tr>
-		{{if $line.Comments}}
+		{{if and $line.Comments (not $.root.CanCommentOnCommit)}}
 			<tr class="add-comment" data-line-type="{{.GetHTMLDiffLineType}}">
 				<td class="add-comment-left add-comment-right" colspan="5">
 					{{template "repo/diff/conversation" dict "." $.root "comments" $line.Comments}}
 				</td>
 			</tr>
 		{{end}}
+		{{template "repo/diff/commit_conversation_row" dict "root" $.root "left" $line.CommitCommentsLeft "right" $line.CommitCommentsRight "lineType" $line.GetHTMLDiffLineType}}
 	{{end}}
 {{end}}

--- a/tests/integration/repo_commit_comment_test.go
+++ b/tests/integration/repo_commit_comment_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	issues_model "gitea.dev/models/issues"
+	"gitea.dev/models/unittest"
+	"gitea.dev/tests"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommitInlineComment(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	const rootSHA = "65f1bf27bc3bf70f64657658635e66094edbcb4d" // adds README.md with 3 lines
+	session := loginUser(t, "user2")
+
+	postComment := func(sha, side, line, content string) string {
+		req := NewRequestWithValues(t, "POST", "/user2/repo1/commit/"+sha+"/comment", map[string]string{
+			"content": content,
+			"path":    "README.md",
+			"side":    side,
+			"line":    line,
+		})
+		return session.MakeRequest(t, req, http.StatusOK).Body.String()
+	}
+
+	t.Run("CreateListDelete", func(t *testing.T) {
+		body := postComment(rootSHA, "proposed", "1", "first commit comment")
+		assert.Contains(t, body, "first commit comment")
+
+		reply := postComment(rootSHA, "proposed", "1", "second commit comment")
+		assert.Contains(t, reply, "first commit comment")
+		assert.Contains(t, reply, "second commit comment")
+
+		resp := session.MakeRequest(t, NewRequest(t, "GET", "/user2/repo1/commit/"+rootSHA), http.StatusOK)
+		page := NewHTMLParser(t, resp.Body)
+		assert.Equal(t, 2, page.Find(".comment-code-cloud .comment").Length())
+		assert.NotZero(t, page.Find(".add-code-comment").Length())
+
+		splitResp := session.MakeRequest(t, NewRequest(t, "GET", "/user2/repo1/commit/"+rootSHA+"?style=split"), http.StatusOK)
+		split := NewHTMLParser(t, splitResp.Body)
+		assert.NotZero(t, split.Find(".add-code-comment").Length(), "split diff should expose inline comment controls")
+		assert.Contains(t, strings.TrimSpace(split.Find(".commit-conversation .comment-body").Text()), "first commit comment")
+
+		comment := unittest.AssertExistsAndLoadBean(t, &issues_model.Comment{Content: "second commit comment", Type: issues_model.CommentTypeCommitComment})
+		url := fmt.Sprintf("/user2/repo1/commit/%s/comment/%d/delete", rootSHA, comment.ID)
+		session.MakeRequest(t, NewRequest(t, "POST", url), http.StatusOK)
+		unittest.AssertNotExistsBean(t, &issues_model.Comment{ID: comment.ID})
+		unittest.AssertNotExistsBean(t, &issues_model.CommitComment{CommentID: comment.ID})
+		session.MakeRequest(t, NewRequest(t, "POST", url), http.StatusNotFound)
+	})
+
+}

--- a/tests/integration/repo_commit_comment_test.go
+++ b/tests/integration/repo_commit_comment_test.go
@@ -57,5 +57,4 @@ func TestCommitInlineComment(t *testing.T) {
 		unittest.AssertNotExistsBean(t, &issues_model.CommitComment{CommentID: comment.ID})
 		session.MakeRequest(t, NewRequest(t, "POST", url), http.StatusNotFound)
 	})
-
 }

--- a/web_src/js/features/repo-issue.ts
+++ b/web_src/js/features/repo-issue.ts
@@ -246,7 +246,8 @@ export function initRepoPullRequestReview() {
   });
 
   // The following part is only for diff views
-  if (!document.querySelector('.repository.pull.diff')) return;
+  // PR files page and commit diff page both expose inline comment controls
+  if (!document.querySelector('.repository.diff')) return;
 
   const elReviewBtn = document.querySelector('.js-btn-review');
   const elReviewPanel = document.querySelector('.review-box-panel.tippy-target');

--- a/web_src/js/features/repo-issue.ts
+++ b/web_src/js/features/repo-issue.ts
@@ -247,8 +247,8 @@ export function initRepoPullRequestReview() {
 
   // The following part is only for diff views that expose inline comment controls:
   // PR files (.repository.pull.diff) and commit diffs (new-comment URL under /commit/).
-  const isPullDiff = !!document.querySelector('.repository.pull.diff');
-  const isCommitDiff = !!document.querySelector('.repository.diff [data-new-comment-url*="/commit/"]');
+  const isPullDiff = Boolean(document.querySelector('.repository.pull.diff'));
+  const isCommitDiff = Boolean(document.querySelector('.repository.diff [data-new-comment-url*="/commit/"]'));
   if (!isPullDiff && !isCommitDiff) return;
 
   const elReviewBtn = document.querySelector('.js-btn-review');

--- a/web_src/js/features/repo-issue.ts
+++ b/web_src/js/features/repo-issue.ts
@@ -245,9 +245,11 @@ export function initRepoPullRequestReview() {
     handleReply(el);
   });
 
-  // The following part is only for diff views
-  // PR files page and commit diff page both expose inline comment controls
-  if (!document.querySelector('.repository.diff')) return;
+  // The following part is only for diff views that expose inline comment controls:
+  // PR files (.repository.pull.diff) and commit diffs (new-comment URL under /commit/).
+  const isPullDiff = !!document.querySelector('.repository.pull.diff');
+  const isCommitDiff = !!document.querySelector('.repository.diff [data-new-comment-url*="/commit/"]');
+  if (!isPullDiff && !isCommitDiff) return;
 
   const elReviewBtn = document.querySelector('.js-btn-review');
   const elReviewPanel = document.querySelector('.review-box-panel.tippy-target');

--- a/web_src/js/features/repo-legacy.ts
+++ b/web_src/js/features/repo-legacy.ts
@@ -57,6 +57,11 @@ export function initRepository() {
   initRepoSettings();
   initRepoIssueWipNewTitle();
 
+  // Conversations exist on issue/PR pages and on commit diffs, so these
+  // delegated handlers follow the markup rather than a page class.
+  initRepoIssueCommentDelete();
+  initRepoIssueCodeCommentCancel();
+
   // Issues
   if (pageContent.matches('.page-content.repository.view.issue')) {
     initRepoIssueCommentEdit();
@@ -67,8 +72,6 @@ export function initRepository() {
 
     initRepoIssueReferenceIssue();
 
-    initRepoIssueCommentDelete();
-    initRepoIssueCodeCommentCancel();
     initCompReactionSelector();
   }
 


### PR DESCRIPTION
## Summary
Implements inline comments on commit files for go-gitea/gitea#4898 (Algora bounty).

- CommentTypeCommitComment + junction storage
- Attachments bound to commit comments
- Unified + split diff UI
- Unit/integration coverage

Supersedes dirty competing work; tip-based branch `feat/commit-inline-comments-v2`.

## Test plan
- [x] Unit tests
- [x] Integration TestCommitInlineComment (sqlite local)
- [ ] CI green on this PR
