### PR TITLE
fix(security): validate git subprocess HTTP redirects via a loopback proxy

### DIFF
--- a/cmd/dump_repo.go
+++ b/cmd/dump_repo.go
@@ -95,6 +95,11 @@ func runDumpRepository(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
+	// builds the allow/block lists the clone path validates remote addresses against
+	if err := migrations.Init(); err != nil {
+		return err
+	}
+
 	log.Info("AppPath: %s", setting.AppPath)
 	log.Info("AppWorkPath: %s", setting.AppWorkPath)
 	log.Info("Custom path: %s", setting.CustomPath)

--- a/modules/git/gitcmd/command.go
+++ b/modules/git/gitcmd/command.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -206,6 +207,50 @@ func (c *Command) AddConfig(key, value string) *Command {
 		c.configArgs = append(c.configArgs, "-c", kv)
 	}
 	return c
+}
+
+// proxyEnvNames are the environment variables libcurl reads to pick or suppress a proxy.
+var proxyEnvNames = []string{
+	"http_proxy", "HTTP_PROXY",
+	"https_proxy", "HTTPS_PROXY",
+	"all_proxy", "ALL_PROXY",
+	"no_proxy", "NO_PROXY",
+}
+
+// removeProxyEnvsIfConfigured strips the proxy environment variables when the command already
+// carries an explicit `-c http.proxy=...`.
+//
+// This matters for security, not just precedence: git has no `http.noProxy` config key, so a
+// `no_proxy` value inherited from Gitea's own environment still applies and makes libcurl ignore
+// the configured proxy for matching hosts. Where that proxy is the SSRF guard from
+// git.HandleGitCmdHTTPRedirection, `no_proxy=*`, common in container images, or a corporate
+// `no_proxy` naming the internal ranges, would silently disable it for exactly the targets it is
+// meant to protect.
+func removeProxyEnvsIfConfigured(env, configArgs []string) []string {
+	configured := false
+	for _, arg := range configArgs {
+		if strings.HasPrefix(arg, "http.proxy=") {
+			configured = true
+			break
+		}
+	}
+	if !configured {
+		return env
+	}
+	kept := make([]string, 0, len(env))
+	for _, kv := range env {
+		name, _, _ := strings.Cut(kv, "=")
+		if !slices.Contains(proxyEnvNames, name) {
+			kept = append(kept, kv)
+		}
+	}
+	return kept
+}
+
+// ConfigArgs returns the `-c key=value` arguments accumulated by AddConfig, as a copy. It exists so
+// callers that configure a command (and their tests) can inspect what was set.
+func (c *Command) ConfigArgs() []string {
+	return slices.Clone(c.configArgs)
 }
 
 // ToTrustedCmdArgs converts a list of strings (trusted as argument) to TrustedCmdArgs
@@ -439,6 +484,7 @@ func (c *Command) Start(ctx context.Context) (retErr error) {
 	}
 
 	c.cmd.Env = append(c.cmd.Env, CommonGitCmdEnvs()...)
+	c.cmd.Env = removeProxyEnvsIfConfigured(c.cmd.Env, c.configArgs)
 	c.cmd.Dir = c.gitDir
 	c.cmd.Stdout = c.cmdStdout
 	c.cmd.Stdin = c.cmdStdin

--- a/modules/git/gitcmd/proxyenv_test.go
+++ b/modules/git/gitcmd/proxyenv_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package gitcmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoveProxyEnvsIfConfigured(t *testing.T) {
+	env := []string{"PATH=/usr/bin", "no_proxy=*", "NO_PROXY=10.0.0.0/8", "https_proxy=http://corp:3128", "HOME=/home/git"}
+
+	t.Run("KeptWithoutProxyConfig", func(t *testing.T) {
+		assert.Equal(t, env, removeProxyEnvsIfConfigured(env, []string{"-c", "http.sslVerify=false"}))
+	})
+
+	t.Run("StrippedWithProxyConfig", func(t *testing.T) {
+		// git has no http.noProxy key, so an inherited no_proxy would otherwise make libcurl ignore
+		// the configured proxy and defeat the redirect guard
+		got := removeProxyEnvsIfConfigured(env, []string{"-c", "http.proxy=http://127.0.0.1:1234"})
+		assert.Equal(t, []string{"PATH=/usr/bin", "HOME=/home/git"}, got)
+	})
+}

--- a/modules/git/redirection.go
+++ b/modules/git/redirection.go
@@ -3,13 +3,54 @@
 
 package git
 
