### PR TITLE
fix: stop treating a runs-on group name as a runner label

### DIFF
--- a/modules/actions/jobparser/jobparser.go
+++ b/modules/actions/jobparser/jobparser.go
@@ -265,7 +265,7 @@ func validateMatrixFilters(job *model.Job) error {
 // buildMatrixCombos builds one Job per matrix combination from src, baking the combination into the
 // strategy and interpolating the name, runs-on and continue-on-error with it.
 func buildMatrixCombos(jobID string, src *Job, matrixes []map[string]any, actJob *model.Job, gitCtx *model.GithubContext, results map[string]*JobResult, vars map[string]string, inputs map[string]any) ([]*Job, error) {
-	srcRunsOn := src.RunsOn()
+	srcRunsOn, srcRunsOnGroup := src.RunsOnLabels(), src.RunsOnGroup()
 	combos := make([]*Job, 0, len(matrixes))
 	var err error
 	for _, matrix := range matrixes {
@@ -284,7 +284,11 @@ func buildMatrixCombos(jobID string, src *Job, matrixes []map[string]any, actJob
 				return nil, fmt.Errorf("interpolate runs-on for job %q: %w", jobID, err)
 			}
 		}
-		combo.RawRunsOn = encodeRunsOn(runsOn)
+		group, err := evaluator.Interpolate(srcRunsOnGroup)
+		if err != nil {
+			return nil, fmt.Errorf("interpolate runs-on group for job %q: %w", jobID, err)
+		}
+		combo.RawRunsOn = encodeRunsOn(runsOn, group)
 		if err := evaluator.EvaluateYamlNode(&combo.RawContinueOnError); err != nil {
 			return nil, fmt.Errorf("evaluate continue-on-error for job %q: %w", jobID, err)
 		}
@@ -344,11 +348,17 @@ func encodeMatrix(matrix map[string]any) yaml.Node {
 	return node
 }
 
-func encodeRunsOn(runsOn []string) yaml.Node {
+func encodeRunsOn(runsOn []string, group string) yaml.Node {
 	node := yaml.Node{}
-	if len(runsOn) == 1 {
+	switch {
+	case group != "":
+		_ = node.Encode(struct {
+			Labels []string `yaml:"labels,omitempty"`
+			Group  string   `yaml:"group"`
+		}{runsOn, group})
+	case len(runsOn) == 1:
 		_ = node.Encode(runsOn[0])
-	} else {
+	default:
 		_ = node.Encode(runsOn)
 	}
 	return node

--- a/modules/actions/jobparser/jobparser_test.go
+++ b/modules/actions/jobparser/jobparser_test.go
@@ -231,7 +231,7 @@ func TestExpandMatrixWithNeeds(t *testing.T) {
 		names := make([]string, 0, len(got))
 		for _, combo := range got {
 			names = append(names, combo.Name)
-			assert.Contains(t, []string{"linux", "darwin"}, combo.RunsOn()[0])
+			assert.Contains(t, []string{"linux", "darwin"}, combo.RunsOnLabels()[0])
 		}
 		// Dimensions are appended in key order, as GitHub names multi-dimension combinations.
 		assert.ElementsMatch(t, []string{
@@ -439,4 +439,34 @@ func TestExpressionIgnoresNeedResults(t *testing.T) {
 	} {
 		assert.Equal(t, want, ExpressionIgnoresNeedResults(value), "value %q", value)
 	}
+}
+
+func TestRunsOnGroupSurvivesMatrixExpansion(t *testing.T) {
+	jobs, err := Parse([]byte(`
+on: push
+jobs:
+  plain:
+    runs-on: [ubuntu-latest]
+    steps: [{run: echo}]
+  grouped:
+    strategy:
+      matrix:
+        v: [1, 2]
+    runs-on:
+      labels: [ubuntu-latest]
+      group: gpu-${{ matrix.v }}
+    steps: [{run: echo}]
+`))
+	require.NoError(t, err)
+
+	got := map[string][]string{}
+	for _, sw := range jobs {
+		_, job := sw.Job()
+		got[job.RunsOnGroup()] = job.RunsOnLabels()
+	}
+	assert.Equal(t, map[string][]string{
+		"":      {"ubuntu-latest"},
+		"gpu-1": {"ubuntu-latest"},
+		"gpu-2": {"ubuntu-latest"},
+	}, got)
 }

--- a/modules/actions/jobparser/model.go
+++ b/modules/actions/jobparser/model.go
@@ -171,8 +171,25 @@ func (j *Job) EraseNeeds() *Job {
 	return j
 }
 
-func (j *Job) RunsOn() []string {
-	return (&model.Job{RawRunsOn: j.RawRunsOn}).RunsOn()
+// TODO: use actionslib's split runs-on accessors from https://gitea.com/gitea/actionslib/pulls/17
+func (j *Job) RunsOnLabels() []string {
+	if j.RawRunsOn.Kind != yaml.MappingNode {
+		return model.RunsOnFromNode(j.RawRunsOn)
+	}
+	var val struct{ Labels yaml.Node }
+	if err := j.RawRunsOn.Decode(&val); err != nil {
+		return nil
+	}
+	return model.RunsOnFromNode(val.Labels)
+}
+
+func (j *Job) RunsOnGroup() string {
+	if j.RawRunsOn.Kind != yaml.MappingNode {
+		return ""
+	}
+	var val struct{ Group string }
+	_ = j.RawRunsOn.Decode(&val)
+	return val.Group
 }
 
 type Step struct {

--- a/services/actions/matrix.go
+++ b/services/actions/matrix.go
@@ -120,7 +120,7 @@ func expandDeferredMatrix(ctx context.Context, job *actions_model.ActionRunJob, 
 			return fmt.Errorf("marshal expanded job: %w", err)
 		}
 		dst.Name = util.EllipsisDisplayString(combo.Name, 255)
-		dst.WorkflowPayload, dst.RunsOn = payload, combo.RunsOn()
+		dst.WorkflowPayload, dst.RunsOn = payload, combo.RunsOnLabels()
 		dst.ContinueOnError = combo.GetContinueOnError()
 		return nil
 	}
@@ -210,7 +210,7 @@ func restoreDeferredMatrixPlaceholder(clone *actions_model.ActionRunJob) error {
 	}
 	clone.Name = util.EllipsisDisplayString(parsed.Name, 255)
 	clone.WorkflowPayload = slices.Clone(clone.DeferredMatrixPayload)
-	clone.RunsOn = parsed.RunsOn()
+	clone.RunsOn = parsed.RunsOnLabels()
 	clone.ContinueOnError = parsed.GetContinueOnError()
 	clone.IsMatrixDeferred = true
 	return nil

--- a/services/actions/reusable_workflow.go
+++ b/services/actions/reusable_workflow.go
@@ -374,7 +374,7 @@ func insertCallerChildren(ctx context.Context, run *actions_model.ActionRun, att
 			JobID:                   jobID,
 			AttemptJobID:            attemptJobID,
 			Needs:                   needs,
-			RunsOn:                  parsedChild.RunsOn(),
+			RunsOn:                  parsedChild.RunsOnLabels(),
 			ContinueOnError:         parsedChild.GetContinueOnError(),
 			MaxParallel:             parseMaxParallel(jobID, parsedChild.Strategy.MaxParallelString),
 			Status:                  actions_model.StatusBlocked,

--- a/services/actions/run.go
+++ b/services/actions/run.go
@@ -214,7 +214,7 @@ func insertRunJob(ctx context.Context, run *actions_model.ActionRun, runAttempt 
 		JobID:                   id,
 		AttemptJobID:            attemptJobID,
 		Needs:                   needs,
-		RunsOn:                  job.RunsOn(),
+		RunsOn:                  job.RunsOnLabels(),
 		Status:                  util.Iif(shouldBlockJob, actions_model.StatusBlocked, actions_model.StatusWaiting),
 		WorkflowSourceRepoID:    run.WorkflowRepoID,
 		WorkflowSourceCommitSHA: run.WorkflowCommitSHA,

--- a/tests/integration/actions_rerun_test.go
+++ b/tests/integration/actions_rerun_test.go
@@ -542,7 +542,7 @@ func mustParseSingleWorkflowPayloads(t *testing.T, workflowContent string) map[s
 			name:    job.Name,
 			payload: payload,
 			needs:   needs,
-			runsOn:  job.RunsOn(),
+			runsOn:  job.RunsOnLabels(),
 		}
 	}
 	return payloads


### PR DESCRIPTION
`RunsOnFromNode` in actionslib folds the group of a `runs-on` mapping into the label list, so this workflow matches any runner merely labelled `gpu`, even one in no group at all:

```yaml
runs-on:
  labels: [ubuntu-latest]
  group: gpu
```

Reads the labels and the group separately, and keeps the group when a matrix combination is re-encoded instead of dropping it.

Prerequisite for https://github.com/go-gitea/gitea/pull/39284, which adds the group side.