### PR TITLE
fix: keep multi-select dropdown labels on one line

### DIFF
--- a/web_src/css/modules/dropdown.css
+++ b/web_src/css/modules/dropdown.css
@@ -436,10 +436,8 @@ select.ui.dropdown {
 }
 
 .ui.multiple.dropdown > .label {
-  white-space: normal;
   font-size: 1em;
   padding: 0.35714286em 0.78571429em;
-  margin: 0.14285714rem 0.28571429rem 0.14285714rem 0;
   box-shadow: 0 0 0 1px var(--color-secondary) inset;
 }
 

--- a/web_src/fomantic/build/components/dropdown.js
+++ b/web_src/fomantic/build/components/dropdown.js
@@ -2788,6 +2788,9 @@ $.fn.dropdown = function(parameters) {
               })
             ;
             module.remove.searchTerm();
+            if(module.is.allFiltered()) {
+              module.hideMenu(); // GITEA-PATCH: "show" already refuses this state, reconcile it after a selection
+            }
           }
         },
 

--- a/web_src/js/features/repo-home.ts
+++ b/web_src/js/features/repo-home.ts
@@ -135,7 +135,7 @@ export function initRepoTopicBar() {
     },
     onLabelCreate(value: string) {
       value = value.toLowerCase().trim();
-      this.attr('data-value', value).contents().first().replaceWith(value);
+      this.attr('data-value', value).contents().first().text(value);
       return fomanticQuery(this);
     },
     onAdd(addedValue: string, _addedText: any, $addedChoice: JQueryElem) {

--- a/web_src/js/modules/fomantic.ts
+++ b/web_src/js/modules/fomantic.ts
@@ -16,7 +16,7 @@ export function initGiteaFomantic() {
   // Always use Gitea's SVG icons
   $.fn.dropdown.settings.templates.label = function(_value: any, text: string, preserveHTML: boolean, className: Record<string, string>) {
     const escape = $.fn.dropdown.settings.templates.escape;
-    return escape(text, preserveHTML) + svg('octicon-x', 16, `${className.delete} icon`);
+    return `<span class="gt-ellipsis">${escape(text, preserveHTML)}</span>${svg('octicon-x', 16, `${className.delete} icon`)}`;
   };
 
   initFomanticTransition();


### PR DESCRIPTION
Two long-standing issues with `.ui.multiple.dropdown` labels.

`.ui.label` already sets `white-space: nowrap`, but the multiple-dropdown rule overrode it back to `normal`, so a long value wrapped the label and grew the control. Since the label is a flex container its text needs its own `gt-ellipsis` box, otherwise the delete icon is clipped away rather than the text being truncated. The label margin also duplicated the gap the control already provides, which made the control taller than its empty state.

Selecting the last available item also left the menu open with nothing in it, collapsed to a sliver and squaring off the control's bottom corners. `show()` already refuses to open in that state, so this reconciles it after a selection.