-import "gitea.dev/modules/git/gitcmd"
+import (
+	"net/url"
+	"strings"
+	"sync/atomic"
 
+	"gitea.dev/modules/git/gitcmd"
+)
+
+// httpProxyProvider yields the address of a loopback proxy that validates every HTTP target,
+// redirect hops included, against the migration allow/block lists. It is registered by the
+// migrations service, which owns those lists; modules/git cannot import services/, hence the hook.
+var httpProxyProvider atomic.Pointer[func() string]
+
+// SetGitCmdHTTPProxyProvider registers the provider used by HandleGitCmdHTTPRedirection. Passing
+// nil clears it, restoring the fallback behaviour.
+func SetGitCmdHTTPProxyProvider(provider func() string) {
+	if provider == nil {
+		httpProxyProvider.Store(nil)
+		return
+	}
+	httpProxyProvider.Store(&provider)
+}
+
+// HandleGitCmdHTTPRedirection protects a git subprocess from being redirected onto an address the
+// allow/block lists forbid (SSRF, e.g. migrating from an attacker-controlled URL).
+//
+// Gitea validates a migration URL by resolving it once and checking the result, but `git` then
+// resolves DNS again and follows HTTP redirects on its own, so an approved external host can answer
+// 30x and send the subprocess to an internal address. Routing the subprocess through the validating
+// proxy puts every hop back under the same policy: a redirect to a permitted target still resolves,
+// a redirect to a forbidden one is refused at connect time.
+//
+// Blanket `http.followRedirects=false` was tried before and reverted: it also rejects the benign
+// redirects real forges emit, e.g. GitLab answering 301 for a clone URL without the .git suffix.
+// It stays only as the fail-closed fallback for the rare caller with no proxy available.
 func HandleGitCmdHTTPRedirection(cmd *gitcmd.Command, targets ...string) {
-	// Protect from SSRF vector (e.g. migrating from an attacker URL).
-	// cmd.AddConfig("http.followRedirects", "false")
-	// However, we can't do so at the moment:
-	// this fails due to 301: git -c http.followRedirects=false clone -v https://gitlab.com/{owner}/{repo}
-	// this succeeds: git -c http.followRedirects=false clone -v https://gitlab.com/{owner}/{repo}.git
-	// FIXME: GIT-CLONE-HTTP-REDIRECT-SSRF: need a complete solution in the future
+	if provider := httpProxyProvider.Load(); provider != nil {
+		if proxyURL := (*provider)(); proxyURL != "" {
+			cmd.AddConfig("http.proxy", proxyURL)
+			return
+		}
+	}
+	cmd.AddConfig("http.followRedirects", "false")
+}
+
+// isHTTPRemote reports whether a clone source is an HTTP(S) URL, i.e. a remote the redirect guard
+// applies to. Local paths and other transports are left alone.
+func isHTTPRemote(from string) bool {
+	u, err := url.Parse(from)
+	return err == nil && (strings.EqualFold(u.Scheme, "http") || strings.EqualFold(u.Scheme, "https"))
 }

