### PR TITLE
enhance(notifications): mark current notification page as read

### DIFF
--- a/options/locale/locale_en-US.json
+++ b/options/locale/locale_en-US.json
@@ -3549,6 +3549,7 @@
   "notification.mark_as_read": "Mark as read",
   "notification.mark_as_unread": "Mark as unread",
   "notification.mark_all_as_read": "Mark all as read",
+  "notification.mark_page_as_read": "Mark this page as read",
   "notification.subscriptions": "Subscriptions",
   "notification.watching": "Watching",
   "notification.no_subscriptions": "No subscriptions",

--- a/routers/web/user/notification.go
+++ b/routers/web/user/notification.go
@@ -7,6 +7,8 @@ import (
 	stdCtx "context"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 
 	activities_model "gitea.dev/models/activities"
@@ -194,6 +196,27 @@ func NotificationPurgePost(ctx *context.Context) {
 	}
 
 	ctx.Redirect(setting.AppSubURL+"/notifications", http.StatusSeeOther)
+}
+
+// NotificationPurgePagePost is a route for marking only the notifications on the current page as read
+func NotificationPurgePagePost(ctx *context.Context) {
+	_ = ctx.Req.ParseForm()
+	for _, idStr := range ctx.Req.Form["notification_id"] {
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil {
+			continue
+		}
+		if _, err := notifications.SetNotificationStatus(ctx, id, ctx.Doer, activities_model.NotificationStatusRead); err != nil {
+			ctx.ServerError("SetNotificationStatus", err)
+			return
+		}
+	}
+
+	redirect := setting.AppSubURL + "/notifications"
+	if pageType := ctx.FormString("type"); pageType != "" {
+		redirect += "?type=" + url.QueryEscape(pageType)
+	}
+	ctx.Redirect(redirect, http.StatusSeeOther)
 }
 
 // NotificationSubscriptions returns the list of subscribed issues

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1767,6 +1767,7 @@ func registerWebRoutes(m *web.Router, webAuth *AuthMiddleware) {
 		m.Get("/watching", user.NotificationWatching)
 		m.Post("/status", user.NotificationStatusPost)
 		m.Post("/purge", user.NotificationPurgePost)
+		m.Post("/purge-page", user.NotificationPurgePagePost)
 		m.Get("/new", user.NewAvailable)
 	}, reqSignIn)
 

--- a/templates/user/notification/notification_div.tmpl
+++ b/templates/user/notification/notification_div.tmpl
@@ -14,11 +14,25 @@
 				</a>
 			</div>
 			{{if and (not $pageTypeIsRead) $notificationUnreadCount}}
-				<form action="{{AppSubUrl}}/notifications/purge" method="post">
-					<button type="submit" class="ui mini button primary tw-mr-0" title="{{ctx.Locale.Tr "notification.mark_all_as_read"}}">
-						{{svg "octicon-checklist"}}
-					</button>
-				</form>
+				<div class="flex-text-inline">
+					{{if .Notifications}}
+						<form action="{{AppSubUrl}}/notifications/purge-page?{{$.PageQueryParams}}" method="post">
+							{{range $one := .Notifications}}
+								{{if ne $one.Status $statusPinned}}
+									<input type="hidden" name="notification_id" value="{{$one.ID}}">
+								{{end}}
+							{{end}}
+							<button type="submit" class="ui mini button tw-mr-0" title="{{ctx.Locale.Tr "notification.mark_page_as_read"}}">
+								{{svg "octicon-check"}}
+							</button>
+						</form>
+					{{end}}
+					<form action="{{AppSubUrl}}/notifications/purge" method="post">
+						<button type="submit" class="ui mini button primary tw-mr-0" title="{{ctx.Locale.Tr "notification.mark_all_as_read"}}">
+							{{svg "octicon-checklist"}}
+						</button>
+					</form>
+				</div>
 			{{end}}
 		</div>
 		<div id="notification_table">


### PR DESCRIPTION
## Summary

- Add an option to mark notifications on the current page as read.
- Preserve the existing option to mark all notifications as read.
- Exclude pinned notifications from the page-level action.
- Preserve the selected notification type after marking the page as read.
- Add the required route, handler, and localization string.

## Related issue

Closes #39273