--- a/modules/git/redirection_test.go
+++ b/modules/git/redirection_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package git
+
+import (
+	"strings"
+	"testing"
+
+	"gitea.dev/modules/git/gitcmd"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandleGitCmdHTTPRedirection(t *testing.T) {
+	t.Run("RoutesThroughValidatingProxy", func(t *testing.T) {
+		SetGitCmdHTTPProxyProvider(func() string { return "http://127.0.0.1:65000" })
+		t.Cleanup(func() { SetGitCmdHTTPProxyProvider(nil) })
+
+		cmd := gitcmd.NewCommand("clone")
+		HandleGitCmdHTTPRedirection(cmd)
+		assert.Contains(t, strings.Join(cmd.ConfigArgs(), " "), "http.proxy=http://127.0.0.1:65000")
+		assert.NotContains(t, strings.Join(cmd.ConfigArgs(), " "), "http.followRedirects")
+	})
+
+	t.Run("FailsClosedWithoutProvider", func(t *testing.T) {
+		SetGitCmdHTTPProxyProvider(nil)
+
+		cmd := gitcmd.NewCommand("clone")
+		HandleGitCmdHTTPRedirection(cmd)
+		assert.Contains(t, strings.Join(cmd.ConfigArgs(), " "), "http.followRedirects=false")
+	})
+
+	t.Run("FailsClosedWhenProxyUnavailable", func(t *testing.T) {
+		SetGitCmdHTTPProxyProvider(func() string { return "" })
+		t.Cleanup(func() { SetGitCmdHTTPProxyProvider(nil) })
+
+		cmd := gitcmd.NewCommand("clone")
+		HandleGitCmdHTTPRedirection(cmd)
+		assert.Contains(t, strings.Join(cmd.ConfigArgs(), " "), "http.followRedirects=false")
+	})
+}
+
+func TestIsHTTPRemote(t *testing.T) {
+	for source, want := range map[string]bool{
+		"https://example.com/o/r.git": true,
+		"http://example.com/o/r.git":  true,
+		"HTTPS://example.com/o/r.git": true,
+		"git://example.com/o/r.git":   false,
+		"ssh://git@example.com/o/r":   false,
+		"git@example.com:o/r.git":     false,
+		"/var/lib/gitea/repos/o/r":    false,
+		"":                            false,
+	} {
+		assert.Equal(t, want, isHTTPRemote(source), source)
+	}
+}

--- a/modules/git/repo.go
+++ b/modules/git/repo.go
@@ -183,7 +183,9 @@ func Clone(ctx context.Context, from, to string, opts CloneRepoOptions) error {
 	}
 
 	cmd := gitcmd.NewCommand().AddArguments("clone")
-	HandleGitCmdHTTPRedirection(cmd, from, to)
+	if isHTTPRemote(from) {
+		HandleGitCmdHTTPRedirection(cmd, from, to)
+	}
 	if opts.SkipTLSVerify {
 		cmd.AddArguments("-c", "http.sslVerify=false")
 	}

--- a/modules/hostmatcher/proxyserver.go
+++ b/modules/hostmatcher/proxyserver.go
@@ -1,0 +1,361 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package hostmatcher
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"gitea.dev/modules/log"
+)
+
+// hopHeaders are the connection-scoped headers a proxy must not forward (RFC 9110 section 7.6.1).
+var hopHeaders = []string{
+	"Connection",
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"Proxy-Connection",
+	"Te",
+	"Trailer",
+	"Transfer-Encoding",
+	"Upgrade",
+}
+
+// errDenied is the body returned to the caller when a target is refused. The reason is logged
+// server-side instead of being returned: a caller that can read it learns how an internal name
+// resolves, which is the very thing the allow/block lists exist to withhold.
+const errDenied = "target refused by the allow/block list"
+
+// ProxyServer is a loopback HTTP proxy that validates every target against the allow/block lists
+// before connecting, including targets reached through an HTTP redirect.
+//
+// It exists for subprocesses we cannot instrument. Gitea's own HTTP clients get connect-time
+// enforcement from NewDialContext, but `git` performs its own DNS resolution and follows HTTP
+// redirects itself, so a URL that passes validation can still land on an internal address once the
+// remote answers with a 30x (SSRF). Pointing the subprocess at this proxy with `http.proxy` puts
+// every hop, initial request and redirect alike, back under the same allow/block policy: the
+// forwarded request is dialled through NewDialContext, and a redirect is returned to the caller
+// unfollowed so its target arrives as a fresh, separately validated request.
+//
+// The listener is bound to loopback only. It is not authenticated: it applies exactly the policy
+// Gitea's own migration client applies, so a local process gains nothing by using it.
+type ProxyServer struct {
+	usage         string
+	allowList     *HostMatchList
+	blockList     *HostMatchList
+	proxyFunc     func(*http.Request) (*url.URL, error)
+	proxyURLFixed *url.URL
+
+	listener  net.Listener
+	server    *http.Server
+	transport *http.Transport
+}
+
+// NewProxyServer starts a validating proxy on a random loopback port and serves it in the
+// background. Close stops it. The arguments mirror NewHTTPTransport: proxyFunc selects the upstream
+// proxy per request (e.g. proxy.Proxy()), proxyURLFixed is the upstream address the dialler must
+// always permit, and tlsConfig may be nil.
+//
+// allowList and blockList must not both be nil: nil lists match nothing, which would make the proxy
+// permit every target and silently turn the guard into a no-op.
+func NewProxyServer(usage string, allowList, blockList *HostMatchList, proxyFunc func(*http.Request) (*url.URL, error), proxyURLFixed *url.URL, tlsConfig *tls.Config) (*ProxyServer, error) {
+	if allowList.IsEmpty() && blockList.IsEmpty() {
+		return nil, fmt.Errorf("%s proxy: refusing to start with no allow or block list, it would permit every target", usage)
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("%s proxy: unable to listen on loopback: %w", usage, err)
+	}
+
+	ps := &ProxyServer{
+		usage:         usage,
+		allowList:     allowList,
+		blockList:     blockList,
+		proxyFunc:     proxyFunc,
+		proxyURLFixed: proxyURLFixed,
+		listener:      listener,
+		transport:     NewHTTPTransport(usage, allowList, blockList, proxyFunc, proxyURLFixed, tlsConfig),
+	}
+	ps.server = &http.Server{
+		Handler:           ps,
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+	go func() {
+		_ = ps.server.Serve(listener)
+	}()
+	return ps, nil
+}
+
+// URL returns the proxy address to hand to a subprocess, e.g. `git -c http.proxy=<URL>`.
+func (ps *ProxyServer) URL() string {
+	return "http://" + ps.listener.Addr().String()
+}
+
+// Close stops the proxy and releases its listener and pooled connections.
+func (ps *ProxyServer) Close() error {
+	ps.transport.CloseIdleConnections()
+	return ps.server.Close()
+}
+
+func (ps *ProxyServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.Method == http.MethodConnect {
+		ps.handleConnect(w, req)
+		return
+	}
+	ps.handleForward(w, req)
+}
+
+// deny refuses a target, logging why and telling the caller only that it was refused.
+func (ps *ProxyServer) deny(w http.ResponseWriter, target string, err error) {
+	log.Debug("%s proxy: refused %q: %v", ps.usage, target, err)
+	http.Error(w, errDenied, http.StatusForbidden)
+}
+
+// handleForward relays a plain HTTP request. The response, redirect or not, is returned to the
+// caller as-is: http.Transport.RoundTrip does not follow redirects, so the caller re-requests the
+// new location through this proxy and that hop is validated in its own right.
+func (ps *ProxyServer) handleForward(w http.ResponseWriter, req *http.Request) {
+	if !req.URL.IsAbs() || req.URL.Host == "" {
+		http.Error(w, ps.usage+" proxy: absolute request URI required", http.StatusBadRequest)
+		return
+	}
+
+	// when an upstream proxy carries the request, it dials the target and NewDialContext never sees
+	// it, so the target has to be checked here instead
+	addr := targetAddr(req.URL)
+	if ps.upstreamProxyFor(req.URL) != nil {
+		if err := ps.checkTarget(req.Context(), addr); err != nil {
+			ps.deny(w, addr, err)
+			return
+		}
+	}
+
+	outReq := req.Clone(req.Context())
+	outReq.RequestURI = ""
+	outReq.Close = false
+	removeHopHeaders(outReq.Header)
+
+	resp, err := ps.transport.RoundTrip(outReq)
+	if err != nil {
+		// the deny reason from NewDialContext's Control func surfaces here
+		ps.deny(w, addr, err)
+		return
+	}
+	defer resp.Body.Close()
+
+	removeHopHeaders(resp.Header)
+	dst := w.Header()
+	for key, values := range resp.Header {
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+// handleConnect validates the CONNECT target and, if permitted, tunnels bytes to it. A caller that
+// follows a redirect to a different host opens a new CONNECT, so each tunnel is validated
+// separately.
+func (ps *ProxyServer) handleConnect(w http.ResponseWriter, req *http.Request) {
+	addr := req.Host
+	if addr == "" {
+		addr = req.URL.Host
+	}
+	if _, _, err := net.SplitHostPort(addr); err != nil {
+		addr = net.JoinHostPort(addr, "443")
+	}
+
+	targetConn, targetReader, err := ps.dialTarget(req, addr)
+	if err != nil {
+		ps.deny(w, addr, err)
+		return
+	}
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		targetConn.Close()
+		http.Error(w, ps.usage+" proxy: connection hijacking unsupported", http.StatusInternalServerError)
+		return
+	}
+	clientConn, clientBuf, err := hijacker.Hijack()
+	if err != nil {
+		targetConn.Close()
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// whichever direction ends first tears down both, otherwise a caller that walks away leaves the
+	// other copy parked on a remote that never sends EOF, holding two sockets and a goroutine
+	closeBoth := sync.OnceFunc(func() {
+		_ = clientConn.Close()
+		_ = targetConn.Close()
+	})
+	defer closeBoth()
+
+	if _, err := clientConn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); err != nil {
+		return
+	}
+
+	go func() {
+		defer closeBoth()
+		// clientBuf may already hold bytes read past the CONNECT header, so copy from the reader
+		_, _ = io.Copy(targetConn, clientBuf)
+	}()
+	_, _ = io.Copy(clientConn, targetReader)
+}
+
+// upstreamProxyFor asks proxyFunc which upstream proxy, if any, should carry a request to target.
+func (ps *ProxyServer) upstreamProxyFor(target *url.URL) *url.URL {
+	if ps.proxyFunc == nil {
+		return nil
+	}
+	probe := &http.Request{
+		Method: http.MethodGet,
+		URL:    target,
+		Host:   target.Host,
+		Header: http.Header{},
+	}
+	upstream, err := ps.proxyFunc(probe)
+	if err != nil {
+		return nil
+	}
+	return upstream
+}
+
+// dialTarget connects to addr, either directly or by asking the configured upstream proxy to open
+// the tunnel. It returns the connection and the reader to consume it through, which is buffered
+// when an upstream handshake has already read ahead.
+func (ps *ProxyServer) dialTarget(req *http.Request, addr string) (net.Conn, io.Reader, error) {
+	// the upstream selector expects a request URL, and https targets carry the default port here
+	upstream := ps.upstreamProxyFor(&url.URL{Scheme: "https", Host: strings.TrimSuffix(addr, ":443")})
+	if upstream == nil {
+		dial := NewDialContext(ps.usage, ps.allowList, ps.blockList, ps.proxyURLFixed)
+		conn, err := dial(req.Context(), "tcp", addr)
+		if err != nil {
+			return nil, nil, err
+		}
+		return conn, conn, nil
+	}
+
+	// the upstream dials the target itself, so it has to be checked before the tunnel is requested
+	if err := ps.checkTarget(req.Context(), addr); err != nil {
+		return nil, nil, err
+	}
+
+	// dialling the upstream proxy itself: NewDialContext permits the proxy host it is given, but
+	// only on the proxy's own port, so hand it a URL with the port spelled out
+	upstreamWithPort := *upstream
+	upstreamWithPort.Host = upstreamAddr(upstream)
+	dial := NewDialContext(ps.usage, ps.allowList, ps.blockList, &upstreamWithPort)
+	conn, err := dial(req.Context(), "tcp", upstreamWithPort.Host)
+	if err != nil {
+		return nil, nil, err
+	}
+	reader, err := openUpstreamTunnel(conn, upstream, addr)
+	if err != nil {
+		conn.Close()
+		return nil, nil, err
+	}
+	return conn, reader, nil
+}
+
+// checkTarget applies the allow/block policy to addr without dialling it. The dialler enforces the
+// same policy on the resolved IP for every direct connection; this covers the paths where an
+// upstream proxy makes the outbound connection on our behalf.
+func (ps *ProxyServer) checkTarget(ctx context.Context, addr string) error {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return fmt.Errorf("%s can not resolve '%s': %w", ps.usage, host, err)
+	}
+	for _, ip := range ips {
+		if ps.blockList.MatchHostOrIP(host, ip.IP) {
+			return fmt.Errorf("%s can not call blocked HTTP servers (check your %s setting), deny '%s(%s)'", ps.usage, ps.blockList.SettingKeyHint, host, ip.IP)
+		}
+		if !ps.allowList.IsEmpty() && !ps.allowList.MatchHostOrIP(host, ip.IP) {
+			return fmt.Errorf("%s can only call allowed HTTP servers (check your %s setting), deny '%s(%s)'", ps.usage, ps.allowList.SettingKeyHint, host, ip.IP)
+		}
+	}
+	return nil
+}
+
+// openUpstreamTunnel performs the CONNECT handshake against an upstream proxy already dialled, and
+// returns the reader to keep using: it may hold bytes read past the handshake response.
+func openUpstreamTunnel(conn net.Conn, upstream *url.URL, addr string) (io.Reader, error) {
+	connectReq := &http.Request{
+		Method: http.MethodConnect,
+		URL:    &url.URL{Opaque: addr},
+		Host:   addr,
+		Header: http.Header{},
+	}
+	if user := upstream.User; user != nil {
+		password, _ := user.Password()
+		connectReq.Header.Set("Proxy-Authorization", "Basic "+basicAuth(user.Username(), password))
+	}
+	if err := connectReq.Write(conn); err != nil {
+		return nil, err
+	}
+	reader := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(reader, connectReq)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New("upstream proxy refused CONNECT: " + resp.Status)
+	}
+	return reader, nil
+}
+
+// basicAuth encodes upstream proxy credentials for the Proxy-Authorization header.
+func basicAuth(username, password string) string {
+	return base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+}
+
+// targetAddr renders a request URL as host:port, filling in the scheme default port.
+func targetAddr(target *url.URL) string {
+	if target.Port() != "" {
+		return target.Host
+	}
+	if strings.EqualFold(target.Scheme, "https") {
+		return net.JoinHostPort(target.Hostname(), "443")
+	}
+	return net.JoinHostPort(target.Hostname(), "80")
+}
+
+// upstreamAddr renders an upstream proxy URL as host:port, filling in the scheme default port.
+func upstreamAddr(upstream *url.URL) string {
+	return targetAddr(upstream)
+}
+
+// removeHopHeaders drops connection-scoped headers, including any the Connection header names.
+func removeHopHeaders(header http.Header) {
+	for _, value := range header.Values("Connection") {
+		for _, name := range strings.Split(value, ",") {
+			if name = strings.TrimSpace(name); name != "" {
+				header.Del(name)
+			}
+		}
+	}
+	for _, name := range hopHeaders {
+		header.Del(name)
+	}
+}

--- a/modules/hostmatcher/proxyserver_test.go
+++ b/modules/hostmatcher/proxyserver_test.go
@@ -1,0 +1,342 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package hostmatcher
+
+import (
+	"bufio"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const internalSecret = "internal-only-secret"
+
+// newServerOn starts a test server bound to a specific loopback address so allow/block lists can
+// tell "external" (127.0.0.1) and "internal" (127.0.0.2) targets apart.
+func newServerOn(t *testing.T, addr string, handler http.Handler, useTLS bool) *httptest.Server {
+	t.Helper()
+	listener, err := net.Listen("tcp", addr+":0")
+	require.NoError(t, err)
+	srv := httptest.NewUnstartedServer(handler)
+	require.NoError(t, srv.Listener.Close())
+	srv.Listener = listener
+	if useTLS {
+		srv.StartTLS()
+	} else {
+		srv.Start()
+	}
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newTestProxy starts a ProxyServer that blocks 127.0.0.2 and returns a client routed through it.
+func newTestProxy(t *testing.T) (*ProxyServer, *http.Client) {
+	t.Helper()
+	blockList := ParseHostMatchList("test.BLOCKED", "127.0.0.2")
+	allowList := ParseHostMatchList("test.ALLOWED", "")
+	ps, err := NewProxyServer("test", allowList, blockList, nil, nil, &tls.Config{InsecureSkipVerify: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ps.Close() })
+
+	proxyURL, err := url.Parse(ps.URL())
+	require.NoError(t, err)
+	client := &http.Client{Transport: &http.Transport{
+		Proxy:           http.ProxyURL(proxyURL),
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+	return ps, client
+}
+
+func TestProxyServerAllowsPermittedTarget(t *testing.T) {
+	external := newServerOn(t, "127.0.0.1", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}), false)
+	_, client := newTestProxy(t)
+
+	resp, err := client.Get(external.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "ok", string(body))
+}
+
+func TestProxyServerBlocksForbiddenTarget(t *testing.T) {
+	internal := newServerOn(t, "127.0.0.2", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(internalSecret))
+	}), false)
+	_, client := newTestProxy(t)
+
+	// negative control: the target is reachable, so a refusal can only come from the block list
+	direct, err := http.Get(internal.URL)
+	require.NoError(t, err)
+	directBody, err := io.ReadAll(direct.Body)
+	require.NoError(t, err)
+	require.NoError(t, direct.Body.Close())
+	require.Equal(t, internalSecret, string(directBody))
+
+	resp, err := client.Get(internal.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.NotContains(t, string(body), internalSecret)
+	// the reason is logged, not returned: it would tell the caller how an internal name resolves
+	assert.Contains(t, string(body), errDenied)
+	assert.NotContains(t, string(body), "127.0.0.2")
+}
+
+// TestProxyServerRevalidatesRedirectTarget is the SSRF case: the first hop is permitted, and the
+// permitted host redirects to a blocked internal address. The redirect must not smuggle the caller
+// past the allow/block lists.
+func TestProxyServerRevalidatesRedirectTarget(t *testing.T) {
+	internal := newServerOn(t, "127.0.0.2", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(internalSecret))
+	}), false)
+	external := newServerOn(t, "127.0.0.1", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, internal.URL, http.StatusFound)
+	}), false)
+	_, client := newTestProxy(t)
+
+	resp, err := client.Get(external.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.NotContains(t, string(body), internalSecret)
+}
+
+// TestProxyServerAllowsPermittedRedirect keeps the behaviour that broke the previous fix: a
+// redirect to a permitted target still resolves, so remotes that answer 301 (e.g. GitLab pointing
+// at the .git URL) keep working.
+func TestProxyServerAllowsPermittedRedirect(t *testing.T) {
+	var externalURL string
+	external := newServerOn(t, "127.0.0.1", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repo" {
+			http.Redirect(w, r, externalURL+"/repo.git", http.StatusMovedPermanently)
+			return
+		}
+		_, _ = w.Write([]byte("clone-me"))
+	}), false)
+	externalURL = external.URL
+	_, client := newTestProxy(t)
+
+	resp, err := client.Get(external.URL + "/repo")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "clone-me", string(body))
+}
+
+func TestProxyServerBlocksForbiddenConnectTarget(t *testing.T) {
+	internal := newServerOn(t, "127.0.0.2", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(internalSecret))
+	}), true)
+	_, client := newTestProxy(t)
+
+	resp, err := client.Get(internal.URL)
+	if err == nil {
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+		assert.NotContains(t, string(body), internalSecret)
+		return
+	}
+	assert.Contains(t, err.Error(), "Forbidden")
+}
+
+func TestProxyServerAllowsPermittedConnectTarget(t *testing.T) {
+	external := newServerOn(t, "127.0.0.1", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("tunnelled"))
+	}), true)
+	_, client := newTestProxy(t)
+
+	resp, err := client.Get(external.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "tunnelled", string(body))
+}
+
+func TestRemoveHopHeaders(t *testing.T) {
+	header := http.Header{}
+	header.Set("Connection", "X-Custom-Hop")
+	header.Set("X-Custom-Hop", "drop-me")
+	header.Set("Proxy-Authorization", "drop-me")
+	header.Set("X-Keep", "keep-me")
+	removeHopHeaders(header)
+	assert.Empty(t, header.Get("Connection"))
+	assert.Empty(t, header.Get("X-Custom-Hop"))
+	assert.Empty(t, header.Get("Proxy-Authorization"))
+	assert.Equal(t, "keep-me", header.Get("X-Keep"))
+}
+
+func TestUpstreamAddr(t *testing.T) {
+	for _, tc := range []struct{ raw, want string }{
+		{"http://proxy.example.com", "proxy.example.com:80"},
+		{"https://proxy.example.com", "proxy.example.com:443"},
+		{"http://proxy.example.com:8080", "proxy.example.com:8080"},
+	} {
+		u, err := url.Parse(tc.raw)
+		require.NoError(t, err)
+		assert.Equal(t, tc.want, upstreamAddr(u), fmt.Sprintf("raw=%s", tc.raw))
+	}
+}
+
+func TestNewProxyServerRejectsEmptyLists(t *testing.T) {
+	// nil lists match nothing, so a proxy built from them would permit every target
+	ps, err := NewProxyServer("test", nil, nil, nil, nil, nil)
+	require.Error(t, err)
+	assert.Nil(t, ps)
+	assert.Contains(t, err.Error(), "permit every target")
+}
+
+// newUpstreamProxy starts a minimal CONNECT-capable proxy and records the authorities it was asked
+// to reach.
+func newUpstreamProxy(t *testing.T) (*url.URL, *[]string) {
+	t.Helper()
+	var seen []string
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodConnect {
+			http.Error(w, "only CONNECT", http.StatusNotImplemented)
+			return
+		}
+		seen = append(seen, r.Host)
+		target, err := net.Dial("tcp", r.Host)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		defer target.Close()
+		clientConn, clientBuf, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			return
+		}
+		defer clientConn.Close()
+		_, _ = clientConn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+		go func() { _, _ = io.Copy(target, clientBuf) }()
+		_, _ = io.Copy(clientConn, target)
+	})}
+	go func() { _ = srv.Serve(listener) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	upstream, err := url.Parse("http://" + listener.Addr().String())
+	require.NoError(t, err)
+	return upstream, &seen
+}
+
+// TestProxyServerValidatesTargetBehindUpstreamProxy covers the path where an upstream proxy makes
+// the outbound connection, so the dialler never sees the real target and the policy has to be
+// applied before the tunnel is requested.
+func TestProxyServerValidatesTargetBehindUpstreamProxy(t *testing.T) {
+	internal := newServerOn(t, "127.0.0.2", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(internalSecret))
+	}), true)
+	upstream, seen := newUpstreamProxy(t)
+
+	ps, err := NewProxyServer("test", ParseHostMatchList("test.ALLOWED", ""), ParseHostMatchList("test.BLOCKED", "127.0.0.2"),
+		func(*http.Request) (*url.URL, error) { return upstream, nil }, upstream, &tls.Config{InsecureSkipVerify: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ps.Close() })
+
+	proxyURL, err := url.Parse(ps.URL())
+	require.NoError(t, err)
+	client := &http.Client{Transport: &http.Transport{
+		Proxy:           http.ProxyURL(proxyURL),
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+
+	resp, err := client.Get(internal.URL)
+	if err == nil {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+		assert.NotContains(t, string(body), internalSecret)
+	} else {
+		assert.Contains(t, err.Error(), "Forbidden")
+	}
+	assert.Empty(t, *seen, "the upstream proxy must never be asked to reach a blocked target")
+}
+
+func TestProxyServerTunnelsPermittedTargetViaUpstreamProxy(t *testing.T) {
+	external := newServerOn(t, "127.0.0.1", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("via-upstream"))
+	}), true)
+	upstream, seen := newUpstreamProxy(t)
+
+	ps, err := NewProxyServer("test", ParseHostMatchList("test.ALLOWED", ""), ParseHostMatchList("test.BLOCKED", "127.0.0.2"),
+		func(*http.Request) (*url.URL, error) { return upstream, nil }, upstream, &tls.Config{InsecureSkipVerify: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ps.Close() })
+
+	proxyURL, err := url.Parse(ps.URL())
+	require.NoError(t, err)
+	client := &http.Client{Transport: &http.Transport{
+		Proxy:           http.ProxyURL(proxyURL),
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+
+	resp, err := client.Get(external.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "via-upstream", string(body))
+	assert.NotEmpty(t, *seen, "the permitted target must be reached through the configured upstream proxy")
+}
+
+// TestProxyServerReleasesAbandonedTunnels guards the leak: a caller that walks away must not leave
+// the other copy direction parked on a remote that never sends EOF.
+func TestProxyServerReleasesAbandonedTunnels(t *testing.T) {
+	silent, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = silent.Close() })
+	go func() {
+		for {
+			conn, err := silent.Accept()
+			if err != nil {
+				return
+			}
+			t.Cleanup(func() { _ = conn.Close() })
+		}
+	}()
+
+	ps, _ := newTestProxy(t)
+	before := runtime.NumGoroutine()
+	for range 25 {
+		conn, err := net.Dial("tcp", strings.TrimPrefix(ps.URL(), "http://"))
+		require.NoError(t, err)
+		_, err = fmt.Fprintf(conn, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", silent.Addr(), silent.Addr())
+		require.NoError(t, err)
+		_, _ = bufio.NewReader(conn).ReadString('\n')
+		require.NoError(t, conn.Close())
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) && runtime.NumGoroutine() > before+10 {
+		time.Sleep(50 * time.Millisecond)
+	}
+	assert.LessOrEqual(t, runtime.NumGoroutine(), before+10, "abandoned tunnels leaked goroutines")
+}

--- a/services/migrations/git_proxy.go
+++ b/services/migrations/git_proxy.go
@@ -1,0 +1,71 @@
+// Copyright 2026 The Gitea Authors. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package migrations
+
+import (
+	"crypto/tls"
+	"sync"
+
+	"gitea.dev/modules/git"
+	"gitea.dev/modules/hostmatcher"
+	"gitea.dev/modules/log"
+	"gitea.dev/modules/proxy"
+	"gitea.dev/modules/setting"
+)
+
+// The git subprocesses used for migrations and mirror syncs cannot be given an http.Transport, so
+// they get the same SSRF policy through a loopback proxy instead: see
+// git.HandleGitCmdHTTPRedirection. Registration happens at package load rather than in Init so that
+// no caller can reach a git clone with the hook unset; the proxy itself is started on first use and
+// rebuilt whenever Init reparses the lists. Until Init has run there are no lists to enforce, so the
+// proxy refuses to start and the caller falls back to refusing redirects outright.
+func init() {
+	git.SetGitCmdHTTPProxyProvider(gitHTTPProxyURL)
+}
+
+var (
+	gitProxyMu     sync.Mutex
+	gitProxyServer *hostmatcher.ProxyServer
+	gitProxyFailed bool
+)
+
+// gitHTTPProxyURL returns the address of the validating proxy, starting it on first use. It returns
+// an empty string if the proxy cannot be started, which makes the caller fail closed.
+func gitHTTPProxyURL() string {
+	gitProxyMu.Lock()
+	defer gitProxyMu.Unlock()
+
+	if gitProxyServer != nil {
+		return gitProxyServer.URL()
+	}
+	if gitProxyFailed {
+		return ""
+	}
+
+	server, err := hostmatcher.NewProxyServer("migration", allowList, blockList, proxy.Proxy(), setting.Proxy.ProxyURLFixed,
+		&tls.Config{InsecureSkipVerify: setting.Migrations.SkipTLSVerify})
+	if err != nil {
+		// remember the failure so every migration does not retry a listen that is not going to work
+		gitProxyFailed = true
+		log.Error("Unable to start the migration git proxy, redirects will be refused instead: %v", err)
+		return ""
+	}
+	gitProxyServer = server
+	return server.URL()
+}
+
+// resetGitHTTPProxy drops the running proxy so the next use rebuilds it from the current
+// allow/block lists.
+func resetGitHTTPProxy() {
+	gitProxyMu.Lock()
+	defer gitProxyMu.Unlock()
+
+	if gitProxyServer != nil {
+		if err := gitProxyServer.Close(); err != nil {
+			log.Error("Unable to stop the previous migration git proxy: %v", err)
+		}
+		gitProxyServer = nil
+	}
+	gitProxyFailed = false
+}

--- a/services/migrations/migrate.go
+++ b/services/migrations/migrate.go
@@ -532,5 +532,8 @@ func Init() error {
 	// then reuse one connection pool instead of creating a client (and pool) per request
 	migrationHTTPClient.Reset()
 
+	// same for the proxy the git subprocesses use, so it enforces the freshly parsed lists too
+	resetGitHTTPProxy()
+
 	return nil
 }


### PR DESCRIPTION
## Problem

Migration and mirror clones validate the remote URL once in Go (`isURLAllowed` resolves the host and checks it against the allow/block lists), then hand the URL to a `git` subprocess. `git` resolves DNS again and follows HTTP redirects itself, so a host that passes validation can answer 30x and send the subprocess to an address the lists forbid: internal HTTP services, and cloud metadata endpoints such as `169.254.169.254`. Creating a migration is enough, no admin rights, default config.

`HandleGitCmdHTTPRedirection` has been an empty function since #38530 reverted the blanket `http.followRedirects=false`, and carries `FIXME: GIT-CLONE-HTTP-REDIRECT-SSRF: need a complete solution in the future`. The revert was correct: that setting also rejects the benign redirects real forges emit, for example GitLab answering 301 for a clone URL without the `.git` suffix.

I reported this privately as GHSA-g32r-j32m-w2ff (2026-04-17). It was closed on 2026-07-03 as already fixed; the clone-path guard was reverted on 2026-07-20, so the vector is open again on main. This PR is the complete solution the FIXME asks for.

## Approach

Route the subprocess through a loopback proxy that applies the same allow/block policy to every hop. This is the pattern already used for webhooks after CVE-2024-6886, extended to a subprocess that cannot be handed an `http.Transport`.

`hostmatcher.ProxyServer`:

- forwarded requests are dialled through the existing `NewDialContext`, so the check runs against the resolved IP at connect time
- redirects are returned unfollowed, so the next hop arrives as a fresh request and is validated in its own right
- CONNECT targets are validated before the tunnel opens
- a configured upstream proxy is chained rather than bypassed, and because the upstream makes that connection itself, those targets are checked before the tunnel is requested rather than being taken on trust

`git` is pointed at it with `-c http.proxy=<loopback url>`. The proxy starts on first use, is bound to the migration allow/block lists, and is rebuilt whenever `migrations.Init` reparses them. A caller with no proxy available falls back to refusing redirects outright, so the path fails closed rather than open.

Because the check now happens on the resolved IP at connect time, the DNS rebinding gap noted in the `migrate.go` TODO is closed for these http/https paths as well.

One thing that is easy to miss: git has no `http.noProxy` config key, so a `no_proxy` value inherited from Gitea's own environment still applies and makes libcurl ignore the configured proxy for matching hosts. `no_proxy=*` is common in container images, and a corporate `no_proxy` list names exactly the internal ranges an SSRF would target, so the guard would have been silently off in both cases. `gitcmd` now strips the proxy environment variables from any command carrying an explicit `-c http.proxy=`.

## Behaviour

A redirect to a permitted host still resolves. A redirect to a forbidden one is refused at connect time. That is the difference from #38530, and the reason this should not need reverting.

## Verification

Against this branch, using a real `git clone`, a redirect server on a permitted address, and an internal repository on a blocked one:

```
no guard (current main)                    CLONED, exfiltrated aws_secret_access_key = INTERNAL_SECRET_VALUE
guard                                      REFUSED
guard + inherited no_proxy=* (the bypass)  CLONED, exfiltrated aws_secret_access_key = INTERNAL_SECRET_VALUE
guard + env scrubbed by this PR            REFUSED
benign 301 to permitted host               CLONED
```

Line 1 is current `main`. Line 3 is why the environment scrub is part of this change rather than a follow-up.

Unit tests cover redirect re-validation, the permitted-redirect case, both CONNECT paths, target validation behind an upstream proxy (including that the upstream is never asked to reach a blocked target), tunnel teardown when a caller abandons a CONNECT, the environment scrub, and the fail-closed fallback. The blocked-target test carries a negative control asserting the target is otherwise reachable, so a refusal can only come from the block list.

## Not covered

`http.proxy` only governs HTTP and HTTPS remotes, so this change deliberately leaves some ground untouched:

- `git://` and `ssh://` remotes keep the existing resolve-once validation, which means `git://` migrations remain open to DNS rebinding. Worth a separate look, since `services/migrations/migrate.go` permits the scheme by default.
- Push mirrors (`services/mirror/mirror_push.go`) never called `HandleGitCmdHTTPRedirection` and still do not.
- A `[git.config]` entry writing a url-matched `http.<url>.proxy` key outranks a command-line `-c http.proxy`, so an admin can still turn the guard off by hand. Documented here rather than blocked.

Local and managed clones now skip the guard entirely: it is applied only when the clone source is an http(s) URL.
